### PR TITLE
Ensure all new favicon assets are referenced

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -35,6 +35,8 @@
         <link rel="icon" href="/favicon.ico" sizes="any">
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+        <link rel="icon" href="/favicon-96x96.png" type="image/png" sizes="96x96">
+        <link rel="manifest" href="/site.webmanifest">
 
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- Link 96×96 PNG favicon and web app manifest in layout so new icons are used by browsers

## Testing
- `npm run lint`
- `npm run types` *(fails: Cannot find module '@/routes' ...)*
- `./vendor/bin/pest` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b961f46c74832ebf214352ed53bd2a