### PR TITLE
Testing: Add workflow for coverage badge generation

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,53 @@
+name: Coverage Badge
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # PHP + Xdebug for Coverage
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: xdebug
+          coverage: xdebug
+
+      - name: Install Composer deps
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Copy .env file
+        run: cp .env.example .env
+
+      - name: Generate application key
+        run: php artisan key:generate --force
+
+      # Laravel Tests with Clover Report
+      - name: Run tests with coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: php artisan test --coverage-clover=coverage.xml
+
+      # Create Badge from coverage.xml and commit
+      - name: Create coverage badge
+        uses: timkrase/phpunit-coverage-badge@v1.2.1
+        with:
+          report: coverage.xml
+          coverage_badge_path: output/coverage.svg
+          push_badge: false
+
+      - name: Git push to image-data branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./output
+          publish_branch: image-data
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,18 +1,18 @@
-name: Pest PHP unit tests
+name: Pest PHP Unit Tests
 
 on:
   push:
     branches:
+      - develop
       - main
   pull_request:
     branches:
+      - develop
       - main
 
 jobs:
   ci:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout
@@ -46,13 +46,5 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
 
-      - name: Execute tests (Unit and Feature tests) via PestPHP
-        run: vendor/bin/pest --coverage-clover clover.xml
-
-      - name: Generate test coverage badge
-        if: github.ref == 'refs/heads/main'
-        uses: timkrase/phpunit-coverage-badge@v1.2.0
-        with:
-          coverage_badge_path: 'badge-coverage.svg'
-          push_badge: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tests
+        run: ./vendor/bin/pest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ERNIE - Earth Research Notary for Information & Editing
 
-[![Test Coverage](https://raw.githubusercontent.com/McNamara84/ernie/main/badge-coverage.svg)](https://packagist.org/packages/McNamara84/ernie)
+![Test Coverage](https://github.com/McNamara84/ernie/blob/image-data/coverage.svg?raw=true)
 
 
 A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate test coverage reporting and badge generation for the project. The workflow runs on every push to the `main` branch, executes tests with coverage, generates a coverage badge, and publishes the badge to a dedicated branch.

**Continuous Integration and Coverage Reporting:**

* Added a new workflow file `.github/workflows/coverage-badge.yml` to automate test coverage reporting and badge creation on pushes to `main`.
* Configured the workflow to set up PHP 8.3 with Xdebug, install dependencies, prepare the environment, and run Laravel tests with Clover coverage reporting.

**Badge Generation and Publishing:**

* Integrated `phpunit-coverage-badge` to generate a coverage badge from the test report and output it to `output/coverage.svg`.
* Configured the workflow to publish the generated badge to the `image-data` branch using `gh-pages` action for easy access and display.