### PR TITLE
Fix coverage badge workflow missing Vite manifest

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -20,8 +20,20 @@ jobs:
           extensions: xdebug
           coverage: xdebug
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
       - name: Install Composer deps
         run: composer install --no-interaction --prefer-dist
+
+      - name: Build assets
+        run: npm run build
 
       - name: Copy .env file
         run: cp .env.example .env


### PR DESCRIPTION
This pull request updates the `.github/workflows/coverage-badge.yml` workflow to ensure Node.js dependencies are installed and assets are built as part of the CI process. These changes help guarantee that the latest frontend assets are available during coverage runs.

**Frontend build integration:**

* Added a step to set up Node.js using `actions/setup-node@v4`, specifying Node version 22 and enabling npm caching.
* Installed Node dependencies using `npm ci` to ensure a clean and reproducible environment.
* Added a step to build frontend assets with `npm run build` before proceeding with other tasks.