### PR TITLE
fix: keep main menu fixed at top

### DIFF
--- a/resources/js/components/app-content.tsx
+++ b/resources/js/components/app-content.tsx
@@ -11,7 +11,7 @@ export function AppContent({ variant = 'header', children, ...props }: AppConten
     }
 
     return (
-        <main className="mx-auto flex h-full w-full max-w-7xl flex-1 flex-col gap-4 rounded-xl" {...props}>
+        <main className="mx-auto flex h-full w-full max-w-7xl flex-1 flex-col gap-4 rounded-xl pt-16" {...props}>
             {children}
         </main>
     );

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -49,7 +49,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
     const getInitials = useInitials();
     return (
         <>
-            <div className="border-b border-sidebar-border/80">
+            <div className="fixed top-0 z-50 w-full border-b border-sidebar-border/80 bg-background">
                 <div className="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                     {/* Mobile Menu */}
                     <div className="lg:hidden">

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -8,27 +8,23 @@ export default function Welcome() {
     return (
         <>
             <Head title="Welcome" />
-            <div className="flex min-h-screen flex-col items-center justify-center bg-[#FDFDFC] p-6 text-[#1b1b18] dark:bg-[#0a0a0a] dark:text-[#EDEDEC]">
-                <header className="mb-6 w-full max-w-4xl">
-                    <nav className="flex items-center justify-end gap-4">
-                        {auth.user ? (
-                            <Link href={dashboard()} className="rounded-sm border px-5 py-1.5">
-                                Dashboard
-                            </Link>
-                        ) : (
-                            <Link href={login()} className="rounded-sm border px-5 py-1.5">
-                                Log in
-                            </Link>
-                        )}
-                    </nav>
-                </header>
+            <header className="fixed top-0 right-0 left-0 z-50 border-b border-sidebar-border/80 bg-background">
+                <nav className="mx-auto flex h-16 w-full max-w-4xl items-center justify-end gap-4 px-6">
+                    {auth.user ? (
+                        <Link href={dashboard()} className="rounded-sm border px-5 py-1.5">
+                            Dashboard
+                        </Link>
+                    ) : (
+                        <Link href={login()} className="rounded-sm border px-5 py-1.5">
+                            Log in
+                        </Link>
+                    )}
+                </nav>
+            </header>
+            <div className="flex min-h-screen flex-col items-center justify-center bg-[#FDFDFC] px-6 pt-16 pb-6 text-[#1b1b18] dark:bg-[#0a0a0a] dark:text-[#EDEDEC]">
                 <main className="text-center">
-                    <h1 className="mb-4 text-2xl font-semibold">
-                        ERNIE - Earth Research Notary for Information & Editing
-                    </h1>
-                    <p>
-                        A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.
-                    </p>
+                    <h1 className="mb-4 text-2xl font-semibold">ERNIE - Earth Research Notary for Information & Editing</h1>
+                    <p>A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.</p>
                 </main>
             </div>
         </>


### PR DESCRIPTION
This pull request updates the layout and positioning of header and main content elements to improve consistency and ensure that headers remain fixed at the top of the page across the application. It also adjusts spacing to accommodate the fixed headers.

**Layout and header positioning improvements:**

* The header in `Welcome` page (`resources/js/pages/welcome.tsx`) is now fixed at the top of the viewport and styled to match the main app header. The main content area has added top padding to prevent overlap with the fixed header. [[1]](diffhunk://#diff-8edc33fdfad4290f7d8a8b572ef18613882634a4494dcd08118064f649c8d8f9L11-R12) [[2]](diffhunk://#diff-8edc33fdfad4290f7d8a8b572ef18613882634a4494dcd08118064f649c8d8f9R24-R27)
* The main application header (`resources/js/components/app-header.tsx`) is now fixed at the top with appropriate z-index and background styling, ensuring it remains visible during scrolling.

**Main content spacing adjustments:**

* The main content container (`AppContent` in `resources/js/components/app-content.tsx`) now includes top padding to account for the fixed header, preventing content from being obscured.