### PR TITLE
Add add-user artisan command

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,19 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('add-user {name} {email} {password}', function (string $name, string $email, string $password) {
+    $user = User::create([
+        'name' => $name,
+        'email' => $email,
+        'password' => Hash::make($password),
+    ]);
+
+    $this->info("User {$user->email} created.");
+})->purpose('Add a new user to the database');


### PR DESCRIPTION
This pull request adds a new Artisan console command to simplify user management directly from the command line. The main change is the introduction of an `add-user` command that allows developers to quickly create new users with hashed passwords.

New console command for user management:

* Added an `add-user {name} {email} {password}` Artisan command in `routes/console.php` to create a new user with a securely hashed password.