### PR TITLE
Use favicon for app logo

### DIFF
--- a/resources/js/components/app-logo-icon.tsx
+++ b/resources/js/components/app-logo-icon.tsx
@@ -1,5 +1,6 @@
 import { ImgHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
 
-export default function AppLogoIcon(props: ImgHTMLAttributes<HTMLImageElement>) {
-    return <img src="/favicon.svg" alt="App logo" {...props} />;
+export default function AppLogoIcon({ className, ...props }: ImgHTMLAttributes<HTMLImageElement>) {
+    return <img src="/favicon.svg" alt="App logo" className={cn('dark:invert', className)} {...props} />;
 }

--- a/resources/js/components/app-logo-icon.tsx
+++ b/resources/js/components/app-logo-icon.tsx
@@ -1,13 +1,5 @@
-import { SVGAttributes } from 'react';
+import { ImgHTMLAttributes } from 'react';
 
-export default function AppLogoIcon(props: SVGAttributes<SVGElement>) {
-    return (
-        <svg {...props} viewBox="0 0 40 42" xmlns="http://www.w3.org/2000/svg">
-            <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M17.2 5.63325L8.6 0.855469L0 5.63325V32.1434L16.2 41.1434L32.4 32.1434V23.699L40 19.4767V9.85547L31.4 5.07769L22.8 9.85547V18.2999L17.2 21.411V5.63325ZM38 18.2999L32.4 21.411V15.2545L38 12.1434V18.2999ZM36.9409 10.4439L31.4 13.5221L25.8591 10.4439L31.4 7.36561L36.9409 10.4439ZM24.8 18.2999V12.1434L30.4 15.2545V21.411L24.8 18.2999ZM23.8 20.0323L29.3409 23.1105L16.2 30.411L10.6591 27.3328L23.8 20.0323ZM7.6 27.9212L15.2 32.1434V38.2999L2 30.9666V7.92116L7.6 11.0323V27.9212ZM8.6 9.29991L3.05913 6.22165L8.6 3.14339L14.1409 6.22165L8.6 9.29991ZM30.4 24.8101L17.2 32.1434V38.2999L30.4 30.9666V24.8101ZM9.6 11.0323L15.2 7.92117V22.5221L9.6 25.6333V11.0323Z"
-            />
-        </svg>
-    );
+export default function AppLogoIcon(props: ImgHTMLAttributes<HTMLImageElement>) {
+    return <img src="/favicon.svg" alt="App logo" {...props} />;
 }

--- a/resources/js/components/app-logo.tsx
+++ b/resources/js/components/app-logo.tsx
@@ -3,8 +3,8 @@ import AppLogoIcon from './app-logo-icon';
 export default function AppLogo() {
     return (
         <>
-            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
-                <AppLogoIcon className="size-5 fill-current text-white dark:text-black" />
+            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-gray-200">
+                <AppLogoIcon className="size-5" />
             </div>
             <div className="ml-1 grid flex-1 text-left text-sm">
                 <span className="mb-0.5 truncate leading-tight font-semibold">Laravel Starter Kit</span>


### PR DESCRIPTION
This pull request refactors the `AppLogoIcon` component to use an image tag instead of inline SVG, simplifying the logo rendering and improving maintainability. It also updates the styling of the logo container for a more consistent appearance.

Logo rendering changes:

* Refactored `AppLogoIcon` in `app-logo-icon.tsx` to render the logo using an `<img>` tag with `src="/favicon.svg"` and improved dark mode support, replacing the previous inline SVG implementation.

Styling updates:

* Updated `AppLogo` in `app-logo.tsx` to use a gray background for the logo container and removed SVG-specific styling from the logo, ensuring consistent sizing and appearance.