### PR TITLE
Add Vitest setup and initial homepage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "format": "prettier --write resources/",
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
-        "types": "tsc --noEmit"
+        "types": "tsc --noEmit",
+        "test": "vitest"
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",

--- a/resources/js/pages/__tests__/welcome.test.tsx
+++ b/resources/js/pages/__tests__/welcome.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import Welcome from '../welcome';
+
+// mock @inertiajs/react and routes used in the component
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+    usePage: () => ({ props: { auth: {} } }),
+}));
+
+vi.mock('@/routes', () => ({
+    dashboard: () => '/dashboard',
+    login: () => '/login',
+}));
+
+describe('Welcome', () => {
+    it('renders the heading', () => {
+        render(<Welcome />);
+        expect(
+            screen.getByRole('heading', {
+                name: /ERNIE - Earth Research Notary for Information & Editing/i,
+            }),
+        ).toBeInTheDocument();
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     plugins: [
@@ -19,5 +19,11 @@ export default defineConfig({
     ],
     esbuild: {
         jsx: 'automatic',
+    },
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        setupFiles: './vitest.setup.ts',
+        include: ['resources/js/**/*.{test,spec}.{js,ts,jsx,tsx}'],
     },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- configure Vitest in Vite config with jsdom and jest-dom setup
- add npm test script and vitest setup file
- add first test for Welcome page heading

## Testing
- `npm test -- --run`
- `npx eslint resources/js/pages/__tests__/welcome.test.tsx vite.config.ts vitest.setup.ts --fix`
- `npm run types` *(fails: Individual declarations in merged declaration 'confirm' must be all exported or all local)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bc782fe0832ebe74f9186e1a2fe7