### PR TITLE
Add initial Playwright login test

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('shows an error for invalid login credentials', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Email address').fill('user@example.com');
+  await page.getByLabel('Password').fill('wrong-password');
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  await expect(page.getByText('These credentials do not match our records.')).toBeVisible();
+  await expect(page).toHaveURL(/\/login/);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://127.0.0.1:8000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -71,9 +71,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'php artisan serve --host=127.0.0.1 --port=8000',
+    url: 'http://127.0.0.1:8000',
+    reuseExistingServer: !process.env.CI,
+  },
 });


### PR DESCRIPTION
This pull request updates the Playwright end-to-end testing setup to work with a Laravel backend running locally and adds a new test for invalid login attempts. The main changes are configuring the test runner to use the correct local server and adding coverage for login error handling.

**Playwright configuration updates:**

* Set the `baseURL` in `playwright.config.ts` to `http://127.0.0.1:8000` to match the Laravel development server.
* Enabled the `webServer` option to automatically start the Laravel server using `php artisan serve` before running tests.

**Test coverage improvements:**

* Added a new end-to-end test in `e2e/login.spec.ts` to verify that an error message is shown for invalid login credentials and that the user remains on the login page.