### PR TITLE
Fix Playwright workflow failing due to missing PHP setup

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,13 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
+    - name: Install PHP dependencies
+      run: composer install
+    - name: Prepare application
+      run: |
+        cp .env.example .env
+        sed -i 's/^SESSION_DRIVER=.*/SESSION_DRIVER=file/' .env
+        php artisan key:generate
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers


### PR DESCRIPTION
This pull request updates the Playwright workflow to ensure the PHP application is properly set up before running tests. The main changes add steps to install PHP dependencies and prepare the application environment.

**Workflow setup improvements:**

* Added a step to install PHP dependencies using `composer install` in the Playwright workflow (`.github/workflows/playwright.yml`).
* Added a step to prepare the application by copying `.env.example` to `.env`, setting the `SESSION_DRIVER` to `file`, and generating an application key with `php artisan key:generate` (`.github/workflows/playwright.yml`).