### PR TITLE
Increase Playwright server startup timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -75,5 +75,6 @@ export default defineConfig({
     command: 'php artisan serve --host=127.0.0.1 --port=8000',
     url: 'http://127.0.0.1:8000',
     reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
   },
 });


### PR DESCRIPTION
This pull request makes a small configuration update to the Playwright test setup by increasing the server startup timeout. This change helps prevent test failures due to slow server startups, especially in slower environments.

- Increased the `timeout` for the `php artisan serve` command to 120 seconds in `playwright.config.ts` to allow more time for the server to start before tests begin.