### PR TITLE
ci: fix Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,18 +12,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
       with:
-        node-version: lts/*
+        php-version: 8.4
+        tools: composer:v2
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - name: Install Node dependencies
+      run: npm ci
     - name: Install PHP dependencies
-      run: composer install
+      run: composer install --no-interaction --prefer-dist --optimize-autoloader
+    - name: Build assets
+      run: npm run build
     - name: Prepare application
       run: |
         cp .env.example .env
         sed -i 's/^SESSION_DRIVER=.*/SESSION_DRIVER=file/' .env
+        touch database/database.sqlite
+        php artisan migrate --force
         php artisan key:generate
-    - name: Install dependencies
-      run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests


### PR DESCRIPTION
This pull request updates the Playwright GitHub Actions workflow to improve the setup and build process for both PHP and Node.js environments. The main changes focus on ensuring all dependencies are installed efficiently and the application is fully prepared before running Playwright tests.

**Workflow setup improvements:**

* Added a dedicated step to set up PHP using `shivammathur/setup-php@v2`, specifying PHP version 8.4 and Composer v2 for dependency management.
* Updated the Node.js setup to use version 22 and enabled npm caching for faster installs.

**Dependency installation and build enhancements:**

* Improved Composer install command with optimized flags for faster and more reliable PHP dependency installation.
* Added a step to build frontend assets with `npm run build` after installing Node dependencies.

**Application preparation improvements:**

* Added commands to create the SQLite database file and run database migrations before generating the application key, ensuring the database is ready for tests.