### PR TITLE
Fix permission issue in coverage badge workflow

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -55,6 +55,9 @@ jobs:
           coverage_badge_path: output/coverage.svg
           push_badge: false
 
+      - name: Ensure output directory is writable
+        run: sudo chown -R $USER:$USER output
+
       - name: Run Vitest with coverage
         env:
           LARAVEL_BYPASS_ENV_CHECK: 1


### PR DESCRIPTION
## Summary
- fix permission issue when generating Vitest coverage badge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68babeae1a58832e9cc0e861cf684d61