### PR TITLE
test: add coverage for appearance and hooks

### DIFF
--- a/resources/js/components/__tests__/appearance-tabs.test.tsx
+++ b/resources/js/components/__tests__/appearance-tabs.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AppearanceTabs from '../appearance-tabs';
+
+const updateAppearance = vi.fn();
+
+vi.mock('@/hooks/use-appearance', () => ({
+    useAppearance: () => ({ appearance: 'system', updateAppearance }),
+}));
+
+describe('AppearanceTabs', () => {
+    it('renders tabs and updates appearance on click', () => {
+        render(<AppearanceTabs />);
+        const darkButton = screen.getByRole('button', { name: /dark/i });
+        const lightButton = screen.getByRole('button', { name: /light/i });
+        const systemButton = screen.getByRole('button', { name: /system/i });
+
+        expect(lightButton).toBeInTheDocument();
+        expect(darkButton).toBeInTheDocument();
+        expect(systemButton).toHaveClass('bg-white');
+
+        fireEvent.click(darkButton);
+        expect(updateAppearance).toHaveBeenCalledWith('dark');
+    });
+});

--- a/resources/js/components/__tests__/breadcrumbs.test.tsx
+++ b/resources/js/components/__tests__/breadcrumbs.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { Breadcrumbs } from '../breadcrumbs';
+import { describe, expect, it } from 'vitest';
+
+describe('Breadcrumbs', () => {
+    it('renders nothing when no breadcrumbs provided', () => {
+        const { container } = render(<Breadcrumbs breadcrumbs={[]} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders links for all but the last breadcrumb', () => {
+        const { container } = render(
+            <Breadcrumbs
+                breadcrumbs={[
+                    { title: 'Home', href: '/' },
+                    { title: 'Settings', href: '/settings' },
+                ]}
+            />,
+        );
+
+        const anchors = container.querySelectorAll('a');
+        expect(anchors).toHaveLength(1);
+        expect(anchors[0]).toHaveAttribute('href', '/');
+
+        const last = screen.getByText('Settings');
+        expect(last.tagName.toLowerCase()).toBe('span');
+        expect(last).toHaveAttribute('aria-current', 'page');
+    });
+});

--- a/resources/js/hooks/__tests__/use-initials.test.ts
+++ b/resources/js/hooks/__tests__/use-initials.test.ts
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useInitials } from '../use-initials';
+
+describe('useInitials', () => {
+    it('returns empty string for empty input', () => {
+        const { result } = renderHook(() => useInitials());
+        expect(result.current('')).toBe('');
+    });
+
+    it('returns first letter for single name', () => {
+        const { result } = renderHook(() => useInitials());
+        expect(result.current('alice')).toBe('A');
+    });
+
+    it('returns initials for multiple names', () => {
+        const { result } = renderHook(() => useInitials());
+        expect(result.current('John Ronald Reuel Tolkien')).toBe('JT');
+    });
+});

--- a/resources/js/pages/settings/__tests__/appearance.test.tsx
+++ b/resources/js/pages/settings/__tests__/appearance.test.tsx
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Appearance from '../appearance';
+
+const updateAppearance = vi.fn();
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/layouts/settings/layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/hooks/use-appearance', () => ({
+    useAppearance: () => ({ appearance: 'system', updateAppearance }),
+}));
+
+vi.mock('@/routes', () => ({
+    appearance: () => ({ url: '/settings/appearance' }),
+}));
+
+describe('Appearance settings page', () => {
+    it('renders heading and updates appearance', () => {
+        render(<Appearance />);
+        expect(screen.getByRole('heading', { name: /appearance settings/i })).toBeInTheDocument();
+        const darkButton = screen.getByRole('button', { name: /dark/i });
+        fireEvent.click(darkButton);
+        expect(updateAppearance).toHaveBeenCalledWith('dark');
+    });
+});


### PR DESCRIPTION
## Summary
- add unit tests for useInitials hook
- cover breadcrumbs rendering and appearance tabs interactions
- verify appearance settings page switches theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badd5d6228832eaced2b3e4404001d