### PR TITLE
test: add coverage for nav menu and settings pages

### DIFF
--- a/resources/js/components/__tests__/nav-main.test.tsx
+++ b/resources/js/components/__tests__/nav-main.test.tsx
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NavMain } from '../nav-main';
+
+vi.mock('@/components/ui/sidebar', () => ({
+    SidebarGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SidebarGroupLabel: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SidebarMenu: ({ children }: { children?: React.ReactNode }) => <ul>{children}</ul>,
+    SidebarMenuButton: ({ children, isActive }: { children?: React.ReactNode; isActive?: boolean }) => (
+        <div data-active={isActive}>{children}</div>
+    ),
+    SidebarMenuItem: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+    usePage: () => ({ url: '/dashboard' }),
+}));
+
+describe('NavMain', () => {
+    it('renders navigation items and highlights active link', () => {
+        render(
+            <NavMain
+                items={[
+                    { title: 'Dashboard', href: '/dashboard' },
+                    { title: 'Settings', href: '/settings' },
+                ]}
+            />
+        );
+
+        const links = screen.getAllByRole('link');
+        expect(links).toHaveLength(2);
+        expect(links[0]).toHaveAttribute('href', '/dashboard');
+        expect(links[1]).toHaveAttribute('href', '/settings');
+
+        const dashboardItem = screen.getByText('Dashboard').closest('[data-active]');
+        expect(dashboardItem).toHaveAttribute('data-active', 'true');
+        const settingsItem = screen.getByText('Settings').closest('[data-active]');
+        expect(settingsItem).toHaveAttribute('data-active', 'false');
+    });
+});
+

--- a/resources/js/components/__tests__/user-info.test.tsx
+++ b/resources/js/components/__tests__/user-info.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/ui/avatar', () => ({
+    Avatar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    AvatarImage: ({ src, alt }: { src?: string; alt?: string }) => <img src={src} alt={alt} />,
+    AvatarFallback: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+}));
+
+import { UserInfo } from '../user-info';
+
+const user = { name: 'Jane Doe', email: 'jane@example.com', avatar: undefined } as const;
+
+describe('UserInfo', () => {
+    it('renders user name and initials', () => {
+        render(<UserInfo user={user} />);
+        expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+        expect(screen.getByText('JD')).toBeInTheDocument();
+        expect(screen.queryByText('jane@example.com')).toBeNull();
+    });
+
+    it('shows email when showEmail is true', () => {
+        render(<UserInfo user={user} showEmail />);
+        expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/pages/settings/__tests__/password.test.tsx
+++ b/resources/js/pages/settings/__tests__/password.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Password from '../password';
+
+let formErrors: Record<string, string> = {};
+let processing = false;
+let recentlySuccessful = false;
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Form: ({ children }: { children: (args: { errors: typeof formErrors; processing: boolean; recentlySuccessful: boolean }) => React.ReactNode }) => (
+        <form>{children({ errors: formErrors, processing, recentlySuccessful })}</form>
+    ),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/layouts/settings/layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/routes/password', () => ({
+    edit: () => ({ url: '/settings/password' }),
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Settings/PasswordController', () => ({
+    default: { update: { form: () => ({}) } },
+}));
+
+describe('Password settings page', () => {
+    beforeEach(() => {
+        formErrors = {};
+        processing = false;
+        recentlySuccessful = false;
+    });
+
+    it('renders fields for updating password', () => {
+        render(<Password />);
+        expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/^new password$/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /save password/i })).toBeInTheDocument();
+    });
+
+    it('shows validation errors', () => {
+        formErrors = {
+            current_password: 'Current password is required',
+            password: 'Password is required',
+            password_confirmation: 'Confirmation is required',
+        };
+        render(<Password />);
+        expect(screen.getByText(/current password is required/i)).toBeInTheDocument();
+        expect(screen.getByText(/^password is required$/i)).toBeInTheDocument();
+        expect(screen.getByText(/confirmation is required/i)).toBeInTheDocument();
+    });
+
+    it('disables button when processing and shows success message', () => {
+        processing = true;
+        recentlySuccessful = true;
+        render(<Password />);
+        expect(screen.getByRole('button', { name: /save password/i })).toBeDisabled();
+        expect(screen.getByText(/saved/i)).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/pages/settings/__tests__/profile.test.tsx
+++ b/resources/js/pages/settings/__tests__/profile.test.tsx
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Profile from '../profile';
+
+let processing = false;
+let formErrors: Record<string, string> = {};
+let recentlySuccessful = false;
+const authUser = { name: 'John Doe', email: 'john@example.com', email_verified_at: null };
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Link: ({ children, href, as, onClick }: { children?: React.ReactNode; href: string; as?: string; onClick?: () => void }) => (
+        <a href={href} data-as={as} onClick={onClick}>
+            {children}
+        </a>
+    ),
+    Form: ({ children }: { children: (args: { processing: boolean; recentlySuccessful: boolean; errors: typeof formErrors }) => React.ReactNode }) => (
+        <form>{children({ processing, recentlySuccessful, errors: formErrors })}</form>
+    ),
+    usePage: () => ({ props: { auth: { user: authUser } } }),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/layouts/settings/layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/delete-user', () => ({
+    default: () => <div data-testid="delete-user" />,
+}));
+
+vi.mock('@/routes/profile', () => ({
+    edit: () => ({ url: '/settings/profile' }),
+}));
+
+vi.mock('@/routes/verification', () => ({
+    send: () => '/email/verification-notification',
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Settings/ProfileController', () => ({
+    default: { update: { form: () => ({}) } },
+}));
+
+describe('Profile settings page', () => {
+    beforeEach(() => {
+        processing = false;
+        formErrors = {};
+        recentlySuccessful = false;
+    });
+
+    it('renders profile form with user data and verification link', () => {
+        render(<Profile mustVerifyEmail={true} />);
+        expect(screen.getByRole('heading', { name: /profile information/i })).toBeInTheDocument();
+        expect(screen.getByLabelText(/name/i)).toHaveValue(authUser.name);
+        expect(screen.getByLabelText(/email address/i)).toHaveValue(authUser.email);
+        const resendLink = screen.getByText(/click here to resend the verification email/i);
+        expect(resendLink).toHaveAttribute('href', '/email/verification-notification');
+    });
+
+    it('shows verification sent message', () => {
+        render(<Profile mustVerifyEmail={true} status="verification-link-sent" />);
+        expect(
+            screen.getByText(/a new verification link has been sent to your email address/i),
+        ).toBeInTheDocument();
+    });
+
+    it('shows validation errors', () => {
+        formErrors = { name: 'Name is required', email: 'Email is invalid' };
+        render(<Profile mustVerifyEmail={false} />);
+        expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+        expect(screen.getByText(/email is invalid/i)).toBeInTheDocument();
+    });
+
+    it('disables save button when processing', () => {
+        processing = true;
+        render(<Profile mustVerifyEmail={false} />);
+        expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several components and pages, focusing on user interface elements and form behaviors. The new tests use Vitest and React Testing Library, and include extensive mocking of dependencies to isolate component logic. The main goal is to improve test coverage for navigation, user info display, and user settings forms.

**Component Tests:**

- Adds tests for the `NavMain` component to verify correct rendering of navigation items and highlighting of the active link. (`resources/js/components/__tests__/nav-main.test.tsx`)
- Adds tests for the `UserInfo` component to ensure user name, initials, and conditional email display are rendered correctly. (`resources/js/components/__tests__/user-info.test.tsx`)

**Settings Page Tests:**

- Adds tests for the profile settings page, including form field rendering, email verification, validation errors, and button states. (`resources/js/pages/settings/__tests__/profile.test.tsx`)
- Adds tests for the password settings page, covering form fields, validation errors, processing state, and success messages. (`resources/js/pages/settings/__tests__/password.test.tsx`)