### PR TITLE
Add button, avatar, and app shell tests

### DIFF
--- a/resources/js/components/__tests__/app-shell.test.tsx
+++ b/resources/js/components/__tests__/app-shell.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppShell } from '../app-shell';
+
+const usePageMock = vi.hoisted(() => vi.fn());
+const SidebarProviderMock = vi.hoisted(() =>
+    vi.fn(({ children }: { children: React.ReactNode; defaultOpen: boolean }) => (
+        <div data-testid="sidebar-provider">{children}</div>
+    ))
+);
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => usePageMock(),
+}));
+
+vi.mock('@/components/ui/sidebar', () => ({
+    SidebarProvider: SidebarProviderMock,
+}));
+
+describe('AppShell', () => {
+    it('renders header variant by default', () => {
+        usePageMock.mockReturnValue({ props: { sidebarOpen: false } });
+        render(
+            <AppShell>
+                <p>Content</p>
+            </AppShell>,
+        );
+        const wrapper = screen.getByText('Content').parentElement as HTMLElement;
+        expect(wrapper).toHaveClass('flex', 'min-h-screen');
+    });
+
+    it('uses SidebarProvider for sidebar variant', () => {
+        usePageMock.mockReturnValue({ props: { sidebarOpen: true } });
+        render(
+            <AppShell variant="sidebar">
+                <p>Sidebar content</p>
+            </AppShell>,
+        );
+        const callArgs = SidebarProviderMock.mock.calls[0][0];
+        expect(callArgs.defaultOpen).toBe(true);
+        expect(screen.getByTestId('sidebar-provider')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/components/ui/__tests__/avatar.test.tsx
+++ b/resources/js/components/ui/__tests__/avatar.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Avatar, AvatarFallback } from '../avatar';
+
+describe('Avatar', () => {
+    it('applies custom class to root', () => {
+        const { container } = render(
+            <Avatar className="custom">
+                <AvatarFallback>AB</AvatarFallback>
+            </Avatar>,
+        );
+        const root = container.querySelector('[data-slot="avatar"]');
+        expect(root).toHaveClass('custom');
+    });
+
+    it('renders fallback content', () => {
+        const { container } = render(
+            <Avatar>
+                <AvatarFallback>AB</AvatarFallback>
+            </Avatar>,
+        );
+        expect(container.textContent).toContain('AB');
+    });
+});
+

--- a/resources/js/components/ui/__tests__/button.test.tsx
+++ b/resources/js/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Button } from '../button';
+
+const BUTTON_TEXT = 'Click me';
+
+describe('Button', () => {
+    it('renders with default styles', () => {
+        render(<Button>{BUTTON_TEXT}</Button>);
+        const btn = screen.getByRole('button', { name: BUTTON_TEXT });
+        expect(btn).toHaveClass('bg-primary');
+        expect(btn).toHaveClass('h-9');
+    });
+
+    it('applies variant and size classes', () => {
+        render(
+            <Button variant="destructive" size="sm">
+                {BUTTON_TEXT}
+            </Button>,
+        );
+        const btn = screen.getByRole('button', { name: BUTTON_TEXT });
+        expect(btn).toHaveClass('bg-destructive');
+        expect(btn).toHaveClass('h-8');
+    });
+
+    it('supports rendering as child element', () => {
+        render(
+            <Button asChild>
+                <a href="#test">{BUTTON_TEXT}</a>
+            </Button>,
+        );
+        const link = screen.getByRole('link', { name: BUTTON_TEXT });
+        expect(link).toHaveAttribute('href', '#test');
+        expect(link).toHaveClass('inline-flex');
+    });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for Button component covering variants and asChild rendering
- test Avatar root styling and fallback rendering
- verify AppShell integrates with SidebarProvider based on Inertia page props

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68baec007e68832ebe58eefab8a6ae53