### PR TITLE
test: expand vitest coverage for UI and auth page

### DIFF
--- a/resources/js/components/__tests__/heading-small.test.tsx
+++ b/resources/js/components/__tests__/heading-small.test.tsx
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import HeadingSmall from '../heading-small';
+
+describe('HeadingSmall', () => {
+    it('renders title and description', () => {
+        render(<HeadingSmall title="Small Title" description="Small Description" />);
+        expect(screen.getByText('Small Title')).toBeInTheDocument();
+        expect(screen.getByText('Small Description')).toBeInTheDocument();
+    });
+
+    it('renders without description', () => {
+        render(<HeadingSmall title="Only Small Title" />);
+        expect(screen.getByText('Only Small Title')).toBeInTheDocument();
+        expect(screen.queryByText('Small Description')).toBeNull();
+    });
+});

--- a/resources/js/components/__tests__/heading.test.tsx
+++ b/resources/js/components/__tests__/heading.test.tsx
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Heading from '../heading';
+
+describe('Heading', () => {
+    it('renders title and description', () => {
+        render(<Heading title="Test Title" description="Test Description" />);
+        expect(screen.getByText('Test Title')).toBeInTheDocument();
+        expect(screen.getByText('Test Description')).toBeInTheDocument();
+    });
+
+    it('renders without description', () => {
+        render(<Heading title="Only Title" />);
+        expect(screen.getByText('Only Title')).toBeInTheDocument();
+        expect(screen.queryByText('Test Description')).toBeNull();
+    });
+});

--- a/resources/js/pages/auth/__tests__/reset-password.test.tsx
+++ b/resources/js/pages/auth/__tests__/reset-password.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import ResetPassword from '../reset-password';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let formErrors: {
+    email?: string;
+    password?: string;
+    password_confirmation?: string;
+};
+let formProcessing: boolean;
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Form: ({ children }: { children: (args: { processing: boolean; errors: typeof formErrors }) => React.ReactNode }) => (
+        <form>{children({ processing: formProcessing, errors: formErrors })}</form>
+    ),
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Auth/NewPasswordController', () => ({
+    default: {
+        store: {
+            form: () => ({}),
+        },
+    },
+}));
+
+describe('ResetPassword page', () => {
+    beforeEach(() => {
+        formErrors = {};
+        formProcessing = false;
+    });
+
+    const token = 'token123';
+    const email = 'user@example.com';
+
+    it('renders fields and submit button with preset email', () => {
+        render(<ResetPassword token={token} email={email} />);
+        expect(screen.getByLabelText(/email/i)).toHaveValue(email);
+        expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument();
+    });
+
+    it('displays validation errors', () => {
+        formErrors = {
+            email: 'Email is required',
+            password: 'Password is required',
+            password_confirmation: 'Confirmation is required',
+        };
+        render(<ResetPassword token={token} email={email} />);
+        expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+        expect(screen.getByText(/password is required/i)).toBeInTheDocument();
+        expect(screen.getByText(/confirmation is required/i)).toBeInTheDocument();
+    });
+
+    it('disables submit button when processing', () => {
+        formProcessing = true;
+        render(<ResetPassword token={token} email={email} />);
+        expect(screen.getByRole('button', { name: /reset password/i })).toBeDisabled();
+    });
+});


### PR DESCRIPTION
## Summary
- add unit tests for Heading and HeadingSmall components
- add integration tests for ResetPassword auth page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf8a55dd8832e93525926b8364df0