### PR TITLE
chore: cache composer dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           php-version: '8.4'
 
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+
       - name: Install Dependencies
         run: |
           composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
@@ -45,6 +51,12 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
 
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,12 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This pull request introduces Composer caching to the GitHub Actions workflows for both linting and testing. By caching Composer dependencies, subsequent workflow runs can be faster and more efficient, as dependencies will only be downloaded when they change.

**CI/CD improvements:**

* Added a "Cache Composer" step using `actions/cache@v4` to the `lint.yml` workflow, ensuring Composer dependencies are cached between runs. [[1]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R25-R30) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R55-R60)
* Added a "Cache Composer" step using `actions/cache@v4` to the `tests.yml` workflow to speed up dependency installation.