### PR TITLE
test: add coverage for auth pages and nav components

### DIFF
--- a/resources/js/components/__tests__/nav-footer.test.tsx
+++ b/resources/js/components/__tests__/nav-footer.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NavFooter } from '../nav-footer';
+
+vi.mock('@/components/ui/sidebar', () => ({
+    SidebarGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SidebarGroupContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SidebarMenu: ({ children }: { children?: React.ReactNode }) => <ul>{children}</ul>,
+    SidebarMenuButton: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+    SidebarMenuItem: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/components/icon', () => ({
+    Icon: ({ iconNode }: { iconNode: React.ReactNode }) => <span data-testid="icon">{iconNode}</span>,
+}));
+
+describe('NavFooter', () => {
+    it('renders footer items with links and icons', () => {
+        render(
+            <NavFooter
+                items={[
+                    { title: 'Docs', href: '/docs', icon: <svg data-testid="svg" /> },
+                    { title: 'GitHub', href: '/github' },
+                ]}
+            />,
+        );
+
+        const links = screen.getAllByRole('link');
+        expect(links).toHaveLength(2);
+        expect(links[0]).toHaveAttribute('href', '/docs');
+        expect(screen.getByTestId('icon')).toBeInTheDocument();
+        expect(links[1]).toHaveAttribute('href', '/github');
+    });
+});
+

--- a/resources/js/components/__tests__/user-menu-content.test.tsx
+++ b/resources/js/components/__tests__/user-menu-content.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@/routes/profile', () => ({
 }));
 
 vi.mock('@/components/user-info', () => ({
-    UserInfo: ({ user, showEmail }: { user: any; showEmail?: boolean }) => (
+    UserInfo: ({ user, showEmail }: { user: { name: string; email: string }; showEmail?: boolean }) => (
         <div>
             <span>{user.name}</span>
             {showEmail && <span>{user.email}</span>}

--- a/resources/js/components/__tests__/user-menu-content.test.tsx
+++ b/resources/js/components/__tests__/user-menu-content.test.tsx
@@ -1,0 +1,83 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserMenuContent } from '../user-menu-content';
+
+const { mockCleanup, flushAll } = vi.hoisted(() => ({
+    mockCleanup: vi.fn(),
+    flushAll: vi.fn(),
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children, href, onClick }: { children?: React.ReactNode; href: string; onClick?: () => void }) => (
+        <a
+            href={href}
+            onClick={(e) => {
+                e.preventDefault();
+                onClick?.();
+            }}
+        >
+            {children}
+        </a>
+    ),
+    router: {
+        flushAll,
+    },
+}));
+
+vi.mock('@/hooks/use-mobile-navigation', () => ({
+    useMobileNavigation: () => mockCleanup,
+}));
+
+vi.mock('@/routes', () => ({
+    logout: () => '/logout',
+}));
+
+vi.mock('@/routes/profile', () => ({
+    edit: () => '/profile/edit',
+}));
+
+vi.mock('@/components/user-info', () => ({
+    UserInfo: ({ user, showEmail }: { user: any; showEmail?: boolean }) => (
+        <div>
+            <span>{user.name}</span>
+            {showEmail && <span>{user.email}</span>}
+        </div>
+    ),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenuGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuItem: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuLabel: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuSeparator: () => <hr />,
+}));
+
+describe('UserMenuContent', () => {
+    beforeEach(() => {
+        mockCleanup.mockClear();
+        flushAll.mockClear();
+    });
+
+    it('renders user info and menu links', () => {
+        render(<UserMenuContent user={{ name: 'Jane', email: 'jane@example.com' }} />);
+        expect(screen.getByText('Jane')).toBeInTheDocument();
+        expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/profile/edit');
+        expect(screen.getByRole('link', { name: /log out/i })).toHaveAttribute('href', '/logout');
+    });
+
+    it('calls cleanup and flushAll on link interactions', async () => {
+        const user = userEvent.setup();
+        render(<UserMenuContent user={{ name: 'Jane', email: 'jane@example.com' }} />);
+
+        await user.click(screen.getByRole('link', { name: /settings/i }));
+        expect(mockCleanup).toHaveBeenCalledTimes(1);
+
+        await user.click(screen.getByRole('link', { name: /log out/i }));
+        expect(mockCleanup).toHaveBeenCalledTimes(2);
+        expect(flushAll).toHaveBeenCalledTimes(1);
+    });
+});
+

--- a/resources/js/pages/auth/__tests__/confirm-password.test.tsx
+++ b/resources/js/pages/auth/__tests__/confirm-password.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import ConfirmPassword from '../confirm-password';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const formErrors: { password?: string } = {};
+let formProcessing = false;
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Form: ({
+        children,
+    }: {
+        children: (args: { processing: boolean; errors: typeof formErrors }) => React.ReactNode;
+    }) => <form>{children({ processing: formProcessing, errors: formErrors })}</form>,
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/routes', () => ({
+    home: () => '/',
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Auth/ConfirmablePasswordController', () => ({
+    default: {
+        store: {
+            form: () => ({}),
+        },
+    },
+}));
+
+describe('ConfirmPassword page', () => {
+    beforeEach(() => {
+        formErrors.password = undefined;
+        formProcessing = false;
+    });
+
+    it('renders password field and submit button', () => {
+        render(<ConfirmPassword />);
+        expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /confirm password/i })).toBeInTheDocument();
+    });
+
+    it('shows validation error', () => {
+        formErrors.password = 'Required';
+        render(<ConfirmPassword />);
+        expect(screen.getByText(/required/i)).toBeInTheDocument();
+    });
+
+    it('disables submit button when processing', () => {
+        formProcessing = true;
+        render(<ConfirmPassword />);
+        expect(screen.getByRole('button', { name: /confirm password/i })).toBeDisabled();
+    });
+});
+

--- a/resources/js/pages/auth/__tests__/verify-email.test.tsx
+++ b/resources/js/pages/auth/__tests__/verify-email.test.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import VerifyEmail from '../verify-email';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let formProcessing: boolean;
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Form: ({ children }: { children: (args: { processing: boolean }) => React.ReactNode }) => (
+        <form>{children({ processing: formProcessing })}</form>
+    ),
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Auth/EmailVerificationNotificationController', () => ({
+    default: {
+        store: {
+            form: () => ({}),
+        },
+    },
+}));
+
+vi.mock('@/routes', () => ({
+    logout: () => '/logout',
+    home: () => '/',
+}));
+
+describe('VerifyEmail page', () => {
+    beforeEach(() => {
+        formProcessing = false;
+    });
+
+    it('shows status message when verification link is sent', () => {
+        render(<VerifyEmail status="verification-link-sent" />);
+        expect(
+            screen.getByText(
+                /a new verification link has been sent to the email address you provided during registration./i,
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('disables resend button when processing', () => {
+        formProcessing = true;
+        render(<VerifyEmail />);
+        expect(screen.getByRole('button', { name: /resend verification email/i })).toBeDisabled();
+    });
+
+    it('links to logout route', () => {
+        render(<VerifyEmail />);
+        expect(screen.getByRole('link', { name: /log out/i })).toHaveAttribute('href', '/logout');
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several React components and authentication pages, focusing on user interface rendering, interaction, and integration with mocked dependencies. The tests ensure that the components behave correctly under different states, such as form validation and navigation, and that they interact as expected with their dependencies.

**Component and UI Tests:**

* Added tests for the `NavFooter` component to verify rendering of footer items with correct links and icons, using mocks for sidebar and icon components.
* Added tests for the `UserMenuContent` component to check rendering of user info, menu links, and correct invocation of cleanup and navigation functions on link interactions, with extensive mocking of dependencies.

**Authentication Page Tests:**

* Added tests for the `ConfirmPassword` page to verify rendering of the password field and submit button, validation error display, and submit button disabling during processing, with mocks for Inertia.js and related actions.
* Added tests for the `VerifyEmail` page to check display of verification status messages, disabling of the resend button during processing, and correct logout link, with appropriate mocking of routes and actions.