### PR TITLE
test: add component and hook tests

### DIFF
--- a/resources/js/components/__tests__/appearance-dropdown.test.tsx
+++ b/resources/js/components/__tests__/appearance-dropdown.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AppearanceToggleDropdown from '../appearance-dropdown';
+
+const updateAppearance = vi.fn();
+const appearanceState = { appearance: 'system' as 'light' | 'dark' | 'system', updateAppearance };
+
+vi.mock('@/hooks/use-appearance', () => ({
+    useAppearance: () => appearanceState,
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+        <button onClick={onClick}>{children}</button>
+    ),
+}));
+
+describe('AppearanceToggleDropdown', () => {
+    beforeEach(() => {
+        updateAppearance.mockClear();
+    });
+
+    it.each([
+        ['light', 'lucide-sun'],
+        ['dark', 'lucide-moon'],
+        ['system', 'lucide-monitor'],
+    ])('renders correct icon for %s appearance', (mode, expectedClass) => {
+        appearanceState.appearance = mode as any;
+        render(<AppearanceToggleDropdown />);
+        const toggle = screen.getByRole('button', { name: /toggle theme/i });
+        const icon = toggle.querySelector('svg');
+        expect(icon).toHaveClass(expectedClass);
+    });
+
+    it('calls updateAppearance when selecting options', async () => {
+        appearanceState.appearance = 'system';
+        render(<AppearanceToggleDropdown />);
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: /light/i }));
+        await user.click(screen.getByRole('button', { name: /dark/i }));
+        await user.click(screen.getByRole('button', { name: /system/i }));
+        expect(updateAppearance).toHaveBeenNthCalledWith(1, 'light');
+        expect(updateAppearance).toHaveBeenNthCalledWith(2, 'dark');
+        expect(updateAppearance).toHaveBeenNthCalledWith(3, 'system');
+    });
+});

--- a/resources/js/components/ui/__tests__/checkbox.test.tsx
+++ b/resources/js/components/ui/__tests__/checkbox.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { Checkbox } from '../checkbox';
+
+describe('Checkbox', () => {
+    it('renders indicator when checked and accepts className', () => {
+        const { container } = render(<Checkbox defaultChecked className="extra" />);
+        const root = screen.getByRole('checkbox');
+        expect(root).toHaveClass('extra');
+        expect(root).toHaveAttribute('data-slot', 'checkbox');
+        expect(root).toHaveAttribute('data-state', 'checked');
+        const indicator = container.querySelector('[data-slot="checkbox-indicator"]');
+        expect(indicator).toBeInTheDocument();
+    });
+
+    it('toggles checked state on click', async () => {
+        const user = userEvent.setup();
+        render(<Checkbox />);
+        const root = screen.getByRole('checkbox');
+        expect(root).not.toHaveAttribute('data-state', 'checked');
+        await user.click(root);
+        expect(root).toHaveAttribute('data-state', 'checked');
+    });
+});

--- a/resources/js/components/ui/__tests__/input.test.tsx
+++ b/resources/js/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Input } from '../input';
+
+describe('Input', () => {
+    it('forwards props and className', () => {
+        render(<Input type="email" className="custom" placeholder="Email" />);
+        const input = screen.getByPlaceholderText('Email');
+        expect(input).toHaveAttribute('type', 'email');
+        expect(input).toHaveAttribute('data-slot', 'input');
+        expect(input).toHaveClass('custom');
+    });
+});

--- a/resources/js/hooks/__tests__/use-mobile.test.ts
+++ b/resources/js/hooks/__tests__/use-mobile.test.ts
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useIsMobile } from '../use-mobile';
+
+describe('useIsMobile', () => {
+    let listeners: Array<() => void>;
+
+    beforeEach(() => {
+        listeners = [];
+        window.matchMedia = vi.fn().mockImplementation(() => ({
+            matches: window.innerWidth < 768,
+            addEventListener: (_: string, listener: () => void) => {
+                listeners.push(listener);
+            },
+            removeEventListener: (_: string, listener: () => void) => {
+                listeners = listeners.filter((l) => l !== listener);
+            },
+        }));
+    });
+
+    it('returns true when width below breakpoint', () => {
+        window.innerWidth = 500;
+        const { result } = renderHook(() => useIsMobile());
+        expect(result.current).toBe(true);
+    });
+
+    it('updates when window width changes', () => {
+        window.innerWidth = 900;
+        const { result } = renderHook(() => useIsMobile());
+        expect(result.current).toBe(false);
+        act(() => {
+            window.innerWidth = 600;
+            listeners.forEach((fn) => fn());
+        });
+        expect(result.current).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- add integration tests for appearance dropdown
- cover checkbox and input UI components
- test mobile detection hook

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68bbe51b8cfc832e86043067b8808462