### PR TITLE
test: expand component and layout coverage

### DIFF
--- a/resources/js/components/__tests__/app-content.test.tsx
+++ b/resources/js/components/__tests__/app-content.test.tsx
@@ -1,0 +1,36 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AppContent } from '../app-content';
+
+vi.mock('@/components/ui/sidebar', () => ({
+    SidebarInset: ({ children, ...props }: { children?: React.ReactNode }) => (
+        <aside data-testid="sidebar-inset" {...props}>{children}</aside>
+    ),
+}));
+
+describe('AppContent', () => {
+    it('renders header variant by default', () => {
+        render(<AppContent>Content</AppContent>);
+        const main = screen.getByRole('main');
+        expect(main).toHaveClass(
+            'mx-auto',
+            'flex',
+            'h-full',
+            'w-full',
+            'max-w-7xl',
+            'flex-1',
+        );
+        expect(main).toHaveTextContent('Content');
+    });
+
+    it('renders sidebar variant using SidebarInset', () => {
+        render(
+            <AppContent variant="sidebar">Sidebar content</AppContent>
+        );
+        const inset = screen.getByTestId('sidebar-inset');
+        expect(inset).toBeInTheDocument();
+        expect(inset).toHaveTextContent('Sidebar content');
+    });
+});
+

--- a/resources/js/components/__tests__/app-sidebar-header.test.tsx
+++ b/resources/js/components/__tests__/app-sidebar-header.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { AppSidebarHeader } from '../app-sidebar-header';
+import { ComponentProps } from 'react';
 
 vi.mock('@/components/breadcrumbs', () => ({
     Breadcrumbs: ({ breadcrumbs }: { breadcrumbs: { title: string }[] }) => (
@@ -14,7 +15,9 @@ vi.mock('@/components/breadcrumbs', () => ({
 }));
 
 vi.mock('@/components/ui/sidebar', () => ({
-    SidebarTrigger: (props: any) => <button data-testid="sidebar-trigger" {...props} />,
+    SidebarTrigger: (props: ComponentProps<'button'>) => (
+        <button data-testid="sidebar-trigger" {...props} />
+    ),
 }));
 
 describe('AppSidebarHeader', () => {

--- a/resources/js/components/__tests__/app-sidebar-header.test.tsx
+++ b/resources/js/components/__tests__/app-sidebar-header.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AppSidebarHeader } from '../app-sidebar-header';
+
+vi.mock('@/components/breadcrumbs', () => ({
+    Breadcrumbs: ({ breadcrumbs }: { breadcrumbs: { title: string }[] }) => (
+        <nav data-testid="breadcrumbs">
+            {breadcrumbs.map((b) => (
+                <span key={b.title}>{b.title}</span>
+            ))}
+        </nav>
+    ),
+}));
+
+vi.mock('@/components/ui/sidebar', () => ({
+    SidebarTrigger: (props: any) => <button data-testid="sidebar-trigger" {...props} />,
+}));
+
+describe('AppSidebarHeader', () => {
+    it('renders sidebar trigger and breadcrumbs', () => {
+        render(
+            <AppSidebarHeader
+                breadcrumbs={[
+                    { title: 'Home', href: '/' },
+                    { title: 'Settings', href: '/settings' },
+                ]}
+            />
+        );
+        expect(screen.getByTestId('sidebar-trigger')).toBeInTheDocument();
+        expect(screen.getByText('Home')).toBeInTheDocument();
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/components/__tests__/app-sidebar.test.tsx
+++ b/resources/js/components/__tests__/app-sidebar.test.tsx
@@ -2,9 +2,10 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { AppSidebar } from '../app-sidebar';
+import type { NavItem } from '@/types';
 
 const NavMainMock = vi.hoisted(() =>
-    vi.fn(({ items }: { items: any[] }) => (
+    vi.fn(({ items }: { items: NavItem[] }) => (
         <nav data-testid="nav-main">
             {items.map((item) => {
                 const href = typeof item.href === 'string' ? item.href : item.href.url;
@@ -19,7 +20,7 @@ const NavMainMock = vi.hoisted(() =>
 );
 
 const NavFooterMock = vi.hoisted(() =>
-    vi.fn(({ items, className }: { items: any[]; className?: string }) => (
+    vi.fn(({ items, className }: { items: NavItem[]; className?: string }) => (
         <footer data-testid="nav-footer" className={className}>
             {items.map((item) => {
                 const href = typeof item.href === 'string' ? item.href : item.href.url;

--- a/resources/js/components/__tests__/app-sidebar.test.tsx
+++ b/resources/js/components/__tests__/app-sidebar.test.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AppSidebar } from '../app-sidebar';
+
+const NavMainMock = vi.hoisted(() =>
+    vi.fn(({ items }: { items: any[] }) => (
+        <nav data-testid="nav-main">
+            {items.map((item) => {
+                const href = typeof item.href === 'string' ? item.href : item.href.url;
+                return (
+                    <a key={item.title} href={href}>
+                        {item.title}
+                    </a>
+                );
+            })}
+        </nav>
+    ))
+);
+
+const NavFooterMock = vi.hoisted(() =>
+    vi.fn(({ items, className }: { items: any[]; className?: string }) => (
+        <footer data-testid="nav-footer" className={className}>
+            {items.map((item) => {
+                const href = typeof item.href === 'string' ? item.href : item.href.url;
+                return (
+                    <a key={item.title} href={href}>
+                        {item.title}
+                    </a>
+                );
+            })}
+        </footer>
+    ))
+);
+
+const NavUserMock = vi.hoisted(() => vi.fn(() => <div data-testid="nav-user" />));
+
+vi.mock('@/components/nav-main', () => ({ NavMain: NavMainMock }));
+vi.mock('@/components/nav-footer', () => ({ NavFooter: NavFooterMock }));
+vi.mock('@/components/nav-user', () => ({ NavUser: NavUserMock }));
+vi.mock('@/components/ui/sidebar', () => ({
+    Sidebar: ({ children }: { children?: React.ReactNode }) => <aside>{children}</aside>,
+    SidebarHeader: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SidebarMenu: ({ children }: { children?: React.ReactNode }) => <ul>{children}</ul>,
+    SidebarMenuItem: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
+    SidebarMenuButton: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+    SidebarContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SidebarFooter: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+vi.mock('@/routes', () => ({
+    dashboard: () => ({ url: '/dashboard' }),
+}));
+vi.mock('../app-logo', () => ({
+    default: () => <span>Logo</span>,
+}));
+
+describe('AppSidebar', () => {
+    it('renders main and footer navigation with user section', () => {
+        render(<AppSidebar />);
+        expect(NavMainMock).toHaveBeenCalled();
+        const dashboardLink = screen.getByRole('link', { name: /dashboard/i });
+        expect(dashboardLink).toHaveAttribute('href', '/dashboard');
+
+        const docsLink = screen.getByRole('link', { name: /documentation/i });
+        expect(docsLink).toHaveAttribute('href', '/docs');
+
+        const footerArgs = NavFooterMock.mock.calls[0][0];
+        expect(footerArgs.className).toBe('mt-auto');
+        expect(screen.getByTestId('nav-user')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/layouts/app/__tests__/app-sidebar-layout.test.tsx
+++ b/resources/js/layouts/app/__tests__/app-sidebar-layout.test.tsx
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AppSidebarLayout from '../app-sidebar-layout';
+
+const AppShellMock = vi.hoisted(() =>
+    vi.fn(({ children, variant }: { children?: React.ReactNode; variant?: string }) => (
+        <div data-testid="app-shell" data-variant={variant}>{children}</div>
+    ))
+);
+const AppSidebarMock = vi.hoisted(() => vi.fn(() => <div data-testid="app-sidebar" />));
+const AppContentMock = vi.hoisted(() =>
+    vi.fn(({ children, variant }: { children?: React.ReactNode; variant?: string }) => (
+        <main data-testid="app-content" data-variant={variant}>{children}</main>
+    ))
+);
+const AppSidebarHeaderMock = vi.hoisted(() =>
+    vi.fn(({ breadcrumbs }: { breadcrumbs?: { title: string }[] }) => (
+        <header data-testid="app-sidebar-header">{breadcrumbs?.map((b) => b.title).join(',')}</header>
+    ))
+);
+
+vi.mock('@/components/app-shell', () => ({ AppShell: AppShellMock }));
+vi.mock('@/components/app-sidebar', () => ({ AppSidebar: AppSidebarMock }));
+vi.mock('@/components/app-content', () => ({ AppContent: AppContentMock }));
+vi.mock('@/components/app-sidebar-header', () => ({ AppSidebarHeader: AppSidebarHeaderMock }));
+
+describe('AppSidebarLayout', () => {
+    it('renders sidebar layout with breadcrumbs and children', () => {
+        render(
+            <AppSidebarLayout breadcrumbs={[{ title: 'Settings', href: '/settings' }]}>Child</AppSidebarLayout>
+        );
+
+        const shellArgs = AppShellMock.mock.calls[0][0];
+        expect(shellArgs.variant).toBe('sidebar');
+        expect(AppSidebarMock).toHaveBeenCalled();
+        const content = screen.getByTestId('app-content');
+        expect(content).toHaveAttribute('data-variant', 'sidebar');
+        expect(screen.getByTestId('app-sidebar-header')).toHaveTextContent('Settings');
+        expect(screen.getByText('Child')).toBeInTheDocument();
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several React components related to the application's sidebar layout. The new tests use Vitest and React Testing Library, and include extensive mocking of child components to isolate the components under test. This improves test coverage, ensures correct rendering and prop passing, and helps prevent regressions in the sidebar and layout-related UI.

**New unit tests for sidebar and layout components:**

* Added tests for `AppContent` to verify rendering of both default and sidebar variants, including correct usage of the `SidebarInset` component.
* Added tests for `AppSidebarHeader` to check that sidebar triggers and breadcrumbs are rendered as expected, with mocks for `Breadcrumbs` and `SidebarTrigger`.
* Added tests for `AppSidebar` to ensure main and footer navigation sections, as well as the user section, are rendered correctly, using mocks for navigation and sidebar UI components.
* Added tests for `AppSidebarLayout` to verify the sidebar layout renders with breadcrumbs and children, with mocks for all major layout components.