### PR TITLE
test: add coverage for auth layouts and ui components

### DIFF
--- a/resources/js/components/ui/__tests__/alert.test.tsx
+++ b/resources/js/components/ui/__tests__/alert.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Alert, AlertTitle, AlertDescription } from '../alert';
+
+const ALERT_TEXT = 'Something happened';
+
+describe('Alert', () => {
+    it('renders default variant with title and description', () => {
+        render(
+            <Alert>
+                <AlertTitle>Warning</AlertTitle>
+                <AlertDescription>{ALERT_TEXT}</AlertDescription>
+            </Alert>,
+        );
+        const alert = screen.getByRole('alert');
+        expect(alert).toHaveAttribute('data-slot', 'alert');
+        expect(alert).not.toHaveClass('text-destructive-foreground');
+        expect(screen.getByText('Warning')).toHaveAttribute('data-slot', 'alert-title');
+        expect(screen.getByText(ALERT_TEXT)).toHaveAttribute('data-slot', 'alert-description');
+    });
+
+    it('applies destructive variant styles', () => {
+        render(<Alert variant="destructive">{ALERT_TEXT}</Alert>);
+        const alert = screen.getByRole('alert');
+        expect(alert).toHaveClass('text-destructive-foreground');
+    });
+});
+

--- a/resources/js/components/ui/__tests__/card.test.tsx
+++ b/resources/js/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '../card';
+
+describe('Card', () => {
+    it('renders card structure with slots', () => {
+        const { container } = render(
+            <Card>
+                <CardHeader>
+                    <CardTitle>Title</CardTitle>
+                    <CardDescription>Description</CardDescription>
+                </CardHeader>
+                <CardContent>Content</CardContent>
+                <CardFooter>Footer</CardFooter>
+            </Card>,
+        );
+
+        const card = container.querySelector('[data-slot="card"]');
+        expect(card).toBeInTheDocument();
+        expect(screen.getByText('Title')).toHaveAttribute('data-slot', 'card-title');
+        expect(screen.getByText('Description')).toHaveAttribute('data-slot', 'card-description');
+        expect(screen.getByText('Content')).toHaveAttribute('data-slot', 'card-content');
+        expect(screen.getByText('Footer')).toHaveAttribute('data-slot', 'card-footer');
+    });
+});
+

--- a/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AuthSimpleLayout from '../auth-simple-layout';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ href, children }: { href: string; children?: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+vi.mock('@/routes', () => ({
+    home: () => '/',
+}));
+
+describe('AuthSimpleLayout', () => {
+    it('renders link to home with title, description and children', () => {
+        render(
+            <AuthSimpleLayout title="Sign in" description="Welcome">
+                <p>Child content</p>
+            </AuthSimpleLayout>,
+        );
+
+        expect(screen.getByRole('link')).toHaveAttribute('href', '/');
+        expect(screen.getByRole('heading', { name: 'Sign in' })).toBeInTheDocument();
+        expect(screen.getByText('Welcome')).toBeInTheDocument();
+        expect(screen.getByText('Child content')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/layouts/auth/__tests__/auth-split-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-split-layout.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthSplitLayout from '../auth-split-layout';
+
+const page: { props: { name: string; quote?: { message: string; author: string } } } = {
+    props: { name: 'Ernie' },
+};
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ href, children }: { href: string; children?: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+    usePage: () => page,
+}));
+
+vi.mock('@/routes', () => ({
+    home: () => '/',
+}));
+
+describe('AuthSplitLayout', () => {
+    beforeEach(() => {
+        page.props = { name: 'Ernie' };
+    });
+
+    it('renders quote when provided', () => {
+        page.props.quote = { message: 'Be yourself', author: 'You' };
+        render(
+            <AuthSplitLayout title="Hello" description="World">
+                <div>Child</div>
+            </AuthSplitLayout>,
+        );
+        expect(screen.getByText(/be yourself/i)).toBeInTheDocument();
+        expect(screen.getByText(/^You$/i)).toBeInTheDocument();
+    });
+
+    it('does not render quote when missing', () => {
+        render(
+            <AuthSplitLayout title="Hello" description="World">
+                <div>Child</div>
+            </AuthSplitLayout>,
+        );
+        expect(screen.queryByText(/be yourself/i)).toBeNull();
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several UI components and authentication layouts to improve test coverage and ensure correct rendering and behavior. The tests use the Vitest testing framework and include mocks for external dependencies.

**UI Component Tests:**

* Added tests for the `Alert` component to verify rendering of default and destructive variants, as well as correct use of title and description slots.
* Added tests for the `Card` component to ensure proper structure and correct rendering of header, title, description, content, and footer slots.

**Authentication Layout Tests:**

* Added tests for `AuthSimpleLayout` to check that it renders the home link, title, description, and children correctly, with mocks for routing dependencies.
* Added tests for `AuthSplitLayout` to verify rendering of quotes when provided and absence when missing, including setup for mocking page props and routing.