### PR TITLE
test: add additional vitest coverage

### DIFF
--- a/resources/js/components/__tests__/delete-user.test.tsx
+++ b/resources/js/components/__tests__/delete-user.test.tsx
@@ -22,7 +22,11 @@ vi.mock('@/components/heading-small', () => ({
 }));
 
 vi.mock('@/components/ui/button', () => ({
-    Button: ({ children, asChild, ...props }: any) =>
+    Button: (
+        { children, asChild, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+            asChild?: boolean;
+        },
+    ) =>
         asChild && React.isValidElement(children)
             ? React.cloneElement(children, props)
             : <button {...props}>{children}</button>,
@@ -45,11 +49,23 @@ vi.mock('@/components/ui/input', () => ({
 }));
 
 vi.mock('@/components/ui/label', () => ({
-    Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+    Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+        <label {...props}>{children}</label>
+    ),
 }));
 
 vi.mock('@inertiajs/react', () => ({
-    Form: ({ children, onError }: any) => {
+    Form: ({
+        children,
+        onError,
+    }: {
+        children: (args: {
+            resetAndClearErrors: () => void;
+            processing: boolean;
+            errors: Record<string, string>;
+        }) => React.ReactNode;
+        onError: (errors: Record<string, string>) => void;
+    }) => {
         onErrorMock.mockImplementation(onError);
         return <div>{children({ resetAndClearErrors: vi.fn(), processing: false, errors: {} })}</div>;
     },

--- a/resources/js/components/__tests__/delete-user.test.tsx
+++ b/resources/js/components/__tests__/delete-user.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import DeleteUser from '../delete-user';
+
+const onErrorMock = vi.fn();
+
+vi.mock('@/actions/App/Http/Controllers/Settings/ProfileController', () => ({
+    default: {
+        destroy: { form: () => ({ action: '/delete', method: 'post' }) },
+    },
+}));
+
+vi.mock('@/components/heading-small', () => ({
+    default: ({ title, description }: { title: string; description: string }) => (
+        <div>
+            <h2>{title}</h2>
+            <p>{description}</p>
+        </div>
+    ),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({ children, asChild, ...props }: any) =>
+        asChild && React.isValidElement(children)
+            ? React.cloneElement(children, props)
+            : <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children: React.ReactNode }) => <h3>{children}</h3>,
+    DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+    DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DialogClose: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/input', () => ({
+    Input: React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>((props, ref) => (
+        <input {...props} ref={ref} />
+    )),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+    Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({ children, onError }: any) => {
+        onErrorMock.mockImplementation(onError);
+        return <div>{children({ resetAndClearErrors: vi.fn(), processing: false, errors: {} })}</div>;
+    },
+}));
+
+vi.mock('@/components/input-error', () => ({
+    default: ({ message }: { message?: string }) => (message ? <div>{message}</div> : null),
+}));
+
+describe('DeleteUser', () => {
+    it('renders warning and delete button', () => {
+        render(<DeleteUser />);
+        const buttons = screen.getAllByRole('button', { name: 'Delete account' });
+        expect(buttons.length).toBeGreaterThan(0);
+        expect(
+            screen.getByText('Please proceed with caution, this cannot be undone.'),
+        ).toBeInTheDocument();
+    });
+
+    it('focuses password input when onError is called', () => {
+        render(<DeleteUser />);
+        const input = screen.getByPlaceholderText('Password') as HTMLInputElement;
+        expect(document.activeElement).not.toBe(input);
+        onErrorMock({});
+        expect(document.activeElement).toBe(input);
+    });
+});
+

--- a/resources/js/hooks/__tests__/use-mobile-navigation.test.ts
+++ b/resources/js/hooks/__tests__/use-mobile-navigation.test.ts
@@ -1,0 +1,16 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, beforeEach, expect } from 'vitest';
+import { useMobileNavigation } from '../use-mobile-navigation';
+
+describe('useMobileNavigation', () => {
+    beforeEach(() => {
+        document.body.style.pointerEvents = 'none';
+    });
+
+    it('removes pointer-events style from body', () => {
+        const { result } = renderHook(() => useMobileNavigation());
+        act(() => result.current());
+        expect(document.body.style.pointerEvents).toBe('');
+    });
+});
+

--- a/resources/js/layouts/app/__tests__/app-header-layout.test.tsx
+++ b/resources/js/layouts/app/__tests__/app-header-layout.test.tsx
@@ -1,0 +1,37 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AppHeaderLayout from '../app-header-layout';
+import type { BreadcrumbItem } from '@/types';
+
+vi.mock('@/components/app-shell', () => ({
+    AppShell: ({ children }: { children?: React.ReactNode }) => <div data-testid="shell">{children}</div>,
+}));
+
+vi.mock('@/components/app-header', () => ({
+    AppHeader: ({ breadcrumbs }: { breadcrumbs?: BreadcrumbItem[] }) => (
+        <div data-testid="header">{breadcrumbs?.map((b) => b.title).join(' > ')}</div>
+    ),
+}));
+
+vi.mock('@/components/app-content', () => ({
+    AppContent: ({ children }: { children?: React.ReactNode }) => <main>{children}</main>,
+}));
+
+describe('AppHeaderLayout', () => {
+    it('renders header with breadcrumbs and content', () => {
+        const crumbs: BreadcrumbItem[] = [
+            { title: 'Home', href: '#' },
+            { title: 'Settings', href: '#' },
+        ];
+        render(
+            <AppHeaderLayout breadcrumbs={crumbs}>
+                <div>Body</div>
+            </AppHeaderLayout>,
+        );
+        expect(screen.getByTestId('shell')).toBeInTheDocument();
+        expect(screen.getByTestId('header')).toHaveTextContent('Home > Settings');
+        expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/layouts/auth/__tests__/auth-card-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-card-layout.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import AuthCardLayout from '../auth-card-layout';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/components/app-logo-icon', () => ({
+    default: () => <svg data-testid="logo" />,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+    Card: ({ children }: { children: React.ReactNode }) => <div data-testid="card">{children}</div>,
+    CardContent: ({ children }: { children: React.ReactNode }) => <div data-testid="card-content">{children}</div>,
+    CardHeader: ({ children }: { children: React.ReactNode }) => <div data-testid="card-header">{children}</div>,
+    CardTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+    CardDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+describe('AuthCardLayout', () => {
+    it('renders logo, title, description and children', () => {
+        render(
+            <AuthCardLayout title="Sign In" description="Welcome">
+                <div>Form</div>
+            </AuthCardLayout>,
+        );
+        expect(screen.getByTestId('logo')).toBeInTheDocument();
+        expect(screen.getByText('Sign In')).toBeInTheDocument();
+        expect(screen.getByText('Welcome')).toBeInTheDocument();
+        expect(screen.getByText('Form')).toBeInTheDocument();
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several React components and a custom hook, focusing on rendering, interaction, and integration with mocked dependencies. The changes improve test coverage and reliability by using Vitest and React Testing Library, and by mocking external modules and UI components.

**Component Test Additions:**

* Added a test suite for the `DeleteUser` component, verifying rendering of warnings, delete button, and input focus behavior on error, with extensive mocking of related UI components and form actions.
* Added a test suite for the `AppHeaderLayout` component, ensuring correct rendering of breadcrumbs and content, with mocks for layout and header components.
* Added a test suite for the `AuthCardLayout` component, testing the presence of logo, title, description, and children, with mocks for UI card components and logo.

**Hook Test Additions:**

* Added a test for the `useMobileNavigation` hook to verify that it correctly removes the `pointer-events` style from the document body.