### PR TITLE
test: add more vitest coverage

### DIFF
--- a/resources/js/components/__tests__/app-header.test.tsx
+++ b/resources/js/components/__tests__/app-header.test.tsx
@@ -2,6 +2,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppHeader } from '../app-header';
+import type { BreadcrumbItem } from '@/types';
+import type { ComponentProps } from 'react';
 
 const usePageMock = vi.fn();
 const getInitialsMock = vi.fn(() => 'JD');
@@ -12,14 +14,16 @@ vi.mock('@inertiajs/react', () => ({
 }));
 
 vi.mock('@/components/breadcrumbs', () => ({
-    Breadcrumbs: ({ breadcrumbs }: { breadcrumbs: Array<any> }) => (
+    Breadcrumbs: ({ breadcrumbs }: { breadcrumbs: Array<BreadcrumbItem> }) => (
         <nav data-testid="breadcrumbs">{breadcrumbs.length}</nav>
     ),
 }));
 vi.mock('@/components/icon', () => ({ Icon: () => <span data-testid="icon" /> }));
 vi.mock('@/components/ui/avatar', () => ({
     Avatar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-    AvatarImage: (props: any) => <img data-testid="avatar-image" {...props} />,
+    AvatarImage: (props: ComponentProps<'img'>) => (
+        <img data-testid="avatar-image" {...props} />
+    ),
     AvatarFallback: ({ children }: { children?: React.ReactNode }) => (
         <div data-testid="avatar-fallback">{children}</div>
     ),

--- a/resources/js/components/__tests__/app-header.test.tsx
+++ b/resources/js/components/__tests__/app-header.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppHeader } from '../app-header';
+
+const usePageMock = vi.fn();
+const getInitialsMock = vi.fn(() => 'JD');
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+    usePage: () => usePageMock(),
+}));
+
+vi.mock('@/components/breadcrumbs', () => ({
+    Breadcrumbs: ({ breadcrumbs }: { breadcrumbs: Array<any> }) => (
+        <nav data-testid="breadcrumbs">{breadcrumbs.length}</nav>
+    ),
+}));
+vi.mock('@/components/icon', () => ({ Icon: () => <span data-testid="icon" /> }));
+vi.mock('@/components/ui/avatar', () => ({
+    Avatar: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    AvatarImage: (props: any) => <img data-testid="avatar-image" {...props} />,
+    AvatarFallback: ({ children }: { children?: React.ReactNode }) => (
+        <div data-testid="avatar-fallback">{children}</div>
+    ),
+}));
+vi.mock('@/components/ui/button', () => ({
+    Button: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+        <button className={className}>{children}</button>
+    ),
+}));
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/navigation-menu', () => ({
+    NavigationMenu: ({ children }: { children?: React.ReactNode }) => <nav>{children}</nav>,
+    NavigationMenuItem: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    NavigationMenuList: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    navigationMenuTriggerStyle: () => '',
+}));
+vi.mock('@/components/ui/sheet', () => ({
+    Sheet: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SheetContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SheetHeader: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SheetTitle: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    SheetTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/tooltip', () => ({
+    TooltipProvider: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    Tooltip: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    TooltipTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    TooltipContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/user-menu-content', () => ({
+    UserMenuContent: () => <div data-testid="user-menu-content" />,
+}));
+vi.mock('../app-logo', () => ({
+    default: () => <div>Logo</div>,
+}));
+vi.mock('../app-logo-icon', () => ({
+    default: () => <div>LogoIcon</div>,
+}));
+vi.mock('@/hooks/use-initials', () => ({
+    useInitials: () => getInitialsMock,
+}));
+vi.mock('lucide-react', () => ({
+    BookOpen: () => <svg />, 
+    LayoutGrid: () => <svg />, 
+    Menu: () => <svg />, 
+    Search: () => <svg />,
+}));
+vi.mock('@/routes', () => ({
+    dashboard: () => ({ url: '/dashboard' }),
+}));
+
+describe('AppHeader', () => {
+    beforeEach(() => {
+        usePageMock.mockReturnValue({
+            props: { auth: { user: { name: 'John Doe', avatar: '/avatar.png' } } },
+            url: '/dashboard',
+        });
+    });
+
+    it('renders navigation links, breadcrumbs and user initials', () => {
+        render(
+            <AppHeader
+                breadcrumbs={[
+                    { title: 'Home', href: '/' },
+                    { title: 'Dashboard', href: '/dashboard' },
+                ]}
+            />
+        );
+        screen
+            .getAllByRole('link', { name: /dashboard/i })
+            .forEach((link) => expect(link).toHaveAttribute('href', '/dashboard'));
+        screen
+            .getAllByRole('link', { name: /documentation/i })
+            .forEach((link) => expect(link).toHaveAttribute('href', '/docs'));
+        expect(getInitialsMock).toHaveBeenCalledWith('John Doe');
+        expect(screen.getByText('JD')).toBeInTheDocument();
+        expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/__tests__/app-header.test.tsx
+++ b/resources/js/components/__tests__/app-header.test.tsx
@@ -70,13 +70,14 @@ vi.mock('@/hooks/use-initials', () => ({
     useInitials: () => getInitialsMock,
 }));
 vi.mock('lucide-react', () => ({
-    BookOpen: () => <svg />, 
-    LayoutGrid: () => <svg />, 
-    Menu: () => <svg />, 
+    BookOpen: () => <svg />,
+    LayoutGrid: () => <svg />,
+    Menu: () => <svg />,
     Search: () => <svg />,
 }));
 vi.mock('@/routes', () => ({
     dashboard: () => ({ url: '/dashboard' }),
+    docs: () => ({ url: '/docs' }),
 }));
 
 describe('AppHeader', () => {
@@ -99,9 +100,8 @@ describe('AppHeader', () => {
         screen
             .getAllByRole('link', { name: /dashboard/i })
             .forEach((link) => expect(link).toHaveAttribute('href', '/dashboard'));
-        screen
-            .getAllByRole('link', { name: /documentation/i })
-            .forEach((link) => expect(link).toHaveAttribute('href', '/docs'));
+        const docLinks = screen.getAllByRole('link', { name: /documentation/i });
+        docLinks.forEach((link) => expect(link).toHaveAttribute('href', '/docs'));
         expect(getInitialsMock).toHaveBeenCalledWith('John Doe');
         expect(screen.getByText('JD')).toBeInTheDocument();
         expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument();

--- a/resources/js/layouts/settings/__tests__/layout.test.tsx
+++ b/resources/js/layouts/settings/__tests__/layout.test.tsx
@@ -38,12 +38,10 @@ vi.mock('@/routes/profile', () => ({
 
 describe('SettingsLayout', () => {
     it('returns null when window is undefined', () => {
-        const g = globalThis as { window?: Window };
-        const realWindow = g.window;
-        delete g.window;
+        vi.stubGlobal('window', undefined as unknown as Window);
         const result = SettingsLayout({ children: <div /> });
         expect(result).toBeNull();
-        g.window = realWindow;
+        vi.unstubAllGlobals();
     });
 
     it('renders navigation and highlights current path', () => {

--- a/resources/js/layouts/settings/__tests__/layout.test.tsx
+++ b/resources/js/layouts/settings/__tests__/layout.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SettingsLayout from '../layout';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/components/heading', () => ({
+    default: ({ title, description }: { title: string; description: string }) => (
+        <header>
+            <h1>{title}</h1>
+            <p>{description}</p>
+        </header>
+    ),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+        <button className={className}>{children}</button>
+    ),
+}));
+
+vi.mock('@/components/ui/separator', () => ({
+    Separator: () => <hr />,
+}));
+
+vi.mock('@/routes', () => ({
+    appearance: () => '/settings/appearance',
+}));
+vi.mock('@/routes/password', () => ({
+    edit: () => '/settings/password',
+}));
+vi.mock('@/routes/profile', () => ({
+    edit: () => '/settings/profile',
+}));
+
+describe('SettingsLayout', () => {
+    it('returns null when window is undefined', () => {
+        const realWindow = (global as any).window;
+        // @ts-expect-error - simulate server environment
+        delete (global as any).window;
+        const result = SettingsLayout({ children: <div /> });
+        expect(result).toBeNull();
+        (global as any).window = realWindow;
+    });
+
+    it('renders navigation and highlights current path', () => {
+        window.history.pushState({}, '', '/settings/profile');
+        render(
+            <SettingsLayout>
+                <p>Profile Content</p>
+            </SettingsLayout>
+        );
+        expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument();
+        const profileLink = screen.getByRole('link', { name: /profile/i });
+        const profileButton = profileLink.closest('button');
+        expect(profileButton).toHaveClass('bg-muted');
+        const passwordLink = screen.getByRole('link', { name: /password/i });
+        const passwordButton = passwordLink.closest('button');
+        expect(passwordButton).not.toHaveClass('bg-muted');
+        expect(screen.getByText('Profile Content')).toBeInTheDocument();
+    });
+});

--- a/resources/js/layouts/settings/__tests__/layout.test.tsx
+++ b/resources/js/layouts/settings/__tests__/layout.test.tsx
@@ -38,12 +38,12 @@ vi.mock('@/routes/profile', () => ({
 
 describe('SettingsLayout', () => {
     it('returns null when window is undefined', () => {
-        const realWindow = (global as any).window;
-        // @ts-expect-error - simulate server environment
-        delete (global as any).window;
+        const g = globalThis as { window?: Window };
+        const realWindow = g.window;
+        delete g.window;
         const result = SettingsLayout({ children: <div /> });
         expect(result).toBeNull();
-        (global as any).window = realWindow;
+        g.window = realWindow;
     });
 
     it('renders navigation and highlights current path', () => {

--- a/resources/js/lib/__tests__/utils.test.ts
+++ b/resources/js/lib/__tests__/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn', () => {
+    it('combines class names', () => {
+        expect(cn('p-2', 'm-2')).toBe('p-2 m-2');
+    });
+
+    it('overrides conflicting tailwind classes', () => {
+        expect(cn('p-2', 'p-4')).toBe('p-4');
+    });
+
+    it('handles conditional classes', () => {
+        expect(cn('p-2', { hidden: false, block: true })).toBe('p-2 block');
+    });
+});


### PR DESCRIPTION
This pull request adds new unit tests for several components and utilities to improve test coverage and ensure correct behavior. The primary focus is on testing the `AppHeader` component, the `SettingsLayout` layout, and the `cn` utility function. The tests use extensive mocking to isolate components and verify their rendering and logic.

**Component and utility testing:**

- Added tests for the `AppHeader` component, including mocks for all child components and dependencies, to verify rendering of navigation links, breadcrumbs, and user initials.
- Added tests for the `SettingsLayout` layout, including navigation highlighting and handling of missing `window` object.
- Added unit tests for the `cn` utility function to check class name combination, overriding, and conditional class handling.