### PR TITLE
refine vitest coverage patterns

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,12 @@ export default defineConfig({
             provider: 'v8',
             reporter: ['text', 'json-summary'],
             reportsDirectory: 'coverage',
+            include: ['resources/js/**/*.{js,ts,jsx,tsx}'],
+            exclude: [
+                'resources/js/**/*.{test,spec}.{js,ts,jsx,tsx}',
+                'resources/js/**/__tests__/**',
+                'resources/js/**/__mocks__/**',
+            ],
         },
     },
 });


### PR DESCRIPTION
This pull request updates the test coverage configuration in `vite.config.ts` to more precisely control which files are included and excluded from coverage reports.

**Test coverage configuration improvements:**

* Added an `include` pattern to only collect coverage from source files in `resources/js` with specific extensions.
* Added `exclude` patterns to omit test files, files in `__tests__`, and files in `__mocks__` directories from coverage reports.