### PR TITLE
test: add unit tests for ui components

### DIFF
--- a/resources/js/components/ui/__tests__/badge.test.tsx
+++ b/resources/js/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Badge } from '../badge';
+
+describe('Badge', () => {
+    it('renders default variant', () => {
+        render(<Badge>Default</Badge>);
+        const badge = screen.getByText('Default');
+        expect(badge).toHaveAttribute('data-slot', 'badge');
+        expect(badge).toHaveClass('bg-primary', { exact: false });
+    });
+
+    it('supports variant and asChild', () => {
+        render(
+            <Badge variant="secondary" asChild>
+                <a href="#">Link</a>
+            </Badge>,
+        );
+        const badgeLink = screen.getByRole('link');
+        expect(badgeLink).toHaveAttribute('data-slot', 'badge');
+        expect(badgeLink).toHaveClass('bg-secondary', { exact: false });
+    });
+});
+

--- a/resources/js/components/ui/__tests__/breadcrumb.test.tsx
+++ b/resources/js/components/ui/__tests__/breadcrumb.test.tsx
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import {
+    Breadcrumb,
+    BreadcrumbList,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbSeparator,
+    BreadcrumbPage,
+    BreadcrumbEllipsis,
+} from '../breadcrumb';
+
+describe('Breadcrumb', () => {
+    it('renders navigation with items and separator', () => {
+        const { container } = render(
+            <Breadcrumb>
+                <BreadcrumbList>
+                    <BreadcrumbItem>
+                        <BreadcrumbLink href="/">Home</BreadcrumbLink>
+                    </BreadcrumbItem>
+                    <BreadcrumbSeparator />
+                    <BreadcrumbItem>
+                        <BreadcrumbPage>Profile</BreadcrumbPage>
+                    </BreadcrumbItem>
+                </BreadcrumbList>
+            </Breadcrumb>,
+        );
+
+        const nav = screen.getByRole('navigation');
+        expect(nav).toHaveAttribute('data-slot', 'breadcrumb');
+        expect(screen.getByText('Home')).toHaveAttribute('data-slot', 'breadcrumb-link');
+        expect(screen.getByText('Profile')).toHaveAttribute('data-slot', 'breadcrumb-page');
+        const separator = container.querySelector('[data-slot="breadcrumb-separator"]');
+        expect(separator).toBeInTheDocument();
+    });
+
+    it('renders ellipsis with accessible text', () => {
+        render(<BreadcrumbEllipsis />);
+        expect(screen.getByText('More')).toBeInTheDocument();
+    });
+});
+

--- a/resources/js/components/ui/__tests__/tooltip.test.tsx
+++ b/resources/js/components/ui/__tests__/tooltip.test.tsx
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../tooltip';
+
+describe('Tooltip', () => {
+    it('renders content when open', () => {
+        render(
+            <Tooltip defaultOpen>
+                <TooltipTrigger>Hover me</TooltipTrigger>
+                <TooltipContent>Tooltip text</TooltipContent>
+            </Tooltip>,
+        );
+        const content = document.querySelector('[data-slot="tooltip-content"]');
+        expect(content).toBeInTheDocument();
+    });
+});
+


### PR DESCRIPTION
This pull request adds unit tests for several UI components to improve test coverage and ensure correct rendering and behavior. The new tests cover the `Badge`, `Breadcrumb`, and `Tooltip` components.

**Added unit tests for UI components:**

*Badge component tests:*
- Added tests to verify that the `Badge` component renders with the correct default and secondary variants, and supports the `asChild` prop.

*Breadcrumb component tests:*
- Added tests to ensure the `Breadcrumb` component and its subcomponents (`BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbSeparator`, `BreadcrumbPage`, `BreadcrumbEllipsis`) render correctly, including navigation roles and accessible text for ellipsis.

*Tooltip component tests:*
- Added a test to check that the `Tooltip` component displays its content when open.