### PR TITLE
test: add ui component tests

### DIFF
--- a/resources/js/components/ui/__tests__/dialog.test.tsx
+++ b/resources/js/components/ui/__tests__/dialog.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import {
+    Dialog,
+    DialogTrigger,
+    DialogContent,
+    DialogTitle,
+    DialogDescription,
+} from '../dialog';
+
+describe('Dialog', () => {
+    it('renders overlay and content when open', () => {
+        render(
+            <Dialog defaultOpen>
+                <DialogContent>
+                    <DialogTitle>Title</DialogTitle>
+                    <DialogDescription>Description</DialogDescription>
+                </DialogContent>
+            </Dialog>,
+        );
+        expect(document.querySelector('[data-slot="dialog-overlay"]')).toBeInTheDocument();
+        expect(screen.getByText('Title')).toBeInTheDocument();
+        expect(screen.getByText('Description')).toBeInTheDocument();
+    });
+
+    it('opens with trigger and closes with close button', async () => {
+        render(
+            <Dialog>
+                <DialogTrigger>Open</DialogTrigger>
+                <DialogContent>
+                    <DialogTitle>Heading</DialogTitle>
+                    <DialogDescription>Details</DialogDescription>
+                    <p>Dialog body</p>
+                </DialogContent>
+            </Dialog>,
+        );
+        const user = userEvent.setup();
+        expect(screen.queryByText('Dialog body')).not.toBeInTheDocument();
+        await user.click(screen.getByText('Open'));
+        expect(screen.getByText('Dialog body')).toBeInTheDocument();
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        await user.click(closeButton);
+        await waitFor(() => expect(screen.queryByText('Dialog body')).not.toBeInTheDocument());
+    });
+});
+

--- a/resources/js/components/ui/__tests__/select.test.tsx
+++ b/resources/js/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, it, expect } from 'vitest';
+import {
+    Select,
+    SelectTrigger,
+    SelectContent,
+    SelectItem,
+    SelectValue,
+    SelectLabel,
+    SelectGroup,
+    SelectSeparator,
+} from '../select';
+
+describe('Select', () => {
+    beforeAll(() => {
+        // Polyfill pointer capture methods required by Radix Select
+        // @ts-expect-error jsdom lacks this method
+        Element.prototype.hasPointerCapture = () => false;
+        // @ts-expect-error jsdom lacks this method
+        Element.prototype.setPointerCapture = () => {};
+        // @ts-expect-error jsdom lacks this method
+        Element.prototype.releasePointerCapture = () => {};
+        // @ts-expect-error jsdom lacks this method
+        Element.prototype.scrollIntoView = () => {};
+    });
+    it('renders groups and items when open', () => {
+        render(
+            <Select defaultOpen>
+                <SelectTrigger data-testid="trigger">
+                    <SelectValue placeholder="Select" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectGroup>
+                        <SelectLabel>Fruits</SelectLabel>
+                        <SelectItem value="apple">Apple</SelectItem>
+                    </SelectGroup>
+                    <SelectSeparator />
+                    <SelectItem value="banana">Banana</SelectItem>
+                </SelectContent>
+            </Select>,
+        );
+        expect(screen.getByText('Fruits')).toBeInTheDocument();
+        expect(screen.getByText('Apple')).toBeInTheDocument();
+        expect(screen.getByText('Banana')).toBeInTheDocument();
+    });
+
+    it('updates trigger text when selecting an item', async () => {
+        render(
+            <Select defaultValue="apple">
+                <SelectTrigger data-testid="trigger">
+                    <SelectValue placeholder="Select" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="apple">Apple</SelectItem>
+                    <SelectItem value="banana">Banana</SelectItem>
+                </SelectContent>
+            </Select>,
+        );
+        const trigger = screen.getByTestId('trigger');
+        expect(trigger).toHaveTextContent('Apple');
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        await user.click(trigger);
+        await user.click(await screen.findByText('Banana'));
+        expect(trigger).toHaveTextContent('Banana');
+    });
+});
+

--- a/resources/js/components/ui/__tests__/toggle-group.test.tsx
+++ b/resources/js/components/ui/__tests__/toggle-group.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { ToggleGroup, ToggleGroupItem } from '../toggle-group';
+
+describe('ToggleGroup', () => {
+    it('passes variant and size to items', () => {
+        render(
+            <ToggleGroup variant="outline" size="sm" type="single">
+                <ToggleGroupItem value="a">A</ToggleGroupItem>
+            </ToggleGroup>,
+        );
+        const item = screen.getByRole('radio', { name: 'A' });
+        expect(item).toHaveAttribute('data-variant', 'outline');
+        expect(item).toHaveAttribute('data-size', 'sm');
+    });
+
+    it('toggles item state when clicked', async () => {
+        render(
+            <ToggleGroup type="single">
+                <ToggleGroupItem value="a">A</ToggleGroupItem>
+                <ToggleGroupItem value="b">B</ToggleGroupItem>
+            </ToggleGroup>,
+        );
+        const user = userEvent.setup();
+        const first = screen.getByRole('radio', { name: 'A' });
+        expect(first).toHaveAttribute('data-state', 'off');
+        await user.click(first);
+        expect(first).toHaveAttribute('data-state', 'on');
+        await user.click(first);
+        expect(first).toHaveAttribute('data-state', 'off');
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for several UI components to ensure their correct behavior and improve reliability. The tests cover rendering, user interactions, and prop handling for the `Dialog`, `Select`, and `ToggleGroup` components.

Component test coverage improvements:

* Added tests for the `Dialog` component, verifying overlay/content rendering, and open/close interactions via trigger and close button.
* Added tests for the `Select` component, including rendering of groups/items, interaction with the trigger, and updating the selected value. Includes necessary polyfills for Radix Select compatibility with jsdom.
* Added tests for the `ToggleGroup` component, checking that variant and size props are passed to items, and that toggling works as expected on click.