### PR TITLE
docs: add sitemap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ Ensure the application server is running and the Playwright browsers are install
 npx playwright install
 npx playwright test
 ```
+
+## Sitemap
+
+- `/` – project root with configuration files.
+- `app/` – Laravel backend code.
+- `resources/` – front-end assets and views.
+- `routes/` – application routes.
+- `tests/` – test suites.
+

--- a/README.md
+++ b/README.md
@@ -76,9 +76,26 @@ npx playwright test
 
 ## Sitemap
 
-- `/` – project root with configuration files.
-- `app/` – Laravel backend code.
-- `resources/` – front-end assets and views.
-- `routes/` – application routes.
-- `tests/` – test suites.
+```
+/
+├─ confirm-password
+├─ dashboard
+├─ docs
+├─ email
+│  └─ verification-notification
+├─ forgot-password
+├─ login
+├─ logout
+├─ reset-password
+│  └─ {token}
+├─ settings
+│  ├─ appearance
+│  ├─ password
+│  └─ profile
+├─ storage
+│  └─ {path}
+├─ up
+└─ verify-email
+   └─ {id}/{hash}
+```
 


### PR DESCRIPTION
This pull request adds a sitemap to the `README.md` file, providing a clear overview of the application's route structure for easier navigation and understanding.

Documentation update:

* Added a visual sitemap to `README.md` to document and clarify the application's main routes and nested paths.