### PR TITLE
Add tests for Wayfinder utilities and route definitions

### DIFF
--- a/resources/js/__tests__/routes.test.ts
+++ b/resources/js/__tests__/routes.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { home, logout } from '../routes/index';
+
+describe('generated routes', () => {
+  it('generates home route definitions', () => {
+    expect(home()).toEqual({ url: '/', method: 'get' });
+    expect(home.url()).toBe('/');
+    expect(home.url({ query: { page: 1 } })).toBe('/?page=1');
+    expect(home.form.get()).toEqual({ action: '/', method: 'get' });
+    expect(home.form.head({ query: { foo: 'bar' } })).toEqual({ action: '/?_method=HEAD&foo=bar', method: 'get' });
+  });
+
+  it('generates logout route definitions', () => {
+    expect(logout()).toEqual({ url: '/logout', method: 'post' });
+    expect(logout.url({ query: { ref: 'x' } })).toBe('/logout?ref=x');
+    expect(logout.form.post({ query: { token: 'abc' } })).toEqual({ action: '/logout?token=abc', method: 'post' });
+  });
+});
+

--- a/resources/js/__tests__/routes.test.ts
+++ b/resources/js/__tests__/routes.test.ts
@@ -7,7 +7,16 @@ describe('generated routes', () => {
     expect(home.url()).toBe('/');
     expect(home.url({ query: { page: 1 } })).toBe('/?page=1');
     expect(home.form.get()).toEqual({ action: '/', method: 'get' });
-    expect(home.form.head({ query: { foo: 'bar' } })).toEqual({ action: '/?_method=HEAD&foo=bar', method: 'get' });
+    expect(home.form.head({ query: { foo: 'bar' } })).toEqual({
+      action: '/?_method=HEAD&foo=bar',
+      method: 'get',
+    });
+    window.history.replaceState({}, '', '/?page=1');
+    expect(home.form.head({ mergeQuery: { foo: 'bar' } })).toEqual({
+      action: '/?page=1&_method=HEAD&foo=bar',
+      method: 'get',
+    });
+    window.history.replaceState({}, '', '/');
   });
 
   it('generates logout route definitions', () => {

--- a/resources/js/__tests__/wayfinder.test.ts
+++ b/resources/js/__tests__/wayfinder.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  queryParams,
+  setUrlDefaults,
+  addUrlDefault,
+  applyUrlDefaults,
+  validateParameters,
+} from '../wayfinder';
+
+describe('wayfinder utilities', () => {
+  beforeEach(() => {
+    // reset url defaults before each test
+    setUrlDefaults({});
+  });
+
+  describe('queryParams', () => {
+    it('builds a query string from simple values', () => {
+      const result = queryParams({ query: { a: 1, b: 'test' } });
+      expect(result).toBe('?a=1&b=test');
+    });
+
+    it('handles arrays, objects and booleans', () => {
+      const result = queryParams({
+        query: {
+          ids: [1, 2],
+          filter: { name: 'john', age: undefined },
+          flag: true,
+          neg: false,
+        },
+      });
+      expect(result).toBe(
+        '?ids%5B%5D=1&ids%5B%5D=2&filter%5Bname%5D=john&flag=1&neg=0',
+      );
+    });
+
+    it('merges with existing search params', () => {
+      window.history.replaceState({}, '', '/?a=1');
+      const result = queryParams({ mergeQuery: { b: '2', a: '3' } });
+      expect(result).toBe('?a=3&b=2');
+    });
+  });
+
+  describe('url defaults', () => {
+    it('applies defaults and added defaults', () => {
+      setUrlDefaults({ a: 1 });
+      addUrlDefault('b', 2);
+      expect(applyUrlDefaults({ b: 5 })).toEqual({ b: 5, a: 1 });
+      expect(applyUrlDefaults(undefined)).toEqual({ a: 1, b: 2 });
+    });
+  });
+
+  describe('validateParameters', () => {
+    it('throws when optional parameters are missing out of order', () => {
+      expect(() => validateParameters({ b: 1 }, ['a', 'b'])).toThrow();
+    });
+
+    it('allows missing trailing optional parameters', () => {
+      expect(() => validateParameters({}, ['a', 'b'])).not.toThrow();
+    });
+  });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the route generation and utility functions in the project, improving test coverage and ensuring the reliability of route handling and URL utilities.

**Route generation tests:**
- Added tests for the `home` and `logout` route definitions, verifying URL generation, HTTP methods, query parameter handling, and form helpers. (`resources/js/__tests__/routes.test.ts`)

**Wayfinder utility tests:**
- Introduced tests for the `wayfinder` utilities, covering query string construction (`queryParams`), URL defaults management (`setUrlDefaults`, `addUrlDefault`, `applyUrlDefaults`), and parameter validation (`validateParameters`). These tests ensure correct handling of query parameters, merging, defaults, and parameter order validation. (`resources/js/__tests__/wayfinder.test.ts`)