### PR TITLE
test: assert login errors

### DIFF
--- a/resources/js/pages/auth/__tests__/login.test.tsx
+++ b/resources/js/pages/auth/__tests__/login.test.tsx
@@ -6,7 +6,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@inertiajs/react', () => ({
     Form: ({ children }: { children?: ReactNode | ((args: { processing: boolean; errors: Record<string, string> }) => ReactNode) }) => (
-        <form>{typeof children === 'function' ? children({ processing: false, errors: {} }) : children}</form>
+        <form>
+            {typeof children === 'function'
+                ? children({ processing: false, errors: { email: 'Invalid email', password: 'Required' } })
+                : children}
+        </form>
     ),
     Head: ({ children }: { children?: ReactNode }) => <>{children}</>,
     Link: ({ href, children }: { href: string; children?: ReactNode }) => <a href={href}>{children}</a>,
@@ -58,5 +62,11 @@ describe('Login page', () => {
     it('displays status message when provided', () => {
         render(<Login canResetPassword={false} status="Password reset" />);
         expect(screen.getByText('Password reset')).toBeInTheDocument();
+    });
+
+    it('renders validation errors', () => {
+        render(<Login canResetPassword={false} />);
+        expect(screen.getByText('Invalid email')).toBeInTheDocument();
+        expect(screen.getByText('Required')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary
- extend Form mock to surface email and password errors
- add test ensuring login renders validation messages

## Testing
- `npm test -- --run resources/js/pages/auth/__tests__/login.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68be663f0ea4832e8a111e87b217f0a4