### PR TITLE
test: verify remember me submission

### DIFF
--- a/resources/js/pages/auth/__tests__/login.test.tsx
+++ b/resources/js/pages/auth/__tests__/login.test.tsx
@@ -148,6 +148,18 @@ describe('Login page', () => {
         await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/dashboard'));
     });
 
+    it('submits remember value when checkbox is selected', async () => {
+        submitMock.mockResolvedValue({ ok: false });
+        renderLogin();
+        fireEvent.click(screen.getByLabelText(/remember me/i));
+        fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+        await waitFor(() =>
+            expect(submitMock).toHaveBeenCalledWith(
+                expect.objectContaining({ remember: 'on' }),
+            ),
+        );
+    });
+
     it('shows error message on invalid credentials', async () => {
         submitMock.mockResolvedValue({
             ok: false,

--- a/resources/js/pages/auth/__tests__/login.test.tsx
+++ b/resources/js/pages/auth/__tests__/login.test.tsx
@@ -38,7 +38,7 @@ vi.mock('@inertiajs/react', () => {
                 }
             };
             return (
-                <form onSubmit={handleSubmit}>
+                <form data-testid="login-form" onSubmit={handleSubmit}>
                     {typeof children === 'function'
                         ? children({ processing, errors })
                         : children}
@@ -144,7 +144,7 @@ describe('Login page', () => {
         fireEvent.input(screen.getByLabelText(/password/i), {
             target: { value: 'password' },
         });
-        fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+        fireEvent.submit(screen.getByTestId('login-form'));
         await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/dashboard'));
     });
 
@@ -152,7 +152,7 @@ describe('Login page', () => {
         submitMock.mockResolvedValue({ ok: false });
         renderLogin();
         fireEvent.click(screen.getByLabelText(/remember me/i));
-        fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+        fireEvent.submit(screen.getByTestId('login-form'));
         await waitFor(() =>
             expect(submitMock).toHaveBeenCalledWith(
                 expect.objectContaining({ remember: 'on' }),
@@ -166,7 +166,7 @@ describe('Login page', () => {
             errors: { email: 'Invalid credentials' },
         });
         renderLogin();
-        fireEvent.submit(screen.getByRole('button', { name: /log in/i }).closest('form')!);
+        fireEvent.submit(screen.getByTestId('login-form'));
         expect(await screen.findByText('Invalid credentials')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
This pull request adds a new test to the login page to ensure that the "remember me" checkbox value is submitted correctly when selected.

Testing improvements:

* Added a test in `login.test.tsx` to verify that the `remember` value is included in the form submission when the "remember me" checkbox is checked.