### PR TITLE
test: ignore non-xml drop

### DIFF
--- a/resources/js/pages/__tests__/dashboard.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.test.tsx
@@ -59,6 +59,15 @@ describe('Dashboard', () => {
         expect(handleXmlFilesSpy).toHaveBeenCalledWith([xmlFile]);
     });
 
+    it('ignores non-xml files on drop', () => {
+        render(<Dashboard onXmlFiles={handleXmlFilesSpy} />);
+        const dropzone = screen.getByText(/drag & drop xml files here/i).parentElement as HTMLElement;
+        const textFile = new File(['data'], 'readme.txt', { type: 'text/plain' });
+        fireEvent.dragOver(dropzone, { dataTransfer: { files: [textFile] } });
+        fireEvent.drop(dropzone, { dataTransfer: { files: [textFile] } });
+        expect(handleXmlFilesSpy).not.toHaveBeenCalled();
+    });
+
     it('handles only xml files on file selection', () => {
         const { container } = render(<Dashboard onXmlFiles={handleXmlFilesSpy} />);
         const input = container.querySelector('input[type="file"]') as HTMLInputElement;


### PR DESCRIPTION
This pull request adds a new test to the `dashboard.test.tsx` file to ensure that the `Dashboard` component correctly ignores non-XML files when they are dropped into the dropzone.

**Testing improvements:**

* Added a test case to verify that dropping non-XML files (e.g., `.txt` files) into the `Dashboard` dropzone does not trigger the `onXmlFiles` handler.