### PR TITLE
Expand Vitest coverage for UI components

### DIFF
--- a/resources/js/components/ui/__tests__/icon.test.tsx
+++ b/resources/js/components/ui/__tests__/icon.test.tsx
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Icon } from '../icon';
+import { XIcon } from 'lucide-react';
+
+describe('UI Icon', () => {
+    it('renders nothing when no iconNode is provided', () => {
+        const { container } = render(<Icon />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders provided icon component', () => {
+        const { container } = render(<Icon iconNode={XIcon} className="w-4" />);
+        const svg = container.querySelector('svg');
+        expect(svg).toBeInTheDocument();
+        expect(svg).toHaveClass('w-4');
+    });
+});
+

--- a/resources/js/components/ui/__tests__/navigation-menu.test.tsx
+++ b/resources/js/components/ui/__tests__/navigation-menu.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import {
+    NavigationMenu,
+    NavigationMenuList,
+    NavigationMenuItem,
+    NavigationMenuTrigger,
+    NavigationMenuContent,
+} from '../navigation-menu';
+
+describe('NavigationMenu', () => {
+    it('renders viewport when an item is opened', async () => {
+        const { container } = render(
+            <NavigationMenu>
+                <NavigationMenuList>
+                    <NavigationMenuItem>
+                        <NavigationMenuTrigger>Item</NavigationMenuTrigger>
+                        <NavigationMenuContent>Content</NavigationMenuContent>
+                    </NavigationMenuItem>
+                </NavigationMenuList>
+            </NavigationMenu>,
+        );
+        const root = container.querySelector('[data-slot="navigation-menu"]');
+        expect(root).toHaveAttribute('data-viewport', 'true');
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        await user.click(screen.getByText('Item'));
+        expect(document.querySelector('[data-slot="navigation-menu-viewport"]')).toBeInTheDocument();
+    });
+
+    it('omits viewport when prop is false', () => {
+        const { container } = render(
+            <NavigationMenu viewport={false}>
+                <NavigationMenuList>
+                    <NavigationMenuItem>
+                        <NavigationMenuTrigger>Item</NavigationMenuTrigger>
+                        <NavigationMenuContent>Content</NavigationMenuContent>
+                    </NavigationMenuItem>
+                </NavigationMenuList>
+            </NavigationMenu>,
+        );
+        const root = container.querySelector('[data-slot="navigation-menu"]');
+        expect(root).toHaveAttribute('data-viewport', 'false');
+        expect(container.querySelector('[data-slot="navigation-menu-viewport"]')).not.toBeInTheDocument();
+    });
+});
+

--- a/resources/js/components/ui/__tests__/placeholder-pattern.test.tsx
+++ b/resources/js/components/ui/__tests__/placeholder-pattern.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PlaceholderPattern } from '../placeholder-pattern';
+
+describe('PlaceholderPattern', () => {
+    it('renders svg with pattern and rect referencing it', () => {
+        const { container } = render(<PlaceholderPattern className="test" />);
+        const svg = container.querySelector('svg');
+        expect(svg).toHaveClass('test');
+        const pattern = container.querySelector('pattern');
+        const rect = container.querySelector('rect');
+        expect(pattern).toBeInTheDocument();
+        expect(rect).toHaveAttribute('fill', `url(#${pattern!.id})`);
+    });
+
+    it('generates unique pattern ids for multiple instances', () => {
+        const { container } = render(
+            <div>
+                <PlaceholderPattern />
+                <PlaceholderPattern />
+            </div>,
+        );
+        const patterns = container.querySelectorAll('pattern');
+        expect(patterns.length).toBe(2);
+        expect(patterns[0].id).not.toBe(patterns[1].id);
+    });
+});
+

--- a/resources/js/components/ui/__tests__/sheet.test.tsx
+++ b/resources/js/components/ui/__tests__/sheet.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import {
+    Sheet,
+    SheetTrigger,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+    SheetDescription,
+} from '../sheet';
+
+describe('Sheet', () => {
+    it('renders overlay and content when open', () => {
+        render(
+            <Sheet defaultOpen>
+                <SheetContent>
+                    <SheetHeader>
+                        <SheetTitle>Title</SheetTitle>
+                        <SheetDescription>Description</SheetDescription>
+                    </SheetHeader>
+                    <p>Body</p>
+                </SheetContent>
+            </Sheet>,
+        );
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+
+    it('opens with trigger and closes with close button', async () => {
+        render(
+            <Sheet>
+                <SheetTrigger>Open</SheetTrigger>
+                <SheetContent>
+                    <SheetHeader>
+                        <SheetTitle>Heading</SheetTitle>
+                        <SheetDescription>Details</SheetDescription>
+                    </SheetHeader>
+                    <p>Content</p>
+                </SheetContent>
+            </Sheet>,
+        );
+        const user = userEvent.setup();
+        expect(screen.queryByText('Content')).not.toBeInTheDocument();
+        await user.click(screen.getByText('Open'));
+        expect(screen.getByText('Content')).toBeInTheDocument();
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        await user.click(closeButton);
+        await waitFor(() => expect(screen.queryByText('Content')).not.toBeInTheDocument());
+    });
+});
+


### PR DESCRIPTION
This pull request adds unit tests for several UI components to improve test coverage and ensure component reliability. The new tests cover rendering behavior, user interactions, and unique identifier generation for components.

**New unit tests for UI components:**

*Icon component tests:*
- Added tests for the `Icon` component to verify it renders nothing when no icon is provided and correctly renders a provided icon with the expected class.

*NavigationMenu component tests:*
- Added tests for the `NavigationMenu` component to check viewport rendering based on the `viewport` prop and user interaction, ensuring correct DOM structure and behavior.

*PlaceholderPattern component tests:*
- Added tests for the `PlaceholderPattern` component to confirm the SVG pattern and rect are rendered as expected and that multiple instances generate unique pattern IDs.

*Sheet component tests:*
- Added tests for the `Sheet` component to verify overlay and content rendering when open, as well as correct open/close behavior via trigger and close button interactions.