### PR TITLE
Add unit tests for layout wrappers

### DIFF
--- a/resources/js/layouts/__tests__/app-layout.test.tsx
+++ b/resources/js/layouts/__tests__/app-layout.test.tsx
@@ -1,19 +1,23 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { BreadcrumbItem } from '@/types';
 import { describe, expect, it, vi } from 'vitest';
 import AppLayout from '../app-layout';
 
 const AppLayoutTemplateMock = vi.hoisted(() =>
-    vi.fn(({ children, breadcrumbs }: any) => (
-        <div>
-            {breadcrumbs && (
-                <nav data-testid="breadcrumbs">
-                    {breadcrumbs.map((b: any) => b.title).join(',')}
-                </nav>
-            )}
-            <div data-testid="content">{children}</div>
-        </div>
-    )),
+    vi.fn(
+        ({ children, breadcrumbs }: { children: ReactNode; breadcrumbs?: BreadcrumbItem[] }) => (
+            <div>
+                {breadcrumbs && (
+                    <nav data-testid="breadcrumbs">
+                        {breadcrumbs.map((b: BreadcrumbItem) => b.title).join(',')}
+                    </nav>
+                )}
+                <div data-testid="content">{children}</div>
+            </div>
+        ),
+    ),
 );
 
 vi.mock('@/layouts/app/app-sidebar-layout', () => ({

--- a/resources/js/layouts/__tests__/app-layout.test.tsx
+++ b/resources/js/layouts/__tests__/app-layout.test.tsx
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AppLayout from '../app-layout';
+
+const AppLayoutTemplateMock = vi.hoisted(() =>
+    vi.fn(({ children, breadcrumbs }: any) => (
+        <div>
+            {breadcrumbs && (
+                <nav data-testid="breadcrumbs">
+                    {breadcrumbs.map((b: any) => b.title).join(',')}
+                </nav>
+            )}
+            <div data-testid="content">{children}</div>
+        </div>
+    )),
+);
+
+vi.mock('@/layouts/app/app-sidebar-layout', () => ({
+    default: AppLayoutTemplateMock,
+}));
+
+describe('AppLayout', () => {
+    it('passes breadcrumbs and renders children', () => {
+        const breadcrumbs = [{ title: 'Home', href: '/' }];
+        render(
+            <AppLayout breadcrumbs={breadcrumbs}>
+                <p>Dashboard</p>
+            </AppLayout>,
+        );
+        expect(screen.getByTestId('content')).toHaveTextContent('Dashboard');
+        expect(screen.getByTestId('breadcrumbs')).toHaveTextContent('Home');
+        expect(AppLayoutTemplateMock).toHaveBeenCalled();
+        const callProps = AppLayoutTemplateMock.mock.calls[0][0];
+        expect(callProps.breadcrumbs).toEqual(breadcrumbs);
+    });
+});
+

--- a/resources/js/layouts/__tests__/auth-layout.test.tsx
+++ b/resources/js/layouts/__tests__/auth-layout.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AuthLayout from '../auth-layout';
+
+const AuthLayoutTemplateMock = vi.hoisted(() =>
+    vi.fn(({ title, description, children }: any) => (
+        <div>
+            <h1>{title}</h1>
+            <p>{description}</p>
+            <div data-testid="content">{children}</div>
+        </div>
+    )),
+);
+
+vi.mock('@/layouts/auth/auth-simple-layout', () => ({
+    default: AuthLayoutTemplateMock,
+}));
+
+describe('AuthLayout', () => {
+    it('renders title, description and children', () => {
+        render(
+            <AuthLayout title="Sign in" description="Please sign in">
+                <form>form</form>
+            </AuthLayout>,
+        );
+        expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Sign in');
+        expect(screen.getByText('Please sign in')).toBeInTheDocument();
+        expect(screen.getByTestId('content')).toHaveTextContent('form');
+        const callProps = AuthLayoutTemplateMock.mock.calls[0][0];
+        expect(callProps.title).toBe('Sign in');
+        expect(callProps.description).toBe('Please sign in');
+    });
+});
+

--- a/resources/js/layouts/__tests__/auth-layout.test.tsx
+++ b/resources/js/layouts/__tests__/auth-layout.test.tsx
@@ -1,16 +1,19 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import AuthLayout from '../auth-layout';
 
 const AuthLayoutTemplateMock = vi.hoisted(() =>
-    vi.fn(({ title, description, children }: any) => (
-        <div>
-            <h1>{title}</h1>
-            <p>{description}</p>
-            <div data-testid="content">{children}</div>
-        </div>
-    )),
+    vi.fn(
+        ({ title, description, children }: { title: string; description: string; children: ReactNode }) => (
+            <div>
+                <h1>{title}</h1>
+                <p>{description}</p>
+                <div data-testid="content">{children}</div>
+            </div>
+        ),
+    ),
 );
 
 vi.mock('@/layouts/auth/auth-simple-layout', () => ({


### PR DESCRIPTION
This pull request adds unit tests for the `AppLayout` and `AuthLayout` components to ensure they correctly render their children and pass props to their respective layout templates. These tests use Vitest and React Testing Library, and mock the underlying template components to verify prop handling.

**New layout component tests:**

* Added a test for `AppLayout` that verifies breadcrumbs and children are rendered, and that props are passed to the mocked `AppSidebarLayout` template. (`resources/js/layouts/__tests__/app-layout.test.tsx`)
* Added a test for `AuthLayout` that checks the title, description, and children are rendered, and that props are passed to the mocked `AuthSimpleLayout` template. (`resources/js/layouts/__tests__/auth-layout.test.tsx`)