### PR TITLE
test: add dropdown menu and sidebar tests

### DIFF
--- a/resources/js/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/resources/js/components/ui/__tests__/dropdown-menu.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '../dropdown-menu';
+
+describe('DropdownMenu', () => {
+  it('opens menu and renders item', async () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item 1</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Open'));
+    expect(await screen.findByText('Item 1')).toBeInTheDocument();
+  });
+
+  it('applies inset and variant to item', async () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Trigger</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem inset variant="destructive">
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Trigger'));
+    const item = await screen.findByText('Delete');
+    expect(item).toHaveAttribute('data-inset', 'true');
+    expect(item).toHaveAttribute('data-variant', 'destructive');
+  });
+});

--- a/resources/js/components/ui/__tests__/sidebar.test.tsx
+++ b/resources/js/components/ui/__tests__/sidebar.test.tsx
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { SidebarProvider, SidebarTrigger, useSidebar } from '../sidebar';
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+describe('Sidebar', () => {
+  it('throws error when used outside provider', () => {
+    const Component = () => {
+      useSidebar();
+      return null;
+    };
+    expect(() => render(<Component />)).toThrow('useSidebar must be used within a SidebarProvider.');
+  });
+
+  it('toggles state using SidebarTrigger', async () => {
+    const user = userEvent.setup();
+    function StateReader() {
+      const { state } = useSidebar();
+      return <span data-testid="state">{state}</span>;
+    }
+    render(
+      <SidebarProvider>
+        <SidebarTrigger />
+        <StateReader />
+      </SidebarProvider>
+    );
+    const button = screen.getByRole('button', { name: /toggle sidebar/i });
+    const state = screen.getByTestId('state');
+    expect(state).toHaveTextContent('expanded');
+    await user.click(button);
+    expect(state).toHaveTextContent('collapsed');
+  });
+});

--- a/resources/js/pages/auth/__tests__/reset-password.integration.test.tsx
+++ b/resources/js/pages/auth/__tests__/reset-password.integration.test.tsx
@@ -1,0 +1,106 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState, type ComponentProps, type ReactNode } from 'react';
+import ResetPassword from '../reset-password';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalLocation = window.location;
+
+vi.mock('@/layouts/auth-layout', () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Auth/NewPasswordController', () => ({
+  default: { store: { form: () => ({}) } },
+}));
+
+vi.mock('@/components/input-error', () => ({
+  default: ({ message }: { message?: string }) => (message ? <p>{message}</p> : null),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: ComponentProps<'button'>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: ComponentProps<'label'>) => <label {...props}>{children}</label>,
+}));
+
+vi.mock('@inertiajs/react', () => {
+  return {
+    Form: ({ children, transform }: { children?: ReactNode | ((args: { processing: boolean; errors: Record<string, string> }) => ReactNode); transform?: (data: any) => any }) => {
+      const [processing, setProcessing] = useState(false);
+      const [errors, setErrors] = useState<Record<string, string>>({});
+      const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setProcessing(true);
+        let data: any = Object.fromEntries(new FormData(e.currentTarget) as any);
+        if (transform) {
+          data = transform(data);
+        }
+        const response = await fetch('/reset-password', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        });
+        setProcessing(false);
+        if (response.ok) {
+          const json = await response.json();
+          window.location.assign(json.redirect);
+        } else {
+          const json = await response.json();
+          setErrors(json.errors ?? {});
+        }
+      };
+      return (
+        <form onSubmit={handleSubmit}>
+          {typeof children === 'function' ? children({ processing, errors }) : children}
+        </form>
+      );
+    },
+    Head: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Link: ({ href, children }: { href: string; children?: ReactNode }) => <a href={href}>{children}</a>,
+  };
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { value: originalLocation });
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ResetPassword integration', () => {
+  const token = 'token123';
+  const email = 'user@example.com';
+
+  it('submits form and redirects on success', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => ({ redirect: '/login' }) }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, 'location', { value: { assign: assignSpy } });
+    render(<ResetPassword token={token} email={email} />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('Password'), 'newpassword');
+    await user.type(screen.getByLabelText(/confirm password/i), 'newpassword');
+    await user.click(screen.getByRole('button', { name: /reset password/i }));
+    await waitFor(() => expect(assignSpy).toHaveBeenCalledWith('/login'));
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.token).toBe(token);
+    expect(body.email).toBe(email);
+  });
+
+  it('shows errors returned from server', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: false, json: async () => ({ errors: { password: 'Too short' } }) }));
+    vi.stubGlobal('fetch', fetchSpy);
+    render(<ResetPassword token={token} email={email} />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('Password'), 'short');
+    await user.type(screen.getByLabelText(/confirm password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /reset password/i }));
+    expect(await screen.findByText('Too short')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for DropdownMenu component
- test sidebar context and trigger behavior
- verify reset-password flow integration with success and error paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfca00b600832e976d578e8947a6bf