### PR TITLE
Add unit tests for routes and verify-email page

### DIFF
--- a/resources/js/__tests__/login-routes.test.ts
+++ b/resources/js/__tests__/login-routes.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { store } from '@/routes/login';
+
+describe('login routes', () => {
+  it('generates store route definitions', () => {
+    expect(store()).toEqual({ url: '/login', method: 'post' });
+    expect(store.url()).toBe('/login');
+    expect(store.url({ query: { ref: 'x' } })).toBe('/login?ref=x');
+    expect(store.post({ query: { token: 'abc' } })).toEqual({ url: '/login?token=abc', method: 'post' });
+    expect(store.form.post({ query: { token: 'abc' } })).toEqual({ action: '/login?token=abc', method: 'post' });
+  });
+});

--- a/resources/js/__tests__/password-routes.test.ts
+++ b/resources/js/__tests__/password-routes.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { edit } from '@/routes/password';
+
+describe('password routes', () => {
+  it('generates edit route and head form with mergeQuery', () => {
+    expect(edit()).toEqual({ url: '/settings/password', method: 'get' });
+    expect(edit.url({ query: { page: 1 } })).toBe('/settings/password?page=1');
+    expect(edit.form.head({ mergeQuery: { foo: 'bar' } })).toEqual({
+      action: '/settings/password?_method=HEAD&foo=bar',
+      method: 'get',
+    });
+  });
+});

--- a/resources/js/pages/auth/__tests__/verify-email.test.tsx
+++ b/resources/js/pages/auth/__tests__/verify-email.test.tsx
@@ -40,6 +40,16 @@ describe('VerifyEmail page', () => {
         ).toBeInTheDocument();
     });
 
+    it('enables resend button by default and hides status message', () => {
+        render(<VerifyEmail />);
+        expect(screen.getByRole('button', { name: /resend verification email/i })).not.toBeDisabled();
+        expect(
+            screen.queryByText(
+                /a new verification link has been sent to the email address you provided during registration./i,
+            ),
+        ).not.toBeInTheDocument();
+    });
+
     it('disables resend button when processing', () => {
         formProcessing = true;
         render(<VerifyEmail />);
@@ -51,4 +61,3 @@ describe('VerifyEmail page', () => {
         expect(screen.getByRole('link', { name: /log out/i })).toHaveAttribute('href', '/logout');
     });
 });
-


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage for authentication-related routes and components. The main focus is on verifying route generation logic for login and password management, as well as enhancing tests for the `VerifyEmail` page to ensure correct UI behavior.

**New route tests:**

* Added tests for the `store` route in `@/routes/login`, verifying route object generation, URL building with query parameters, and form action creation.
* Added tests for the `edit` route in `@/routes/password`, checking route object creation, URL generation with queries, and form action with merged query parameters.

**Enhancements to VerifyEmail page tests:**

* Added a test to ensure the "resend verification email" button is enabled by default and the status message is hidden on initial render.
* Minor formatting adjustment at the end of the `verify-email.test.tsx` file.