### PR TITLE
Add tests for curation page and language constants

### DIFF
--- a/resources/js/constants/__tests__/languages.test.ts
+++ b/resources/js/constants/__tests__/languages.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { LANGUAGE_OPTIONS } from '../languages';
+
+describe('LANGUAGE_OPTIONS', () => {
+  it('contains expected language entries', () => {
+    expect(LANGUAGE_OPTIONS).toEqual([
+      { value: 'en', label: 'English' },
+      { value: 'de', label: 'German' },
+      { value: 'fr', label: 'French' },
+    ]);
+  });
+});
+

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+  Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+let DataCiteFormMock: any;
+vi.mock('@/components/curation/datacite-form', () => {
+  DataCiteFormMock = vi.fn(() => <div>DataCiteForm</div>);
+  return {
+    default: DataCiteFormMock,
+  };
+});
+
+describe('Curation page', () => {
+  it('renders DataCiteForm with provided resource types', async () => {
+    const { default: Curation } = await import('../curation');
+    const resourceTypes = [{ id: 1, name: 'Dataset' }];
+    render(<Curation resourceTypes={resourceTypes} />);
+    expect(screen.getByText('DataCiteForm')).toBeInTheDocument();
+    expect(DataCiteFormMock).toHaveBeenCalledWith({ resourceTypes }, undefined);
+  });
+});
+

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -9,13 +9,10 @@ vi.mock('@/layouts/app-layout', () => ({
   default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
 
-let DataCiteFormMock: any;
-vi.mock('@/components/curation/datacite-form', () => {
-  DataCiteFormMock = vi.fn(() => <div>DataCiteForm</div>);
-  return {
-    default: DataCiteFormMock,
-  };
-});
+const DataCiteFormMock = vi.fn(() => <div>DataCiteForm</div>);
+vi.mock('@/components/curation/datacite-form', () => ({
+  default: DataCiteFormMock,
+}));
 
 describe('Curation page', () => {
   it('renders DataCiteForm with provided resource types', async () => {


### PR DESCRIPTION
This pull request adds new unit tests for language options and the curation page to improve test coverage and reliability. The changes focus on verifying that language constants are correct and that the `Curation` page correctly renders its main form component with the expected props.

**Testing improvements:**

* Added a test for `LANGUAGE_OPTIONS` in `languages.test.ts` to ensure it contains the expected language entries.
* Added a test for the `Curation` page in `curation.test.tsx` that mocks dependencies and verifies the `DataCiteForm` component is rendered with the correct props.