### PR TITLE
fix: stabilize title limit e2e test

### DIFF
--- a/e2e/curation-titles.spec.ts
+++ b/e2e/curation-titles.spec.ts
@@ -32,7 +32,8 @@ test('limits title rows to 100', async ({ page }) => {
 
   await page.goto('/curation');
   const addButton = page.getByRole('button', { name: 'Add title' });
-  for (let i = 0; i < 99 && (await addButton.isEnabled()); i++) {
+  for (let i = 0; i < 99; i++) {
+    if (!(await addButton.isEnabled())) break;
     await addButton.click();
   }
   const titleInputs = page.getByRole('textbox', { name: 'Title' });

--- a/e2e/curation-titles.spec.ts
+++ b/e2e/curation-titles.spec.ts
@@ -23,6 +23,7 @@ test('user can add and remove title rows', async ({ page }) => {
 });
 
 test('limits title rows to 100', async ({ page }) => {
+  test.setTimeout(120_000);
   await page.goto('/login');
   await page.getByLabel('Email address').fill(TEST_USER_EMAIL);
   await page.getByLabel('Password').fill(TEST_USER_PASSWORD);
@@ -31,7 +32,7 @@ test('limits title rows to 100', async ({ page }) => {
 
   await page.goto('/curation');
   const addButton = page.getByRole('button', { name: 'Add title' });
-  for (let i = 0; i < 99; i++) {
+  for (let i = 0; i < 99 && (await addButton.isEnabled()); i++) {
     await addButton.click();
   }
   const titleInputs = page.getByRole('textbox', { name: 'Title' });


### PR DESCRIPTION
This pull request makes small improvements to the end-to-end test covering the title row limit in the curation feature. The changes help ensure the test is more robust and reliable.

- **Test reliability improvements:**
  * Increased the timeout for the `'limits title rows to 100'` test to 120 seconds to prevent timeouts during execution.
  * Added a check to ensure the "Add title" button is enabled before clicking it in the loop, making the test more resilient to UI state changes.