### PR TITLE
fix: close Title Type dropdown before removing row in e2e test

### DIFF
--- a/e2e/curation-titles.spec.ts
+++ b/e2e/curation-titles.spec.ts
@@ -18,6 +18,7 @@ test('user can add and remove title rows', async ({ page }) => {
   await expect(titleInputs).toHaveCount(2);
   await page.getByRole('combobox', { name: 'Title Type' }).nth(1).click();
   await expect(page.getByRole('option', { name: 'Main Title' })).toHaveCount(0);
+  await page.keyboard.press('Escape');
   await page.getByRole('button', { name: 'Remove title' }).click();
   await expect(titleInputs).toHaveCount(1);
 });


### PR DESCRIPTION
This pull request makes a minor improvement to the end-to-end test for adding and removing title rows. Specifically, it ensures that the dropdown menu is closed before attempting to remove a title row, which helps prevent potential interaction issues during the test.

* Testing improvement:
  * In `e2e/curation-titles.spec.ts`, added a keyboard press of 'Escape' to close the dropdown before clicking the 'Remove title' button in the "user can add and remove title rows" test.