### PR TITLE
test: improve frontend coverage

### DIFF
--- a/resources/js/__tests__/redirect-controller.test.ts
+++ b/resources/js/__tests__/redirect-controller.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import RedirectController from '@/actions/Illuminate/Routing/RedirectController';
+
+// Unit tests for route generation helpers
+
+describe('RedirectController', () => {
+    it('generates basic route definitions and urls', () => {
+        expect(RedirectController()).toEqual({ url: '/settings', method: 'get' });
+        expect(RedirectController.url()).toBe('/settings');
+        expect(RedirectController.url({ query: { foo: 'bar' } })).toBe('/settings?foo=bar');
+        expect(RedirectController.post()).toEqual({ url: '/settings', method: 'post' });
+    });
+
+    it('generates form definitions for different methods', () => {
+        expect(RedirectController.form.get()).toEqual({ action: '/settings', method: 'get' });
+        expect(RedirectController.form.head()).toEqual({ action: '/settings?_method=HEAD', method: 'get' });
+
+        const del = RedirectController.form.delete({ query: { foo: 'bar' } });
+        const url = new URL(del.action, 'http://localhost');
+        expect(url.pathname).toBe('/settings');
+        expect(url.searchParams.get('_method')).toBe('DELETE');
+        expect(url.searchParams.get('foo')).toBe('bar');
+        expect(del.method).toBe('post');
+    });
+});
+

--- a/resources/js/pages/auth/__tests__/verify-email.integration.test.tsx
+++ b/resources/js/pages/auth/__tests__/verify-email.integration.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState, type ComponentProps, type ReactNode } from 'react';
+import VerifyEmail from '../verify-email';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/auth-layout', () => ({
+  default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Auth/EmailVerificationNotificationController', () => ({
+  default: { store: { form: () => ({}) } },
+}));
+
+vi.mock('@/components/text-link', () => ({
+  default: ({ href, children }: { href: string; children?: ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: ComponentProps<'button'>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/routes', () => ({
+  logout: () => '/logout',
+}));
+
+vi.mock('@inertiajs/react', () => {
+  return {
+    Form: ({ children }: { children?: ReactNode | ((args: { processing: boolean }) => ReactNode) }) => {
+      const [processing, setProcessing] = useState(false);
+      const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setProcessing(true);
+        await fetch('/email/verification-notification', { method: 'POST' });
+        setProcessing(false);
+      };
+      return (
+        <form onSubmit={handleSubmit}>
+          {typeof children === 'function' ? children({ processing }) : children}
+        </form>
+      );
+    },
+    Head: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Link: ({ href, children }: { href: string; children?: ReactNode }) => <a href={href}>{children}</a>,
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('VerifyEmail integration', () => {
+  it('submits resend verification request', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchSpy);
+    render(<VerifyEmail />);
+    const button = screen.getByRole('button', { name: /resend verification email/i });
+    const form = button.closest('form');
+    if (!form) throw new Error('Form not found');
+    fireEvent.submit(form);
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    expect(fetchSpy).toHaveBeenCalledWith('/email/verification-notification', expect.objectContaining({ method: 'POST' }));
+  });
+});
+


### PR DESCRIPTION
This pull request adds new unit and integration tests to improve test coverage for route generation helpers and the email verification flow. The most significant changes are the introduction of comprehensive tests for the `RedirectController` and the integration of mocks and tests for the email verification process.

**New tests for route and form helpers:**

* Added unit tests for `RedirectController` in `redirect-controller.test.ts`, verifying route and form generation for various HTTP methods and query parameters.

**Integration tests and mocking for auth flow:**

* Added an integration test for the email verification page in `verify-email.integration.test.tsx`, including mocks for layout, controllers, UI components, and Inertia.js, to simulate and verify the resend verification email functionality.