### PR TITLE
Add public footer and legal information pages

### DIFF
--- a/resources/js/components/__tests__/app-header.test.tsx
+++ b/resources/js/components/__tests__/app-header.test.tsx
@@ -79,6 +79,8 @@ vi.mock('lucide-react', () => ({
 vi.mock('@/routes', () => ({
     dashboard: () => ({ url: '/dashboard' }),
     docs: () => ({ url: '/docs' }),
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('AppHeader', () => {

--- a/resources/js/components/__tests__/app-sidebar.test.tsx
+++ b/resources/js/components/__tests__/app-sidebar.test.tsx
@@ -55,6 +55,8 @@ vi.mock('@inertiajs/react', () => ({
 }));
 vi.mock('@/routes', () => ({
     dashboard: () => ({ url: '/dashboard' }),
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 vi.mock('../app-logo', () => ({
     default: () => <span>Logo</span>,

--- a/resources/js/components/__tests__/user-menu-content.test.tsx
+++ b/resources/js/components/__tests__/user-menu-content.test.tsx
@@ -32,6 +32,8 @@ vi.mock('@/hooks/use-mobile-navigation', () => ({
 
 vi.mock('@/routes', () => ({
     logout: () => '/logout',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 vi.mock('@/routes/profile', () => ({

--- a/resources/js/components/app-footer.tsx
+++ b/resources/js/components/app-footer.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@inertiajs/react';
+import { about, legalNotice } from '@/routes';
 
 export function AppFooter() {
     return (
@@ -6,10 +7,10 @@ export function AppFooter() {
             <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-2 px-4 md:flex-row">
                 <span>ERNIE v0.1.0</span>
                 <div className="flex gap-4">
-                    <Link href="/about" className="hover:underline">
+                    <Link href={about()} className="hover:underline">
                         About
                     </Link>
-                    <Link href="/legal-notice" className="hover:underline">
+                    <Link href={legalNotice()} className="hover:underline">
                         Legal Notice
                     </Link>
                 </div>

--- a/resources/js/components/app-footer.tsx
+++ b/resources/js/components/app-footer.tsx
@@ -1,0 +1,21 @@
+import { Link } from '@inertiajs/react';
+
+export function AppFooter() {
+    return (
+        <footer className="border-t py-4 text-sm text-neutral-600 dark:text-neutral-300">
+            <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-2 px-4 md:flex-row">
+                <span>ERNIE v0.1.0</span>
+                <div className="flex gap-4">
+                    <Link href="/about" className="hover:underline">
+                        About
+                    </Link>
+                    <Link href="/legal-notice" className="hover:underline">
+                        Legal Notice
+                    </Link>
+                </div>
+            </div>
+        </footer>
+    );
+}
+
+export default AppFooter;

--- a/resources/js/layouts/app/app-header-layout.tsx
+++ b/resources/js/layouts/app/app-header-layout.tsx
@@ -1,4 +1,5 @@
 import { AppContent } from '@/components/app-content';
+import { AppFooter } from '@/components/app-footer';
 import { AppHeader } from '@/components/app-header';
 import { AppShell } from '@/components/app-shell';
 import { type BreadcrumbItem } from '@/types';
@@ -9,6 +10,7 @@ export default function AppHeaderLayout({ children, breadcrumbs }: PropsWithChil
         <AppShell>
             <AppHeader breadcrumbs={breadcrumbs} />
             <AppContent>{children}</AppContent>
+            <AppFooter />
         </AppShell>
     );
 }

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -1,4 +1,5 @@
 import { AppContent } from '@/components/app-content';
+import { AppFooter } from '@/components/app-footer';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
@@ -12,6 +13,7 @@ export default function AppSidebarLayout({ children, breadcrumbs = [] }: PropsWi
             <AppContent variant="sidebar" className="overflow-x-hidden">
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
                 {children}
+                <AppFooter />
             </AppContent>
         </AppShell>
     );

--- a/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
@@ -11,6 +11,8 @@ vi.mock('@inertiajs/react', () => ({
 
 vi.mock('@/routes', () => ({
     home: () => '/',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('AuthSimpleLayout', () => {

--- a/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
@@ -21,7 +21,7 @@ describe('AuthSimpleLayout', () => {
             </AuthSimpleLayout>,
         );
 
-        expect(screen.getByRole('link')).toHaveAttribute('href', '/');
+        expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/');
         expect(screen.getByRole('heading', { name: 'Sign in' })).toBeInTheDocument();
         expect(screen.getByText('Welcome')).toBeInTheDocument();
         expect(screen.getByText('Child content')).toBeInTheDocument();

--- a/resources/js/layouts/auth/__tests__/auth-split-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-split-layout.test.tsx
@@ -16,6 +16,8 @@ vi.mock('@inertiajs/react', () => ({
 
 vi.mock('@/routes', () => ({
     home: () => '/',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('AuthSplitLayout', () => {

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -1,4 +1,5 @@
 import AppLogoIcon from '@/components/app-logo-icon';
+import { AppFooter } from '@/components/app-footer';
 import { home } from '@/routes';
 import { Link } from '@inertiajs/react';
 import { type PropsWithChildren } from 'react';
@@ -11,25 +12,28 @@ interface AuthLayoutProps {
 
 export default function AuthSimpleLayout({ children, title, description }: PropsWithChildren<AuthLayoutProps>) {
     return (
-        <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
-            <div className="w-full max-w-sm">
-                <div className="flex flex-col gap-8">
-                    <div className="flex flex-col items-center gap-4">
-                        <Link href={home()} className="flex flex-col items-center gap-2 font-medium">
-                            <div className="mb-1 flex h-9 w-9 items-center justify-center rounded-md">
-                                <AppLogoIcon className="size-9 fill-current text-[var(--foreground)] dark:text-white" />
-                            </div>
-                            <span className="sr-only">{title}</span>
-                        </Link>
+        <div className="flex min-h-svh flex-col bg-background p-6 md:p-10">
+            <div className="flex flex-1 flex-col items-center justify-center gap-6">
+                <div className="w-full max-w-sm">
+                    <div className="flex flex-col gap-8">
+                        <div className="flex flex-col items-center gap-4">
+                            <Link href={home()} className="flex flex-col items-center gap-2 font-medium">
+                                <div className="mb-1 flex h-9 w-9 items-center justify-center rounded-md">
+                                    <AppLogoIcon className="size-9 fill-current text-[var(--foreground)] dark:text-white" />
+                                </div>
+                                <span className="sr-only">{title}</span>
+                            </Link>
 
-                        <div className="space-y-2 text-center">
-                            <h1 className="text-xl font-medium">{title}</h1>
-                            <p className="text-center text-sm text-muted-foreground">{description}</p>
+                            <div className="space-y-2 text-center">
+                                <h1 className="text-xl font-medium">{title}</h1>
+                                <p className="text-center text-sm text-muted-foreground">{description}</p>
+                            </div>
                         </div>
+                        {children}
                     </div>
-                    {children}
                 </div>
             </div>
+            <AppFooter />
         </div>
     );
 }

--- a/resources/js/layouts/public-layout.tsx
+++ b/resources/js/layouts/public-layout.tsx
@@ -1,0 +1,28 @@
+import { AppFooter } from '@/components/app-footer';
+import { dashboard, login } from '@/routes';
+import { type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
+import { type PropsWithChildren } from 'react';
+
+export default function PublicLayout({ children }: PropsWithChildren) {
+    const { auth } = usePage<SharedData>().props;
+    return (
+        <div className="flex min-h-screen flex-col bg-background text-foreground">
+            <header className="border-b border-sidebar-border/80 bg-background">
+                <nav className="mx-auto flex h-16 w-full max-w-4xl items-center justify-end gap-4 px-6">
+                    {auth.user ? (
+                        <Link href={dashboard()} className="rounded-sm border px-5 py-1.5">
+                            Dashboard
+                        </Link>
+                    ) : (
+                        <Link href={login()} className="rounded-sm border px-5 py-1.5">
+                            Log in
+                        </Link>
+                    )}
+                </nav>
+            </header>
+            <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-6 py-12">{children}</main>
+            <AppFooter />
+        </div>
+    );
+}

--- a/resources/js/layouts/settings/__tests__/layout.test.tsx
+++ b/resources/js/layouts/settings/__tests__/layout.test.tsx
@@ -28,6 +28,8 @@ vi.mock('@/components/ui/separator', () => ({
 
 vi.mock('@/routes', () => ({
     appearance: () => '/settings/appearance',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 vi.mock('@/routes/password', () => ({
     edit: () => '/settings/password',

--- a/resources/js/pages/__tests__/dashboard.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.test.tsx
@@ -17,6 +17,8 @@ vi.mock('@/layouts/app-layout', () => ({
 
 vi.mock('@/routes', () => ({
     dashboard: () => ({ url: '/dashboard' }),
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('Dashboard', () => {

--- a/resources/js/pages/__tests__/welcome.test.tsx
+++ b/resources/js/pages/__tests__/welcome.test.tsx
@@ -15,6 +15,8 @@ vi.mock('@inertiajs/react', () => ({
 vi.mock('@/routes', () => ({
     dashboard: () => '/dashboard',
     login: () => '/login',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('Welcome', () => {

--- a/resources/js/pages/about.tsx
+++ b/resources/js/pages/about.tsx
@@ -1,0 +1,29 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Head } from '@inertiajs/react';
+
+export default function About() {
+    return (
+        <PublicLayout>
+            <Head title="About" />
+            <h1 className="mb-4 text-2xl font-semibold">About ERNIE</h1>
+            <p className="mb-4">
+                ERNIE (Earth Research Notary for Information &amp; Editing) is a metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.
+            </p>
+            <p className="mb-4">This project is currently under active development; features and interfaces may change.</p>
+            <p className="mb-4">
+                The source code is available on{' '}
+                <a href="https://github.com/McNamara84/ernie" target="_blank" rel="noreferrer" className="text-primary underline">
+                    GitHub
+                </a>
+                .
+            </p>
+            <p>
+                For inquiries, contact{' '}
+                <a href="mailto:ehrmann@gfz.de" className="text-primary underline">
+                    ehrmann@gfz.de
+                </a>
+                .
+            </p>
+        </PublicLayout>
+    );
+}

--- a/resources/js/pages/auth/__tests__/confirm-password.test.tsx
+++ b/resources/js/pages/auth/__tests__/confirm-password.test.tsx
@@ -18,6 +18,8 @@ vi.mock('@inertiajs/react', () => ({
 
 vi.mock('@/routes', () => ({
     home: () => '/',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 vi.mock('@/actions/App/Http/Controllers/Auth/ConfirmablePasswordController', () => ({

--- a/resources/js/pages/auth/__tests__/forgot-password.test.tsx
+++ b/resources/js/pages/auth/__tests__/forgot-password.test.tsx
@@ -25,6 +25,8 @@ vi.mock('@/actions/App/Http/Controllers/Auth/PasswordResetLinkController', () =>
 vi.mock('@/routes', () => ({
     login: () => '/login',
     home: () => '/',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('ForgotPassword page', () => {

--- a/resources/js/pages/auth/__tests__/verify-email.test.tsx
+++ b/resources/js/pages/auth/__tests__/verify-email.test.tsx
@@ -24,6 +24,8 @@ vi.mock('@/actions/App/Http/Controllers/Auth/EmailVerificationNotificationContro
 vi.mock('@/routes', () => ({
     logout: () => '/logout',
     home: () => '/',
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('VerifyEmail page', () => {

--- a/resources/js/pages/legal-notice.tsx
+++ b/resources/js/pages/legal-notice.tsx
@@ -1,0 +1,117 @@
+import PublicLayout from '@/layouts/public-layout';
+import { Head } from '@inertiajs/react';
+
+export default function LegalNotice() {
+    return (
+        <PublicLayout>
+            <Head title="Legal Notice" />
+            <h1 className="mb-4 text-2xl font-semibold">Legal information / Provider Identification</h1>
+            <p className="mb-4">
+                Imprint according to § 5 DDG (German Digital Services Act) and § 18 (2) of the State Media Treaty (Medienstaatsvertrag, MstV).
+            </p>
+            <p className="mb-4">
+                <strong>Provider</strong>
+                <br />The provider of this internet presence is the GFZ Helmholtz Centre for Geosciences.
+            </p>
+            <p className="mb-4">
+                <strong>Address</strong>
+                <br />GFZ Helmholtz Centre for Geosciences
+                <br />Telegrafenberg
+                <br />14473 Potsdam, Germany
+                <br />Tel.: +49 331 6264 0
+                <br />Website:{' '}
+                <a
+                    href="https://www.gfz.de/en/"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary underline"
+                >
+                    www.gfz.de
+                </a>
+            </p>
+            <p className="mb-4">
+                <strong>Legal form</strong>
+                <br />The GFZ Helmholtz Centre for Geosciences is a foundation under public law of the State of Brandenburg. The GFZ is a member of the{' '}
+                <a
+                    href="https://www.helmholtz.de/en/"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary underline"
+                >
+                    Helmholtz Association of German Research Centres
+                </a>
+                .
+            </p>
+            <p className="mb-4">
+                <strong>Representatives</strong>
+                <br />The GFZ is legally represented by Prof. Dr. Susanne Buiter (Chairperson of the Board and Scientific Executive Director) and Dr. Marco Kupzig [Administrative Executive Director (ad interim)].
+            </p>
+            <p className="mb-4">
+                <strong>VAT ID</strong>
+                <br />VAT Identification Number according to § 27a VAT Tax Act: DE138407750
+            </p>
+            <p className="mb-4">
+                <strong>Editorial responsibility</strong>
+                <br />Editorial responsibility for this website in accordance with § 18 (2) of the State Media Treaty:
+                <br />Kirsten Elger (GFZ Data and Information Services)
+                <br />Phone: +49 331 6264-2822
+                <br />E-Mail:{' '}
+                <a href="mailto:kirsten.elger@gfz.de" className="text-primary underline">
+                    kirsten.elger@gfz.de
+                </a>
+            </p>
+            <p className="mb-4">
+                <strong>Web concept and Screendesign</strong>
+                <br />Dr. Kirsten Elger and Alexander Brauser (GFZ Data and Information Services)
+            </p>
+            <p className="mb-4">
+                <strong>Technical Realization and support</strong>
+                <br />Responsible for the technical implementation is the unit{' '}
+                <a
+                    href="https://www.gfz.de/en/section/it-services-and-operation/overview"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary underline"
+                >
+                    IT Services and Operations
+                </a>
+                <br />E-Mail:{' '}
+                <a href="mailto:webmaster@gfz.de" className="text-primary underline">
+                    webmaster@gfz.de
+                </a>
+            </p>
+            <p className="mb-4">
+                <strong>Copyright</strong>
+                <br />Texts and photos on the GFZ website are protected by copyright. Copying these files or printing these files is only permitted for private use.
+            </p>
+            <p className="mb-4">
+                All other forms of use, such as the reproduction, modification or use of graphics, audio documents, video sequences and texts on the websites and in other electronic or printed publications for non-commercial or commercial purposes — even if they are not expressly marked as copyright-protected documents — are not permitted without the prior written consent of the copyright holder.
+            </p>
+            <p className="mb-4">
+                Content published under special licences is identified as such. It may be used in accordance with the terms of the specific licence.
+            </p>
+            <p className="mb-4">
+                Some of the data on this data portal originates from other sources. If you wish to use this data, please contact the owner of the data for the terms of use/see the respective terms of use on the websites.
+            </p>
+            <p className="mb-4">
+                <strong>Disclaimer</strong>
+                <br />The editorial staff controls and updates the available information on these websites at regular intervals. Despite all care, information, data or links may have changed in the meantime. There is no liability or guarantee for the currentness, accuracy and completeness of the information provided.
+            </p>
+            <p className="mb-4">
+                The same applies to all other websites, which are referred to by hyperlink. There is not responsibility for the content of the websites that are reached as a result of such a connection. Instead the relevant provider is always responsible for the contents of the linked pages.
+            </p>
+            <p className="mb-4">
+                In establishing the initial link, the editorial staff has reviewed the relevant external content in order to determine that they were free of illegal content at the time of linking.
+            </p>
+            <p className="mb-4">
+                If you detect errors in content or technology, please let us know.
+            </p>
+            <hr className="my-6" />
+            <p>
+                <a href="/web/about-us/data-protection" className="text-primary underline">
+                    Data Privacy Protection
+                </a>
+            </p>
+        </PublicLayout>
+    );
+}

--- a/resources/js/pages/legal-notice.tsx
+++ b/resources/js/pages/legal-notice.tsx
@@ -108,7 +108,12 @@ export default function LegalNotice() {
             </p>
             <hr className="my-6" />
             <p>
-                <a href="/web/about-us/data-protection" className="text-primary underline">
+                <a
+                    href="https://dataservices.gfz-potsdam.de/web/about-us/data-protection"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-primary underline"
+                >
                     Data Privacy Protection
                 </a>
             </p>

--- a/resources/js/pages/settings/__tests__/appearance.test.tsx
+++ b/resources/js/pages/settings/__tests__/appearance.test.tsx
@@ -23,6 +23,8 @@ vi.mock('@/hooks/use-appearance', () => ({
 
 vi.mock('@/routes', () => ({
     appearance: () => ({ url: '/settings/appearance' }),
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
 }));
 
 describe('Appearance settings page', () => {

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1,32 +1,16 @@
-import { dashboard, login } from '@/routes';
-import { type SharedData } from '@/types';
-import { Head, Link, usePage } from '@inertiajs/react';
+import PublicLayout from '@/layouts/public-layout';
+import { Head } from '@inertiajs/react';
 
 export default function Welcome() {
-    const { auth } = usePage<SharedData>().props;
-
     return (
-        <>
+        <PublicLayout>
             <Head title="Welcome" />
-            <header className="fixed top-0 right-0 left-0 z-50 border-b border-sidebar-border/80 bg-background">
-                <nav className="mx-auto flex h-16 w-full max-w-4xl items-center justify-end gap-4 px-6">
-                    {auth.user ? (
-                        <Link href={dashboard()} className="rounded-sm border px-5 py-1.5">
-                            Dashboard
-                        </Link>
-                    ) : (
-                        <Link href={login()} className="rounded-sm border px-5 py-1.5">
-                            Log in
-                        </Link>
-                    )}
-                </nav>
-            </header>
-            <div className="flex min-h-screen flex-col items-center justify-center bg-[#FDFDFC] px-6 pt-16 pb-6 text-[#1b1b18] dark:bg-[#0a0a0a] dark:text-[#EDEDEC]">
-                <main className="text-center">
-                    <h1 className="mb-4 text-2xl font-semibold">ERNIE - Earth Research Notary for Information & Editing</h1>
-                    <p>A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.</p>
-                </main>
+            <div className="flex flex-1 flex-col items-center justify-center text-center">
+                <h1 className="mb-4 text-2xl font-semibold">
+                    ERNIE - Earth Research Notary for Information & Editing
+                </h1>
+                <p>A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.</p>
             </div>
-        </>
+        </PublicLayout>
     );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,14 @@ Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
 
+Route::get('/about', function () {
+    return Inertia::render('about');
+})->name('about');
+
+Route::get('/legal-notice', function () {
+    return Inertia::render('legal-notice');
+})->name('legal-notice');
+
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');


### PR DESCRIPTION
This pull request introduces a new site-wide footer component and adds two new public pages: "About" and "Legal Notice". The footer is integrated across all major layouts, ensuring consistent navigation and access to legal and informational links throughout the application. Additionally, the test mocks are updated to reflect the new routes for "About" and "Legal Notice".

**New features and pages:**

* Added `AppFooter` component, which includes links to the new "About" and "Legal Notice" pages using the application's routing system. (`resources/js/components/app-footer.tsx`)
* Implemented new public pages: `about.tsx` and `legal-notice.tsx`, providing project information and legal details respectively. (`resources/js/pages/about.tsx`, `resources/js/pages/legal-notice.tsx`) [[1]](diffhunk://#diff-72f139db55b3344eab209fd281fa90d84b3f0e8e59835890b7688829bec88caaR1-R29) [[2]](diffhunk://#diff-3b10560e0f3b7cfe603e77b20c1217db56a17d0794c8b30fd91c78693292278fR1-R122)

**Layout updates:**

* Integrated `AppFooter` into all main layouts, including header, sidebar, authentication, and the new public layout, ensuring the footer appears consistently across the site. (`resources/js/layouts/app/app-header-layout.tsx`, `resources/js/layouts/app/app-sidebar-layout.tsx`, `resources/js/layouts/auth/auth-simple-layout.tsx`, `resources/js/layouts/public-layout.tsx`) [[1]](diffhunk://#diff-a8231c46bf167eb3e475e51f4a6fa493ce700ebe2e3cab41a4fa1051cb41725cR2) [[2]](diffhunk://#diff-a8231c46bf167eb3e475e51f4a6fa493ce700ebe2e3cab41a4fa1051cb41725cR13) [[3]](diffhunk://#diff-8045c01f98384f22791508a70267beab55aa0a99ff9abe80823a375f3801a570R2) [[4]](diffhunk://#diff-8045c01f98384f22791508a70267beab55aa0a99ff9abe80823a375f3801a570R16) [[5]](diffhunk://#diff-5208fa9c4ab557113c4733186bcfdbfd6e7abf1d3e62b1bb127d7841d9b806f3R2) [[6]](diffhunk://#diff-5208fa9c4ab557113c4733186bcfdbfd6e7abf1d3e62b1bb127d7841d9b806f3L14-R16) [[7]](diffhunk://#diff-5208fa9c4ab557113c4733186bcfdbfd6e7abf1d3e62b1bb127d7841d9b806f3R36-R37) [[8]](diffhunk://#diff-0ced32ee356e0e88ee3704e0e8bfe5f3c5dd332316a14cfb1d43abc9bc573577R1-R28)

**Testing and route updates:**

* Updated all relevant test files to mock the new `about` and `legalNotice` routes, ensuring tests remain accurate and comprehensive. [[1]](diffhunk://#diff-6ac759d3adc008639bbccdaaf5d1fdafa0f7ca7d9b8361441daf38e260ab3776R82-R83) [[2]](diffhunk://#diff-ad7a3d8bd56f6ae670679d87e3433cbee43c72b730af2edd2b1dca28684a5d4bR58-R59) [[3]](diffhunk://#diff-1da03cf606b559b88b43501deb6b6c6f199285576ea2d8660cd13fc77e3fe699R35-R36) [[4]](diffhunk://#diff-4745369a7f1e7eb063f4e760643f89220e2eaea3b836061faa3fc9a4577659deR14-R15) [[5]](diffhunk://#diff-4c20b111a88349fd25ef0790e537d6e3887cfa42adc89e5ecbe400b23a1da622R19-R20) [[6]](diffhunk://#diff-b8e1bb20966b433500ff822e1a4ebee1234f469e7eff9f45012faed978a9fbeaR31-R32) [[7]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR20-R21) [[8]](diffhunk://#diff-42bb08f71bc97d68094a044e56b610ab893f8bf35eb1d521d357bfd14b98af2cR18-R19) [[9]](diffhunk://#diff-b780ead234ac5324e1a2070be1eb36a7f97fa297585e109eecaa58608928c0eeR21-R22) [[10]](diffhunk://#diff-7308e165d1a37719aee0e88b582e40a0ee69cde6d96955c42ae8327aa1eb69bcR28-R29) [[11]](diffhunk://#diff-dde5d075757741c1e540b1a7d7afb5429cefcb7a15583cd166b52e176604502dR27-R28) [[12]](diffhunk://#diff-1ddbc70cef5f891f75181ef7302b4e29ec499c636047c44992e23c72e884fd1dR26-R27)

**Minor test improvement:**

* Improved a test assertion in `auth-simple-layout.test.tsx` to check the link by accessible name rather than assuming a single link, increasing test robustness.