### PR TITLE
Add feature tests for docs, static pages, and settings appearance

### DIFF
--- a/tests/Feature/DocsTest.php
+++ b/tests/Feature/DocsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use function Pest\Laravel\withoutVite;
+
+uses(RefreshDatabase::class);
+
+test('guests are redirected to login when visiting docs', function () {
+    $this->get(route('docs'))->assertRedirect(route('login'));
+});
+
+test('authenticated users can view the docs page', function () {
+    $this->actingAs(User::factory()->create());
+    withoutVite();
+    $response = $this->get(route('docs'))->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page->component('docs'));
+});
+
+test('guests are redirected to login when visiting users docs', function () {
+    $this->get(route('docs.users'))->assertRedirect(route('login'));
+});
+
+test('authenticated users can view the users docs page', function () {
+    $this->actingAs(User::factory()->create());
+    withoutVite();
+    $response = $this->get(route('docs.users'))->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page->component('docs-users'));
+});

--- a/tests/Feature/Settings/AppearanceTest.php
+++ b/tests/Feature/Settings/AppearanceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use function Pest\Laravel\withoutVite;
+
+uses(RefreshDatabase::class);
+
+test('guests are redirected to login when accessing settings root', function () {
+    $this->get('/settings')->assertRedirect(route('login'));
+});
+
+test('guests are redirected to login when accessing appearance settings', function () {
+    $this->get(route('appearance'))->assertRedirect(route('login'));
+});
+
+test('authenticated users are redirected to profile when visiting settings root', function () {
+    $this->actingAs(User::factory()->create());
+    $this->get('/settings')->assertRedirect('/settings/profile');
+});
+
+test('authenticated users can view the appearance settings page', function () {
+    $this->actingAs(User::factory()->create());
+    withoutVite();
+    $response = $this->get(route('appearance'))->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page->component('settings/appearance'));
+});

--- a/tests/Feature/StaticPagesTest.php
+++ b/tests/Feature/StaticPagesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+use function Pest\Laravel\withoutVite;
+
+it('displays the welcome page', function () {
+    withoutVite();
+    $response = $this->get(route('home'))->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page->component('welcome'));
+});
+
+it('displays the about page', function () {
+    withoutVite();
+    $response = $this->get(route('about'))->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page->component('about'));
+});
+
+it('displays the legal notice page', function () {
+    withoutVite();
+    $response = $this->get(route('legal-notice'))->assertOk();
+    $response->assertInertia(fn (Assert $page) => $page->component('legal-notice'));
+});


### PR DESCRIPTION
## Summary
- cover public pages with Inertia assertions
- test docs pages for authentication and component rendering
- verify settings redirects and appearance page accessibility

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c1071304a8832e87134673797cad44