### PR TITLE
test: add coverage for public pages and footer

### DIFF
--- a/resources/js/components/__tests__/app-footer.test.tsx
+++ b/resources/js/components/__tests__/app-footer.test.tsx
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import AppFooter from '../app-footer';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    Link: ({ href, children }: { href: string; children?: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock('@/routes', () => ({
+    about: () => '/about',
+    legalNotice: () => '/legal-notice',
+}));
+
+describe('AppFooter', () => {
+    it('displays version and navigation links', () => {
+        render(<AppFooter />);
+        expect(screen.getByText('ERNIE v0.1.0')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /about/i })).toHaveAttribute('href', '/about');
+        expect(screen.getByRole('link', { name: /legal notice/i })).toHaveAttribute('href', '/legal-notice');
+    });
+});
+

--- a/resources/js/pages/__tests__/about.integration.test.tsx
+++ b/resources/js/pages/__tests__/about.integration.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import About from '../about';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/public-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+describe('About integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        render(<About />);
+        expect(document.title).toBe('About');
+    });
+});
+

--- a/resources/js/pages/__tests__/about.test.tsx
+++ b/resources/js/pages/__tests__/about.test.tsx
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import About from '../about';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/public-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('About', () => {
+    it('renders heading and GitHub link', () => {
+        render(<About />);
+        expect(screen.getByRole('heading', { name: /about ernie/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /github/i })).toHaveAttribute(
+            'href',
+            'https://github.com/McNamara84/ernie',
+        );
+    });
+});
+

--- a/resources/js/pages/__tests__/legal-notice.integration.test.tsx
+++ b/resources/js/pages/__tests__/legal-notice.integration.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import LegalNotice from '../legal-notice';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/public-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+describe('LegalNotice integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        render(<LegalNotice />);
+        expect(document.title).toBe('Legal Notice');
+    });
+});
+

--- a/resources/js/pages/__tests__/legal-notice.test.tsx
+++ b/resources/js/pages/__tests__/legal-notice.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import LegalNotice from '../legal-notice';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/public-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('LegalNotice', () => {
+    it('renders heading and GFZ link', () => {
+        render(<LegalNotice />);
+        expect(
+            screen.getByRole('heading', { name: /legal information \/ provider identification/i }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /www\.gfz\.de/i })).toHaveAttribute(
+            'href',
+            'https://www.gfz.de/en/',
+        );
+    });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive unit and integration tests for the `About`, `LegalNotice`, and `AppFooter` components. The new tests ensure correct rendering of headings, links, and document titles, while using mocks for external dependencies such as layouts and routing. This improves test coverage and reliability for key informational pages and the footer.

**Component Test Additions:**

* Added unit tests for the `About` page to verify heading and GitHub link rendering, using mocks for layout and Inertia's `Head` component.
* Added unit tests for the `LegalNotice` page to check heading and GFZ link rendering, with similar mocking as above.
* Added unit tests for the `AppFooter` component to ensure version and navigation links are displayed correctly, mocking routing and Inertia's `Link`.

**Integration Test Additions:**

* Added integration tests for the `About` page to verify that the document title is set correctly, with mocks for layout and Inertia's `Head` component.
* Added integration tests for the `LegalNotice` page to confirm correct document title setting, using the same mocking approach.