### PR TITLE
test: add settings integration tests

### DIFF
--- a/resources/js/components/__tests__/delete-user.test.tsx
+++ b/resources/js/components/__tests__/delete-user.test.tsx
@@ -1,10 +1,11 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import DeleteUser from '../delete-user';
 
 const onErrorMock = vi.fn();
+const resetAndClearErrorsMock = vi.fn();
 
 vi.mock('@/actions/App/Http/Controllers/Settings/ProfileController', () => ({
     default: {
@@ -67,7 +68,11 @@ vi.mock('@inertiajs/react', () => ({
         onError: (errors: Record<string, string>) => void;
     }) => {
         onErrorMock.mockImplementation(onError);
-        return <div>{children({ resetAndClearErrors: vi.fn(), processing: false, errors: {} })}</div>;
+        return (
+            <div>
+                {children({ resetAndClearErrors: resetAndClearErrorsMock, processing: false, errors: {} })}
+            </div>
+        );
     },
 }));
 
@@ -91,6 +96,13 @@ describe('DeleteUser', () => {
         expect(document.activeElement).not.toBe(input);
         onErrorMock({});
         expect(document.activeElement).toBe(input);
+    });
+
+    it('resets form when cancel is clicked', () => {
+        render(<DeleteUser />);
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+        fireEvent.click(cancelButton);
+        expect(resetAndClearErrorsMock).toHaveBeenCalled();
     });
 });
 

--- a/resources/js/pages/settings/__tests__/password.integration.test.tsx
+++ b/resources/js/pages/settings/__tests__/password.integration.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Form: ({ children, onError }: { children: (args: { errors: Record<string, string>; processing: boolean; recentlySuccessful: boolean }) => React.ReactNode; onError?: (e: Record<string, string>) => void; }) => {
+        const [processing, setProcessing] = React.useState(false);
+        const [errors, setErrors] = React.useState<Record<string, string>>({});
+        const [recentlySuccessful, setRecentlySuccessful] = React.useState(false);
+        const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            setProcessing(true);
+            const data = new FormData(e.currentTarget);
+            const response = await fetch('/settings/password', { method: 'POST', body: data });
+            setProcessing(false);
+            if (response.ok) {
+                setErrors({});
+                setRecentlySuccessful(true);
+            } else {
+                const json = await response.json();
+                setErrors(json.errors ?? {});
+                onError?.(json.errors ?? {});
+            }
+        };
+        return <form onSubmit={handleSubmit}>{children({ errors, processing, recentlySuccessful })}</form>;
+    },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({ default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div> }));
+vi.mock('@/layouts/settings/layout', () => ({ default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div> }));
+vi.mock('@/components/heading-small', () => ({ default: ({ title, description }: { title: string; description: string }) => (<div><h2>{title}</h2><p>{description}</p></div>) }));
+vi.mock('@/components/input-error', () => ({ default: ({ message }: { message?: string }) => (message ? <p>{message}</p> : null) }));
+vi.mock('@/components/ui/button', () => ({ Button: ({ children, ...props }: React.ComponentProps<'button'>) => <button {...props}>{children}</button> }));
+vi.mock('@/components/ui/input', () => ({ Input: (props: React.ComponentProps<'input'>) => <input {...props} /> }));
+vi.mock('@/components/ui/label', () => ({ Label: ({ children, ...props }: React.ComponentProps<'label'>) => <label {...props}>{children}</label> }));
+vi.mock('@/routes/password', () => ({ edit: () => ({ url: '/settings/password' }) }));
+vi.mock('@/actions/App/Http/Controllers/Settings/PasswordController', () => ({ default: { update: { form: () => ({}) } } }));
+
+import Password from '../password';
+
+afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('Password settings integration', () => {
+    it('updates password successfully', async () => {
+        const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(<Password />);
+        fireEvent.input(screen.getByLabelText(/current password/i), { target: { value: 'oldpass' } });
+        fireEvent.input(screen.getByLabelText(/^new password$/i), { target: { value: 'newpass' } });
+        fireEvent.input(screen.getByLabelText(/confirm password/i), { target: { value: 'newpass' } });
+        const button = screen.getByRole('button', { name: /save password/i });
+        fireEvent.submit(button.closest('form')!);
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        expect(await screen.findByText('Saved')).toBeInTheDocument();
+    });
+
+    it('focuses current password on error', async () => {
+        const fetchMock = vi.fn(async () => ({ ok: false, json: async () => ({ errors: { current_password: 'Incorrect' } }) }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(<Password />);
+        const current = screen.getByLabelText(/current password/i) as HTMLInputElement;
+        const button = screen.getByRole('button', { name: /save password/i });
+        fireEvent.submit(button.closest('form')!);
+        expect(await screen.findByText('Incorrect')).toBeInTheDocument();
+        expect(document.activeElement).toBe(current);
+    });
+});

--- a/resources/js/pages/settings/__tests__/profile.integration.test.tsx
+++ b/resources/js/pages/settings/__tests__/profile.integration.test.tsx
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const authUser = { name: 'John Doe', email: 'john@example.com', email_verified_at: null };
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Link: ({ href, children }: { href: string; children?: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+    usePage: () => ({ props: { auth: { user: authUser } } }),
+    Form: ({ children }: { children: (args: { processing: boolean; recentlySuccessful: boolean; errors: Record<string, string> }) => React.ReactNode }) => {
+        const [processing, setProcessing] = React.useState(false);
+        const [errors, setErrors] = React.useState<Record<string, string>>({});
+        const [recentlySuccessful, setRecentlySuccessful] = React.useState(false);
+        const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
+            setProcessing(true);
+            const data = new FormData(e.currentTarget);
+            const response = await fetch('/settings/profile', { method: 'POST', body: data });
+            setProcessing(false);
+            if (response.ok) {
+                setErrors({});
+                setRecentlySuccessful(true);
+            } else {
+                const json = await response.json();
+                setErrors(json.errors ?? {});
+            }
+        };
+        return <form onSubmit={handleSubmit}>{children({ processing, recentlySuccessful, errors })}</form>;
+    },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({ default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div> }));
+vi.mock('@/layouts/settings/layout', () => ({ default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div> }));
+vi.mock('@/components/delete-user', () => ({ default: () => <div /> }));
+vi.mock('@/components/heading-small', () => ({ default: ({ title, description }: { title: string; description: string }) => (<div><h2>{title}</h2><p>{description}</p></div>) }));
+vi.mock('@/components/input-error', () => ({ default: ({ message }: { message?: string }) => (message ? <p>{message}</p> : null) }));
+vi.mock('@/components/ui/button', () => ({ Button: ({ children, ...props }: React.ComponentProps<'button'>) => <button {...props}>{children}</button> }));
+vi.mock('@/components/ui/input', () => ({ Input: (props: React.ComponentProps<'input'>) => <input {...props} /> }));
+vi.mock('@/components/ui/label', () => ({ Label: ({ children, ...props }: React.ComponentProps<'label'>) => <label {...props}>{children}</label> }));
+vi.mock('@/routes/profile', () => ({ edit: () => ({ url: '/settings/profile' }) }));
+vi.mock('@/routes/verification', () => ({ send: () => '/email/verification-notification' }));
+vi.mock('@/actions/App/Http/Controllers/Settings/ProfileController', () => ({ default: { update: { form: () => ({}) } } }));
+
+import Profile from '../profile';
+
+afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+});
+
+describe('Profile settings integration', () => {
+    it('submits profile successfully', async () => {
+        const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(<Profile mustVerifyEmail={false} />);
+        fireEvent.input(screen.getByLabelText(/name/i), { target: { value: 'Jane Doe' } });
+        fireEvent.input(screen.getByLabelText(/email address/i), { target: { value: 'jane@example.com' } });
+        const button = screen.getByRole('button', { name: /^save$/i });
+        fireEvent.submit(button.closest('form')!);
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        expect(await screen.findByText('Saved')).toBeInTheDocument();
+    });
+
+    it('shows validation errors from server', async () => {
+        const fetchMock = vi.fn(async () => ({ ok: false, json: async () => ({ errors: { name: 'Required' } }) }));
+        vi.stubGlobal('fetch', fetchMock);
+        render(<Profile mustVerifyEmail={false} />);
+        const button = screen.getByRole('button', { name: /^save$/i });
+        fireEvent.submit(button.closest('form')!);
+        expect(await screen.findByText('Required')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
- add cancel reset coverage to delete user component
- add integration tests for profile and password settings pages

## Testing
- `npx vitest run resources/js/components/__tests__/delete-user.test.tsx resources/js/pages/settings/__tests__/profile.integration.test.tsx resources/js/pages/settings/__tests__/password.integration.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c111394c34832e93e2b32f03a29564