### PR TITLE
test: add integration tests for more pages

### DIFF
--- a/resources/js/pages/__tests__/curation.integration.test.tsx
+++ b/resources/js/pages/__tests__/curation.integration.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import Curation from '../curation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResourceType, TitleType } from '@/types';
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+vi.mock('@/components/curation/datacite-form', () => ({
+    default: () => <div />,
+}));
+
+describe('Curation integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        const resourceTypes: ResourceType[] = [];
+        const titleTypes: TitleType[] = [];
+        render(<Curation resourceTypes={resourceTypes} titleTypes={titleTypes} />);
+        expect(document.title).toBe('Curation');
+    });
+});
+

--- a/resources/js/pages/__tests__/dashboard.integration.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.integration.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import Dashboard from '../dashboard';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const usePageMock = vi.fn();
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+    usePage: () => usePageMock(),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/routes', () => ({
+    dashboard: () => ({ url: '/dashboard' }),
+}));
+
+describe('Dashboard integration', () => {
+    beforeEach(() => {
+        document.title = '';
+        usePageMock.mockReturnValue({ props: { auth: { user: { name: 'Jane' } } } });
+    });
+
+    it('sets the document title', () => {
+        render(<Dashboard />);
+        expect(document.title).toBe('Dashboard');
+    });
+});
+

--- a/resources/js/pages/__tests__/docs-users.integration.test.tsx
+++ b/resources/js/pages/__tests__/docs-users.integration.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import DocsUsers from '../docs-users';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+describe('DocsUsers integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        render(<DocsUsers />);
+        expect(document.title).toBe('User Documentation');
+    });
+});
+

--- a/resources/js/pages/__tests__/docs.integration.test.tsx
+++ b/resources/js/pages/__tests__/docs.integration.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import Docs from '../docs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+describe('Docs integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        render(<Docs />);
+        expect(document.title).toBe('Documentation');
+    });
+});
+

--- a/resources/js/pages/__tests__/welcome.integration.test.tsx
+++ b/resources/js/pages/__tests__/welcome.integration.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import Welcome from '../welcome';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/public-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+describe('Welcome integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        render(<Welcome />);
+        expect(document.title).toBe('Welcome');
+    });
+});
+

--- a/resources/js/pages/settings/__tests__/appearance.integration.test.tsx
+++ b/resources/js/pages/settings/__tests__/appearance.integration.test.tsx
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom/vitest';
+import { render } from '@testing-library/react';
+import Appearance from '../appearance';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/layouts/settings/layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
+        if (title) document.title = title;
+        return <>{children}</>;
+    },
+}));
+
+vi.mock('@/components/appearance-tabs', () => ({
+    default: () => <div />,
+}));
+
+vi.mock('@/components/heading-small', () => ({
+    default: () => <div />,
+}));
+
+vi.mock('@/routes', () => ({
+    appearance: () => ({ url: '/settings/appearance' }),
+}));
+
+describe('Appearance settings integration', () => {
+    beforeEach(() => {
+        document.title = '';
+    });
+
+    it('sets the document title', () => {
+        render(<Appearance />);
+        expect(document.title).toBe('Appearance settings');
+    });
+});
+


### PR DESCRIPTION
This pull request introduces integration tests for several page components to verify that each page correctly sets the document title when rendered. The tests use the Testing Library and Vitest for rendering and mocking dependencies, ensuring isolation from external modules and layouts.

Integration test additions:

* Added new integration tests for the following pages to confirm they set the correct document title:
  - `curation` (`curation.integration.test.tsx`)
  - `dashboard` (`dashboard.integration.test.tsx`)
  - `docs` (`docs.integration.test.tsx`)
  - `docs-users` (`docs-users.integration.test.tsx`)
  - `welcome` (`welcome.integration.test.tsx`)
  - `settings/appearance` (`appearance.integration.test.tsx`)

Testing setup improvements:

* Mocked layout components (such as `app-layout`, `public-layout`, and `settings/layout`) and key dependencies (like `@inertiajs/react` and route helpers) to isolate component rendering and focus tests on document title behavior. [[1]](diffhunk://#diff-e3328bddb5a0de5bfee3afe353fca0c8936dcd37c84af29856040c061a504af5R1-R34) [[2]](diffhunk://#diff-da6f059ab4afac8885d24a8dfecaab9b84e911c2511cd9326cac8d3f783bbdc8R1-R35) [[3]](diffhunk://#diff-3e13e67baaba32a739d5d5bece286fb4c8f5cb7ef3dfe4b3668bb4069d8513b4R1-R27) [[4]](diffhunk://#diff-867a7e489adf06c57a52ce9605d8f567d85c26afc9b2b78d487bf043a2d4aa64R1-R27) [[5]](diffhunk://#diff-25ba86d9c46302b13a87e1e7e30a0f524c73cc4038c8677c24a71694f54908e6R1-R27) [[6]](diffhunk://#diff-9f3d814bd535739676f2483f0e5f131f060a1b9a9207b33a87127dea36dc50a5R1-R43)