### PR TITLE
Prefill publication year from uploaded XML

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -18,7 +18,11 @@ class UploadXmlController extends Controller
 
         $reader = XmlReader::fromString($contents);
         $doi = $reader->xpathValue('//identifier[@identifierType="DOI"]')->first();
+        $year = $reader->xpathValue('//publicationYear')->first();
 
-        return response()->json(['doi' => $doi]);
+        return response()->json([
+            'doi' => $doi,
+            'year' => $year,
+        ]);
     }
 }

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -99,6 +99,17 @@ describe('DataCiteForm', () => {
         expect(screen.getByLabelText('DOI')).toHaveValue('10.1234/abc');
     });
 
+    it('prefills Year when initialYear is provided', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                initialYear="2024"
+            />,
+        );
+        expect(screen.getByLabelText('Year')).toHaveValue(2024);
+    });
+
     it(
         'limits title rows to 100',
         async () => {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -30,6 +30,7 @@ interface DataCiteFormProps {
     titleTypes: TitleType[];
     maxTitles?: number;
     initialDoi?: string;
+    initialYear?: string;
 }
 
 export default function DataCiteForm({
@@ -37,11 +38,12 @@ export default function DataCiteForm({
     titleTypes,
     maxTitles = 100,
     initialDoi = '',
+    initialYear = '',
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
-        year: '',
+        year: initialYear,
         resourceType: '',
         version: '',
         language: '',

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -53,4 +53,23 @@ describe('Curation page', () => {
             expect.objectContaining({ initialDoi: '10.1234/xyz' })
         );
     });
+
+    it('passes year to DataCiteForm when provided', () => {
+        const resourceTypes: ResourceType[] = [
+            { id: 1, name: 'Dataset', slug: 'dataset' },
+        ];
+        const titleTypes: TitleType[] = [
+            { id: 1, name: 'Main Title', slug: 'main-title' },
+        ];
+        render(
+            <Curation
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                year="2024"
+            />,
+        );
+        expect(renderForm).toHaveBeenCalledWith(
+            expect.objectContaining({ initialYear: '2024' })
+        );
+    });
 });

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -14,9 +14,10 @@ interface CurationProps {
     resourceTypes: ResourceType[];
     titleTypes: TitleType[];
     doi?: string;
+    year?: string;
 }
 
-export default function Curation({ resourceTypes, titleTypes, doi = '' }: CurationProps) {
+export default function Curation({ resourceTypes, titleTypes, doi = '', year = '' }: CurationProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Curation" />
@@ -25,6 +26,7 @@ export default function Curation({ resourceTypes, titleTypes, doi = '' }: Curati
                     resourceTypes={resourceTypes}
                     titleTypes={titleTypes}
                     initialDoi={doi}
+                    initialYear={year}
                 />
             </div>
         </AppLayout>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -37,8 +37,11 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             }
             throw new Error(message);
         }
-        const data: { doi?: string | null } = await response.json();
-        router.get('/curation', data.doi ? { doi: data.doi } : {});
+        const data: { doi?: string | null; year?: string | null } = await response.json();
+        const query: Record<string, string> = {};
+        if (data.doi) query.doi = data.doi;
+        if (data.year) query.year = data.year;
+        router.get('/curation', query);
     } catch (error) {
         console.error('XML upload failed', error);
         if (error instanceof Error) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'resourceTypes' => ResourceType::orderBy('name')->get(),
             'titleTypes' => TitleType::orderBy('name')->get(),
             'doi' => $request->query('doi'),
+            'year' => $request->query('year'),
         ]);
     })->name('curation');
 });

--- a/tests/Feature/XmlUploadTest.php
+++ b/tests/Feature/XmlUploadTest.php
@@ -5,10 +5,10 @@ use Illuminate\Http\UploadedFile;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
-it('extracts doi from uploaded xml', function () {
+it('extracts doi and publication year from uploaded xml', function () {
     $this->actingAs(User::factory()->create());
 
-    $xml = '<resource><identifier identifierType="DOI">10.1234/xyz</identifier></resource>';
+    $xml = '<resource><identifier identifierType="DOI">10.1234/xyz</identifier><publicationYear>2024</publicationYear></resource>';
     $file = UploadedFile::fake()->createWithContent('test.xml', $xml);
 
     $response = $this->post(route('dashboard.upload-xml'), [
@@ -16,10 +16,10 @@ it('extracts doi from uploaded xml', function () {
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => '10.1234/xyz']);
+    $response->assertOk()->assertJson(['doi' => '10.1234/xyz', 'year' => '2024']);
 });
 
-it('returns null when doi is missing', function () {
+it('returns null when doi and publication year are missing', function () {
     $this->actingAs(User::factory()->create());
 
     $xml = '<resource></resource>';
@@ -30,7 +30,7 @@ it('returns null when doi is missing', function () {
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => null]);
+    $response->assertOk()->assertJson(['doi' => null, 'year' => null]);
 });
 
 it('validates xml file type and size', function () {


### PR DESCRIPTION
This pull request adds support for extracting and handling the publication year from uploaded XML files in addition to the DOI. The year is now parsed server-side, passed through the backend and frontend, and prefilled in the relevant form fields. Comprehensive tests have been added and updated to ensure correct handling of both DOI and year in all relevant flows.

**Backend extraction and response:**
- The `UploadXmlController` now extracts the publication year from the uploaded XML and includes it in the JSON response, alongside the DOI.
- The curation route in `web.php` now passes the `year` query parameter to the frontend, making it available for pre-filling forms.

**Frontend data handling and form updates:**
- The `handleXmlFiles` function in `dashboard.tsx` now supports both `doi` and `year`, passing them as query parameters to the curation page.
- The `Curation` page and its props now accept and forward the `year` value to the `DataCiteForm` as `initialYear`. [[1]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR17-R20) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR29)
- The `DataCiteForm` component and its props now support an `initialYear` value, which is used to prefill the year field.

**Testing improvements:**
- Feature and unit tests have been updated and expanded to cover scenarios involving both DOI and year, including cases where one or both are missing. [[1]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL8-R22) [[2]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL33-R33) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL102-R127) [[4]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR137-R152) [[5]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40R56-R74) [[6]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R102-R112)