### PR TITLE
Extract version from uploaded XML and prefill curation form

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -19,10 +19,12 @@ class UploadXmlController extends Controller
         $reader = XmlReader::fromString($contents);
         $doi = $reader->xpathValue('//identifier[@identifierType="DOI"]')->first();
         $year = $reader->xpathValue('//publicationYear')->first();
+        $version = $reader->xpathValue('//version')->first();
 
         return response()->json([
             'doi' => $doi,
             'year' => $year,
+            'version' => $version,
         ]);
     }
 }

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -110,6 +110,17 @@ describe('DataCiteForm', () => {
         expect(screen.getByLabelText('Year')).toHaveValue(2024);
     });
 
+    it('prefills Version when initialVersion is provided', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                initialVersion="1.5"
+            />,
+        );
+        expect(screen.getByLabelText('Version')).toHaveValue('1.5');
+    });
+
     it(
         'limits title rows to 100',
         async () => {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -31,6 +31,7 @@ interface DataCiteFormProps {
     maxTitles?: number;
     initialDoi?: string;
     initialYear?: string;
+    initialVersion?: string;
 }
 
 export default function DataCiteForm({
@@ -39,13 +40,14 @@ export default function DataCiteForm({
     maxTitles = 100,
     initialDoi = '',
     initialYear = '',
+    initialVersion = '',
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
         year: initialYear,
         resourceType: '',
-        version: '',
+        version: initialVersion,
         language: '',
     });
 

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -66,10 +66,29 @@ describe('Curation page', () => {
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 year="2024"
-            />,
+            />, 
         );
         expect(renderForm).toHaveBeenCalledWith(
             expect.objectContaining({ initialYear: '2024' })
+        );
+    });
+
+    it('passes version to DataCiteForm when provided', () => {
+        const resourceTypes: ResourceType[] = [
+            { id: 1, name: 'Dataset', slug: 'dataset' },
+        ];
+        const titleTypes: TitleType[] = [
+            { id: 1, name: 'Main Title', slug: 'main-title' },
+        ];
+        render(
+            <Curation
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                version="2.0"
+            />,
+        );
+        expect(renderForm).toHaveBeenCalledWith(
+            expect.objectContaining({ initialVersion: '2.0' })
         );
     });
 });

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -15,9 +15,16 @@ interface CurationProps {
     titleTypes: TitleType[];
     doi?: string;
     year?: string;
+    version?: string;
 }
 
-export default function Curation({ resourceTypes, titleTypes, doi = '', year = '' }: CurationProps) {
+export default function Curation({
+    resourceTypes,
+    titleTypes,
+    doi = '',
+    year = '',
+    version = '',
+}: CurationProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Curation" />
@@ -27,6 +34,7 @@ export default function Curation({ resourceTypes, titleTypes, doi = '', year = '
                     titleTypes={titleTypes}
                     initialDoi={doi}
                     initialYear={year}
+                    initialVersion={version}
                 />
             </div>
         </AppLayout>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -37,10 +37,12 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             }
             throw new Error(message);
         }
-        const data: { doi?: string | null; year?: string | null } = await response.json();
+        const data: { doi?: string | null; year?: string | null; version?: string | null } =
+            await response.json();
         const query: Record<string, string> = {};
         if (data.doi) query.doi = data.doi;
         if (data.year) query.year = data.year;
+        if (data.version) query.version = data.version;
         router.get('/curation', query);
     } catch (error) {
         console.error('XML upload failed', error);

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'titleTypes' => TitleType::orderBy('name')->get(),
             'doi' => $request->query('doi'),
             'year' => $request->query('year'),
+            'version' => $request->query('version'),
         ]);
     })->name('curation');
 });

--- a/tests/Feature/XmlUploadTest.php
+++ b/tests/Feature/XmlUploadTest.php
@@ -5,10 +5,10 @@ use Illuminate\Http\UploadedFile;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
-it('extracts doi and publication year from uploaded xml', function () {
+it('extracts doi, publication year and version from uploaded xml', function () {
     $this->actingAs(User::factory()->create());
 
-    $xml = '<resource><identifier identifierType="DOI">10.1234/xyz</identifier><publicationYear>2024</publicationYear></resource>';
+    $xml = '<resource><identifier identifierType="DOI">10.1234/xyz</identifier><publicationYear>2024</publicationYear><version>1.0</version></resource>';
     $file = UploadedFile::fake()->createWithContent('test.xml', $xml);
 
     $response = $this->post(route('dashboard.upload-xml'), [
@@ -16,10 +16,10 @@ it('extracts doi and publication year from uploaded xml', function () {
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => '10.1234/xyz', 'year' => '2024']);
+    $response->assertOk()->assertJson(['doi' => '10.1234/xyz', 'year' => '2024', 'version' => '1.0']);
 });
 
-it('returns null when doi and publication year are missing', function () {
+it('returns null when doi, publication year and version are missing', function () {
     $this->actingAs(User::factory()->create());
 
     $xml = '<resource></resource>';
@@ -30,7 +30,7 @@ it('returns null when doi and publication year are missing', function () {
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => null, 'year' => null]);
+    $response->assertOk()->assertJson(['doi' => null, 'year' => null, 'version' => null]);
 });
 
 it('validates xml file type and size', function () {


### PR DESCRIPTION
This pull request adds support for extracting, passing, and displaying the "version" field from uploaded XML files throughout the application's upload and curation workflow. This includes updating backend extraction logic, API responses, React component props, and associated tests to handle the version field alongside DOI and publication year.

**Backend extraction and API changes:**

* Updated `UploadXmlController` to extract the `<version>` field from uploaded XML and include it in the JSON response.
* Adjusted feature tests in `XmlUploadTest.php` to assert the presence of the version field in upload responses, both when present and missing. [[1]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL8-R22) [[2]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL33-R33)

**Frontend data flow and component updates:**

* Modified `handleXmlFiles` in `dashboard.tsx` to handle the version field in API responses and include it in the redirect to the curation page.
* Updated the curation route and `Curation` page to accept and pass the version field to the `DataCiteForm` component. [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR43) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR18-R27) [[3]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR37)
* Enhanced `DataCiteForm` to accept an `initialVersion` prop and prefill the version field in the form. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R34) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R43-R50)

**Testing improvements:**

* Added and updated tests in both dashboard and curation page test suites to verify correct handling and propagation of the version field throughout the workflow. [[1]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL102-R107) [[2]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL116-R130) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR157-R172) [[4]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40R75-R93) [[5]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R113-R123)