### PR TITLE
Preselect language from uploaded XML

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -20,11 +20,13 @@ class UploadXmlController extends Controller
         $doi = $reader->xpathValue('//identifier[@identifierType="DOI"]')->first();
         $year = $reader->xpathValue('//publicationYear')->first();
         $version = $reader->xpathValue('//version')->first();
+        $language = $reader->xpathValue('//language')->first();
 
         return response()->json([
             'doi' => $doi,
             'year' => $year,
             'version' => $version,
+            'language' => $language,
         ]);
     }
 }

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -121,6 +121,19 @@ describe('DataCiteForm', () => {
         expect(screen.getByLabelText('Version')).toHaveValue('1.5');
     });
 
+    it('prefills Language when initialLanguage is provided', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                initialLanguage="de"
+            />,
+        );
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'German',
+        );
+    });
+
     it(
         'limits title rows to 100',
         async () => {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -32,6 +32,7 @@ interface DataCiteFormProps {
     initialDoi?: string;
     initialYear?: string;
     initialVersion?: string;
+    initialLanguage?: string;
 }
 
 export default function DataCiteForm({
@@ -41,6 +42,7 @@ export default function DataCiteForm({
     initialDoi = '',
     initialYear = '',
     initialVersion = '',
+    initialLanguage = '',
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const [form, setForm] = useState<DataCiteFormData>({
@@ -48,7 +50,7 @@ export default function DataCiteForm({
         year: initialYear,
         resourceType: '',
         version: initialVersion,
-        language: '',
+        language: initialLanguage,
     });
 
     const [titles, setTitles] = useState<TitleEntry[]>([

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -91,4 +91,23 @@ describe('Curation page', () => {
             expect.objectContaining({ initialVersion: '2.0' })
         );
     });
+
+    it('passes language to DataCiteForm when provided', () => {
+        const resourceTypes: ResourceType[] = [
+            { id: 1, name: 'Dataset', slug: 'dataset' },
+        ];
+        const titleTypes: TitleType[] = [
+            { id: 1, name: 'Main Title', slug: 'main-title' },
+        ];
+        render(
+            <Curation
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                language="de"
+            />,
+        );
+        expect(renderForm).toHaveBeenCalledWith(
+            expect.objectContaining({ initialLanguage: 'de' })
+        );
+    });
 });

--- a/resources/js/pages/__tests__/dashboard.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.test.tsx
@@ -99,12 +99,12 @@ describe('handleXmlFiles', () => {
         document.head.innerHTML = '<meta name="csrf-token" content="test-token">';
     });
 
-    it('posts xml file with csrf token and redirects to curation with DOI, Year and Version', async () => {
+    it('posts xml file with csrf token and redirects to curation with DOI, Year, Version and Language', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: '10.1234/abc', year: '2024', version: '1.0' }) } as Response,
+                { ok: true, json: async () => ({ doi: '10.1234/abc', year: '2024', version: '1.0', language: 'en' }) } as Response,
             );
 
         await handleXmlFiles([file]);
@@ -117,17 +117,18 @@ describe('handleXmlFiles', () => {
             doi: '10.1234/abc',
             year: '2024',
             version: '1.0',
+            language: 'en',
         });
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation without DOI, Year or Version when none is returned', async () => {
+    it('redirects to curation without DOI, Year, Version or Language when none is returned', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: null, version: null }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: null }) } as Response,
             );
 
         await handleXmlFiles([file]);
@@ -138,34 +139,50 @@ describe('handleXmlFiles', () => {
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation with Year when DOI is missing', async () => {
+    it('redirects to curation with Year and Language when DOI is missing', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: '2023' }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: '2023', language: 'en' }) } as Response,
             );
 
         await handleXmlFiles([file]);
 
         expect(fetchMock).toHaveBeenCalled();
-        expect(routerMock.get).toHaveBeenCalledWith('/curation', { year: '2023' });
+        expect(routerMock.get).toHaveBeenCalledWith('/curation', { year: '2023', language: 'en' });
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation with Version when DOI and Year are missing', async () => {
+    it('redirects to curation with Version and Language when DOI and Year are missing', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: null, version: '2.0' }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: null, version: '2.0', language: 'en' }) } as Response,
             );
 
         await handleXmlFiles([file]);
 
         expect(fetchMock).toHaveBeenCalled();
-        expect(routerMock.get).toHaveBeenCalledWith('/curation', { version: '2.0' });
+        expect(routerMock.get).toHaveBeenCalledWith('/curation', { version: '2.0', language: 'en' });
+        fetchMock.mockRestore();
+        routerMock.get.mockReset();
+    });
+
+    it('redirects to curation with Language when DOI, Year and Version are missing', async () => {
+        const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
+        const fetchMock = vi
+            .spyOn(global, 'fetch')
+            .mockResolvedValue(
+                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: 'de' }) } as Response,
+            );
+
+        await handleXmlFiles([file]);
+
+        expect(fetchMock).toHaveBeenCalled();
+        expect(routerMock.get).toHaveBeenCalledWith('/curation', { language: 'de' });
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -16,6 +16,7 @@ interface CurationProps {
     doi?: string;
     year?: string;
     version?: string;
+    language?: string;
 }
 
 export default function Curation({
@@ -24,6 +25,7 @@ export default function Curation({
     doi = '',
     year = '',
     version = '',
+    language = '',
 }: CurationProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -35,6 +37,7 @@ export default function Curation({
                     initialDoi={doi}
                     initialYear={year}
                     initialVersion={version}
+                    initialLanguage={language}
                 />
             </div>
         </AppLayout>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -37,12 +37,17 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             }
             throw new Error(message);
         }
-        const data: { doi?: string | null; year?: string | null; version?: string | null } =
-            await response.json();
+        const data: {
+            doi?: string | null;
+            year?: string | null;
+            version?: string | null;
+            language?: string | null;
+        } = await response.json();
         const query: Record<string, string> = {};
         if (data.doi) query.doi = data.doi;
         if (data.year) query.year = data.year;
         if (data.version) query.version = data.version;
+        if (data.language) query.language = data.language;
         router.get('/curation', query);
     } catch (error) {
         console.error('XML upload failed', error);

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'doi' => $request->query('doi'),
             'year' => $request->query('year'),
             'version' => $request->query('version'),
+            'language' => $request->query('language'),
         ]);
     })->name('curation');
 });

--- a/tests/Feature/XmlUploadTest.php
+++ b/tests/Feature/XmlUploadTest.php
@@ -5,10 +5,10 @@ use Illuminate\Http\UploadedFile;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
-it('extracts doi, publication year and version from uploaded xml', function () {
+it('extracts doi, publication year, version and language from uploaded xml', function () {
     $this->actingAs(User::factory()->create());
 
-    $xml = '<resource><identifier identifierType="DOI">10.1234/xyz</identifier><publicationYear>2024</publicationYear><version>1.0</version></resource>';
+    $xml = '<resource><identifier identifierType="DOI">10.1234/xyz</identifier><publicationYear>2024</publicationYear><version>1.0</version><language>de</language></resource>';
     $file = UploadedFile::fake()->createWithContent('test.xml', $xml);
 
     $response = $this->post(route('dashboard.upload-xml'), [
@@ -16,10 +16,10 @@ it('extracts doi, publication year and version from uploaded xml', function () {
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => '10.1234/xyz', 'year' => '2024', 'version' => '1.0']);
+    $response->assertOk()->assertJson(['doi' => '10.1234/xyz', 'year' => '2024', 'version' => '1.0', 'language' => 'de']);
 });
 
-it('returns null when doi, publication year and version are missing', function () {
+it('returns null when doi, publication year, version and language are missing', function () {
     $this->actingAs(User::factory()->create());
 
     $xml = '<resource></resource>';
@@ -30,7 +30,7 @@ it('returns null when doi, publication year and version are missing', function (
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => null, 'year' => null, 'version' => null]);
+    $response->assertOk()->assertJson(['doi' => null, 'year' => null, 'version' => null, 'language' => null]);
 });
 
 it('validates xml file type and size', function () {


### PR DESCRIPTION
This pull request extends the XML upload and curation flow to support extracting, passing, and pre-filling the "language" field in addition to the existing DOI, publication year, and version fields. The changes ensure that the language information is consistently handled across the backend, frontend components, and tests.

**Backend extraction and response:**
- The backend (`UploadXmlController.php`) now extracts the `<language>` field from uploaded XML and includes it in the JSON response.
- The curation route now accepts a `language` query parameter and passes it to the frontend.

**Frontend data flow and form prefill:**
- The dashboard upload handler (`dashboard.tsx`) now parses and passes the `language` field to the curation page if present.
- The curation page and form (`curation.tsx`, `datacite-form.tsx`) accept and prefill the language field using the new `initialLanguage` prop. [[1]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR19) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR28) [[3]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR40) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R35) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R45-R53)

**Testing updates:**
- Tests for XML upload, dashboard, curation page, and form have been updated or added to verify correct handling and pre-filling of the language field throughout the flow. [[1]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL8-R22) [[2]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL33-R33) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL102-R107) [[4]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR120-R131) [[5]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL141-R185) [[6]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R124-R136) [[7]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40R94-R112)

**Summary of most important changes:**

**Backend extraction and propagation:**
- Added extraction of the `<language>` field from XML uploads and included it in the JSON response in `UploadXmlController.php`.
- Updated the curation route to accept and forward the `language` query parameter.

**Frontend data handling and form updates:**
- Modified the XML upload handler to parse and forward the `language` field to the curation page.
- Updated `Curation` and `DataCiteForm` components to accept and prefill the language field via new props. [[1]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR19) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR28) [[3]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR40) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R35) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R45-R53)

**Testing:**
- Extended feature and unit tests to cover the language field in the upload, dashboard, curation, and form flows. [[1]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL8-R22) [[2]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL33-R33) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL102-R107) [[4]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR120-R131) [[5]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL141-R185) [[6]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R124-R136) [[7]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40R94-R112)