### PR TITLE
Prefill resource type from uploaded XML

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use App\Models\ResourceType;
+use Illuminate\Support\Str;
 use Saloon\XmlWrangler\XmlReader;
 
 class UploadXmlController extends Controller
@@ -22,11 +24,21 @@ class UploadXmlController extends Controller
         $version = $reader->xpathValue('//version')->first();
         $language = $reader->xpathValue('//language')->first();
 
+        $resourceTypeElement = $reader->xpathElement('//resourceType')->first();
+        $resourceTypeName = $resourceTypeElement?->getAttribute('resourceTypeGeneral');
+        $resourceType = null;
+
+        if ($resourceTypeName !== null) {
+            $resourceTypeModel = ResourceType::whereRaw('LOWER(name) = ?', [Str::lower($resourceTypeName)])->first();
+            $resourceType = $resourceTypeModel?->slug;
+        }
+
         return response()->json([
             'doi' => $doi,
             'year' => $year,
             'version' => $version,
             'language' => $language,
+            'resourceType' => $resourceType,
         ]);
     }
 }

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -134,6 +134,19 @@ describe('DataCiteForm', () => {
         );
     });
 
+    it('prefills Resource Type when initialResourceType is provided', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                initialResourceType="dataset"
+            />,
+        );
+        expect(screen.getByLabelText('Resource Type')).toHaveTextContent(
+            'Dataset',
+        );
+    });
+
     it(
         'limits title rows to 100',
         async () => {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -33,6 +33,7 @@ interface DataCiteFormProps {
     initialYear?: string;
     initialVersion?: string;
     initialLanguage?: string;
+    initialResourceType?: string;
 }
 
 export default function DataCiteForm({
@@ -43,12 +44,13 @@ export default function DataCiteForm({
     initialYear = '',
     initialVersion = '',
     initialLanguage = '',
+    initialResourceType = '',
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
         year: initialYear,
-        resourceType: '',
+        resourceType: initialResourceType,
         version: initialVersion,
         language: initialLanguage,
     });

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -110,4 +110,23 @@ describe('Curation page', () => {
             expect.objectContaining({ initialLanguage: 'de' })
         );
     });
+
+    it('passes resource type to DataCiteForm when provided', () => {
+        const resourceTypes: ResourceType[] = [
+            { id: 1, name: 'Dataset', slug: 'dataset' },
+        ];
+        const titleTypes: TitleType[] = [
+            { id: 1, name: 'Main Title', slug: 'main-title' },
+        ];
+        render(
+            <Curation
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                resourceType="dataset"
+            />,
+        );
+        expect(renderForm).toHaveBeenCalledWith(
+            expect.objectContaining({ initialResourceType: 'dataset' })
+        );
+    });
 });

--- a/resources/js/pages/__tests__/dashboard.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.test.tsx
@@ -99,12 +99,12 @@ describe('handleXmlFiles', () => {
         document.head.innerHTML = '<meta name="csrf-token" content="test-token">';
     });
 
-    it('posts xml file with csrf token and redirects to curation with DOI, Year, Version and Language', async () => {
+    it('posts xml file with csrf token and redirects to curation with DOI, Year, Version, Language and Resource Type', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: '10.1234/abc', year: '2024', version: '1.0', language: 'en' }) } as Response,
+                { ok: true, json: async () => ({ doi: '10.1234/abc', year: '2024', version: '1.0', language: 'en', resourceType: 'dataset' }) } as Response,
             );
 
         await handleXmlFiles([file]);
@@ -118,17 +118,18 @@ describe('handleXmlFiles', () => {
             year: '2024',
             version: '1.0',
             language: 'en',
+            resourceType: 'dataset',
         });
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation without DOI, Year, Version or Language when none is returned', async () => {
+    it('redirects to curation without DOI, Year, Version, Language or Resource Type when none is returned', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: null }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: null, resourceType: null }) } as Response,
             );
 
         await handleXmlFiles([file]);
@@ -139,12 +140,12 @@ describe('handleXmlFiles', () => {
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation with Year and Language when DOI is missing', async () => {
+    it('redirects to curation with Year and Language when DOI and Resource Type are missing', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: '2023', language: 'en' }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: '2023', language: 'en', resourceType: null }) } as Response,
             );
 
         await handleXmlFiles([file]);
@@ -155,12 +156,12 @@ describe('handleXmlFiles', () => {
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation with Version and Language when DOI and Year are missing', async () => {
+    it('redirects to curation with Version and Language when DOI, Year and Resource Type are missing', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: null, version: '2.0', language: 'en' }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: null, version: '2.0', language: 'en', resourceType: null }) } as Response,
             );
 
         await handleXmlFiles([file]);
@@ -171,18 +172,34 @@ describe('handleXmlFiles', () => {
         routerMock.get.mockReset();
     });
 
-    it('redirects to curation with Language when DOI, Year and Version are missing', async () => {
+    it('redirects to curation with Language when DOI, Year, Version and Resource Type are missing', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: 'de' }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: 'de', resourceType: null }) } as Response,
             );
 
         await handleXmlFiles([file]);
 
         expect(fetchMock).toHaveBeenCalled();
         expect(routerMock.get).toHaveBeenCalledWith('/curation', { language: 'de' });
+        fetchMock.mockRestore();
+        routerMock.get.mockReset();
+    });
+
+    it('redirects to curation with Resource Type when DOI, Year, Version and Language are missing', async () => {
+        const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
+        const fetchMock = vi
+            .spyOn(global, 'fetch')
+            .mockResolvedValue(
+                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: null, resourceType: 'dataset' }) } as Response,
+            );
+
+        await handleXmlFiles([file]);
+
+        expect(fetchMock).toHaveBeenCalled();
+        expect(routerMock.get).toHaveBeenCalledWith('/curation', { resourceType: 'dataset' });
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -17,6 +17,7 @@ interface CurationProps {
     year?: string;
     version?: string;
     language?: string;
+    resourceType?: string;
 }
 
 export default function Curation({
@@ -26,6 +27,7 @@ export default function Curation({
     year = '',
     version = '',
     language = '',
+    resourceType = '',
 }: CurationProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -38,6 +40,7 @@ export default function Curation({
                     initialYear={year}
                     initialVersion={version}
                     initialLanguage={language}
+                    initialResourceType={resourceType}
                 />
             </div>
         </AppLayout>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -42,12 +42,14 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             year?: string | null;
             version?: string | null;
             language?: string | null;
+            resourceType?: string | null;
         } = await response.json();
         const query: Record<string, string> = {};
         if (data.doi) query.doi = data.doi;
         if (data.year) query.year = data.year;
         if (data.version) query.version = data.version;
         if (data.language) query.language = data.language;
+        if (data.resourceType) query.resourceType = data.resourceType;
         router.get('/curation', query);
     } catch (error) {
         console.error('XML upload failed', error);

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'year' => $request->query('year'),
             'version' => $request->query('version'),
             'language' => $request->query('language'),
+            'resourceType' => $request->query('resourceType'),
         ]);
     })->name('curation');
 });


### PR DESCRIPTION
This pull request enhances the XML upload and curation workflow by adding support for extracting and handling the resource type from uploaded XML files. The resource type is now parsed, passed through the backend and frontend, and prefilled in the curation form. Tests and route handling have also been updated to ensure this new field is correctly processed and validated.

**Backend extraction and API changes:**
- The backend (`UploadXmlController`) now extracts the `resourceType` from the uploaded XML, matches it case-insensitively against the `ResourceType` model, and returns its slug in the JSON response. [[1]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R7-R8) [[2]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R27-R41)
- The curation route in `web.php` has been updated to accept and pass along the `resourceType` query parameter.

**Frontend and form handling:**
- The `handleXmlFiles` function in the dashboard now includes `resourceType` in the query parameters when redirecting to curation.
- The `Curation` and `DataCiteForm` components and their props have been updated to accept and prefill the `resourceType` field. [[1]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR20) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR30) [[3]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR43) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R36) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R47-R53)

**Testing improvements:**
- Feature and unit tests have been updated and expanded to verify that `resourceType` is correctly extracted, returned, and handled throughout the upload and curation process. This includes new and updated test cases for both backend and frontend logic. [[1]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceR4-R30) [[2]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL33-R41) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL102-R107) [[4]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR121-R132) [[5]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL142-R148) [[6]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL158-R164) [[7]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL174-R180) [[8]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR191-R206) [[9]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R137-R149) [[10]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40R113-R131)

These changes ensure that resource type information is seamlessly integrated into the XML upload and curation flow, improving data accuracy and user experience.