### PR TITLE
feat(curation): highlight required fields

### DIFF
--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -46,11 +46,11 @@ describe('DataCiteForm', () => {
 
         // basic fields
         expect(screen.getByLabelText('DOI')).toBeInTheDocument();
-        expect(screen.getByLabelText('Year')).toBeInTheDocument();
+        expect(screen.getByLabelText('Year', { exact: false })).toBeInTheDocument();
         expect(screen.getByLabelText('Version')).toBeInTheDocument();
 
         // resource type option
-        const resourceTypeTrigger = screen.getByLabelText('Resource Type');
+        const resourceTypeTrigger = screen.getByLabelText('Resource Type', { exact: false });
         await user.click(resourceTypeTrigger);
         expect(
             await screen.findByRole('option', { name: 'Dataset' }),
@@ -109,7 +109,7 @@ describe('DataCiteForm', () => {
                 initialYear="2024"
             />,
         );
-        expect(screen.getByLabelText('Year')).toHaveValue(2024);
+        expect(screen.getByLabelText('Year', { exact: false })).toHaveValue(2024);
     });
 
     it('prefills Version when initialVersion is provided', () => {
@@ -144,9 +144,19 @@ describe('DataCiteForm', () => {
                 initialResourceType="dataset"
             />,
         );
-        expect(screen.getByLabelText('Resource Type')).toHaveTextContent(
+        expect(screen.getByLabelText('Resource Type', { exact: false })).toHaveTextContent(
             'Dataset',
         );
+    });
+
+    it('marks year and resource type as required', () => {
+        render(<DataCiteForm resourceTypes={resourceTypes} titleTypes={titleTypes} />);
+        const yearInput = screen.getByLabelText('Year', { exact: false });
+        expect(yearInput).toBeRequired();
+        const resourceTrigger = screen.getByLabelText('Resource Type', { exact: false });
+        expect(resourceTrigger).toHaveAttribute('aria-required', 'true');
+        expect(screen.getByText('Year')).toHaveTextContent('*');
+        expect(screen.getByText('Resource Type')).toHaveTextContent('*');
     });
 
     it('prefills titles when initialTitles are provided', () => {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -125,6 +125,7 @@ export default function DataCiteForm({
                                 onChange={(e) => handleChange('year', e.target.value)}
                                 placeholder="2024"
                                 className="md:col-span-2"
+                                required
                             />
                             <SelectField
                                 id="resourceType"
@@ -136,6 +137,7 @@ export default function DataCiteForm({
                                     label: type.name,
                                 }))}
                                 className="md:col-span-4"
+                                required
                             />
                             <InputField
                                 id="version"

--- a/resources/js/components/curation/fields/__tests__/input-field.test.tsx
+++ b/resources/js/components/curation/fields/__tests__/input-field.test.tsx
@@ -16,4 +16,11 @@ describe('InputField', () => {
         const wrapper = screen.getByLabelText('Class').parentElement;
         expect(wrapper).toHaveClass('col-span-2');
     });
+
+    it('renders required indicator', () => {
+        render(<InputField id="req" label="Required" required />);
+        const input = screen.getByLabelText('Required', { exact: false });
+        expect(input).toBeRequired();
+        expect(screen.getByText('Required')).toHaveTextContent('*');
+    });
 });

--- a/resources/js/components/curation/fields/__tests__/select-field.test.tsx
+++ b/resources/js/components/curation/fields/__tests__/select-field.test.tsx
@@ -44,4 +44,20 @@ describe('SelectField', () => {
         const wrapper = trigger.closest('.col-span-2');
         expect(wrapper).toHaveClass('col-span-2');
     });
+
+    it('renders required indicator', () => {
+        render(
+            <SelectField
+                id="req"
+                label="Required"
+                value=""
+                onValueChange={() => {}}
+                options={[]}
+                required
+            />,
+        );
+        const trigger = screen.getByLabelText('Required', { exact: false });
+        expect(trigger).toHaveAttribute('aria-required', 'true');
+        expect(screen.getByText('Required')).toHaveTextContent('*');
+    });
 });

--- a/resources/js/components/curation/fields/input-field.tsx
+++ b/resources/js/components/curation/fields/input-field.tsx
@@ -16,14 +16,16 @@ export function InputField({
     hideLabel = false,
     type = 'text',
     className,
+    required,
     ...props
 }: InputFieldProps) {
     return (
         <div className={cn('flex flex-col gap-2', className)}>
             <Label htmlFor={id} className={hideLabel ? 'sr-only' : undefined}>
                 {label}
+                {required && <span className="text-destructive ml-1">*</span>}
             </Label>
-            <Input id={id} type={type} {...props} />
+            <Input id={id} type={type} required={required} {...props} />
         </div>
     );
 }

--- a/resources/js/components/curation/fields/select-field.tsx
+++ b/resources/js/components/curation/fields/select-field.tsx
@@ -22,6 +22,7 @@ interface SelectFieldProps {
     placeholder?: string;
     className?: string;
     hideLabel?: boolean;
+    required?: boolean;
 }
 
 export function SelectField({
@@ -33,13 +34,15 @@ export function SelectField({
     placeholder = 'Select',
     className,
     hideLabel = false,
+    required = false,
 }: SelectFieldProps) {
     return (
         <div className={cn('flex flex-col gap-2', className)}>
             <Label htmlFor={id} className={hideLabel ? 'sr-only' : undefined}>
                 {label}
+                {required && <span className="text-destructive ml-1">*</span>}
             </Label>
-            <Select value={value} onValueChange={onValueChange}>
+            <Select value={value} onValueChange={onValueChange} required={required}>
                 <SelectTrigger id={id}>
                     <SelectValue placeholder={placeholder} />
                 </SelectTrigger>


### PR DESCRIPTION
This pull request improves form accessibility and user experience by marking required fields in the DataCite form and its underlying components. It ensures that the "Year" and "Resource Type" fields are visually and programmatically indicated as required, and updates tests to verify this behavior.

**Form validation and accessibility improvements:**

* The `DataCiteForm` component now marks the "Year" and "Resource Type" fields as required, both visually (with an asterisk) and programmatically (using the `required` attribute and `aria-required`). [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R128) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R140)
* The `InputField` and `SelectField` components are updated to accept a `required` prop, display an asterisk next to required labels, and propagate the `required` attribute to the underlying input/select elements. [[1]](diffhunk://#diff-a37f616729d3cdabab0fc9b8a411e9d0c98c3f0162e123286200e109603c0befR19-R28) [[2]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfR25) [[3]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfR37-R45)

**Testing updates:**

* Tests for `DataCiteForm`, `InputField`, and `SelectField` are updated or added to verify that required indicators and attributes are rendered correctly for required fields. [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L49-R53) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L112-R112) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L147-R161) [[4]](diffhunk://#diff-4364b3a019a7086de1715033705f5738a8e3455d783067dea9dfd2abef1950edR19-R25) [[5]](diffhunk://#diff-64491adf73a5101ad4ab179f651bc185d1e340395940d51b37602674c0c9d471R47-R62)