### PR TITLE
Mark main title field as required

### DIFF
--- a/e2e/curation-titles.spec.ts
+++ b/e2e/curation-titles.spec.ts
@@ -9,7 +9,7 @@ test('user can add and remove title rows', async ({ page }) => {
     await page.waitForURL(/\/dashboard/);
 
     await page.goto('/curation');
-    const titleInputs = page.getByRole('textbox', { name: 'Title' });
+    const titleInputs = page.getByRole('textbox', { name: /Title/ });
     await expect(titleInputs.first()).toBeVisible();
     await titleInputs.first().fill('First title');
     const addButton = page.getByRole('button', { name: 'Add title' });
@@ -32,7 +32,7 @@ test('limits title rows to 100', async ({ page }) => {
 
     await page.goto('/curation');
     const addButton = page.getByRole('button', { name: 'Add title' });
-    const titleInputs = page.getByRole('textbox', { name: 'Title' });
+    const titleInputs = page.getByRole('textbox', { name: /Title/ });
     for (let i = 0; i < 99; i++) {
         await titleInputs.nth(i).fill(`Title ${i + 1}`);
         await addButton.click();

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -109,7 +109,7 @@ describe('DataCiteForm', () => {
         ).toHaveLength(1);
 
         // title fields
-        const titleInput = screen.getByRole('textbox', { name: 'Title' });
+        const titleInput = screen.getByRole('textbox', { name: /Title/ });
         expect(titleInput).toBeInTheDocument();
         const titleTypeTrigger = screen.getByRole('combobox', { name: 'Title Type' });
         expect(titleTypeTrigger).toHaveTextContent('Main Title');
@@ -120,7 +120,7 @@ describe('DataCiteForm', () => {
         await user.type(titleInput, 'First Title');
         expect(addButton).toBeEnabled();
         await user.click(addButton);
-        const titleInputs = screen.getAllByRole('textbox', { name: 'Title' });
+        const titleInputs = screen.getAllByRole('textbox', { name: /Title/ });
         expect(titleInputs).toHaveLength(2);
         expect(addButton).toBeDisabled();
         const secondTitleTypeTrigger = screen.getAllByRole('combobox', {
@@ -134,7 +134,9 @@ describe('DataCiteForm', () => {
         await user.click(secondTitleTypeTrigger);
         const removeButton = screen.getByRole('button', { name: 'Remove title' });
         await user.click(removeButton);
-        expect(screen.getAllByRole('textbox', { name: 'Title' })).toHaveLength(1);
+        expect(
+            screen.getAllByRole('textbox', { name: /Title/ }),
+        ).toHaveLength(1);
     });
 
     it('prefills DOI when initialDoi is provided', () => {
@@ -227,7 +229,7 @@ describe('DataCiteForm', () => {
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
-            />,
+            />, 
         );
         const yearInput = screen.getByLabelText('Year', { exact: false });
         expect(yearInput).toBeRequired();
@@ -235,6 +237,30 @@ describe('DataCiteForm', () => {
         expect(resourceTrigger).toHaveAttribute('aria-required', 'true');
         expect(screen.getByText('Year')).toHaveTextContent('*');
         expect(screen.getByText('Resource Type')).toHaveTextContent('*');
+    });
+
+    it('marks only first title as required', async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+            />,
+        );
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const titleInput = screen.getByRole('textbox', { name: /Title/ });
+        expect(titleInput).toBeRequired();
+        expect(screen.getByText('Title')).toHaveTextContent('*');
+        const addButton = screen.getByRole('button', { name: 'Add title' });
+        await user.type(titleInput, 'My Title');
+        await user.click(addButton);
+        const titleInputs = screen.getAllByRole('textbox', { name: /Title/ });
+        expect(titleInputs[1]).not.toBeRequired();
+        const labels = screen
+            .getAllByText(/Title/, { selector: 'label' })
+            .filter((l) => ['Title', 'Title*'].includes(l.textContent?.trim() ?? ''));
+        expect(labels[0]).toHaveTextContent('*');
+        expect(labels[1]).not.toHaveTextContent('*');
     });
 
     it('prefills titles when initialTitles are provided', () => {
@@ -251,7 +277,7 @@ describe('DataCiteForm', () => {
                 ]}
             />,
         );
-        const inputs = screen.getAllByRole('textbox', { name: 'Title' });
+        const inputs = screen.getAllByRole('textbox', { name: /Title/ });
         expect(inputs[0]).toHaveValue('Example Title');
         expect(inputs[1]).toHaveValue('Example Subtitle');
         expect(inputs[2]).toHaveValue('Example TranslatedTitle');
@@ -272,7 +298,7 @@ describe('DataCiteForm', () => {
                 initialTitles={[{ title: 'A mandatory Event', titleType: 'main-title' }]}
             />,
         );
-        expect(screen.getByRole('textbox', { name: 'Title' })).toHaveValue(
+        expect(screen.getByRole('textbox', { name: /Title/ })).toHaveValue(
             'A mandatory Event',
         );
         expect(screen.getByRole('combobox', { name: 'Title Type' })).toHaveTextContent(
@@ -293,14 +319,14 @@ describe('DataCiteForm', () => {
             );
             const user = userEvent.setup();
             const addButton = screen.getByRole('button', { name: 'Add title' });
-            const firstInput = screen.getByRole('textbox', { name: 'Title' });
+        const firstInput = screen.getByRole('textbox', { name: /Title/ });
             await user.type(firstInput, 'One');
             await user.click(addButton);
-            const secondInput = screen.getAllByRole('textbox', { name: 'Title' })[1];
+        const secondInput = screen.getAllByRole('textbox', { name: /Title/ })[1];
             await user.type(secondInput, 'Two');
             await user.click(addButton);
             expect(
-                screen.getAllByRole('textbox', { name: 'Title' }),
+                screen.getAllByRole('textbox', { name: /Title/ }),
             ).toHaveLength(3);
             expect(addButton).toBeDisabled();
         },

--- a/resources/js/components/curation/fields/__tests__/title-field.test.tsx
+++ b/resources/js/components/curation/fields/__tests__/title-field.test.tsx
@@ -76,10 +76,49 @@ describe('TitleField', () => {
                 onRemove={() => {}}
                 isFirst
                 canAdd={false}
-            />, 
+            />,
         );
         expect(
             screen.getByRole('button', { name: 'Add title' }),
         ).toBeDisabled();
+    });
+
+    it('marks title input as required only for first row', () => {
+        const { rerender } = render(
+            <TitleField
+                id="row-0"
+                title=""
+                titleType=""
+                options={[]}
+                onTitleChange={() => {}}
+                onTypeChange={() => {}}
+                onAdd={() => {}}
+                onRemove={() => {}}
+                isFirst
+            />,
+        );
+        const firstInput = screen.getByRole('textbox', { name: /Title/ });
+        expect(firstInput).toBeRequired();
+        const firstLabel = screen.getAllByText(/Title/, {
+            selector: 'label',
+        })[0];
+        expect(firstLabel).toHaveTextContent('*');
+
+        rerender(
+            <TitleField
+                id="row-1"
+                title=""
+                titleType=""
+                options={[]}
+                onTitleChange={() => {}}
+                onTypeChange={() => {}}
+                onAdd={() => {}}
+                onRemove={() => {}}
+                isFirst={false}
+            />,
+        );
+        const secondInput = screen.getByRole('textbox', { name: /Title/ });
+        expect(secondInput).not.toBeRequired();
+        expect(screen.getByText('Title')).not.toHaveTextContent('*');
     });
 });

--- a/resources/js/components/curation/fields/title-field.tsx
+++ b/resources/js/components/curation/fields/title-field.tsx
@@ -45,6 +45,7 @@ export function TitleField({
                 onChange={(e) => onTitleChange(e.target.value)}
                 hideLabel={!isFirst}
                 className="md:col-span-8"
+                required={isFirst}
             />
             <SelectField
                 id={`${id}-titleType`}


### PR DESCRIPTION
This pull request updates how required fields are handled for title inputs in the curation forms and tests, ensuring that only the first title row is marked as required. It also improves the robustness of test queries by using regular expressions to match input labels. The main changes are grouped below:

**Form and Field Behavior:**

* The `TitleField` component now marks only the first title input as required, both in the input field (using the `required` attribute) and in the label (displaying an asterisk).
* Added and updated tests in both `TitleField` and `DataCiteForm` to verify that only the first title input is required, and subsequent title rows are optional and not marked with an asterisk. [[1]](diffhunk://#diff-148bfd11e654c641d2546012f79cf21b2e1c479aeb610432450bfd20a781810cR85-R123) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R242-R265)

**Test Improvements:**

* Updated all relevant tests in `DataCiteForm` and end-to-end tests to use regular expressions for matching the "Title" input field, making them more robust to label changes (e.g., matching "Title", "Title*", etc.). [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L112-R112) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L123-R123) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L137-R139) [[4]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L254-R280) [[5]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L275-R301) [[6]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L296-R329) [[7]](diffhunk://#diff-2b30c0152fc9d39acd05c3b08affcbb151250940305bc9395777750d5ec4ca3dL12-R12) [[8]](diffhunk://#diff-2b30c0152fc9d39acd05c3b08affcbb151250940305bc9395777750d5ec4ca3dL35-R35)