### PR TITLE
test: align changelog tests with new release entries

### DIFF
--- a/resources/js/pages/__tests__/changelog.test.tsx
+++ b/resources/js/pages/__tests__/changelog.test.tsx
@@ -62,31 +62,6 @@ describe('Changelog', () => {
                             },
                         ],
                     },
-                    {
-                        version: '1.0.0',
-                        date: '2025-01-15',
-                        features: [
-                            {
-                                title: 'Interactive Timeline',
-                                description:
-                                    'Introduced interactive timeline for changelog entries.',
-                            },
-                        ],
-                        fixes: [
-                            {
-                                title: 'Fixed accessibility issues',
-                                description:
-                                    'Resolved color contrast and focus styles.',
-                            },
-                        ],
-                        improvements: [
-                            {
-                                title: 'Performance enhancements',
-                                description:
-                                    'Optimized rendering of changelog entries.',
-                            },
-                        ],
-                    },
                 ]),
         }) as unknown as typeof fetch;
         // framer-motion calls scrollTo in tests
@@ -100,16 +75,15 @@ describe('Changelog', () => {
         const list = await screen.findByRole('list', { name: /changelog timeline/i });
         expect(list).toBeInTheDocument();
         const firstButton = await screen.findByRole('button', { name: /version 0.1.0/i });
-        const lastButton = await screen.findByRole('button', { name: /version 1.0.0/i });
+        const lastButton = await screen.findByRole('button', { name: /version 0.2.0/i });
         expect(firstButton).toBeInTheDocument();
         expect(lastButton).toBeInTheDocument();
         await user.click(firstButton);
         expect(await screen.findByText(/Resource Information form group/i)).toBeInTheDocument();
         expect(screen.getByText('License and Rights')).toBeInTheDocument();
         await user.click(lastButton);
-        expect((await screen.findAllByText(/Interactive Timeline/i))[0]).toBeInTheDocument();
-        expect(screen.getByText(/Fixed accessibility issues/i)).toBeInTheDocument();
-        expect(screen.getByText(/Performance enhancements/i)).toBeInTheDocument();
+        expect(await screen.findByText(/Minor improvements/i)).toBeInTheDocument();
+        expect(screen.getByText(/UI enhancements/i)).toBeInTheDocument();
     });
 
     it('colors anchors based on version changes', async () => {
@@ -118,7 +92,6 @@ describe('Changelog', () => {
         expect(anchors[0]).toHaveClass('ring-green-500');
         expect(anchors[1]).toHaveClass('ring-red-500');
         expect(anchors[2]).toHaveClass('ring-blue-500');
-        expect(anchors[3]).toHaveClass('ring-green-500');
     });
 
     it('shows an error message when fetch fails', async () => {


### PR DESCRIPTION
This pull request updates the changelog test suite to reflect the removal of the `1.0.0` version entry from the test data and adjusts the related assertions accordingly.

Test data and assertion updates:

* Removed the mock changelog data for version `1.0.0`, including its features, fixes, and improvements, from the test setup in `changelog.test.tsx`.
* Updated test assertions to expect `0.2.0` as the last version instead of `1.0.0`, and to check for the new features and improvements associated with `0.2.0`.
* Removed an assertion that checked for a fourth anchor's color ring, since the corresponding version data was deleted.