### PR TITLE
feat: import licenses from XML uploads

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -24,6 +24,18 @@ class UploadXmlController extends Controller
         $version = $reader->xpathValue('//*[local-name()="version"]')->first();
         $language = $reader->xpathValue('//*[local-name()="language"]')->first();
 
+        $rightsElements = $reader
+            ->xpathElement('//*[local-name()="rightsList"]/*[local-name()="rights"]')
+            ->get();
+        $licenses = [];
+
+        foreach ($rightsElements as $element) {
+            $identifier = $element->getAttribute('rightsIdentifier');
+            if ($identifier) {
+                $licenses[] = $identifier;
+            }
+        }
+
         $titleElements = $reader
             ->xpathElement('//*[local-name()="resource"]/*[local-name()="titles"]/*[local-name()="title"]')
             ->get();
@@ -63,6 +75,7 @@ class UploadXmlController extends Controller
             'language' => $language,
             'resourceType' => $resourceType,
             'titles' => $titles,
+            'licenses' => $licenses,
         ]);
     }
 }

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -245,6 +245,20 @@ describe('DataCiteForm', () => {
         );
     });
 
+    it('prefills licenses when initialLicenses are provided', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                initialLicenses={['MIT', 'Apache-2.0']}
+            />,
+        );
+        const triggers = screen.getAllByLabelText(/^License/, { selector: 'button' });
+        expect(triggers[0]).toHaveTextContent('MIT License');
+        expect(triggers[1]).toHaveTextContent('Apache License 2.0');
+    });
+
     it('marks year, resource type and license as required', () => {
         render(
             <DataCiteForm

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -185,4 +185,28 @@ describe('Curation page', () => {
             expect.objectContaining({ initialTitles: titles })
         );
     });
+
+    it('passes initial licenses to DataCiteForm when provided', () => {
+        const resourceTypes: ResourceType[] = [
+            { id: 1, name: 'Dataset', slug: 'dataset' },
+        ];
+        const titleTypes: TitleType[] = [
+            { id: 1, name: 'Main Title', slug: 'main-title' },
+        ];
+        const licenses: License[] = [
+            { id: 1, identifier: 'MIT', name: 'MIT License' },
+        ];
+        const initialLicenses = ['MIT'];
+        render(
+            <Curation
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                initialLicenses={initialLicenses}
+            />,
+        );
+        expect(renderForm).toHaveBeenCalledWith(
+            expect.objectContaining({ initialLicenses })
+        );
+    });
 });

--- a/resources/js/pages/__tests__/dashboard.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.test.tsx
@@ -114,7 +114,7 @@ describe('handleXmlFiles', () => {
         document.head.innerHTML = '<meta name="csrf-token" content="test-token">';
     });
 
-    it('posts xml file with csrf token and redirects to curation with DOI, Year, Version, Language, Resource Type and Titles', async () => {
+    it('posts xml file with csrf token and redirects to curation with DOI, Year, Version, Language, Resource Type, Titles and Licenses', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const fetchMock = vi
             .spyOn(global, 'fetch')
@@ -133,6 +133,7 @@ describe('handleXmlFiles', () => {
                             { title: 'Example TranslatedTitle', titleType: 'translated-title' },
                             { title: 'Example AlternativeTitle', titleType: 'alternative-title' },
                         ],
+                        licenses: ['CC-BY-4.0', 'MIT'],
                     }),
                 } as Response,
             );
@@ -157,6 +158,8 @@ describe('handleXmlFiles', () => {
             'titles[2][titleType]': 'translated-title',
             'titles[3][title]': 'Example AlternativeTitle',
             'titles[3][titleType]': 'alternative-title',
+            'licenses[0]': 'CC-BY-4.0',
+            'licenses[1]': 'MIT',
         });
         fetchMock.mockRestore();
         routerMock.get.mockReset();

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -20,6 +20,7 @@ interface CurationProps {
     language?: string;
     resourceType?: string;
     titles?: { title: string; titleType: string }[];
+    initialLicenses?: string[];
 }
 
 export default function Curation({
@@ -32,6 +33,7 @@ export default function Curation({
     language = '',
     resourceType = '',
     titles = [],
+    initialLicenses = [],
 }: CurationProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -47,6 +49,7 @@ export default function Curation({
                     initialLanguage={language}
                     initialResourceType={resourceType}
                     initialTitles={titles}
+                    initialLicenses={initialLicenses}
                 />
             </div>
         </AppLayout>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -45,6 +45,7 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             language?: string | null;
             resourceType?: string | null;
             titles?: { title: string; titleType: string }[] | null;
+            licenses?: string[] | null;
         } = await response.json();
         const query: Record<string, unknown> = {};
         if (data.doi) query.doi = data.doi;
@@ -56,6 +57,11 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             data.titles.forEach((t, i) => {
                 query[`titles[${i}][title]`] = t.title;
                 query[`titles[${i}][titleType]`] = t.titleType;
+            });
+        }
+        if (data.licenses && data.licenses.length > 0) {
+            data.licenses.forEach((l, i) => {
+                query[`licenses[${i}]`] = l;
             });
         }
         router.get('/curation', query);

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'language' => $request->query('language'),
             'resourceType' => $request->query('resourceType'),
             'titles' => $request->query('titles', []),
+            'initialLicenses' => $request->query('licenses', []),
         ]);
     })->name('curation');
 });

--- a/tests/Feature/XmlUploadTest.php
+++ b/tests/Feature/XmlUploadTest.php
@@ -16,6 +16,10 @@ it('extracts doi, publication year, version, language, resource type and titles 
     <publicationYear>2024</publicationYear>
     <version>1.0</version>
     <language>de</language>
+    <rightsList>
+        <rights rightsURI="https://creativecommons.org/licenses/by/4.0/legalcode" rightsIdentifier="CC-BY-4.0" rightsIdentifierScheme="SPDX" schemeURI="https://spdx.org/licenses/">Creative Commons Attribution 4.0 International</rights>
+        <rights rightsIdentifier="MIT" rightsIdentifierScheme="SPDX" schemeURI="https://spdx.org/licenses/">MIT License</rights>
+    </rightsList>
     <titles>
         <title>Example Title</title>
         <title titleType="Subtitle">Example Subtitle</title>
@@ -50,6 +54,7 @@ XML;
             ['title' => 'Example TranslatedTitle', 'titleType' => 'translated-title'],
             ['title' => 'Example AlternativeTitle', 'titleType' => 'alternative-title'],
         ],
+        'licenses' => ['CC-BY-4.0', 'MIT'],
     ]);
 });
 
@@ -64,7 +69,7 @@ it('returns null when doi, publication year, version, language and resource type
         '_token' => csrf_token(),
     ]);
 
-    $response->assertOk()->assertJson(['doi' => null, 'year' => null, 'version' => null, 'language' => null, 'resourceType' => null, 'titles' => []]);
+    $response->assertOk()->assertJson(['doi' => null, 'year' => null, 'version' => null, 'language' => null, 'resourceType' => null, 'titles' => [], 'licenses' => []]);
 });
 
 it('handles xml with a single main title', function () {
@@ -82,6 +87,7 @@ it('handles xml with a single main title', function () {
         'titles' => [
             ['title' => 'A mandatory Event', 'titleType' => 'main-title'],
         ],
+        'licenses' => [],
     ]);
 });
 
@@ -344,6 +350,7 @@ XML;
         'titles' => [
             ['title' => 'A mandatory Event', 'titleType' => 'main-title'],
         ],
+        'licenses' => ['CC-BY-4.0'],
     ]);
 });
 


### PR DESCRIPTION
This pull request adds support for extracting license information from uploaded XML files and ensures that license data is correctly passed through the backend and frontend layers, including tests and UI components. The changes ensure that licenses are parsed, returned in API responses, passed as query parameters, and prefilled in the curation form.

**Backend: License Extraction and API Response**

- Added logic in `UploadXmlController.php` to extract license identifiers from the XML `<rightsList>` and include them in the API response as a `licenses` array. [[1]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R27-R38) [[2]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R78)
- Updated feature tests in `XmlUploadTest.php` to cover scenarios with and without licenses, ensuring the API returns the correct license data. [[1]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceR19-R22) [[2]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceR57) [[3]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL67-R72) [[4]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceR90) [[5]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceR353)

**Frontend: Propagation and Usage of License Data**

- Modified `dashboard.tsx` to handle the `licenses` field in API responses and include it as query parameters when redirecting to the curation page. [[1]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR48) [[2]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR62-R66)
- Updated the curation route in `web.php` to accept `licenses` as `initialLicenses` and pass it to the frontend.
- Updated `curation.tsx` to accept and forward `initialLicenses` to the `DataCiteForm` component. [[1]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR23) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR36) [[3]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR52)

**Frontend: UI and Test Enhancements**

- Enhanced tests for the dashboard and curation pages to verify that licenses are correctly handled and passed between components. [[1]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL117-R117) [[2]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR136) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR161-R162) [[4]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40R188-R211)
- Added a test to ensure that `DataCiteForm` correctly pre-fills license fields when `initialLicenses` are provided.