### PR TITLE
feat: toggle active resource types

### DIFF
--- a/app/Http/Controllers/Settings/EditorSettingsController.php
+++ b/app/Http/Controllers/Settings/EditorSettingsController.php
@@ -13,7 +13,7 @@ class EditorSettingsController extends Controller
     public function index()
     {
         return Inertia::render('settings/index', [
-            'resourceTypes' => ResourceType::orderBy('id')->get(['id', 'name']),
+            'resourceTypes' => ResourceType::orderBy('id')->get(['id', 'name', 'active']),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),
             'maxLicenses' => (int) Setting::getValue('max_licenses', Setting::DEFAULT_LIMIT),
         ]);
@@ -25,12 +25,16 @@ class EditorSettingsController extends Controller
             'resourceTypes' => ['required', 'array'],
             'resourceTypes.*.id' => ['required', 'integer', 'exists:resource_types,id'],
             'resourceTypes.*.name' => ['required', 'string'],
+            'resourceTypes.*.active' => ['required', 'boolean'],
             'maxTitles' => ['required', 'integer', 'min:1'],
             'maxLicenses' => ['required', 'integer', 'min:1'],
         ]);
 
         foreach ($validated['resourceTypes'] as $type) {
-            ResourceType::where('id', $type['id'])->update(['name' => $type['name']]);
+            ResourceType::where('id', $type['id'])->update([
+                'name' => $type['name'],
+                'active' => $type['active'],
+            ]);
         }
 
         Setting::updateOrCreate(['key' => 'max_titles'], ['value' => $validated['maxTitles']]);

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -12,5 +12,10 @@ class ResourceType extends Model
     protected $fillable = [
         'name',
         'slug',
+        'active',
+    ];
+
+    protected $casts = [
+        'active' => 'boolean',
     ];
 }

--- a/database/migrations/2024_05_14_000000_add_active_to_resource_types_table.php
+++ b/database/migrations/2024_05_14_000000_add_active_to_resource_types_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('resource_types', function (Blueprint $table) {
+            $table->boolean('active')->default(true)->after('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('resource_types', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -16,7 +16,7 @@ describe('DataCiteForm', () => {
     });
 
     const resourceTypes: ResourceType[] = [
-        { id: 1, name: 'Dataset', slug: 'dataset' },
+        { id: 1, name: 'Dataset', slug: 'dataset', active: true },
     ];
 
     const titleTypes: TitleType[] = [

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -24,7 +24,7 @@ vi.mock('@/components/curation/datacite-form', () => ({
 describe('Curation page', () => {
     it('passes resource, title types and licenses to DataCiteForm', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -66,7 +66,7 @@ describe('Curation page', () => {
 
     it('passes doi to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -91,7 +91,7 @@ describe('Curation page', () => {
 
     it('passes year to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -116,7 +116,7 @@ describe('Curation page', () => {
 
     it('passes version to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -141,7 +141,7 @@ describe('Curation page', () => {
 
     it('passes language to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -166,7 +166,7 @@ describe('Curation page', () => {
 
     it('passes resource type to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -191,7 +191,7 @@ describe('Curation page', () => {
 
     it('passes titles to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -220,7 +220,7 @@ describe('Curation page', () => {
 
     it('passes initial licenses to DataCiteForm when provided', () => {
         const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset' },
+            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
         ];
         const titleTypes: TitleType[] = [
             { id: 1, name: 'Main Title', slug: 'main-title' },

--- a/resources/js/pages/settings/__tests__/editor.test.tsx
+++ b/resources/js/pages/settings/__tests__/editor.test.tsx
@@ -42,14 +42,21 @@ describe('EditorSettings page', () => {
     it('renders resource types and settings fields', () => {
         render(
             <EditorSettings
-                resourceTypes={[{ id: 1, name: 'Dataset' }]}
+                resourceTypes={[{ id: 1, name: 'Dataset', active: true }]}
                 maxTitles={10}
                 maxLicenses={5}
             />,
         );
         expect(screen.getByLabelText('Name')).toBeInTheDocument();
+        expect(screen.getByLabelText('Active')).toBeInTheDocument();
         expect(screen.getByLabelText('Max Titles')).toBeInTheDocument();
         expect(screen.getByLabelText('Max Licenses')).toBeInTheDocument();
-        expect(useFormMock).toHaveBeenCalled();
+        expect(useFormMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                resourceTypes: [{ id: 1, name: 'Dataset', active: true }],
+                maxTitles: 10,
+                maxLicenses: 5,
+            }),
+        );
     });
 });

--- a/resources/js/pages/settings/index.tsx
+++ b/resources/js/pages/settings/index.tsx
@@ -3,12 +3,14 @@ import AppLayout from '@/layouts/app-layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { settings } from '@/routes';
 import { type BreadcrumbItem } from '@/types';
 
 interface ResourceTypeRow {
     id: number;
     name: string;
+    active: boolean;
 }
 
 interface EditorSettingsProps {
@@ -21,13 +23,23 @@ const breadcrumbs: BreadcrumbItem[] = [{ title: 'Editor Settings', href: setting
 
 export default function EditorSettings({ resourceTypes, maxTitles, maxLicenses }: EditorSettingsProps) {
     const { data, setData, post, processing } = useForm({
-        resourceTypes: resourceTypes.map((r) => ({ id: r.id, name: r.name })),
+        resourceTypes: resourceTypes.map((r) => ({ id: r.id, name: r.name, active: r.active })),
         maxTitles,
         maxLicenses,
     });
 
     const handleTypeChange = (index: number, value: string) => {
-        setData('resourceTypes', data.resourceTypes.map((r, i) => (i === index ? { ...r, name: value } : r)));
+        setData(
+            'resourceTypes',
+            data.resourceTypes.map((r, i) => (i === index ? { ...r, name: value } : r)),
+        );
+    };
+
+    const handleActiveChange = (index: number, value: boolean) => {
+        setData(
+            'resourceTypes',
+            data.resourceTypes.map((r, i) => (i === index ? { ...r, active: value } : r)),
+        );
     };
 
     const handleSubmit = (e: React.FormEvent) => {
@@ -46,6 +58,7 @@ export default function EditorSettings({ resourceTypes, maxTitles, maxLicenses }
                             <tr className="text-left">
                                 <th className="border-b p-2">ID</th>
                                 <th className="border-b p-2">Name</th>
+                                <th className="border-b p-2">Active</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -60,6 +73,18 @@ export default function EditorSettings({ resourceTypes, maxTitles, maxLicenses }
                                             id={`rt-${type.id}`}
                                             value={type.name}
                                             onChange={(e) => handleTypeChange(index, e.target.value)}
+                                        />
+                                    </td>
+                                    <td className="border-b p-2 text-center">
+                                        <Label htmlFor={`active-${type.id}`} className="sr-only">
+                                            Active
+                                        </Label>
+                                        <Checkbox
+                                            id={`active-${type.id}`}
+                                            checked={type.active}
+                                            onCheckedChange={(checked) =>
+                                                handleActiveChange(index, checked === true)
+                                            }
                                         />
                                     </td>
                                 </tr>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -45,6 +45,7 @@ export interface ResourceType {
     id: number;
     name: string;
     slug: string;
+    active: boolean;
 }
 
 export interface TitleType {

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('curation', function (\Illuminate\Http\Request $request) {
         return Inertia::render('curation', [
-            'resourceTypes' => ResourceType::orderBy('name')->get(),
+            'resourceTypes' => ResourceType::where('active', true)->orderBy('name')->get(['id', 'name', 'slug', 'active']),
             'titleTypes' => TitleType::orderBy('name')->get(),
             'licenses' => License::orderBy('name')->get(),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -19,6 +19,7 @@ test('guests are redirected to login page', function () {
 test('authenticated users can view curation page with resource and title types', function () {
     $this->seed([ResourceTypeSeeder::class, TitleTypeSeeder::class]);
     License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
+    ResourceType::create(['name' => 'Inactive', 'slug' => 'inactive', 'active' => false]);
     $this->actingAs(User::factory()->create());
 
     withoutVite();
@@ -27,7 +28,7 @@ test('authenticated users can view curation page with resource and title types',
 
     $response->assertInertia(fn (Assert $page) =>
         $page->component('curation')
-            ->has('resourceTypes', ResourceType::count())
+            ->has('resourceTypes', ResourceType::where('active', true)->count())
             ->has('titleTypes', TitleType::count())
             ->has('licenses', License::count())
             ->where('titles', [])

--- a/tests/Feature/Settings/EditorSettingsTest.php
+++ b/tests/Feature/Settings/EditorSettingsTest.php
@@ -24,6 +24,7 @@ test('authenticated users can view editor settings page', function () {
     $response->assertInertia(fn (Assert $page) => $page
         ->component('settings/index')
         ->has('resourceTypes', 1)
+        ->where('resourceTypes.0.active', true)
         ->where('maxTitles', Setting::DEFAULT_LIMIT)
         ->where('maxLicenses', Setting::DEFAULT_LIMIT)
     );
@@ -38,13 +39,13 @@ test('authenticated users can update resource types and settings', function () {
 
     $this->post(route('settings.update'), [
         'resourceTypes' => [
-            ['id' => $type->id, 'name' => 'Data Set'],
+            ['id' => $type->id, 'name' => 'Data Set', 'active' => false],
         ],
         'maxTitles' => 10,
         'maxLicenses' => 7,
     ])->assertRedirect();
 
-    $this->assertDatabaseHas('resource_types', ['id' => $type->id, 'name' => 'Data Set']);
+    $this->assertDatabaseHas('resource_types', ['id' => $type->id, 'name' => 'Data Set', 'active' => false]);
     expect(Setting::getValue('max_titles'))->toBe('10');
     expect(Setting::getValue('max_licenses'))->toBe('7');
 });


### PR DESCRIPTION
This pull request introduces an "active" status for resource types, allowing them to be enabled or disabled throughout the application. The changes span the backend (database, models, controllers), frontend (forms, tables), and associated tests to support and validate this new functionality.

**Backend: Resource Type Activation**

* Added a new `active` boolean column to the `resource_types` table with a default value of `true`, along with migration for adding/removing the column.
* Updated the `ResourceType` model to include `active` in the `$fillable` array and to cast it as a boolean.
* Modified the `EditorSettingsController` to handle the `active` attribute when fetching, validating, and updating resource types. [[1]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28L16-R16) [[2]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28R28-R37)
* Changed the curation page route to only display resource types where `active` is `true`.

**Frontend: Editor Settings and Curation**

* Updated the Editor Settings page to display and allow toggling the "Active" status for each resource type, including UI changes and state handling for the checkbox. [[1]](diffhunk://#diff-38fbf189fb47a9ea661c35fc32eb12d880633a202344baa50240409d77f29577R6-R13) [[2]](diffhunk://#diff-38fbf189fb47a9ea661c35fc32eb12d880633a202344baa50240409d77f29577L24-R42) [[3]](diffhunk://#diff-38fbf189fb47a9ea661c35fc32eb12d880633a202344baa50240409d77f29577R61) [[4]](diffhunk://#diff-38fbf189fb47a9ea661c35fc32eb12d880633a202344baa50240409d77f29577R78-R89)
* Adjusted test data and assertions in frontend tests to include the `active` property for resource types. [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L19-R19) [[2]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L27-R27) [[3]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L69-R69) [[4]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L94-R94) [[5]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L119-R119) [[6]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L144-R144) [[7]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L169-R169) [[8]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L194-R194) [[9]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L223-R223) [[10]](diffhunk://#diff-5fcecd37b0141b59e438b89cc5877e035324421ffa8c5e40660f06bbb5d4069aL45-R60)

**Testing: Backend Validation**

* Updated feature tests to verify that resource types' "active" status is correctly handled in both settings and curation contexts, including database assertions and Inertia checks. [[1]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57R22) [[2]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57L30-R31) [[3]](diffhunk://#diff-a36bcb4c09d9987dd3b6813c415878e679ee02b1d1b6871be08471bab4462706R27) [[4]](diffhunk://#diff-a36bcb4c09d9987dd3b6813c415878e679ee02b1d1b6871be08471bab4462706L41-R48)