### PR TITLE
Expose Ernie resource types via API for curation

### DIFF
--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -19,4 +19,17 @@ class ResourceTypeController extends Controller
 
         return response()->json($types);
     }
+
+    /**
+     * Return all resource types that are active for Ernie.
+     */
+    public function ernie(): JsonResponse
+    {
+        $types = ResourceType::query()
+            ->where('active', true)
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug', 'active']);
+
+        return response()->json($types);
+    }
 }

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -24,6 +24,26 @@
           }
         }
       }
+    },
+    "/api/v1/resource-types/ernie": {
+      "get": {
+        "summary": "List active resource types for Ernie",
+        "responses": {
+          "200": {
+            "description": "List of resource types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ErnieResourceType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -33,6 +53,15 @@
         "properties": {
           "id": { "type": "integer", "readOnly": true },
           "name": { "type": "string" }
+        }
+      },
+      "ErnieResourceType": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "readOnly": true },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "active": { "type": "boolean" }
         }
       }
     }

--- a/resources/js/__tests__/swagger.test.tsx
+++ b/resources/js/__tests__/swagger.test.tsx
@@ -7,7 +7,7 @@ vi.mock('swagger-ui-react', () => ({
   default: ({ spec }: { spec: { info: { title: string } } }) => (
     <div>{spec.info.title}</div>
   ),
-}));
+}), { virtual: true });
 
 import { renderSwagger } from '../swagger';
 

--- a/resources/js/pages/__tests__/curation.integration.test.tsx
+++ b/resources/js/pages/__tests__/curation.integration.test.tsx
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom/vitest';
 import { render } from '@testing-library/react';
 import Curation from '../curation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ResourceType, TitleType, License } from '@/types';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { TitleType, License } from '@/types';
 
 vi.mock('@/layouts/app-layout', () => ({
     default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -22,15 +22,18 @@ vi.mock('@/components/curation/datacite-form', () => ({
 describe('Curation integration', () => {
     beforeEach(() => {
         document.title = '';
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
     });
 
     it('sets the document title', () => {
-        const resourceTypes: ResourceType[] = [];
         const titleTypes: TitleType[] = [];
         const licenses: License[] = [];
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
@@ -40,4 +43,3 @@ describe('Curation integration', () => {
         expect(document.title).toBe('Curation');
     });
 });
-

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -1,8 +1,18 @@
 import '@testing-library/jest-dom/vitest';
-import { render } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import Curation from '../curation';
 import type { ResourceType, TitleType, License } from '@/types';
+
+const resourceTypes: ResourceType[] = [
+    { id: 1, name: 'Dataset', slug: 'dataset', active: true },
+];
+const titleTypes: TitleType[] = [
+    { id: 1, name: 'Main Title', slug: 'main-title' },
+];
+const licenses: License[] = [
+    { id: 1, identifier: 'MIT', name: 'MIT License' },
+];
 
 const renderForm = vi.fn(() => null);
 
@@ -22,225 +32,185 @@ vi.mock('@/components/curation/datacite-form', () => ({
 }));
 
 describe('Curation page', () => {
-    it('passes resource, title types and licenses to DataCiteForm', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    beforeEach(() => {
+        renderForm.mockClear();
+        vi.stubGlobal('fetch', vi.fn(() =>
+            Promise.resolve({ ok: true, json: () => Promise.resolve(resourceTypes) }),
+        ));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('fetches resource types and passes data to DataCiteForm', async () => {
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ resourceTypes, titleTypes, licenses })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ resourceTypes, titleTypes, licenses }),
+            ),
         );
     });
 
-    it('passes limits to DataCiteForm', () => {
-        const resourceTypes: ResourceType[] = [];
-        const titleTypes: TitleType[] = [];
-        const licenses: License[] = [];
+    it('shows loading state before resource types load', () => {
+        (fetch as unknown as vi.Mock).mockImplementation(
+            () => new Promise(() => {}),
+        );
         render(
             <Curation
-                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                maxTitles={99}
+                maxLicenses={99}
+            />, 
+        );
+        expect(screen.getByRole('status')).toHaveTextContent(/loading resource types/i);
+    });
+
+    it('passes limits to DataCiteForm', async () => {
+        render(
+            <Curation
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={5}
                 maxLicenses={7}
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ maxTitles: 5, maxLicenses: 7 })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ maxTitles: 5, maxLicenses: 7 }),
+            ),
         );
     });
 
-    it('passes doi to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes doi to DataCiteForm when provided', async () => {
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 doi="10.1234/xyz"
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialDoi: '10.1234/xyz' })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialDoi: '10.1234/xyz' }),
+            ),
         );
     });
 
-    it('passes year to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes year to DataCiteForm when provided', async () => {
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 year="2024"
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialYear: '2024' })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialYear: '2024' }),
+            ),
         );
     });
 
-    it('passes version to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes version to DataCiteForm when provided', async () => {
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 version="2.0"
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialVersion: '2.0' })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialVersion: '2.0' }),
+            ),
         );
     });
 
-    it('passes language to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes language to DataCiteForm when provided', async () => {
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 language="de"
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialLanguage: 'de' })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialLanguage: 'de' }),
+            ),
         );
     });
 
-    it('passes resource type to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes resource type to DataCiteForm when provided', async () => {
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 resourceType="dataset"
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialResourceType: 'dataset' })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialResourceType: 'dataset' }),
+            ),
         );
     });
 
-    it('passes titles to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes titles to DataCiteForm when provided', async () => {
         const titles = [
             { title: 'Main', titleType: 'main-title' },
             { title: 'Alt', titleType: 'alternative-title' },
         ];
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 titles={titles}
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialTitles: titles })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialTitles: titles }),
+            ),
         );
     });
 
-    it('passes initial licenses to DataCiteForm when provided', () => {
-        const resourceTypes: ResourceType[] = [
-            { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-        ];
-        const titleTypes: TitleType[] = [
-            { id: 1, name: 'Main Title', slug: 'main-title' },
-        ];
-        const licenses: License[] = [
-            { id: 1, identifier: 'MIT', name: 'MIT License' },
-        ];
+    it('passes initial licenses to DataCiteForm when provided', async () => {
         const initialLicenses = ['MIT'];
         render(
             <Curation
-                resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 initialLicenses={initialLicenses}
-            />,
+            />, 
         );
-        expect(renderForm).toHaveBeenCalledWith(
-            expect.objectContaining({ initialLicenses })
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialLicenses }),
+            ),
         );
     });
 });

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -1,7 +1,13 @@
 import AppLayout from '@/layouts/app-layout';
 import DataCiteForm from '@/components/curation/datacite-form';
 import { Head } from '@inertiajs/react';
-import { type BreadcrumbItem, type ResourceType, type TitleType, type License } from '@/types';
+import { useEffect, useState } from 'react';
+import {
+    type BreadcrumbItem,
+    type ResourceType,
+    type TitleType,
+    type License,
+} from '@/types';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -11,7 +17,6 @@ const breadcrumbs: BreadcrumbItem[] = [
 ];
 
 interface CurationProps {
-    resourceTypes: ResourceType[];
     titleTypes: TitleType[];
     licenses: License[];
     maxTitles: number;
@@ -26,7 +31,6 @@ interface CurationProps {
 }
 
 export default function Curation({
-    resourceTypes,
     titleTypes,
     licenses,
     maxTitles,
@@ -39,24 +43,49 @@ export default function Curation({
     titles = [],
     initialLicenses = [],
 }: CurationProps) {
+    const [resourceTypes, setResourceTypes] = useState<ResourceType[] | null>(null);
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        fetch('/api/v1/resource-types/ernie')
+            .then((res) => {
+                if (!res.ok) throw new Error('Network error');
+                return res.json();
+            })
+            .then((data: ResourceType[]) => setResourceTypes(data))
+            .catch(() => setError(true));
+    }, []);
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Curation" />
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    licenses={licenses}
-                    maxTitles={maxTitles}
-                    maxLicenses={maxLicenses}
-                    initialDoi={doi}
-                    initialYear={year}
-                    initialVersion={version}
-                    initialLanguage={language}
-                    initialResourceType={resourceType}
-                    initialTitles={titles}
-                    initialLicenses={initialLicenses}
-                />
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4" aria-busy={resourceTypes === null}>
+                {error && (
+                    <p role="alert" className="text-red-600">
+                        Unable to load resource types.
+                    </p>
+                )}
+                {resourceTypes === null && !error && (
+                    <p role="status" aria-live="polite">
+                        Loading resource types...
+                    </p>
+                )}
+                {resourceTypes && (
+                    <DataCiteForm
+                        resourceTypes={resourceTypes}
+                        titleTypes={titleTypes}
+                        licenses={licenses}
+                        maxTitles={maxTitles}
+                        maxLicenses={maxLicenses}
+                        initialDoi={doi}
+                        initialYear={year}
+                        initialVersion={version}
+                        initialLanguage={language}
+                        initialResourceType={resourceType}
+                        initialTitles={titles}
+                        initialLicenses={initialLicenses}
+                    />
+                )}
             </div>
         </AppLayout>
     );

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,4 +8,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/changelog', [ChangelogController::class, 'index']);
 
 Route::get('/v1/resource-types/elmo', [ResourceTypeController::class, 'elmo']);
+Route::get('/v1/resource-types/ernie', [ResourceTypeController::class, 'ernie']);
 Route::get('/v1/doc', ApiDocController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('curation', function (\Illuminate\Http\Request $request) {
         return Inertia::render('curation', [
-            'resourceTypes' => ResourceType::where('active', true)->orderBy('name')->get(['id', 'name', 'slug', 'active']),
             'titleTypes' => TitleType::orderBy('name')->get(),
             'licenses' => License::orderBy('name')->get(),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -1,10 +1,8 @@
 <?php
 
 use App\Models\User;
-use App\Models\ResourceType;
 use App\Models\TitleType;
 use App\Models\License;
-use Database\Seeders\ResourceTypeSeeder;
 use Database\Seeders\TitleTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -16,10 +14,9 @@ test('guests are redirected to login page', function () {
     $this->get(route('curation'))->assertRedirect(route('login'));
 });
 
-test('authenticated users can view curation page with resource and title types', function () {
-    $this->seed([ResourceTypeSeeder::class, TitleTypeSeeder::class]);
+test('authenticated users can view curation page with title types and licenses', function () {
+    $this->seed([TitleTypeSeeder::class]);
     License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
-    ResourceType::create(['name' => 'Inactive', 'slug' => 'inactive', 'active' => false]);
     $this->actingAs(User::factory()->create());
 
     withoutVite();
@@ -28,7 +25,6 @@ test('authenticated users can view curation page with resource and title types',
 
     $response->assertInertia(fn (Assert $page) =>
         $page->component('curation')
-            ->has('resourceTypes', ResourceType::where('active', true)->count())
             ->has('titleTypes', TitleType::count())
             ->has('licenses', License::count())
             ->where('titles', [])

--- a/tests/Feature/ResourceTypeApiTest.php
+++ b/tests/Feature/ResourceTypeApiTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\ResourceType;
+use Database\Seeders\ResourceTypeSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('returns active resource types for Ernie', function () {
+    $this->seed(ResourceTypeSeeder::class);
+    ResourceType::create(['name' => 'Inactive', 'slug' => 'inactive', 'active' => false]);
+
+    $response = $this->getJson('/api/v1/resource-types/ernie')->assertOk();
+
+    $response->assertJsonCount(ResourceType::where('active', true)->count());
+    $response->assertJsonStructure([
+        '*' => ['id', 'name', 'slug', 'active'],
+    ]);
+});


### PR DESCRIPTION
This pull request refactors how resource types are loaded for the curation page, moving from server-side rendering to client-side fetching via a new API endpoint. It introduces a new API route for fetching active resource types, updates the OpenAPI spec, and adjusts both backend and frontend code accordingly. Tests are updated and added to reflect these changes.

**API and Backend Changes:**

* Added a new controller method `ernie` in `ResourceTypeController` to return all active resource types for Ernie (`app/Http/Controllers/ResourceTypeController.php`).
* Registered a new API route `/api/v1/resource-types/ernie` for fetching active resource types (`routes/api.php`).
* Updated the OpenAPI spec to document the new endpoint and its response schema (`resources/data/openapi.json`). [[1]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R27-R46) [[2]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R57-R65)

**Frontend Changes:**

* Refactored the `Curation` page to fetch resource types from the new API endpoint on mount, handling loading and error states, and removed the `resourceTypes` prop from server-side rendering (`resources/js/pages/curation.tsx`). [[1]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eL4-R10) [[2]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eL14) [[3]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eL29) [[4]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR46-R73) [[5]](diffhunk://#diff-ae1822318bd7c2dbdeb4dd0f23289bfe0a38841158f5eab36f1dee3068df316eR88)

**Testing Updates:**

* Updated and expanded frontend integration and unit tests to mock the fetch call, check loading/error states, and ensure correct prop passing to `DataCiteForm` (`resources/js/pages/__tests__/curation.test.tsx`, `resources/js/pages/__tests__/curation.integration.test.tsx`). [[1]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L2-R16) [[2]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L25-R213) [[3]](diffhunk://#diff-e3328bddb5a0de5bfee3afe353fca0c8936dcd37c84af29856040c061a504af5L4-R5) [[4]](diffhunk://#diff-e3328bddb5a0de5bfee3afe353fca0c8936dcd37c84af29856040c061a504af5R25-L33) [[5]](diffhunk://#diff-e3328bddb5a0de5bfee3afe353fca0c8936dcd37c84af29856040c061a504af5L43)
* Removed server-side resource type assertions from the curation feature test and added a new feature test for the Ernie resource types API endpoint (`tests/Feature/CurationTest.php`, `tests/Feature/ResourceTypeApiTest.php`). [[1]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57L4-L7) [[2]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57L19-L22) [[3]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57L31) [[4]](diffhunk://#diff-f81ff33cedec1d40d4c20003f4c2e9aa0ca0d386b6294f1c96ddd12cc0c403faR1-R19)

**Other Minor Changes:**

* Minor fix to the mocking of `swagger-ui-react` in its test (`resources/js/__tests__/swagger.test.tsx`).
* Cleaned up unused imports and test setup in various files. [[1]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57L4-L7) [[2]](diffhunk://#diff-ebf44a6abfe22e2db1648e9ecfd588c514788b649dd0045fe0c84190e5a41a57L19-L22) [[3]](diffhunk://#diff-e3328bddb5a0de5bfee3afe353fca0c8936dcd37c84af29856040c061a504af5L4-R5)