### PR TITLE
Add resource types endpoint and link API documentation

### DIFF
--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -8,6 +8,18 @@ use Illuminate\Http\JsonResponse;
 class ResourceTypeController extends Controller
 {
     /**
+     * Return all resource types.
+     */
+    public function index(): JsonResponse
+    {
+        $types = ResourceType::query()
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug', 'active', 'elmo_active']);
+
+        return response()->json($types);
+    }
+
+    /**
      * Return all resource types that are active for ELMO.
      */
     public function elmo(): JsonResponse

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -83,8 +83,7 @@
           "slug": { "type": "string" },
           "active": { "type": "boolean" }
         }
-      }
-      ,
+      },
       "ResourceType": {
         "type": "object",
         "properties": {

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -5,6 +5,26 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/api/v1/resource-types": {
+      "get": {
+        "summary": "List all resource types",
+        "responses": {
+          "200": {
+            "description": "List of resource types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResourceType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/resource-types/elmo": {
       "get": {
         "summary": "List resource types enabled for ELMO",
@@ -62,6 +82,17 @@
           "name": { "type": "string" },
           "slug": { "type": "string" },
           "active": { "type": "boolean" }
+        }
+      }
+      ,
+      "ResourceType": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "readOnly": true },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "active": { "type": "boolean" },
+          "elmo_active": { "type": "boolean" }
         }
       }
     }

--- a/resources/js/components/__tests__/app-header.test.tsx
+++ b/resources/js/components/__tests__/app-header.test.tsx
@@ -77,6 +77,7 @@ vi.mock('lucide-react', () => ({
     Database: () => <svg />,
     History: () => <svg />,
     Settings: () => <svg />,
+    FileText: () => <svg />,
 }));
 const settingsRoute = vi.hoisted(() => ({ url: '/settings' }));
 vi.mock('@/routes', () => ({
@@ -109,8 +110,10 @@ describe('AppHeader', () => {
             .forEach((link) => expect(link).toHaveAttribute('href', '/dashboard'));
         const changelogLinks = screen.getAllByRole('link', { name: /changelog/i });
         changelogLinks.forEach((link) => expect(link).toHaveAttribute('href', '/changelog'));
-        const docLinks = screen.getAllByRole('link', { name: /documentation/i });
+        const docLinks = screen.getAllByRole('link', { name: /^documentation$/i });
         docLinks.forEach((link) => expect(link).toHaveAttribute('href', '/docs'));
+        const apiDocLinks = screen.getAllByRole('link', { name: /api documentation/i });
+        apiDocLinks.forEach((link) => expect(link).toHaveAttribute('href', '/api/v1/doc'));
         const curationLinks = screen.getAllByRole('link', { name: /curation/i });
         curationLinks.forEach((link) => expect(link).toHaveAttribute('href', '/curation'));
         const settingsLinks = screen.getAllByRole('link', { name: /editor settings/i });

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils';
 import { dashboard, settings } from '@/routes';
 import { type BreadcrumbItem, type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import { BookOpen, LayoutGrid, Menu, Search, Database, History, Settings } from 'lucide-react';
+import { BookOpen, LayoutGrid, Menu, Search, Database, History, Settings, FileText } from 'lucide-react';
 import AppLogo from './app-logo';
 import AppLogoIcon from './app-logo-icon';
 
@@ -44,6 +44,11 @@ const rightNavItems: NavItem[] = [
         title: 'Documentation',
         href: '/docs',
         icon: BookOpen,
+    },
+    {
+        title: 'API Documentation',
+        href: '/api/v1/doc',
+        icon: FileText,
     },
 ];
 

--- a/resources/js/pages/__tests__/docs.test.tsx
+++ b/resources/js/pages/__tests__/docs.test.tsx
@@ -16,6 +16,7 @@ describe('Docs page', () => {
         render(<Docs />);
         expect(screen.getByText('For Users')).toBeInTheDocument();
         expect(screen.getByText('For Admins')).toBeInTheDocument();
+        expect(screen.getByText('For Developers')).toBeInTheDocument();
     });
 
     it('toggles admin collapsible content', () => {
@@ -34,6 +35,13 @@ describe('Docs page', () => {
         fireEvent.click(screen.getByText('For Users'));
         const link = screen.getByText('Go to the user documentation');
         expect(link).toHaveAttribute('href', '/docs/users');
+    });
+
+    it('links to API documentation', () => {
+        render(<Docs />);
+        fireEvent.click(screen.getByText('For Developers'));
+        const link = screen.getByText('View the API documentation');
+        expect(link).toHaveAttribute('href', '/api/v1/doc');
     });
 });
 

--- a/resources/js/pages/__tests__/welcome.integration.test.tsx
+++ b/resources/js/pages/__tests__/welcome.integration.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@inertiajs/react', () => ({
         if (title) document.title = title;
         return <>{children}</>;
     },
+    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
 }));
 
 describe('Welcome integration', () => {

--- a/resources/js/pages/__tests__/welcome.test.tsx
+++ b/resources/js/pages/__tests__/welcome.test.tsx
@@ -43,4 +43,12 @@ describe('Welcome', () => {
         render(<Welcome />);
         expect(screen.getByRole('link', { name: /dashboard/i })).toHaveAttribute('href', '/dashboard');
     });
+
+    it('includes link to API documentation', () => {
+        render(<Welcome />);
+        expect(screen.getByRole('link', { name: /api documentation/i })).toHaveAttribute(
+            'href',
+            '/api/v1/doc'
+        );
+    });
 });

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -64,6 +64,22 @@ export default function Docs() {
                         <p>This fetches the latest license identifiers and names from SPDX.</p>
                     </CollapsibleContent>
                 </Collapsible>
+                <Collapsible className="w-full rounded-lg border">
+                    <CollapsibleTrigger className="group flex w-full items-center justify-between p-4 text-left font-medium">
+                        For Developers
+                        <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                    </CollapsibleTrigger>
+                    <CollapsibleContent
+                        className="prose max-w-none space-y-2 p-4 pt-0 dark:prose-invert"
+                    >
+                        <p>Explore the REST API for integrating with the platform.</p>
+                        <p>
+                            <a href="/api/v1/doc" className="underline">
+                                View the API documentation
+                            </a>
+                        </p>
+                    </CollapsibleContent>
+                </Collapsible>
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1,5 +1,5 @@
 import PublicLayout from '@/layouts/public-layout';
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 
 export default function Welcome() {
     return (
@@ -9,7 +9,17 @@ export default function Welcome() {
                 <h1 className="mb-4 text-2xl font-semibold">
                     ERNIE - Earth Research Notary for Information & Editing
                 </h1>
-                <p>A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.</p>
+                <p>
+                    A metadata editor for reviewers of research data at GFZ Helmholtz Centre for Geosciences.
+                </p>
+                <p className="mt-6">
+                    <Link
+                        href="/api/v1/doc"
+                        className="rounded-sm border px-5 py-1.5 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                        API Documentation
+                    </Link>
+                </p>
             </div>
         </PublicLayout>
     );

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/changelog', [ChangelogController::class, 'index']);
 
+Route::get('/v1/resource-types', [ResourceTypeController::class, 'index']);
 Route::get('/v1/resource-types/elmo', [ResourceTypeController::class, 'elmo']);
 Route::get('/v1/resource-types/ernie', [ResourceTypeController::class, 'ernie']);
 Route::get('/v1/doc', ApiDocController::class);

--- a/tests/Feature/AllResourceTypeApiTest.php
+++ b/tests/Feature/AllResourceTypeApiTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\ResourceType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('returns all resource types', function () {
+    $typeA = ResourceType::create([
+        'name' => 'Type A',
+        'slug' => 'type-a',
+        'active' => true,
+        'elmo_active' => true,
+    ]);
+
+    $typeB = ResourceType::create([
+        'name' => 'Type B',
+        'slug' => 'type-b',
+        'active' => false,
+        'elmo_active' => false,
+    ]);
+
+    $response = $this->getJson('/api/v1/resource-types')->assertOk();
+
+    $response->assertJsonCount(ResourceType::count());
+    $response->assertJsonStructure([
+        '*' => ['id', 'name', 'slug', 'active', 'elmo_active'],
+    ]);
+    $response->assertJsonFragment([
+        'id' => $typeB->id,
+        'name' => 'Type B',
+        'slug' => 'type-b',
+        'active' => false,
+        'elmo_active' => false,
+    ]);
+});
+


### PR DESCRIPTION
This pull request introduces a new API endpoint for retrieving all resource types, adds visibility and access to API documentation throughout the application, and updates related tests and documentation. The changes improve both developer and user experience by making the API and its documentation more discoverable and by expanding test coverage for new features.

**API Enhancements**

* Added a new endpoint `/api/v1/resource-types` to return all resource types, including controller logic (`ResourceTypeController@index`), route definition, and an OpenAPI schema. [[1]](diffhunk://#diff-3a99f212e67ffc3aaecd790a0271aba63ea14cf246adab4985291065e4ac1895R10-R21) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR10) [[3]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R8-R27) [[4]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R86-R95)
* Added a feature test to verify the new endpoint returns all resource types with the correct structure and data.

**API Documentation Visibility**

* Added an "API Documentation" link to the main navigation (`app-header.tsx`), the Welcome page, and the Docs page, making the API docs easily accessible for users and developers. [[1]](diffhunk://#diff-e93188a864f7af449d4b29df16b91db77b206f891eef34b28856d7b5565e537dL15-R15) [[2]](diffhunk://#diff-e93188a864f7af449d4b29df16b91db77b206f891eef34b28856d7b5565e537dR48-R52) [[3]](diffhunk://#diff-8edc33fdfad4290f7d8a8b572ef18613882634a4494dcd08118064f649c8d8f9L2-R2) [[4]](diffhunk://#diff-8edc33fdfad4290f7d8a8b572ef18613882634a4494dcd08118064f649c8d8f9L12-R22) [[5]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR67-R82)
* Updated tests to check for the presence and correct linking of the API documentation in the UI and documentation pages. [[1]](diffhunk://#diff-6ac759d3adc008639bbccdaaf5d1fdafa0f7ca7d9b8361441daf38e260ab3776L112-R116) [[2]](diffhunk://#diff-cf8de5389d60157c373c3e0904c33f1e2c5696c65fd1866956ddbf38896b78dbR19) [[3]](diffhunk://#diff-cf8de5389d60157c373c3e0904c33f1e2c5696c65fd1866956ddbf38896b78dbR39-R45) [[4]](diffhunk://#diff-42bb08f71bc97d68094a044e56b610ab893f8bf35eb1d521d357bfd14b98af2cR46-R53)