### PR TITLE
Return consistent resource type schema

### DIFF
--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -14,7 +14,7 @@ class ResourceTypeController extends Controller
     {
         $types = ResourceType::query()
             ->orderBy('name')
-            ->get(['id', 'name', 'slug', 'active', 'elmo_active']);
+            ->get(['id', 'name']);
 
         return response()->json($types);
     }
@@ -40,7 +40,7 @@ class ResourceTypeController extends Controller
         $types = ResourceType::query()
             ->where('active', true)
             ->orderBy('name')
-            ->get(['id', 'name', 'slug', 'active']);
+            ->get(['id', 'name']);
 
         return response()->json($types);
     }

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -65,7 +65,7 @@ class UploadXmlController extends Controller
 
         if ($resourceTypeName !== null) {
             $resourceTypeModel = ResourceType::whereRaw('LOWER(name) = ?', [Str::lower($resourceTypeName)])->first();
-            $resourceType = $resourceTypeModel?->slug;
+            $resourceType = $resourceTypeModel?->id;
         }
 
         return response()->json([
@@ -73,7 +73,7 @@ class UploadXmlController extends Controller
             'year' => $year,
             'version' => $version,
             'language' => $language,
-            'resourceType' => $resourceType,
+            'resourceType' => $resourceType !== null ? (string) $resourceType : null,
             'titles' => $titles,
             'licenses' => $licenses,
         ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3813,9 +3813,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
-      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
+      "version": "22.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.3.tgz",
+      "integrity": "sha512-gTVM8js2twdtqM+AE2PdGEe9zGQY4UvmFjan9rZcVb6FGdStfjWoWejdmy4CfWVO9rh5MiYQGZloKAGkJt8lMw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3832,9 +3832,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -16,7 +16,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ResourceType"
+                    "$ref": "#/components/schemas/ElmoResourceType"
                   }
                 }
               }
@@ -56,7 +56,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ErnieResourceType"
+                    "$ref": "#/components/schemas/ElmoResourceType"
                   }
                 }
               }
@@ -73,25 +73,6 @@
         "properties": {
           "id": { "type": "integer", "readOnly": true },
           "name": { "type": "string" }
-        }
-      },
-      "ErnieResourceType": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "integer", "readOnly": true },
-          "name": { "type": "string" },
-          "slug": { "type": "string" },
-          "active": { "type": "boolean" }
-        }
-      },
-      "ResourceType": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "integer", "readOnly": true },
-          "name": { "type": "string" },
-          "slug": { "type": "string" },
-          "active": { "type": "boolean" },
-          "elmo_active": { "type": "boolean" }
         }
       }
     }

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -15,9 +15,7 @@ describe('DataCiteForm', () => {
         Element.prototype.scrollIntoView = () => {};
     });
 
-    const resourceTypes: ResourceType[] = [
-        { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-    ];
+    const resourceTypes: ResourceType[] = [{ id: 1, name: 'Dataset' }];
 
     const titleTypes: TitleType[] = [
         { id: 1, name: 'Main Title', slug: 'main-title' },
@@ -237,7 +235,7 @@ describe('DataCiteForm', () => {
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
                 licenses={licenses}
-                initialResourceType="dataset"
+                initialResourceType="1"
             />,
         );
         expect(screen.getByLabelText('Resource Type', { exact: false })).toHaveTextContent(

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -194,7 +194,7 @@ export default function DataCiteForm({
                                 value={form.resourceType}
                                 onValueChange={(val) => handleChange('resourceType', val)}
                                 options={resourceTypes.map((type) => ({
-                                    value: type.slug,
+                                    value: String(type.id),
                                     label: type.name,
                                 }))}
                                 className="md:col-span-4"

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -4,9 +4,7 @@ import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import Curation from '../curation';
 import type { ResourceType, TitleType, License } from '@/types';
 
-const resourceTypes: ResourceType[] = [
-    { id: 1, name: 'Dataset', slug: 'dataset', active: true },
-];
+const resourceTypes: ResourceType[] = [{ id: 1, name: 'Dataset' }];
 const titleTypes: TitleType[] = [
     { id: 1, name: 'Main Title', slug: 'main-title' },
 ];
@@ -165,12 +163,12 @@ describe('Curation page', () => {
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
-                resourceType="dataset"
-            />, 
+                resourceType="1"
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
-                expect.objectContaining({ initialResourceType: 'dataset' }),
+                expect.objectContaining({ initialResourceType: '1' }),
             ),
         );
     });

--- a/resources/js/pages/__tests__/dashboard.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.test.tsx
@@ -126,7 +126,7 @@ describe('handleXmlFiles', () => {
                         year: '2024',
                         version: '1.0',
                         language: 'en',
-                        resourceType: 'dataset',
+                        resourceType: '1',
                         titles: [
                             { title: 'Example Title', titleType: 'main-title' },
                             { title: 'Example Subtitle', titleType: 'subtitle' },
@@ -149,7 +149,7 @@ describe('handleXmlFiles', () => {
             year: '2024',
             version: '1.0',
             language: 'en',
-            resourceType: 'dataset',
+            resourceType: '1',
             'titles[0][title]': 'Example Title',
             'titles[0][titleType]': 'main-title',
             'titles[1][title]': 'Example Subtitle',
@@ -260,13 +260,13 @@ describe('handleXmlFiles', () => {
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
-                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: null, resourceType: 'dataset' }) } as Response,
+                { ok: true, json: async () => ({ doi: null, year: null, version: null, language: null, resourceType: '1' }) } as Response,
             );
 
         await handleXmlFiles([file]);
 
         expect(fetchMock).toHaveBeenCalled();
-        expect(routerMock.get).toHaveBeenCalledWith('/curation', { resourceType: 'dataset' });
+        expect(routerMock.get).toHaveBeenCalledWith('/curation', { resourceType: '1' });
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -44,9 +44,6 @@ export interface User {
 export interface ResourceType {
     id: number;
     name: string;
-    slug: string;
-    active: boolean;
-    elmo_active?: boolean;
 }
 
 export interface TitleType {

--- a/tests/Feature/AllResourceTypeApiTest.php
+++ b/tests/Feature/AllResourceTypeApiTest.php
@@ -24,14 +24,12 @@ test('returns all resource types', function () {
 
     $response->assertJsonCount(ResourceType::count());
     $response->assertJsonStructure([
-        '*' => ['id', 'name', 'slug', 'active', 'elmo_active'],
+        '*' => ['id', 'name'],
     ]);
     $response->assertJsonFragment([
         'id' => $typeB->id,
         'name' => 'Type B',
-        'slug' => 'type-b',
-        'active' => false,
-        'elmo_active' => false,
     ]);
+    $response->assertJsonMissingPath('0.slug');
 });
 

--- a/tests/Feature/ApiDocEndpointTest.php
+++ b/tests/Feature/ApiDocEndpointTest.php
@@ -17,7 +17,11 @@ it('returns the OpenAPI documentation as JSON', function () {
         ->assertOk()
         ->assertJsonPath('openapi', '3.1.0')
         ->assertJsonPath('paths./api/v1/resource-types/elmo.get.summary', 'List resource types enabled for ELMO')
+        ->assertJsonPath('paths./api/v1/resource-types.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
         ->assertJsonPath('paths./api/v1/resource-types/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
+        ->assertJsonPath('paths./api/v1/resource-types/ernie.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
+        ->assertJsonMissingPath('components.schemas.ResourceType')
+        ->assertJsonMissingPath('components.schemas.ErnieResourceType')
         ->assertJsonPath('components.schemas.ElmoResourceType.properties.id.type', 'integer')
         ->assertJsonPath('components.schemas.ElmoResourceType.properties.name.type', 'string');
 });

--- a/tests/Feature/ResourceTypeApiTest.php
+++ b/tests/Feature/ResourceTypeApiTest.php
@@ -14,6 +14,7 @@ test('returns active resource types for Ernie', function () {
 
     $response->assertJsonCount(ResourceType::where('active', true)->count());
     $response->assertJsonStructure([
-        '*' => ['id', 'name', 'slug', 'active'],
+        '*' => ['id', 'name'],
     ]);
+    $response->assertJsonMissingPath('0.slug');
 });

--- a/tests/Feature/UploadXmlControllerTest.php
+++ b/tests/Feature/UploadXmlControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\ResourceType;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('returns resource type id from uploaded XML', function () {
+    $this->actingAs(User::factory()->create());
+
+    $type = ResourceType::create([
+        'name' => 'Dataset',
+        'slug' => 'dataset',
+        'active' => true,
+        'elmo_active' => true,
+    ]);
+
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <resourceType resourceTypeGeneral="Dataset">Dataset</resourceType>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('test.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertJsonPath('resourceType', (string) $type->id);
+});

--- a/tests/Feature/XmlUploadTest.php
+++ b/tests/Feature/XmlUploadTest.php
@@ -8,7 +8,7 @@ uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 it('extracts doi, publication year, version, language, resource type and titles from uploaded xml, ignoring related item titles', function () {
     $this->actingAs(User::factory()->create());
-    ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
+    $type = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
 
     $xml = <<<XML
 <resource>
@@ -47,7 +47,7 @@ XML;
         'year' => '2024',
         'version' => '1.0',
         'language' => 'de',
-        'resourceType' => 'dataset',
+        'resourceType' => (string) $type->id,
         'titles' => [
             ['title' => 'Example Title', 'titleType' => 'main-title'],
             ['title' => 'Example Subtitle', 'titleType' => 'subtitle'],
@@ -93,7 +93,7 @@ it('handles xml with a single main title', function () {
 
 it('extracts main title from namespaced DataCite xml inside an envelope', function () {
     $this->actingAs(User::factory()->create());
-    ResourceType::create(['name' => 'Book', 'slug' => 'book']);
+    $type = ResourceType::create(['name' => 'Book', 'slug' => 'book']);
 
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -346,7 +346,7 @@ XML;
     $response->assertOk()->assertJson([
         'year' => '1956',
         'language' => 'en',
-        'resourceType' => 'book',
+        'resourceType' => (string) $type->id,
         'titles' => [
             ['title' => 'A mandatory Event', 'titleType' => 'main-title'],
         ],


### PR DESCRIPTION
This pull request standardizes the handling of resource types across the application by removing unused fields from API responses and switching from using the resource type slug to the resource type id (as a string) in both backend and frontend code. It also updates the OpenAPI specification and related tests to reflect these changes, ensuring consistency and simplifying the data model.

**API Response and Data Model Simplification**
- Resource type API endpoints now return only `id` and `name` fields, removing `slug`, `active`, and `elmo_active` from responses. [[1]](diffhunk://#diff-3a99f212e67ffc3aaecd790a0271aba63ea14cf246adab4985291065e4ac1895L17-R17) [[2]](diffhunk://#diff-3a99f212e67ffc3aaecd790a0271aba63ea14cf246adab4985291065e4ac1895L43-R43)
- The OpenAPI schema is updated to use `ElmoResourceType` (with only `id` and `name`) for all resource type endpoints, and the old `ResourceType` and `ErnieResourceType` schemas are removed. [[1]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487L19-R19) [[2]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487L59-R59) [[3]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487L77-L95)

**Switch from Slug to ID for Resource Type**
- The backend now returns the resource type id (as a string) instead of the slug when extracting data from uploaded XML files.
- Frontend components and tests are updated to use the resource type id (as a string) instead of the slug for selection, initial values, and assertions. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L197-R197) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L18-R18) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L240-R238) [[4]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L7-R7) [[5]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L168-R171) [[6]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL129-R129) [[7]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL152-R152) [[8]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL263-R269)

**Test Updates**
- Feature and unit tests are updated to match the new API response structure and the use of resource type id. [[1]](diffhunk://#diff-60907fa8bdc8d839f5be7e38705a263c4897f99f843eac142763dcbc0a756a4bL27-R33) [[2]](diffhunk://#diff-f81ff33cedec1d40d4c20003f4c2e9aa0ca0d386b6294f1c96ddd12cc0c403faL17-R19) [[3]](diffhunk://#diff-7909130d9bf112b5496e91c8091db51ac3c7c1eaa85fa6f17b9cf43a51a93c73R20-R24) [[4]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL11-R11) [[5]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL50-R50) [[6]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL96-R96) [[7]](diffhunk://#diff-3ea9d5b2296b4b6c90be30ff2ded71c0cf42f8d8f6dc047f155bb2ef0e89c7ceL349-R349) [[8]](diffhunk://#diff-b67b16e15c232d4c98c30bbf32cd3af0424362124119122acaaa4d497268dd97R1-R33)