### PR TITLE
Refactor validation into dedicated FormRequests

### DIFF
--- a/app/Http/Controllers/Settings/EditorSettingsController.php
+++ b/app/Http/Controllers/Settings/EditorSettingsController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateSettingsRequest;
 use App\Models\ResourceType;
 use App\Models\Setting;
-use Illuminate\Http\Request;
 use Inertia\Inertia;
 
 class EditorSettingsController extends Controller
@@ -19,17 +19,9 @@ class EditorSettingsController extends Controller
         ]);
     }
 
-    public function update(Request $request)
+    public function update(UpdateSettingsRequest $request)
     {
-        $validated = $request->validate([
-            'resourceTypes' => ['required', 'array'],
-            'resourceTypes.*.id' => ['required', 'integer', 'exists:resource_types,id'],
-            'resourceTypes.*.name' => ['required', 'string'],
-            'resourceTypes.*.active' => ['required', 'boolean'],
-            'resourceTypes.*.elmo_active' => ['required', 'boolean'],
-            'maxTitles' => ['required', 'integer', 'min:1'],
-            'maxLicenses' => ['required', 'integer', 'min:1'],
-        ]);
+        $validated = $request->validated();
 
         foreach ($validated['resourceTypes'] as $type) {
             ResourceType::where('id', $type['id'])->update([

--- a/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/Http/Controllers/Settings/PasswordController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdatePasswordRequest;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
@@ -23,12 +23,9 @@ class PasswordController extends Controller
     /**
      * Update the user's password.
      */
-    public function update(Request $request): RedirectResponse
+    public function update(UpdatePasswordRequest $request): RedirectResponse
     {
-        $validated = $request->validate([
-            'current_password' => ['required', 'current_password'],
-            'password' => ['required', Password::defaults(), 'confirmed'],
-        ]);
+        $validated = $request->validated();
 
         $request->user()->update([
             'password' => Hash::make($validated['password']),

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -2,21 +2,19 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
+use App\Http\Requests\UploadXmlRequest;
 use App\Models\ResourceType;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Str;
 use Saloon\XmlWrangler\XmlReader;
 
 class UploadXmlController extends Controller
 {
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(UploadXmlRequest $request): JsonResponse
     {
-        $request->validate([
-            'file' => ['required', 'file', 'mimes:xml', 'max:4096'],
-        ]);
+        $validated = $request->validated();
 
-        $contents = $request->file('file')->get();
+        $contents = $validated['file']->get();
 
         $reader = XmlReader::fromString($contents);
         $doi = $reader->xpathValue('//*[local-name()="identifier" and @identifierType="DOI"]')->first();

--- a/app/Http/Requests/Settings/UpdatePasswordRequest.php
+++ b/app/Http/Requests/Settings/UpdatePasswordRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class UpdatePasswordRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'current_password' => ['required', 'current_password'],
+            'password' => ['required', Password::defaults(), 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/UpdateSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateSettingsRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSettingsRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'resourceTypes' => ['required', 'array'],
+            'resourceTypes.*.id' => ['required', 'integer', 'exists:resource_types,id'],
+            'resourceTypes.*.name' => ['required', 'string'],
+            'resourceTypes.*.active' => ['required', 'boolean'],
+            'resourceTypes.*.elmo_active' => ['required', 'boolean'],
+            'maxTitles' => ['required', 'integer', 'min:1'],
+            'maxLicenses' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/UploadXmlRequest.php
+++ b/app/Http/Requests/UploadXmlRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadXmlRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'mimes:xml', 'max:4096'],
+        ];
+    }
+}

--- a/tests/Feature/Settings/EditorSettingsTest.php
+++ b/tests/Feature/Settings/EditorSettingsTest.php
@@ -55,3 +55,21 @@ test('authenticated users can update resource types and settings', function () {
     expect(Setting::getValue('max_titles'))->toBe('10');
     expect(Setting::getValue('max_licenses'))->toBe('7');
 });
+
+test('updating settings with invalid data returns errors', function () {
+    $user = User::factory()->create();
+    $type = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
+    $this->actingAs($user);
+
+    $response = $this->from(route('settings'))
+        ->post(route('settings.update'), [
+            'resourceTypes' => [
+                ['id' => $type->id, 'name' => 'Data Set', 'active' => true, 'elmo_active' => false],
+            ],
+            'maxTitles' => 0,
+            'maxLicenses' => 7,
+        ]);
+
+    $response->assertSessionHasErrors('maxTitles')
+        ->assertRedirect(route('settings'));
+});

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -50,3 +50,20 @@ test('correct password must be provided to update password', function () {
         ->assertSessionHasErrors('current_password')
         ->assertRedirect(route('password.edit'));
 });
+
+test('password must be confirmed', function () {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->from(route('password.edit'))
+        ->put(route('password.update'), [
+            'current_password' => 'password',
+            'password' => 'new-password',
+            'password_confirmation' => 'different-password',
+        ]);
+
+    $response
+        ->assertSessionHasErrors('password')
+        ->assertRedirect(route('password.edit'));
+});

--- a/tests/Feature/UploadXmlControllerTest.php
+++ b/tests/Feature/UploadXmlControllerTest.php
@@ -31,3 +31,13 @@ XML;
 
     $response->assertJsonPath('resourceType', (string) $type->id);
 });
+
+test('uploading a non-xml file returns validation errors', function () {
+    $this->actingAs(User::factory()->create());
+
+    $file = UploadedFile::fake()->create('test.txt', 10, 'text/plain');
+
+    $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertStatus(422)
+        ->assertInvalid('file');
+});


### PR DESCRIPTION
This pull request refactors request validation in several controllers by introducing dedicated Form Request classes, improving code clarity and maintainability. It also adds new feature tests to ensure that validation errors are properly handled and returned for invalid inputs.

### Refactoring: Move Validation Logic to Form Requests

* Introduced new Form Request classes: `UpdatePasswordRequest`, `UpdateSettingsRequest`, and `UploadXmlRequest`, each encapsulating their respective validation rules. [[1]](diffhunk://#diff-3efcfdbefb79fdbec9c55f97ffdaff1278f9b4fb3634259414e7a651325a7986R1-R21) [[2]](diffhunk://#diff-9691f0fb86445705547d5fac4688c92c2188dd4635b308e390250ff0b29a2a6fR1-R25) [[3]](diffhunk://#diff-732d797c2fd5ced7dd70044a4da50b9ce18d6b8c501e8141206c086f7ab76e35R1-R19)
* Updated `EditorSettingsController`, `PasswordController`, and `UploadXmlController` to use the new Form Request classes instead of inline validation, simplifying the controller methods. [[1]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28R6-L8) [[2]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28L22-R24) [[3]](diffhunk://#diff-89e25c93bc2cf386da84973771cdf6b6c1220a168564c3a732b942061ed84436R6-L7) [[4]](diffhunk://#diff-89e25c93bc2cf386da84973771cdf6b6c1220a168564c3a732b942061ed84436L26-R28) [[5]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09L5-R17)

### Testing: Add Validation Error Tests

* Added feature tests to verify that invalid data submitted to settings update, password update, and XML upload endpoints correctly returns validation errors. [[1]](diffhunk://#diff-a36bcb4c09d9987dd3b6813c415878e679ee02b1d1b6871be08471bab4462706R58-R75) [[2]](diffhunk://#diff-3e1fc8d8a83536a8c4434ee2f9296726e73333263a32ac74adc58289b0955f4bR53-R69) [[3]](diffhunk://#diff-b67b16e15c232d4c98c30bbf32cd3af0424362124119122acaaa4d497268dd97R34-R43)