### PR TITLE
Group API endpoints under Editor Configuration

### DIFF
--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -4,9 +4,15 @@
     "title": "Ernie API",
     "version": "1.0.0"
   },
+  "tags": [
+    {
+      "name": "Editor Configuration"
+    }
+  ],
   "paths": {
     "/api/v1/resource-types": {
       "get": {
+        "tags": ["Editor Configuration"],
         "summary": "List all resource types",
         "responses": {
           "200": {
@@ -27,6 +33,7 @@
     },
     "/api/v1/resource-types/elmo": {
       "get": {
+        "tags": ["Editor Configuration"],
         "summary": "List resource types enabled for ELMO",
         "responses": {
           "200": {
@@ -47,6 +54,7 @@
     },
     "/api/v1/resource-types/ernie": {
       "get": {
+        "tags": ["Editor Configuration"],
         "summary": "List active resource types for Ernie",
         "responses": {
           "200": {

--- a/tests/Feature/ApiDocEndpointTest.php
+++ b/tests/Feature/ApiDocEndpointTest.php
@@ -12,14 +12,18 @@ it('renders the API documentation with Swagger UI', function () {
         ->assertDontSee('unpkg.com');
 });
 
-it('returns the OpenAPI documentation as JSON', function () {
-    getJson('/api/v1/doc')
-        ->assertOk()
-        ->assertJsonPath('openapi', '3.1.0')
-        ->assertJsonPath('paths./api/v1/resource-types/elmo.get.summary', 'List resource types enabled for ELMO')
-        ->assertJsonPath('paths./api/v1/resource-types.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
-        ->assertJsonPath('paths./api/v1/resource-types/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
-        ->assertJsonPath('paths./api/v1/resource-types/ernie.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
+  it('returns the OpenAPI documentation as JSON', function () {
+      getJson('/api/v1/doc')
+          ->assertOk()
+          ->assertJsonPath('openapi', '3.1.0')
+          ->assertJsonPath('tags.0.name', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/resource-types.get.tags.0', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/resource-types/elmo.get.tags.0', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/resource-types/ernie.get.tags.0', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/resource-types/elmo.get.summary', 'List resource types enabled for ELMO')
+          ->assertJsonPath('paths./api/v1/resource-types.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
+          ->assertJsonPath('paths./api/v1/resource-types/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
+          ->assertJsonPath('paths./api/v1/resource-types/ernie.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
         ->assertJsonMissingPath('components.schemas.ResourceType')
         ->assertJsonMissingPath('components.schemas.ErnieResourceType')
         ->assertJsonPath('components.schemas.ElmoResourceType.properties.id.type', 'integer')


### PR DESCRIPTION
This pull request adds OpenAPI tags for better organization and documentation of the API endpoints related to editor configuration. It also updates the API documentation test to verify the presence of these tags.

OpenAPI documentation improvements:

* Added a new `"Editor Configuration"` tag to the top-level `tags` array in `openapi.json`, and applied this tag to the `/api/v1/resource-types`, `/api/v1/resource-types/elmo`, and `/api/v1/resource-types/ernie` endpoints. [[1]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R7-R15) [[2]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R36) [[3]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R57)

Testing updates:

* Updated `ApiDocEndpointTest.php` to assert that the new `"Editor Configuration"` tag is present in the OpenAPI JSON output and correctly applied to the relevant endpoints.