### PR TITLE
Refactor ResourceType queries with scopes and tests

### DIFF
--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -13,7 +13,7 @@ class ResourceTypeController extends Controller
     public function index(): JsonResponse
     {
         $types = ResourceType::query()
-            ->orderBy('name')
+            ->orderByName()
             ->get(['id', 'name']);
 
         return response()->json($types);
@@ -25,8 +25,9 @@ class ResourceTypeController extends Controller
     public function elmo(): JsonResponse
     {
         $types = ResourceType::query()
-            ->where('active', true)
-            ->where('elmo_active', true)
+            ->active()
+            ->elmoActive()
+            ->orderByName()
             ->get(['id', 'name']);
 
         return response()->json($types);
@@ -38,8 +39,8 @@ class ResourceTypeController extends Controller
     public function ernie(): JsonResponse
     {
         $types = ResourceType::query()
-            ->where('active', true)
-            ->orderBy('name')
+            ->active()
+            ->orderByName()
             ->get(['id', 'name']);
 
         return response()->json($types);

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class ResourceType extends Model
 {
@@ -20,4 +21,19 @@ class ResourceType extends Model
         'active' => 'boolean',
         'elmo_active' => 'boolean',
     ];
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    public function scopeElmoActive(Builder $query): Builder
+    {
+        return $query->where('elmo_active', true);
+    }
+
+    public function scopeOrderByName(Builder $query): Builder
+    {
+        return $query->orderBy('name');
+    }
 }

--- a/tests/Feature/ResourceTypeControllerTest.php
+++ b/tests/Feature/ResourceTypeControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\ResourceType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ResourceType::create(['name' => 'Alpha', 'slug' => 'alpha', 'active' => true, 'elmo_active' => true]);
+    ResourceType::create(['name' => 'Bravo', 'slug' => 'bravo', 'active' => true, 'elmo_active' => false]);
+    ResourceType::create(['name' => 'Charlie', 'slug' => 'charlie', 'active' => false, 'elmo_active' => true]);
+    ResourceType::create(['name' => 'Delta', 'slug' => 'delta', 'active' => false, 'elmo_active' => false]);
+});
+
+test('returns all resource types ordered by name', function () {
+    $response = $this->getJson('/api/v1/resource-types')->assertOk();
+    expect($response->json())->toHaveCount(4);
+    expect(array_column($response->json(), 'name'))->toBe([
+        'Alpha',
+        'Bravo',
+        'Charlie',
+        'Delta',
+    ]);
+});
+
+test('returns only active resource types for Ernie', function () {
+    $response = $this->getJson('/api/v1/resource-types/ernie')->assertOk();
+    expect($response->json())->toHaveCount(2);
+    expect(array_column($response->json(), 'name'))->toBe([
+        'Alpha',
+        'Bravo',
+    ]);
+});
+
+test('returns only active and elmo-active resource types', function () {
+    $response = $this->getJson('/api/v1/resource-types/elmo')->assertOk();
+    expect($response->json())->toHaveCount(1);
+    expect(array_column($response->json(), 'name'))->toBe([
+        'Alpha',
+    ]);
+});


### PR DESCRIPTION
This pull request refactors the way resource types are queried in the `ResourceTypeController` by introducing query scopes in the `ResourceType` model for common filters and ordering. It also adds comprehensive feature tests to ensure correct behavior for each endpoint.

**Model enhancements:**

* Added query scopes to `ResourceType` model: `active`, `elmoActive`, and `orderByName` for reusable and readable query logic.

**Controller refactoring:**

* Updated `ResourceTypeController` to use the new model scopes in its `index`, `elmo`, and `ernie` methods, improving readability and maintainability. [[1]](diffhunk://#diff-3a99f212e67ffc3aaecd790a0271aba63ea14cf246adab4985291065e4ac1895L16-R16) [[2]](diffhunk://#diff-3a99f212e67ffc3aaecd790a0271aba63ea14cf246adab4985291065e4ac1895L28-R30) [[3]](diffhunk://#diff-3a99f212e67ffc3aaecd790a0271aba63ea14cf246adab4985291065e4ac1895L41-R43)

**Testing improvements:**

* Added new feature tests in `ResourceTypeControllerTest.php` to verify correct filtering and ordering for all resource type endpoints.

**Code quality:**

* Added missing import for `Illuminate\Database\Eloquent\Builder` in `ResourceType.php` to support the new scopes.