### PR TITLE
feat: add configurable title types

### DIFF
--- a/app/Http/Controllers/Settings/EditorSettingsController.php
+++ b/app/Http/Controllers/Settings/EditorSettingsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Settings;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\UpdateSettingsRequest;
 use App\Models\ResourceType;
+use App\Models\TitleType;
 use App\Models\Setting;
 use Inertia\Inertia;
 
@@ -14,6 +15,7 @@ class EditorSettingsController extends Controller
     {
         return Inertia::render('settings/index', [
             'resourceTypes' => ResourceType::orderBy('id')->get(['id', 'name', 'active', 'elmo_active']),
+            'titleTypes' => TitleType::orderBy('id')->get(['id', 'name', 'slug', 'active', 'elmo_active']),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),
             'maxLicenses' => (int) Setting::getValue('max_licenses', Setting::DEFAULT_LIMIT),
         ]);
@@ -26,6 +28,15 @@ class EditorSettingsController extends Controller
         foreach ($validated['resourceTypes'] as $type) {
             ResourceType::where('id', $type['id'])->update([
                 'name' => $type['name'],
+                'active' => $type['active'],
+                'elmo_active' => $type['elmo_active'],
+            ]);
+        }
+
+        foreach ($validated['titleTypes'] as $type) {
+            TitleType::where('id', $type['id'])->update([
+                'name' => $type['name'],
+                'slug' => $type['slug'],
                 'active' => $type['active'],
                 'elmo_active' => $type['elmo_active'],
             ]);

--- a/app/Http/Controllers/TitleTypeController.php
+++ b/app/Http/Controllers/TitleTypeController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TitleType;
+use Illuminate\Http\JsonResponse;
+
+class TitleTypeController extends Controller
+{
+    /**
+     * Return all title types.
+     */
+    public function index(): JsonResponse
+    {
+        $types = TitleType::query()
+            ->orderByName()
+            ->get(['id', 'name', 'slug']);
+
+        return response()->json($types);
+    }
+
+    /**
+     * Return all title types that are active for ELMO.
+     */
+    public function elmo(): JsonResponse
+    {
+        $types = TitleType::query()
+            ->active()
+            ->elmoActive()
+            ->orderByName()
+            ->get(['id', 'name', 'slug']);
+
+        return response()->json($types);
+    }
+
+    /**
+     * Return all title types that are active for Ernie.
+     */
+    public function ernie(): JsonResponse
+    {
+        $types = TitleType::query()
+            ->active()
+            ->orderByName()
+            ->get(['id', 'name', 'slug']);
+
+        return response()->json($types);
+    }
+}

--- a/app/Http/Requests/Settings/UpdateSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateSettingsRequest.php
@@ -18,6 +18,12 @@ class UpdateSettingsRequest extends FormRequest
             'resourceTypes.*.name' => ['required', 'string'],
             'resourceTypes.*.active' => ['required', 'boolean'],
             'resourceTypes.*.elmo_active' => ['required', 'boolean'],
+            'titleTypes' => ['required', 'array'],
+            'titleTypes.*.id' => ['required', 'integer', 'exists:title_types,id'],
+            'titleTypes.*.name' => ['required', 'string'],
+            'titleTypes.*.slug' => ['required', 'string'],
+            'titleTypes.*.active' => ['required', 'boolean'],
+            'titleTypes.*.elmo_active' => ['required', 'boolean'],
             'maxTitles' => ['required', 'integer', 'min:1'],
             'maxLicenses' => ['required', 'integer', 'min:1'],
         ];

--- a/app/Models/TitleType.php
+++ b/app/Models/TitleType.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class TitleType extends Model
 {
@@ -12,5 +13,27 @@ class TitleType extends Model
     protected $fillable = [
         'name',
         'slug',
+        'active',
+        'elmo_active',
     ];
+
+    protected $casts = [
+        'active' => 'boolean',
+        'elmo_active' => 'boolean',
+    ];
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    public function scopeElmoActive(Builder $query): Builder
+    {
+        return $query->where('elmo_active', true);
+    }
+
+    public function scopeOrderByName(Builder $query): Builder
+    {
+        return $query->orderBy('name');
+    }
 }

--- a/database/migrations/2025_09_13_000002_add_active_to_title_types_table.php
+++ b/database/migrations/2025_09_13_000002_add_active_to_title_types_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('title_types', function (Blueprint $table) {
+            $table->boolean('active')->default(true)->after('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('title_types', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/database/migrations/2025_09_13_000003_add_elmo_active_to_title_types_table.php
+++ b/database/migrations/2025_09_13_000003_add_elmo_active_to_title_types_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('title_types', function (Blueprint $table) {
+            $table->boolean('elmo_active')->default(false)->after('active');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('title_types', function (Blueprint $table) {
+            $table->dropColumn('elmo_active');
+        });
+    }
+};

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -72,6 +72,69 @@
           }
         }
       }
+    },
+    "/api/v1/title-types": {
+      "get": {
+        "tags": ["Editor Configuration"],
+        "summary": "List all title types",
+        "responses": {
+          "200": {
+            "description": "List of title types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TitleType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/title-types/elmo": {
+      "get": {
+        "tags": ["Editor Configuration"],
+        "summary": "List title types enabled for ELMO",
+        "responses": {
+          "200": {
+            "description": "List of title types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TitleType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/title-types/ernie": {
+      "get": {
+        "tags": ["Editor Configuration"],
+        "summary": "List active title types for Ernie",
+        "responses": {
+          "200": {
+            "description": "List of title types",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TitleType"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -81,6 +144,14 @@
         "properties": {
           "id": { "type": "integer", "readOnly": true },
           "name": { "type": "string" }
+        }
+      },
+      "TitleType": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "readOnly": true },
+          "name": { "type": "string" },
+          "slug": { "type": "string" }
         }
       }
     }

--- a/resources/js/pages/__tests__/curation.integration.test.tsx
+++ b/resources/js/pages/__tests__/curation.integration.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest';
 import { render } from '@testing-library/react';
 import Curation from '../curation';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import type { TitleType, License } from '@/types';
+import type { License } from '@/types';
 
 vi.mock('@/layouts/app-layout', () => ({
     default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -30,15 +30,9 @@ describe('Curation integration', () => {
     });
 
     it('sets the document title', () => {
-        const titleTypes: TitleType[] = [];
         const licenses: License[] = [];
         render(
-            <Curation
-                titleTypes={titleTypes}
-                licenses={licenses}
-                maxTitles={99}
-                maxLicenses={99}
-            />,
+            <Curation licenses={licenses} maxTitles={99} maxLicenses={99} />,
         );
         expect(document.title).toBe('Curation');
     });

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -71,6 +71,19 @@ describe('Curation page', () => {
         );
     });
 
+    it('shows loading state when only one type set has loaded', async () => {
+        const unresolved = new Promise<unknown>(() => {});
+        (fetch as unknown as vi.Mock).mockImplementation((url: RequestInfo) =>
+            url.toString().includes('resource-types')
+                ? Promise.resolve({ ok: true, json: () => Promise.resolve(resourceTypes) })
+                : unresolved,
+        );
+        render(<Curation licenses={licenses} maxTitles={99} maxLicenses={99} />);
+        expect(screen.getByRole('status')).toHaveTextContent(
+            /loading resource and title types/i,
+        );
+    });
+
     it('passes limits to DataCiteForm', async () => {
         render(
             <Curation licenses={licenses} maxTitles={5} maxLicenses={7} />,

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -32,9 +32,20 @@ vi.mock('@/components/curation/datacite-form', () => ({
 describe('Curation page', () => {
     beforeEach(() => {
         renderForm.mockClear();
-        vi.stubGlobal('fetch', vi.fn(() =>
-            Promise.resolve({ ok: true, json: () => Promise.resolve(resourceTypes) }),
-        ));
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((url: RequestInfo) =>
+                Promise.resolve({
+                    ok: true,
+                    json: () =>
+                        Promise.resolve(
+                            url.toString().includes('resource-types')
+                                ? resourceTypes
+                                : titleTypes,
+                        ),
+                }),
+            ),
+        );
     });
 
     afterEach(() => {
@@ -42,14 +53,7 @@ describe('Curation page', () => {
     });
 
     it('fetches resource types and passes data to DataCiteForm', async () => {
-        render(
-            <Curation
-                titleTypes={titleTypes}
-                licenses={licenses}
-                maxTitles={99}
-                maxLicenses={99}
-            />, 
-        );
+        render(<Curation licenses={licenses} maxTitles={99} maxLicenses={99} />);
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
                 expect.objectContaining({ resourceTypes, titleTypes, licenses }),
@@ -57,29 +61,19 @@ describe('Curation page', () => {
         );
     });
 
-    it('shows loading state before resource types load', () => {
+    it('shows loading state before types load', () => {
         (fetch as unknown as vi.Mock).mockImplementation(
             () => new Promise(() => {}),
         );
-        render(
-            <Curation
-                titleTypes={titleTypes}
-                licenses={licenses}
-                maxTitles={99}
-                maxLicenses={99}
-            />, 
+        render(<Curation licenses={licenses} maxTitles={99} maxLicenses={99} />);
+        expect(screen.getByRole('status')).toHaveTextContent(
+            /loading resource and title types/i,
         );
-        expect(screen.getByRole('status')).toHaveTextContent(/loading resource types/i);
     });
 
     it('passes limits to DataCiteForm', async () => {
         render(
-            <Curation
-                titleTypes={titleTypes}
-                licenses={licenses}
-                maxTitles={5}
-                maxLicenses={7}
-            />, 
+            <Curation licenses={licenses} maxTitles={5} maxLicenses={7} />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
@@ -91,12 +85,11 @@ describe('Curation page', () => {
     it('passes doi to DataCiteForm when provided', async () => {
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 doi="10.1234/xyz"
-            />, 
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
@@ -108,12 +101,11 @@ describe('Curation page', () => {
     it('passes year to DataCiteForm when provided', async () => {
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 year="2024"
-            />, 
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
@@ -125,12 +117,11 @@ describe('Curation page', () => {
     it('passes version to DataCiteForm when provided', async () => {
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 version="2.0"
-            />, 
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
@@ -142,12 +133,11 @@ describe('Curation page', () => {
     it('passes language to DataCiteForm when provided', async () => {
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 language="de"
-            />, 
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
@@ -159,7 +149,6 @@ describe('Curation page', () => {
     it('passes resource type to DataCiteForm when provided', async () => {
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
@@ -180,12 +169,11 @@ describe('Curation page', () => {
         ];
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 titles={titles}
-            />, 
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
@@ -198,12 +186,11 @@ describe('Curation page', () => {
         const initialLicenses = ['MIT'];
         render(
             <Curation
-                titleTypes={titleTypes}
                 licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 initialLicenses={initialLicenses}
-            />, 
+            />,
         );
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(

--- a/resources/js/pages/__tests__/settings.test.tsx
+++ b/resources/js/pages/__tests__/settings.test.tsx
@@ -113,5 +113,21 @@ describe('EditorSettings page', () => {
             { id: 1, name: 'Dataset', active: true, elmo_active: true },
         ]);
     });
+
+    it('renders limit fields without extra top margin', () => {
+        const resourceTypes = [
+            { id: 1, name: 'Dataset', active: true, elmo_active: false },
+        ];
+        render(
+            <EditorSettings
+                resourceTypes={resourceTypes}
+                titleTypes={[]}
+                maxTitles={1}
+                maxLicenses={1}
+            />,
+        );
+        const grid = screen.getByLabelText('Max Titles').closest('div')!.parentElement;
+        expect(grid).not.toHaveClass('mt-8');
+    });
 });
 

--- a/resources/js/pages/__tests__/settings.test.tsx
+++ b/resources/js/pages/__tests__/settings.test.tsx
@@ -55,16 +55,25 @@ describe('EditorSettings page', () => {
             { id: 1, name: 'Dataset', active: true, elmo_active: false },
         ];
         render(
-            <EditorSettings resourceTypes={resourceTypes} maxTitles={1} maxLicenses={1} />,
+            <EditorSettings
+                resourceTypes={resourceTypes}
+                titleTypes={[]}
+                maxTitles={1}
+                maxLicenses={1}
+            />,
         );
-        const ernieHeader = screen.getByRole('columnheader', { name: 'ERNIE active' });
+        const [ernieHeader] = screen.getAllByRole('columnheader', {
+            name: 'ERNIE active',
+        });
         expect(ernieHeader).toHaveClass('text-center');
         expect(ernieHeader.innerHTML).toContain('ERNIE<br');
-        const elmoHeader = screen.getByRole('columnheader', { name: 'ELMO active' });
+        const [elmoHeader] = screen.getAllByRole('columnheader', {
+            name: 'ELMO active',
+        });
         expect(elmoHeader).toHaveClass('text-center');
         expect(elmoHeader.innerHTML).toContain('ELMO<br');
-        const ernieCell = screen.getByLabelText('ERNIE active').closest('td')!;
-        const elmoCell = screen.getByLabelText('ELMO active').closest('td')!;
+        const ernieCell = screen.getAllByLabelText('ERNIE active')[0].closest('td')!;
+        const elmoCell = screen.getAllByLabelText('ELMO active')[0].closest('td')!;
         expect(ernieCell).toHaveClass('text-center');
         expect(elmoCell).toHaveClass('text-center');
     });
@@ -74,7 +83,12 @@ describe('EditorSettings page', () => {
             { id: 1, name: 'Dataset', active: false, elmo_active: false },
         ];
         render(
-            <EditorSettings resourceTypes={resourceTypes} maxTitles={1} maxLicenses={1} />,
+            <EditorSettings
+                resourceTypes={resourceTypes}
+                titleTypes={[]}
+                maxTitles={1}
+                maxLicenses={1}
+            />,
         );
         fireEvent.click(screen.getByLabelText('ERNIE active'));
         expect(setData).toHaveBeenCalledWith('resourceTypes', [
@@ -87,7 +101,12 @@ describe('EditorSettings page', () => {
             { id: 1, name: 'Dataset', active: true, elmo_active: false },
         ];
         render(
-            <EditorSettings resourceTypes={resourceTypes} maxTitles={1} maxLicenses={1} />,
+            <EditorSettings
+                resourceTypes={resourceTypes}
+                titleTypes={[]}
+                maxTitles={1}
+                maxLicenses={1}
+            />,
         );
         fireEvent.click(screen.getByLabelText('ELMO active'));
         expect(setData).toHaveBeenCalledWith('resourceTypes', [

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -74,7 +74,7 @@ export default function Curation({
                         Unable to load resource or title types.
                     </p>
                 )}
-                {resourceTypes === null && titleTypes === null && !error && (
+                {(resourceTypes === null || titleTypes === null) && !error && (
                     <p role="status" aria-live="polite">
                         Loading resource and title types...
                     </p>

--- a/resources/js/pages/settings/__tests__/editor.test.tsx
+++ b/resources/js/pages/settings/__tests__/editor.test.tsx
@@ -39,22 +39,33 @@ vi.mock('@/components/ui/label', () => ({
 }));
 
 describe('EditorSettings page', () => {
-    it('renders resource types and settings fields', () => {
+    it('renders resource and title types and settings fields', () => {
         render(
             <EditorSettings
                 resourceTypes={[{ id: 1, name: 'Dataset', active: true, elmo_active: false }]}
+                titleTypes={[{ id: 1, name: 'Main Title', slug: 'main-title', active: true, elmo_active: false }]}
                 maxTitles={10}
                 maxLicenses={5}
             />,
         );
-        expect(screen.getByLabelText('Name')).toBeInTheDocument();
-        expect(screen.getByLabelText('ERNIE active')).toBeInTheDocument();
-        expect(screen.getByLabelText('ELMO active')).toBeInTheDocument();
+        expect(screen.getAllByLabelText('Name')).toHaveLength(2);
+        expect(screen.getAllByLabelText('ERNIE active')).toHaveLength(2);
+        expect(screen.getAllByLabelText('ELMO active')).toHaveLength(2);
+        expect(screen.getByLabelText('Slug')).toBeInTheDocument();
         expect(screen.getByLabelText('Max Titles')).toBeInTheDocument();
         expect(screen.getByLabelText('Max Licenses')).toBeInTheDocument();
         expect(useFormMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 resourceTypes: [{ id: 1, name: 'Dataset', active: true, elmo_active: false }],
+                titleTypes: [
+                    {
+                        id: 1,
+                        name: 'Main Title',
+                        slug: 'main-title',
+                        active: true,
+                        elmo_active: false,
+                    },
+                ],
                 maxTitles: 10,
                 maxLicenses: 5,
             }),

--- a/resources/js/pages/settings/index.tsx
+++ b/resources/js/pages/settings/index.tsx
@@ -157,7 +157,7 @@ export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, m
                 </div>
 
                 <div>
-                    <h2 className="mb-4 mt-8 text-lg font-semibold">Title Types</h2>
+                    <h2 className="mb-4 text-lg font-semibold">Title Types</h2>
                     <table className="w-full border-collapse">
                         <thead>
                             <tr className="text-left">
@@ -226,7 +226,7 @@ export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, m
                     </table>
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2 mt-8">
+                <div className="grid gap-4 md:grid-cols-2">
                     <div className="grid gap-2">
                         <Label htmlFor="maxTitles">Max Titles</Label>
                         <Input

--- a/resources/js/pages/settings/index.tsx
+++ b/resources/js/pages/settings/index.tsx
@@ -14,21 +14,37 @@ interface ResourceTypeRow {
     elmo_active: boolean;
 }
 
+interface TitleTypeRow {
+    id: number;
+    name: string;
+    slug: string;
+    active: boolean;
+    elmo_active: boolean;
+}
+
 interface EditorSettingsProps {
     resourceTypes: ResourceTypeRow[];
+    titleTypes: TitleTypeRow[];
     maxTitles: number;
     maxLicenses: number;
 }
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Editor Settings', href: settings().url }];
 
-export default function EditorSettings({ resourceTypes, maxTitles, maxLicenses }: EditorSettingsProps) {
+export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, maxLicenses }: EditorSettingsProps) {
     const { data, setData, post, processing } = useForm({
         resourceTypes: resourceTypes.map((r) => ({
             id: r.id,
             name: r.name,
             active: r.active,
             elmo_active: r.elmo_active,
+        })),
+        titleTypes: titleTypes.map((t) => ({
+            id: t.id,
+            name: t.name,
+            slug: t.slug,
+            active: t.active,
+            elmo_active: t.elmo_active,
         })),
         maxTitles,
         maxLicenses,
@@ -52,6 +68,27 @@ export default function EditorSettings({ resourceTypes, maxTitles, maxLicenses }
         setData(
             'resourceTypes',
             data.resourceTypes.map((r, i) => (i === index ? { ...r, elmo_active: value } : r)),
+        );
+    };
+
+    const handleTitleTypeChange = (index: number, field: 'name' | 'slug', value: string) => {
+        setData(
+            'titleTypes',
+            data.titleTypes.map((t, i) => (i === index ? { ...t, [field]: value } : t)),
+        );
+    };
+
+    const handleTitleActiveChange = (index: number, value: boolean) => {
+        setData(
+            'titleTypes',
+            data.titleTypes.map((t, i) => (i === index ? { ...t, active: value } : t)),
+        );
+    };
+
+    const handleTitleElmoActiveChange = (index: number, value: boolean) => {
+        setData(
+            'titleTypes',
+            data.titleTypes.map((t, i) => (i === index ? { ...t, elmo_active: value } : t)),
         );
     };
 
@@ -119,7 +156,77 @@ export default function EditorSettings({ resourceTypes, maxTitles, maxLicenses }
                     </table>
                 </div>
 
-                <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                    <h2 className="mb-4 mt-8 text-lg font-semibold">Title Types</h2>
+                    <table className="w-full border-collapse">
+                        <thead>
+                            <tr className="text-left">
+                                <th className="border-b p-2">ID</th>
+                                <th className="border-b p-2">Name</th>
+                                <th className="border-b p-2">Slug</th>
+                                <th className="border-b p-2 text-center">ERNIE<br />active</th>
+                                <th className="border-b p-2 text-center">ELMO<br />active</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data.titleTypes.map((type, index) => (
+                                <tr key={type.id}>
+                                    <td className="border-b p-2">{type.id}</td>
+                                    <td className="border-b p-2">
+                                        <Label htmlFor={`tt-name-${type.id}`} className="sr-only">
+                                            Name
+                                        </Label>
+                                        <Input
+                                            id={`tt-name-${type.id}`}
+                                            value={type.name}
+                                            onChange={(e) =>
+                                                handleTitleTypeChange(index, 'name', e.target.value)
+                                            }
+                                        />
+                                    </td>
+                                    <td className="border-b p-2">
+                                        <Label htmlFor={`tt-slug-${type.id}`} className="sr-only">
+                                            Slug
+                                        </Label>
+                                        <Input
+                                            id={`tt-slug-${type.id}`}
+                                            value={type.slug}
+                                            onChange={(e) =>
+                                                handleTitleTypeChange(index, 'slug', e.target.value)
+                                            }
+                                        />
+                                    </td>
+                                    <td className="border-b p-2 text-center">
+                                        <Label htmlFor={`tt-active-${type.id}`} className="sr-only">
+                                            ERNIE active
+                                        </Label>
+                                        <Checkbox
+                                            id={`tt-active-${type.id}`}
+                                            checked={type.active}
+                                            onCheckedChange={(checked) =>
+                                                handleTitleActiveChange(index, checked === true)
+                                            }
+                                        />
+                                    </td>
+                                    <td className="border-b p-2 text-center">
+                                        <Label htmlFor={`tt-elmo-active-${type.id}`} className="sr-only">
+                                            ELMO active
+                                        </Label>
+                                        <Checkbox
+                                            id={`tt-elmo-active-${type.id}`}
+                                            checked={type.elmo_active}
+                                            onCheckedChange={(checked) =>
+                                                handleTitleElmoActiveChange(index, checked === true)
+                                            }
+                                        />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2 mt-8">
                     <div className="grid gap-2">
                         <Label htmlFor="maxTitles">Max Titles</Label>
                         <Input

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ApiDocController;
 use App\Http\Controllers\ChangelogController;
 use App\Http\Controllers\ResourceTypeController;
+use App\Http\Controllers\TitleTypeController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/changelog', [ChangelogController::class, 'index']);
@@ -10,4 +11,7 @@ Route::get('/changelog', [ChangelogController::class, 'index']);
 Route::get('/v1/resource-types', [ResourceTypeController::class, 'index']);
 Route::get('/v1/resource-types/elmo', [ResourceTypeController::class, 'elmo']);
 Route::get('/v1/resource-types/ernie', [ResourceTypeController::class, 'ernie']);
+Route::get('/v1/title-types', [TitleTypeController::class, 'index']);
+Route::get('/v1/title-types/elmo', [TitleTypeController::class, 'elmo']);
+Route::get('/v1/title-types/ernie', [TitleTypeController::class, 'ernie']);
 Route::get('/v1/doc', ApiDocController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Models\ResourceType;
-use App\Models\TitleType;
 use App\Http\Controllers\UploadXmlController;
 use App\Models\License;
 use App\Models\Setting;
@@ -42,7 +40,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('curation', function (\Illuminate\Http\Request $request) {
         return Inertia::render('curation', [
-            'titleTypes' => TitleType::orderBy('name')->get(),
             'licenses' => License::orderBy('name')->get(),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),
             'maxLicenses' => (int) Setting::getValue('max_licenses', Setting::DEFAULT_LIMIT),

--- a/tests/Feature/AllTitleTypeApiTest.php
+++ b/tests/Feature/AllTitleTypeApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\TitleType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('returns all title types', function () {
+    $typeA = TitleType::create([
+        'name' => 'Main',
+        'slug' => 'main',
+        'active' => true,
+        'elmo_active' => true,
+    ]);
+
+    $typeB = TitleType::create([
+        'name' => 'Alt',
+        'slug' => 'alt',
+        'active' => false,
+        'elmo_active' => false,
+    ]);
+
+    $response = $this->getJson('/api/v1/title-types')->assertOk();
+
+    $response->assertJsonCount(TitleType::count());
+    $response->assertJsonFragment(['id' => $typeB->id, 'name' => 'Alt', 'slug' => 'alt']);
+    $response->assertJsonStructure([
+        '*' => ['id', 'name', 'slug'],
+    ]);
+});

--- a/tests/Feature/ApiDocEndpointTest.php
+++ b/tests/Feature/ApiDocEndpointTest.php
@@ -20,14 +20,22 @@ it('renders the API documentation with Swagger UI', function () {
           ->assertJsonPath('paths./api/v1/resource-types.get.tags.0', 'Editor Configuration')
           ->assertJsonPath('paths./api/v1/resource-types/elmo.get.tags.0', 'Editor Configuration')
           ->assertJsonPath('paths./api/v1/resource-types/ernie.get.tags.0', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/title-types.get.tags.0', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/title-types/elmo.get.tags.0', 'Editor Configuration')
+          ->assertJsonPath('paths./api/v1/title-types/ernie.get.tags.0', 'Editor Configuration')
           ->assertJsonPath('paths./api/v1/resource-types/elmo.get.summary', 'List resource types enabled for ELMO')
+          ->assertJsonPath('paths./api/v1/title-types/elmo.get.summary', 'List title types enabled for ELMO')
           ->assertJsonPath('paths./api/v1/resource-types.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
           ->assertJsonPath('paths./api/v1/resource-types/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
           ->assertJsonPath('paths./api/v1/resource-types/ernie.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/ElmoResourceType')
+          ->assertJsonPath('paths./api/v1/title-types.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/TitleType')
+          ->assertJsonPath('paths./api/v1/title-types/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/TitleType')
+          ->assertJsonPath('paths./api/v1/title-types/ernie.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/TitleType')
         ->assertJsonMissingPath('components.schemas.ResourceType')
         ->assertJsonMissingPath('components.schemas.ErnieResourceType')
         ->assertJsonPath('components.schemas.ElmoResourceType.properties.id.type', 'integer')
-        ->assertJsonPath('components.schemas.ElmoResourceType.properties.name.type', 'string');
+        ->assertJsonPath('components.schemas.ElmoResourceType.properties.name.type', 'string')
+        ->assertJsonPath('components.schemas.TitleType.properties.slug.type', 'string');
 });
 
 it('returns 500 when the OpenAPI file is missing (JSON)', function () {

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -1,9 +1,7 @@
 <?php
 
 use App\Models\User;
-use App\Models\TitleType;
 use App\Models\License;
-use Database\Seeders\TitleTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use function Pest\Laravel\withoutVite;
@@ -14,8 +12,7 @@ test('guests are redirected to login page', function () {
     $this->get(route('curation'))->assertRedirect(route('login'));
 });
 
-test('authenticated users can view curation page with title types and licenses', function () {
-    $this->seed([TitleTypeSeeder::class]);
+test('authenticated users can view curation page with licenses', function () {
     License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
     $this->actingAs(User::factory()->create());
 
@@ -25,7 +22,6 @@ test('authenticated users can view curation page with title types and licenses',
 
     $response->assertInertia(fn (Assert $page) =>
         $page->component('curation')
-            ->has('titleTypes', TitleType::count())
             ->has('licenses', License::count())
             ->where('titles', [])
     );

--- a/tests/Feature/ElmoTitleTypeApiTest.php
+++ b/tests/Feature/ElmoTitleTypeApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\TitleType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\getJson;
+
+uses(RefreshDatabase::class);
+
+it('returns only title types enabled for ELMO', function () {
+    $enabled = TitleType::create([
+        'name' => 'Main',
+        'slug' => 'main',
+        'active' => true,
+        'elmo_active' => true,
+    ]);
+
+    TitleType::create([
+        'name' => 'Alt',
+        'slug' => 'alt',
+        'active' => true,
+        'elmo_active' => false,
+    ]);
+
+    $response = getJson('/api/v1/title-types/elmo')
+        ->assertOk()
+        ->assertJsonCount(1);
+
+    expect($response->json('0'))
+        ->toBe(['id' => $enabled->id, 'name' => 'Main', 'slug' => 'main']);
+});

--- a/tests/Feature/TitleTypeApiTest.php
+++ b/tests/Feature/TitleTypeApiTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\TitleType;
+use Database\Seeders\TitleTypeSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('returns active title types for Ernie', function () {
+    $this->seed(TitleTypeSeeder::class);
+    TitleType::create(['name' => 'Inactive', 'slug' => 'inactive', 'active' => false]);
+
+    $response = $this->getJson('/api/v1/title-types/ernie')->assertOk();
+
+    $response->assertJsonCount(TitleType::where('active', true)->count());
+    $response->assertJsonStructure([
+        '*' => ['id', 'name', 'slug'],
+    ]);
+});

--- a/tests/Feature/TitleTypeControllerTest.php
+++ b/tests/Feature/TitleTypeControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\TitleType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    TitleType::create(['name' => 'Alpha', 'slug' => 'alpha', 'active' => true, 'elmo_active' => true]);
+    TitleType::create(['name' => 'Bravo', 'slug' => 'bravo', 'active' => true, 'elmo_active' => false]);
+    TitleType::create(['name' => 'Charlie', 'slug' => 'charlie', 'active' => false, 'elmo_active' => true]);
+    TitleType::create(['name' => 'Delta', 'slug' => 'delta', 'active' => false, 'elmo_active' => false]);
+});
+
+test('returns all title types ordered by name', function () {
+    $response = $this->getJson('/api/v1/title-types')->assertOk();
+    expect($response->json())->toHaveCount(4);
+    expect(array_column($response->json(), 'name'))->toBe([
+        'Alpha',
+        'Bravo',
+        'Charlie',
+        'Delta',
+    ]);
+});
+
+test('returns only active title types for Ernie', function () {
+    $response = $this->getJson('/api/v1/title-types/ernie')->assertOk();
+    expect($response->json())->toHaveCount(2);
+    expect(array_column($response->json(), 'name'))->toBe([
+        'Alpha',
+        'Bravo',
+    ]);
+});
+
+test('returns only active and elmo-active title types', function () {
+    $response = $this->getJson('/api/v1/title-types/elmo')->assertOk();
+    expect($response->json())->toHaveCount(1);
+    expect(array_column($response->json(), 'name'))->toBe([
+        'Alpha',
+    ]);
+});

--- a/tests/Unit/TitleTypeSeederTest.php
+++ b/tests/Unit/TitleTypeSeederTest.php
@@ -10,4 +10,6 @@ uses(TestCase::class, RefreshDatabase::class);
 test('title types are seeded', function () {
     $this->seed(TitleTypeSeeder::class);
     expect(TitleType::count())->toBe(5);
+    expect(TitleType::where('active', true)->count())->toBe(5);
+    expect(TitleType::where('elmo_active', true)->count())->toBe(0);
 });


### PR DESCRIPTION
This pull request introduces support for managing "Title Types" alongside "Resource Types" throughout the application, including backend models, migrations, API endpoints, validation, and frontend integration. The changes add new fields to the `title_types` table, expose new API endpoints, and update settings and curation logic to handle title types in a consistent way similar to resource types.

**Backend: Title Types Model, Migration, and API**

* Added `active` and `elmo_active` boolean columns to the `title_types` table via new migrations, and updated the `TitleType` model to include fillable fields, casting, and query scopes for these attributes. [[1]](diffhunk://#diff-c37069a788f6de0bf377a2a403e3cc153bd8b62c073209a5595c1e0837190987R16-R38) [[2]](diffhunk://#diff-d0446bd3f113167d14b6ccb5c71b3454055c81b05cae9294c5b5d14188e57fecR1-R21) [[3]](diffhunk://#diff-b4ce02dd9e85a1d14c10d86269b7144a8a26f4dc5f02c18f69ae077dda202271R1-R21)
* Created a new `TitleTypeController` with endpoints to list all title types, ELMO-enabled title types, and active title types for Ernie.
* Updated OpenAPI documentation to describe the new `/api/v1/title-types`, `/api/v1/title-types/elmo`, and `/api/v1/title-types/ernie` endpoints, and added a `TitleType` schema. [[1]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R75-R137) [[2]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R148-R155)

**Settings Management**

* Updated `EditorSettingsController` to load and update title types in addition to resource types, and adjusted validation rules in `UpdateSettingsRequest` to include title types. [[1]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28R8) [[2]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28R18) [[3]](diffhunk://#diff-e8f817248eccf4c0b43617178bdab1b189b2d15c765b227b844c48a431022c28R36-R44) [[4]](diffhunk://#diff-9691f0fb86445705547d5fac4688c92c2188dd4635b308e390250ff0b29a2a6fR21-R26)

**Frontend and Tests**

* Updated frontend tests for the Curation and EditorSettings pages to handle the new `titleTypes` prop, and adjusted test logic to account for fetching and loading both resource and title types. Also added a test to ensure limit fields render without extra margin. [[1]](diffhunk://#diff-e3328bddb5a0de5bfee3afe353fca0c8936dcd37c84af29856040c061a504af5L5-R5) [[2]](diffhunk://#diff-30195ec393e17332fd3ccaaebf3fd3f51f4374cfb27ea25f01ffdb8049151d40L35-R89) [[3]](diffhunk://#diff-b7b448886b8ee79b3a8a8c7cf1fce5c19628bafed625f56392c14f8b350697e1L58-R76) [[4]](diffhunk://#diff-b7b448886b8ee79b3a8a8c7cf1fce5c19628bafed625f56392c14f8b350697e1L77-R91) [[5]](diffhunk://#diff-b7b448886b8ee79b3a8a8c7cf1fce5c19628bafed625f56392c14f8b350697e1L90-R131)

These changes collectively enable full CRUD and configuration support for title types, mirroring the existing resource types functionality.