### PR TITLE
feat: expose configurable licenses via API

### DIFF
--- a/app/Http/Controllers/LicenseController.php
+++ b/app/Http/Controllers/LicenseController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\License;
+use Illuminate\Http\JsonResponse;
+
+class LicenseController extends Controller
+{
+    /**
+     * Return all licenses.
+     */
+    public function index(): JsonResponse
+    {
+        $licenses = License::query()
+            ->orderByName()
+            ->get(['id', 'identifier', 'name']);
+
+        return response()->json($licenses);
+    }
+
+    /**
+     * Return all licenses that are active for ELMO.
+     */
+    public function elmo(): JsonResponse
+    {
+        $licenses = License::query()
+            ->active()
+            ->elmoActive()
+            ->orderByName()
+            ->get(['id', 'identifier', 'name']);
+
+        return response()->json($licenses);
+    }
+
+    /**
+     * Return all licenses that are active for Ernie.
+     */
+    public function ernie(): JsonResponse
+    {
+        $licenses = License::query()
+            ->active()
+            ->orderByName()
+            ->get(['id', 'identifier', 'name']);
+
+        return response()->json($licenses);
+    }
+}

--- a/app/Http/Controllers/Settings/EditorSettingsController.php
+++ b/app/Http/Controllers/Settings/EditorSettingsController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\UpdateSettingsRequest;
 use App\Models\ResourceType;
 use App\Models\TitleType;
+use App\Models\License;
 use App\Models\Setting;
 use Inertia\Inertia;
 
@@ -16,6 +17,7 @@ class EditorSettingsController extends Controller
         return Inertia::render('settings/index', [
             'resourceTypes' => ResourceType::orderBy('id')->get(['id', 'name', 'active', 'elmo_active']),
             'titleTypes' => TitleType::orderBy('id')->get(['id', 'name', 'slug', 'active', 'elmo_active']),
+            'licenses' => License::orderBy('id')->get(['id', 'identifier', 'name', 'active', 'elmo_active']),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),
             'maxLicenses' => (int) Setting::getValue('max_licenses', Setting::DEFAULT_LIMIT),
         ]);
@@ -39,6 +41,13 @@ class EditorSettingsController extends Controller
                 'slug' => $type['slug'],
                 'active' => $type['active'],
                 'elmo_active' => $type['elmo_active'],
+            ]);
+        }
+
+        foreach ($validated['licenses'] as $license) {
+            License::where('id', $license['id'])->update([
+                'active' => $license['active'],
+                'elmo_active' => $license['elmo_active'],
             ]);
         }
 

--- a/app/Http/Requests/Settings/UpdateSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateSettingsRequest.php
@@ -24,6 +24,10 @@ class UpdateSettingsRequest extends FormRequest
             'titleTypes.*.slug' => ['required', 'string'],
             'titleTypes.*.active' => ['required', 'boolean'],
             'titleTypes.*.elmo_active' => ['required', 'boolean'],
+            'licenses' => ['required', 'array'],
+            'licenses.*.id' => ['required', 'integer', 'exists:licenses,id'],
+            'licenses.*.active' => ['required', 'boolean'],
+            'licenses.*.elmo_active' => ['required', 'boolean'],
             'maxTitles' => ['required', 'integer', 'min:1'],
             'maxLicenses' => ['required', 'integer', 'min:1'],
         ];

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class License extends Model
 {
@@ -12,6 +13,28 @@ class License extends Model
     protected $fillable = [
         'identifier',
         'name',
+        'active',
+        'elmo_active',
     ];
+
+    protected $casts = [
+        'active' => 'boolean',
+        'elmo_active' => 'boolean',
+    ];
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    public function scopeElmoActive(Builder $query): Builder
+    {
+        return $query->where('elmo_active', true);
+    }
+
+    public function scopeOrderByName(Builder $query): Builder
+    {
+        return $query->orderBy('name');
+    }
 }
 

--- a/database/migrations/2025_09_14_000000_add_active_to_licenses_table.php
+++ b/database/migrations/2025_09_14_000000_add_active_to_licenses_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->boolean('active')->default(true)->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/database/migrations/2025_09_14_000001_add_elmo_active_to_licenses_table.php
+++ b/database/migrations/2025_09_14_000001_add_elmo_active_to_licenses_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->boolean('elmo_active')->default(false)->after('active');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dropColumn('elmo_active');
+        });
+    }
+};

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -135,6 +135,63 @@
           }
         }
       }
+    },
+    "/api/v1/licenses": {
+      "get": {
+        "tags": ["Editor Configuration"],
+        "summary": "List all licenses",
+        "responses": {
+          "200": {
+            "description": "List of licenses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/License" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/licenses/elmo": {
+      "get": {
+        "tags": ["Editor Configuration"],
+        "summary": "List licenses enabled for ELMO",
+        "responses": {
+          "200": {
+            "description": "List of licenses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/License" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/licenses/ernie": {
+      "get": {
+        "tags": ["Editor Configuration"],
+        "summary": "List active licenses for Ernie",
+        "responses": {
+          "200": {
+            "description": "List of licenses",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/License" }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -152,6 +209,14 @@
           "id": { "type": "integer", "readOnly": true },
           "name": { "type": "string" },
           "slug": { "type": "string" }
+        }
+      },
+      "License": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "readOnly": true },
+          "identifier": { "type": "string" },
+          "name": { "type": "string" }
         }
       }
     }

--- a/resources/js/pages/__tests__/curation.integration.test.tsx
+++ b/resources/js/pages/__tests__/curation.integration.test.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom/vitest';
 import { render } from '@testing-library/react';
 import Curation from '../curation';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import type { License } from '@/types';
 
 vi.mock('@/layouts/app-layout', () => ({
     default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -30,10 +29,7 @@ describe('Curation integration', () => {
     });
 
     it('sets the document title', () => {
-        const licenses: License[] = [];
-        render(
-            <Curation licenses={licenses} maxTitles={99} maxLicenses={99} />,
-        );
+        render(<Curation maxTitles={99} maxLicenses={99} />);
         expect(document.title).toBe('Curation');
     });
 });

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -41,7 +41,9 @@ describe('Curation page', () => {
                         Promise.resolve(
                             url.toString().includes('resource-types')
                                 ? resourceTypes
-                                : titleTypes,
+                                : url.toString().includes('title-types')
+                                  ? titleTypes
+                                  : licenses,
                         ),
                 }),
             ),
@@ -53,7 +55,7 @@ describe('Curation page', () => {
     });
 
     it('fetches resource types and passes data to DataCiteForm', async () => {
-        render(<Curation licenses={licenses} maxTitles={99} maxLicenses={99} />);
+        render(<Curation maxTitles={99} maxLicenses={99} />);
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
                 expect.objectContaining({ resourceTypes, titleTypes, licenses }),
@@ -65,9 +67,9 @@ describe('Curation page', () => {
         (fetch as unknown as vi.Mock).mockImplementation(
             () => new Promise(() => {}),
         );
-        render(<Curation licenses={licenses} maxTitles={99} maxLicenses={99} />);
+        render(<Curation maxTitles={99} maxLicenses={99} />);
         expect(screen.getByRole('status')).toHaveTextContent(
-            /loading resource and title types/i,
+            /loading resource and title types and licenses/i,
         );
     });
 
@@ -78,16 +80,14 @@ describe('Curation page', () => {
                 ? Promise.resolve({ ok: true, json: () => Promise.resolve(resourceTypes) })
                 : unresolved,
         );
-        render(<Curation licenses={licenses} maxTitles={99} maxLicenses={99} />);
+        render(<Curation maxTitles={99} maxLicenses={99} />);
         expect(screen.getByRole('status')).toHaveTextContent(
-            /loading resource and title types/i,
+            /loading resource and title types and licenses/i,
         );
     });
 
     it('passes limits to DataCiteForm', async () => {
-        render(
-            <Curation licenses={licenses} maxTitles={5} maxLicenses={7} />,
-        );
+        render(<Curation maxTitles={5} maxLicenses={7} />);
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
                 expect.objectContaining({ maxTitles: 5, maxLicenses: 7 }),
@@ -98,7 +98,6 @@ describe('Curation page', () => {
     it('passes doi to DataCiteForm when provided', async () => {
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 doi="10.1234/xyz"
@@ -114,7 +113,6 @@ describe('Curation page', () => {
     it('passes year to DataCiteForm when provided', async () => {
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 year="2024"
@@ -130,7 +128,6 @@ describe('Curation page', () => {
     it('passes version to DataCiteForm when provided', async () => {
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 version="2.0"
@@ -146,7 +143,6 @@ describe('Curation page', () => {
     it('passes language to DataCiteForm when provided', async () => {
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 language="de"
@@ -162,7 +158,6 @@ describe('Curation page', () => {
     it('passes resource type to DataCiteForm when provided', async () => {
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 resourceType="1"
@@ -182,7 +177,6 @@ describe('Curation page', () => {
         ];
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 titles={titles}
@@ -199,7 +193,6 @@ describe('Curation page', () => {
         const initialLicenses = ['MIT'];
         render(
             <Curation
-                licenses={licenses}
                 maxTitles={99}
                 maxLicenses={99}
                 initialLicenses={initialLicenses}

--- a/resources/js/pages/__tests__/settings.test.tsx
+++ b/resources/js/pages/__tests__/settings.test.tsx
@@ -58,6 +58,7 @@ describe('EditorSettings page', () => {
             <EditorSettings
                 resourceTypes={resourceTypes}
                 titleTypes={[]}
+                licenses={[]}
                 maxTitles={1}
                 maxLicenses={1}
             />,
@@ -86,6 +87,7 @@ describe('EditorSettings page', () => {
             <EditorSettings
                 resourceTypes={resourceTypes}
                 titleTypes={[]}
+                licenses={[]}
                 maxTitles={1}
                 maxLicenses={1}
             />,
@@ -104,6 +106,7 @@ describe('EditorSettings page', () => {
             <EditorSettings
                 resourceTypes={resourceTypes}
                 titleTypes={[]}
+                licenses={[]}
                 maxTitles={1}
                 maxLicenses={1}
             />,
@@ -122,12 +125,34 @@ describe('EditorSettings page', () => {
             <EditorSettings
                 resourceTypes={resourceTypes}
                 titleTypes={[]}
+                licenses={[]}
                 maxTitles={1}
                 maxLicenses={1}
             />,
         );
         const grid = screen.getByLabelText('Max Titles').closest('div')!.parentElement;
         expect(grid).not.toHaveClass('mt-8');
+    });
+});
+
+describe('License settings', () => {
+    it('updates license ERNIE active when toggled', () => {
+        const licenses = [
+            { id: 1, identifier: 'MIT', name: 'MIT License', active: false, elmo_active: false },
+        ];
+        render(
+            <EditorSettings
+                resourceTypes={[]}
+                titleTypes={[]}
+                licenses={licenses}
+                maxTitles={1}
+                maxLicenses={1}
+            />,
+        );
+        fireEvent.click(screen.getByLabelText('ERNIE active'));
+        expect(setData).toHaveBeenCalledWith('licenses', [
+            { id: 1, identifier: 'MIT', name: 'MIT License', active: true, elmo_active: false },
+        ]);
     });
 });
 

--- a/resources/js/pages/settings/index.tsx
+++ b/resources/js/pages/settings/index.tsx
@@ -22,16 +22,31 @@ interface TitleTypeRow {
     elmo_active: boolean;
 }
 
+interface LicenseRow {
+    id: number;
+    identifier: string;
+    name: string;
+    active: boolean;
+    elmo_active: boolean;
+}
+
 interface EditorSettingsProps {
     resourceTypes: ResourceTypeRow[];
     titleTypes: TitleTypeRow[];
+    licenses: LicenseRow[];
     maxTitles: number;
     maxLicenses: number;
 }
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Editor Settings', href: settings().url }];
 
-export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, maxLicenses }: EditorSettingsProps) {
+export default function EditorSettings({
+    resourceTypes,
+    titleTypes,
+    licenses,
+    maxTitles,
+    maxLicenses,
+}: EditorSettingsProps) {
     const { data, setData, post, processing } = useForm({
         resourceTypes: resourceTypes.map((r) => ({
             id: r.id,
@@ -45,6 +60,13 @@ export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, m
             slug: t.slug,
             active: t.active,
             elmo_active: t.elmo_active,
+        })),
+        licenses: licenses.map((l) => ({
+            id: l.id,
+            identifier: l.identifier,
+            name: l.name,
+            active: l.active,
+            elmo_active: l.elmo_active,
         })),
         maxTitles,
         maxLicenses,
@@ -89,6 +111,20 @@ export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, m
         setData(
             'titleTypes',
             data.titleTypes.map((t, i) => (i === index ? { ...t, elmo_active: value } : t)),
+        );
+    };
+
+    const handleLicenseActiveChange = (index: number, value: boolean) => {
+        setData(
+            'licenses',
+            data.licenses.map((l, i) => (i === index ? { ...l, active: value } : l)),
+        );
+    };
+
+    const handleLicenseElmoActiveChange = (index: number, value: boolean) => {
+        setData(
+            'licenses',
+            data.licenses.map((l, i) => (i === index ? { ...l, elmo_active: value } : l)),
         );
     };
 
@@ -217,6 +253,57 @@ export default function EditorSettings({ resourceTypes, titleTypes, maxTitles, m
                                             checked={type.elmo_active}
                                             onCheckedChange={(checked) =>
                                                 handleTitleElmoActiveChange(index, checked === true)
+                                            }
+                                        />
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div>
+                    <h2 className="mb-4 text-lg font-semibold">Licenses</h2>
+                    <table className="w-full border-collapse">
+                        <thead>
+                            <tr className="text-left">
+                                <th className="border-b p-2">ID</th>
+                                <th className="border-b p-2">Identifier</th>
+                                <th className="border-b p-2">Name</th>
+                                <th className="border-b p-2 text-center">ERNIE<br />active</th>
+                                <th className="border-b p-2 text-center">ELMO<br />active</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data.licenses.map((license, index) => (
+                                <tr key={license.id}>
+                                    <td className="border-b p-2">{license.id}</td>
+                                    <td className="border-b p-2">{license.identifier}</td>
+                                    <td className="border-b p-2">{license.name}</td>
+                                    <td className="border-b p-2 text-center">
+                                        <Label htmlFor={`lic-active-${license.id}`} className="sr-only">
+                                            ERNIE active
+                                        </Label>
+                                        <Checkbox
+                                            id={`lic-active-${license.id}`}
+                                            checked={license.active}
+                                            onCheckedChange={(checked) =>
+                                                handleLicenseActiveChange(index, checked === true)
+                                            }
+                                        />
+                                    </td>
+                                    <td className="border-b p-2 text-center">
+                                        <Label htmlFor={`lic-elmo-active-${license.id}`} className="sr-only">
+                                            ELMO active
+                                        </Label>
+                                        <Checkbox
+                                            id={`lic-elmo-active-${license.id}`}
+                                            checked={license.elmo_active}
+                                            onCheckedChange={(checked) =>
+                                                handleLicenseElmoActiveChange(
+                                                    index,
+                                                    checked === true,
+                                                )
                                             }
                                         />
                                     </td>

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ApiDocController;
 use App\Http\Controllers\ChangelogController;
 use App\Http\Controllers\ResourceTypeController;
 use App\Http\Controllers\TitleTypeController;
+use App\Http\Controllers\LicenseController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/changelog', [ChangelogController::class, 'index']);
@@ -14,4 +15,7 @@ Route::get('/v1/resource-types/ernie', [ResourceTypeController::class, 'ernie'])
 Route::get('/v1/title-types', [TitleTypeController::class, 'index']);
 Route::get('/v1/title-types/elmo', [TitleTypeController::class, 'elmo']);
 Route::get('/v1/title-types/ernie', [TitleTypeController::class, 'ernie']);
+Route::get('/v1/licenses', [LicenseController::class, 'index']);
+Route::get('/v1/licenses/elmo', [LicenseController::class, 'elmo']);
+Route::get('/v1/licenses/ernie', [LicenseController::class, 'ernie']);
 Route::get('/v1/doc', ApiDocController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,6 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('curation', function (\Illuminate\Http\Request $request) {
         return Inertia::render('curation', [
-            'licenses' => License::orderBy('name')->get(),
             'maxTitles' => (int) Setting::getValue('max_titles', Setting::DEFAULT_LIMIT),
             'maxLicenses' => (int) Setting::getValue('max_licenses', Setting::DEFAULT_LIMIT),
             'doi' => $request->query('doi'),

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\User;
-use App\Models\License;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use function Pest\Laravel\withoutVite;
@@ -12,8 +11,7 @@ test('guests are redirected to login page', function () {
     $this->get(route('curation'))->assertRedirect(route('login'));
 });
 
-test('authenticated users can view curation page with licenses', function () {
-    License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
+test('authenticated users can view curation page', function () {
     $this->actingAs(User::factory()->create());
 
     withoutVite();
@@ -22,7 +20,7 @@ test('authenticated users can view curation page with licenses', function () {
 
     $response->assertInertia(fn (Assert $page) =>
         $page->component('curation')
-            ->has('licenses', License::count())
             ->where('titles', [])
+            ->where('initialLicenses', [])
     );
 });

--- a/tests/Feature/LicenseApiTest.php
+++ b/tests/Feature/LicenseApiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\License;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('lists all licenses', function () {
+    License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
+
+    $this->getJson('/api/v1/licenses')
+        ->assertOk()
+        ->assertJsonCount(1);
+});
+
+it('lists ELMO-active licenses', function () {
+    License::create(['identifier' => 'MIT', 'name' => 'MIT License', 'active' => true, 'elmo_active' => true]);
+    License::create(['identifier' => 'Apache', 'name' => 'Apache', 'active' => true, 'elmo_active' => false]);
+
+    $this->getJson('/api/v1/licenses/elmo')
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.identifier', 'MIT');
+});
+
+it('lists ERNIE-active licenses', function () {
+    License::create(['identifier' => 'MIT', 'name' => 'MIT License', 'active' => true]);
+    License::create(['identifier' => 'Apache', 'name' => 'Apache', 'active' => false]);
+
+    $this->getJson('/api/v1/licenses/ernie')
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.identifier', 'MIT');
+});

--- a/tests/Feature/Settings/EditorSettingsTest.php
+++ b/tests/Feature/Settings/EditorSettingsTest.php
@@ -3,6 +3,7 @@
 use App\Models\User;
 use App\Models\ResourceType;
 use App\Models\TitleType;
+use App\Models\License;
 use App\Models\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -18,6 +19,7 @@ test('authenticated users can view editor settings page', function () {
     $user = User::factory()->create();
     ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
     TitleType::create(['name' => 'Main Title', 'slug' => 'main-title']);
+    License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
     Setting::create(['key' => 'max_titles', 'value' => (string) Setting::DEFAULT_LIMIT]);
     Setting::create(['key' => 'max_licenses', 'value' => (string) Setting::DEFAULT_LIMIT]);
     $this->actingAs($user);
@@ -27,10 +29,13 @@ test('authenticated users can view editor settings page', function () {
         ->component('settings/index')
         ->has('resourceTypes', 1)
         ->has('titleTypes', 1)
+        ->has('licenses', 1)
         ->where('resourceTypes.0.active', true)
         ->where('resourceTypes.0.elmo_active', false)
         ->where('titleTypes.0.active', true)
         ->where('titleTypes.0.elmo_active', false)
+        ->where('licenses.0.active', true)
+        ->where('licenses.0.elmo_active', false)
         ->where('maxTitles', Setting::DEFAULT_LIMIT)
         ->where('maxLicenses', Setting::DEFAULT_LIMIT)
     );
@@ -40,6 +45,7 @@ test('authenticated users can update resource and title types and settings', fun
     $user = User::factory()->create();
     $type = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
     $title = TitleType::create(['name' => 'Main Title', 'slug' => 'main-title']);
+    $license = License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
     Setting::create(['key' => 'max_titles', 'value' => '5']);
     Setting::create(['key' => 'max_licenses', 'value' => '2']);
     $this->actingAs($user);
@@ -50,6 +56,9 @@ test('authenticated users can update resource and title types and settings', fun
         ],
         'titleTypes' => [
             ['id' => $title->id, 'name' => 'Main', 'slug' => 'main', 'active' => false, 'elmo_active' => true],
+        ],
+        'licenses' => [
+            ['id' => $license->id, 'active' => false, 'elmo_active' => true],
         ],
         'maxTitles' => 10,
         'maxLicenses' => 7,
@@ -68,6 +77,11 @@ test('authenticated users can update resource and title types and settings', fun
         'active' => false,
         'elmo_active' => true,
     ]);
+    $this->assertDatabaseHas('licenses', [
+        'id' => $license->id,
+        'active' => false,
+        'elmo_active' => true,
+    ]);
     expect(Setting::getValue('max_titles'))->toBe('10');
     expect(Setting::getValue('max_licenses'))->toBe('7');
 });
@@ -76,6 +90,7 @@ test('updating settings with invalid data returns errors', function () {
     $user = User::factory()->create();
     $type = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
     $title = TitleType::create(['name' => 'Main Title', 'slug' => 'main-title']);
+    $license = License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
     $this->actingAs($user);
 
     $response = $this->from(route('settings'))
@@ -85,6 +100,9 @@ test('updating settings with invalid data returns errors', function () {
             ],
             'titleTypes' => [
                 ['id' => $title->id, 'name' => 'Main Title', 'slug' => 'main-title', 'active' => true, 'elmo_active' => false],
+            ],
+            'licenses' => [
+                ['id' => $license->id, 'active' => true, 'elmo_active' => false],
             ],
             'maxTitles' => 0,
             'maxLicenses' => 7,


### PR DESCRIPTION
## Summary
- add `active` and `elmo_active` flags for licenses
- expose license lookup API and use it in curation
- allow configuring license availability in editor settings

## Testing
- `npm test -- --run`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f6f7c9e0832e84aed5668177e783