### PR TITLE
feat: add curation save functionality

### DIFF
--- a/app/Http/Controllers/CurationController.php
+++ b/app/Http/Controllers/CurationController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Language;
+use App\Models\License;
+use App\Models\Resource;
+use App\Models\TitleType;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class CurationController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'doi' => ['nullable', 'string'],
+            'year' => ['required', 'integer'],
+            'resourceType' => ['required', 'exists:resource_types,id'],
+            'version' => ['nullable', 'string'],
+            'language' => ['nullable', 'exists:languages,code'],
+            'titles' => ['required', 'array', 'min:1'],
+            'titles.*.title' => ['required', 'string'],
+            'titles.*.titleType' => ['required', 'exists:title_types,slug'],
+            'licenses' => ['required', 'array', 'min:1'],
+            'licenses.*' => ['required', 'exists:licenses,identifier'],
+        ]);
+
+        $languageId = null;
+        if (isset($validated['language'])) {
+            $languageId = Language::where('code', $validated['language'])->value('id');
+        }
+
+        $resource = Resource::create([
+            'doi' => $validated['doi'] ?? null,
+            'year' => $validated['year'],
+            'resource_type_id' => $validated['resourceType'],
+            'version' => $validated['version'] ?? null,
+            'language_id' => $languageId,
+            'last_editor_id' => Auth::id(),
+        ]);
+
+        foreach ($validated['titles'] as $titleData) {
+            $titleTypeId = TitleType::where('slug', $titleData['titleType'])->value('id');
+            $resource->titles()->create([
+                'title' => $titleData['title'],
+                'title_type_id' => $titleTypeId,
+            ]);
+        }
+
+        $licenseIds = License::whereIn('identifier', $validated['licenses'])->pluck('id');
+        $resource->licenses()->sync($licenseIds);
+
+        return redirect()->route('curation');
+    }
+}

--- a/app/Models/Language.php
+++ b/app/Models/Language.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
 
 class Language extends Model
 {
@@ -35,5 +36,13 @@ class Language extends Model
     public function scopeOrderByName(Builder $query): Builder
     {
         return $query->orderBy('name');
+    }
+
+    public static function idByCode(string $code): ?int
+    {
+        return Cache::rememberForever(
+            "language_id:{$code}",
+            fn () => static::where('code', $code)->value('id')
+        );
     }
 }

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Collection;
 
 class License extends Model
 {
@@ -35,6 +37,11 @@ class License extends Model
     public function scopeOrderByName(Builder $query): Builder
     {
         return $query->orderBy('name');
+    }
+
+    public static function idsByIdentifier(): Collection
+    {
+        return Cache::rememberForever('license_ids_by_identifier', fn () => static::pluck('id', 'identifier'));
     }
 }
 

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Resource extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'doi',
+        'year',
+        'resource_type_id',
+        'version',
+        'language_id',
+        'last_editor_id',
+        'curation',
+    ];
+
+    protected $casts = [
+        'curation' => 'boolean',
+    ];
+
+    public function titles(): HasMany
+    {
+        return $this->hasMany(Title::class);
+    }
+
+    public function licenses(): BelongsToMany
+    {
+        return $this->belongsToMany(License::class);
+    }
+
+    public function resourceType(): BelongsTo
+    {
+        return $this->belongsTo(ResourceType::class);
+    }
+
+    public function language(): BelongsTo
+    {
+        return $this->belongsTo(Language::class);
+    }
+
+    public function lastEditor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'last_editor_id');
+    }
+}

--- a/app/Models/Title.php
+++ b/app/Models/Title.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Title extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'resource_id',
+        'title',
+        'title_type_id',
+    ];
+
+    public function resource(): BelongsTo
+    {
+        return $this->belongsTo(Resource::class);
+    }
+
+    public function titleType(): BelongsTo
+    {
+        return $this->belongsTo(TitleType::class);
+    }
+}

--- a/app/Models/TitleType.php
+++ b/app/Models/TitleType.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Collection;
 
 class TitleType extends Model
 {
@@ -35,5 +37,10 @@ class TitleType extends Model
     public function scopeOrderByName(Builder $query): Builder
     {
         return $query->orderBy('name');
+    }
+
+    public static function idsBySlug(): Collection
+    {
+        return Cache::rememberForever('title_type_ids_by_slug', fn () => static::pluck('id', 'slug'));
     }
 }

--- a/database/migrations/2025_09_14_191814_create_resources_table.php
+++ b/database/migrations/2025_09_14_191814_create_resources_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('resources', function (Blueprint $table) {
+            $table->id();
+            $table->string('doi')->nullable();
+            $table->unsignedInteger('year');
+            $table->foreignId('resource_type_id')->constrained()->cascadeOnDelete();
+            $table->string('version')->nullable();
+            $table->foreignId('language_id')->nullable()->constrained('languages')->nullOnDelete();
+            $table->foreignId('last_editor_id')->constrained('users');
+            $table->boolean('curation')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('resources');
+    }
+};

--- a/database/migrations/2025_09_14_191816_create_titles_table.php
+++ b/database/migrations/2025_09_14_191816_create_titles_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('titles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('resource_id')->constrained()->cascadeOnDelete();
+            $table->text('title');
+            $table->foreignId('title_type_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('titles');
+    }
+};

--- a/database/migrations/2025_09_14_191818_create_license_resource_table.php
+++ b/database/migrations/2025_09_14_191818_create_license_resource_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('license_resource', function (Blueprint $table) {
+            $table->foreignId('license_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('resource_id')->constrained()->cascadeOnDelete();
+            $table->primary(['license_id', 'resource_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('license_resource');
+    }
+};

--- a/e2e/curation-save.spec.ts
+++ b/e2e/curation-save.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from './constants';
+
+async function login(page) {
+    await page.goto('/login');
+    await page.getByLabel('Email address').fill(TEST_USER_EMAIL);
+    await page.getByLabel('Password').fill(TEST_USER_PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+    await page.waitForURL(/\/dashboard/);
+}
+
+test('enables Save when required fields are filled', async ({ page }) => {
+    await login(page);
+    await page.goto('/curation');
+
+    await page.getByLabel('Year').fill('2024');
+    await page.getByRole('combobox', { name: 'Resource Type' }).click();
+    await page.getByRole('option').first().click();
+    await page.getByRole('combobox', { name: 'Language of Dataset' }).click();
+    await page.getByRole('option', { name: 'English' }).click();
+    await page.getByRole('textbox', { name: 'Title' }).fill('Main title');
+    await page.getByRole('combobox', { name: 'License' }).click();
+    await page.getByRole('option').first().click();
+
+    const save = page.getByRole('button', { name: 'Save' });
+    await expect(save).toBeEnabled();
+    await expect(save).toHaveAttribute('aria-disabled', 'false');
+});
+
+test('keeps Save disabled when a required field is missing', async ({ page }) => {
+    await login(page);
+    await page.goto('/curation');
+
+    await page.getByLabel('Year').fill('2024');
+    await page.getByRole('combobox', { name: 'Resource Type' }).click();
+    await page.getByRole('option').first().click();
+    await page.getByRole('textbox', { name: 'Title' }).fill('Main title');
+    await page.getByRole('combobox', { name: 'License' }).click();
+    await page.getByRole('option').first().click();
+
+    const save = page.getByRole('button', { name: 'Save' });
+    await expect(save).toBeDisabled();
+    await expect(save).toHaveAttribute('aria-disabled', 'true');
+});

--- a/e2e/curation-save.spec.ts
+++ b/e2e/curation-save.spec.ts
@@ -1,7 +1,7 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, Page } from '@playwright/test';
 import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from './constants';
 
-async function login(page) {
+async function login(page: Page) {
     await page.goto('/login');
     await page.getByLabel('Email address').fill(TEST_USER_EMAIL);
     await page.getByLabel('Password').fill(TEST_USER_PASSWORD);

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -146,7 +146,7 @@ describe('DataCiteForm', () => {
         expect(
             screen.getAllByRole('textbox', { name: /Title/ }),
         ).toHaveLength(1);
-    });
+    }, 10000);
 
     it('prefills DOI when initialDoi is provided', () => {
         render(

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -141,6 +141,17 @@ export default function DataCiteForm({
     };
 
     const mainTitleUsed = titles.some((t) => t.titleType === 'main-title');
+    const hasMainTitle = titles.some(
+        (t) => t.title && t.titleType === 'main-title',
+    );
+    const hasLicense = licenseEntries.some((l) => l.license);
+    const isFormValid = Boolean(
+        form.year &&
+            form.resourceType &&
+            form.language &&
+            hasMainTitle &&
+            hasLicense,
+    );
 
     const handleLicenseChange = (index: number, value: string) => {
         setLicenseEntries((prev) => {
@@ -222,7 +233,7 @@ export default function DataCiteForm({
                             />
                             <SelectField
                                 id="language"
-                                label="Language of Data"
+                                label="Language of Dataset"
                                 value={form.language}
                                 onValueChange={(val) => handleChange('language', val)}
                                 options={languages.map((l) => ({
@@ -230,6 +241,7 @@ export default function DataCiteForm({
                                     label: l.name,
                                 }))}
                                 className="md:col-span-2"
+                                required
                             />
                         </div>
                         <div className="space-y-4 mt-3">
@@ -293,7 +305,9 @@ export default function DataCiteForm({
                 </AccordionItem>
             </Accordion>
             <div className="mt-4">
-                <Button type="submit">Save</Button>
+                <Button type="submit" disabled={!isFormValid} aria-disabled={!isFormValid}>
+                    Save
+                </Button>
             </div>
         </form>
     );

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { router } from '@inertiajs/react';
 import InputField from './fields/input-field';
 import { SelectField } from './fields/select-field';
 import TitleField from './fields/title-field';
@@ -10,6 +11,7 @@ import {
     AccordionTrigger,
 } from '@/components/ui/accordion';
 import type { ResourceType, TitleType, License, Language } from '@/types';
+import { Button } from '@/components/ui/button';
 
 interface DataCiteFormData {
     doi: string;
@@ -160,8 +162,17 @@ export default function DataCiteForm({
         setLicenseEntries((prev) => prev.filter((_, i) => i !== index));
     };
 
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        router.post('/curation', {
+            ...form,
+            titles: titles.map(({ title, titleType }) => ({ title, titleType })),
+            licenses: licenseEntries.map((l) => l.license),
+        });
+    };
+
     return (
-        <form>
+        <form onSubmit={handleSubmit}>
             <Accordion
                 type="multiple"
                 defaultValue={['resource-info', 'licenses-rights']}
@@ -281,6 +292,9 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
             </Accordion>
+            <div className="mt-4">
+                <Button type="submit">Save</Button>
+            </div>
         </form>
     );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\UploadXmlController;
+use App\Http\Controllers\CurationController;
 use App\Models\License;
 use App\Models\Setting;
 use Illuminate\Support\Facades\Route;
@@ -51,6 +52,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'initialLicenses' => $request->query('licenses', []),
         ]);
     })->name('curation');
+
+    Route::post('curation', [CurationController::class, 'store'])
+        ->name('curation.store');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -19,7 +19,8 @@ test('guests are redirected to login page', function () {
 });
 
 test('authenticated users can view curation page', function () {
-    $this->actingAs(User::factory()->create());
+    $user = User::factory()->create();
+    $this->actingAs($user);
 
     withoutVite();
 
@@ -33,7 +34,8 @@ test('authenticated users can view curation page', function () {
 });
 
 test('authenticated users can save curation data', function () {
-    $this->actingAs($user = User::factory()->create());
+    $user = User::factory()->create();
+    $this->actingAs($user);
 
     $resourceType = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
     $titleTypes = [

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -34,7 +34,10 @@ test('authenticated users can save curation data', function () {
     $this->actingAs($user = User::factory()->create());
 
     $resourceType = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
-    $titleType = TitleType::create(['name' => 'Main Title', 'slug' => 'main-title']);
+    $titleTypes = [
+        'main-title' => TitleType::create(['name' => 'Main Title', 'slug' => 'main-title']),
+        'alternative-title' => TitleType::create(['name' => 'Alternative Title', 'slug' => 'alternative-title']),
+    ];
     $license = License::create(['identifier' => 'MIT', 'name' => 'MIT License']);
     $language = Language::create(['code' => 'en', 'name' => 'English']);
 
@@ -46,6 +49,7 @@ test('authenticated users can save curation data', function () {
         'language' => $language->code,
         'titles' => [
             ['title' => 'My Title', 'titleType' => 'main-title'],
+            ['title' => 'Another Title', 'titleType' => 'alternative-title'],
         ],
         'licenses' => [$license->identifier],
     ];
@@ -66,7 +70,12 @@ test('authenticated users can save curation data', function () {
     $this->assertDatabaseHas('titles', [
         'resource_id' => $resource->id,
         'title' => 'My Title',
-        'title_type_id' => $titleType->id,
+        'title_type_id' => $titleTypes['main-title']->id,
+    ]);
+    $this->assertDatabaseHas('titles', [
+        'resource_id' => $resource->id,
+        'title' => 'Another Title',
+        'title_type_id' => $titleTypes['alternative-title']->id,
     ]);
     $this->assertDatabaseHas('license_resource', [
         'resource_id' => $resource->id,

--- a/tests/Feature/CurationTest.php
+++ b/tests/Feature/CurationTest.php
@@ -8,6 +8,8 @@ use App\Models\Language;
 use App\Models\Resource;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
 use function Pest\Laravel\withoutVite;
 
 uses(RefreshDatabase::class);
@@ -53,6 +55,19 @@ test('authenticated users can save curation data', function () {
         ],
         'licenses' => [$license->identifier],
     ];
+
+    Cache::shouldReceive('rememberForever')
+        ->with("language_id:{$language->code}", Mockery::type('Closure'))
+        ->once()
+        ->andReturnUsing(fn ($key, $closure) => $closure());
+    Cache::shouldReceive('rememberForever')
+        ->with('title_type_ids_by_slug', Mockery::type('Closure'))
+        ->once()
+        ->andReturnUsing(fn ($key, $closure) => $closure());
+    Cache::shouldReceive('rememberForever')
+        ->with('license_ids_by_identifier', Mockery::type('Closure'))
+        ->once()
+        ->andReturnUsing(fn ($key, $closure) => $closure());
 
     $this->post(route('curation.store'), $data)->assertRedirect(route('curation'));
 


### PR DESCRIPTION
This pull request introduces the backend and frontend implementation for saving curated resources, including models, migrations, controller logic, and comprehensive tests. It establishes the necessary database schema and relationships for resources, titles, and licenses, implements a form with validation and submission logic, and adds automated tests to ensure correct behavior and required field enforcement.

**Backend: Resource Curation Models, Logic, and Persistence**

* Added new models: `Resource` and `Title` with appropriate relationships and fillable fields to support curated resources and their titles. (`app/Models/Resource.php` [[1]](diffhunk://#diff-2eeb95c4271950b7d4b77ff1f3760cd13affdf60345ec793f0f93e54ad89803cR1-R53) `app/Models/Title.php` [[2]](diffhunk://#diff-21ff4bba5b7cc36dd378b063052d7b12c8df97ebdf6c440f3b9ac68163deba0cR1-R28)
* Created migrations for the `resources`, `titles`, and pivot `license_resource` tables to establish the database schema for resources, their titles, and associated licenses. (`database/migrations/2025_09_14_191814_create_resources_table.php` [[1]](diffhunk://#diff-33a051a64b579c028fc1a24f9200a59c4053468bff38ba8c457b050eec4d6ccbR1-R28) `database/migrations/2025_09_14_191816_create_titles_table.php` [[2]](diffhunk://#diff-65f739120c28feccbf7474111937c51a5888600e4c633b9f147e31ffaf31bd32R1-R24) `database/migrations/2025_09_14_191818_create_license_resource_table.php` [[3]](diffhunk://#diff-24253396409f5932be1b096fe521764029f717d218d22ccd32bdac6bc9bf4016R1-R22)
* Implemented the `CurationController@store` method to validate incoming form data, create resources, associate titles and licenses, and redirect after successful creation. (`app/Http/Controllers/CurationController.php` [app/Http/Controllers/CurationController.phpR1-R59](diffhunk://#diff-e488a6f4aa7f83e2542754482e39257afeaa6f66ecad8848583424b2edd42c2cR1-R59))

**Backend: Performance Improvements and Helper Methods**

* Added static helper methods with caching to `Language`, `License`, and `TitleType` models for efficient lookups by code, identifier, and slug, respectively. (`app/Models/Language.php` [[1]](diffhunk://#diff-572e1cd52c655e30b00f36f050821033ae09cb16ff5ac3cf695e0ca387054722R40-R47) `app/Models/License.php` [[2]](diffhunk://#diff-9569a6cb05f81a7aed31a4a8e74c4340a46c7683fe0f8fb86ee22d7b685971b7R41-R45) `app/Models/TitleType.php` [[3]](diffhunk://#diff-c37069a788f6de0bf377a2a403e3cc153bd8b62c073209a5595c1e0837190987R41-R45)

**Frontend: Form Validation, Submission, and UI**

* Updated the `DataCiteForm` component to enforce required fields (year, resource type, language, main title, license), enable/disable the Save button accordingly, and submit form data to the backend via Inertia router. (`resources/js/components/curation/datacite-form.tsx` [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R144-R154) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R176-R186)
* Adjusted field labels and required indicators for clarity and accessibility in the form and tests. (`resources/js/components/curation/__tests__/datacite-form.test.tsx` [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L74-R81) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L236-R245) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R293-R309)

**Testing: Automated Backend and Frontend Tests**

* Added Playwright end-to-end tests to verify Save button enablement/disablement based on required fields. (`e2e/curation-save.spec.ts` [e2e/curation-save.spec.tsR1-R44](diffhunk://#diff-1a466e5fa5b1ff0d9f871bd9f7ab2fba039510f9d75e1df61b87c56078b1fc20R1-R44))
* Extended frontend unit tests for the form to cover required field logic, Save button state, and form submission. (`resources/js/components/curation/__tests__/datacite-form.test.tsx` [resources/js/components/curation/__tests__/datacite-form.test.tsxR399-R465](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R399-R465))

These changes lay the foundation for resource curation, ensuring robust backend support, efficient lookups, and a user-friendly, validated frontend form.