### PR TITLE
Add heading and aria-labelledby for limits settings section

### DIFF
--- a/resources/js/pages/__tests__/settings.test.tsx
+++ b/resources/js/pages/__tests__/settings.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import EditorSettings from '../settings/index';
 
@@ -136,6 +136,28 @@ describe('EditorSettings page', () => {
         );
         const grid = screen.getByLabelText('Max Titles').closest('div')!.parentElement;
         expect(grid).not.toHaveClass('mt-8');
+    });
+
+    it('associates limits section with a heading for accessibility', () => {
+        const resourceTypes = [
+            { id: 1, name: 'Dataset', active: true, elmo_active: false },
+        ];
+        render(
+            <EditorSettings
+                resourceTypes={resourceTypes}
+                titleTypes={[]}
+                licenses={[]}
+                languages={[]}
+                maxTitles={1}
+                maxLicenses={1}
+            />,
+        );
+        const region = screen.getByRole('region', { name: 'Limits' });
+        expect(region).toHaveAttribute('aria-labelledby', 'limits-heading');
+        const heading = within(region).getByRole('heading', { name: 'Limits' });
+        expect(heading).toHaveAttribute('id', 'limits-heading');
+        expect(within(region).getByLabelText('Max Titles')).toBeInTheDocument();
+        expect(within(region).getByLabelText('Max Licenses')).toBeInTheDocument();
     });
 });
 

--- a/resources/js/pages/settings/index.tsx
+++ b/resources/js/pages/settings/index.tsx
@@ -415,7 +415,10 @@ export default function EditorSettings({ resourceTypes, titleTypes, licenses, la
                         </div>
                     </BentoGridItem>
 
-                    <BentoGridItem>
+                    <BentoGridItem aria-labelledby="limits-heading">
+                        <h2 id="limits-heading" className="text-lg font-semibold">
+                            Limits
+                        </h2>
                         <div className="grid gap-4 md:grid-cols-2">
                             <div className="grid gap-2">
                                 <Label htmlFor="maxTitles">Max Titles</Label>


### PR DESCRIPTION
This pull request improves the accessibility of the "Limits" section in the `EditorSettings` page by associating it with a heading using appropriate ARIA attributes. It also adds a test to ensure this accessibility feature is correctly implemented.

Accessibility improvements:

* The "Limits" section in the `EditorSettings` page is now wrapped in a region labeled by a heading with `aria-labelledby="limits-heading"`, and the heading itself has the corresponding `id="limits-heading"` for proper association. (`resources/js/pages/settings/index.tsx`)

Testing enhancements:

* Added a test to verify that the "Limits" section is correctly associated with its heading for accessibility, ensuring that ARIA attributes and labels are present and correct. (`resources/js/pages/__tests__/settings.test.tsx`)
* Imported the `within` utility from Testing Library to facilitate more precise queries within the accessibility test. (`resources/js/pages/__tests__/settings.test.tsx`)