### PR TITLE
Configure Vite build assets directory for prefixed deployments

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Vite::useBuildDirectory('assets');
     }
 }

--- a/resources/js/__tests__/vite-config.test.ts
+++ b/resources/js/__tests__/vite-config.test.ts
@@ -1,0 +1,15 @@
+import { assetsBuildDirectory, laravelPluginOptions, viteBasePath } from '../config/vite';
+
+describe('vite configuration', () => {
+    it('exposes the assets build directory constant', () => {
+        expect(assetsBuildDirectory).toBe('assets');
+    });
+
+    it('passes the build directory to the laravel plugin', () => {
+        expect(laravelPluginOptions.buildDirectory).toBe(assetsBuildDirectory);
+    });
+
+    it('retains the production base path', () => {
+        expect(viteBasePath).toBe('/ernie/');
+    });
+});

--- a/resources/js/config/vite.ts
+++ b/resources/js/config/vite.ts
@@ -1,0 +1,10 @@
+export const assetsBuildDirectory = 'assets';
+
+export const laravelPluginOptions = {
+    input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
+    ssr: 'resources/js/ssr.tsx',
+    refresh: true,
+    buildDirectory: assetsBuildDirectory,
+};
+
+export const viteBasePath = '/ernie/';

--- a/tests/Unit/ViteBuildDirectoryTest.php
+++ b/tests/Unit/ViteBuildDirectoryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Providers\AppServiceProvider;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Vite;
+
+it('configures vite to use the assets build directory', function () {
+    $app = new Application(dirname(__DIR__, 2));
+    Facade::setFacadeApplication($app);
+
+    Vite::shouldReceive('useBuildDirectory')->once()->with('assets');
+
+    $provider = new AppServiceProvider($app);
+    $provider->boot();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,12 @@ import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
 
+import { laravelPluginOptions, viteBasePath } from './resources/js/config/vite';
+
 export default defineConfig({
-    base: '/ernie/',
+    base: viteBasePath,
     plugins: [
-        laravel({
-            input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
-            ssr: 'resources/js/ssr.tsx',
-            refresh: true,
-        }),
+        laravel(laravelPluginOptions),
         react(),
         tailwindcss(),
         wayfinder({


### PR DESCRIPTION
This pull request standardizes and centralizes the Vite build directory and base path configuration across the Laravel backend and the frontend Vite setup. It introduces shared constants for the assets build directory and base path, ensures the Laravel backend uses the correct Vite build directory, and adds tests to verify these configurations.

**Vite build directory and base path centralization:**

* Added `assetsBuildDirectory`, `laravelPluginOptions`, and `viteBasePath` constants to `resources/js/config/vite.ts` to centralize configuration for the Vite build directory and base path.
* Updated `vite.config.ts` to use the new constants for the base path and Laravel plugin options, ensuring consistency between frontend and backend builds.

**Backend configuration:**

* Modified `AppServiceProvider` to call `Vite::useBuildDirectory('assets')` in the `boot` method, ensuring Laravel uses the correct Vite build directory. [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR5) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL22-R23)

**Testing:**

* Added a unit test in `tests/Unit/ViteBuildDirectoryTest.php` to verify that the Laravel backend configures Vite to use the `assets` build directory.
* Added frontend tests in `resources/js/__tests__/vite-config.test.ts` to ensure the exported constants and plugin options are correct.