### PR TITLE
Fix Vite asset base path for prefixed deployments

### DIFF
--- a/resources/js/__tests__/vite.config.test.ts
+++ b/resources/js/__tests__/vite.config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeBasePath } from '../../../vite.config';
+
+describe('computeBasePath', () => {
+    it('returns default build path when asset url is not provided', () => {
+        expect(computeBasePath()).toBe('/build/');
+    });
+
+    it('returns default build path when asset url is empty', () => {
+        expect(computeBasePath('')).toBe('/build/');
+    });
+
+    it('appends build directory to relative paths', () => {
+        expect(computeBasePath('/ernie')).toBe('/ernie/build/');
+    });
+
+    it('appends build directory to relative paths with trailing slashes', () => {
+        expect(computeBasePath('/ernie/')).toBe('/ernie/build/');
+    });
+
+    it('preserves fully qualified urls', () => {
+        expect(computeBasePath('https://example.com/ernie')).toBe('https://example.com/ernie/build/');
+    });
+
+    it('normalizes fully qualified urls with trailing slashes', () => {
+        expect(computeBasePath('https://example.com/ernie/')).toBe('https://example.com/ernie/build/');
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,22 @@ import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({
-    base: '/ernie/',
+export const computeBasePath = (assetUrl?: string): string => {
+    if (!assetUrl) {
+        return '/build/';
+    }
+
+    const normalizedUrl = assetUrl.endsWith('/') ? assetUrl.slice(0, -1) : assetUrl;
+
+    return `${normalizedUrl}/build/`;
+};
+
+export default defineConfig(({ command }) => ({
+    ...(command === 'build'
+        ? {
+              base: computeBasePath(process.env.ASSET_URL),
+          }
+        : {}),
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
@@ -38,4 +52,4 @@ export default defineConfig({
             ],
         },
     },
-});
+}));


### PR DESCRIPTION
## Summary
- compute the Vite base path from the ASSET_URL so built assets resolve correctly when the app is hosted under a path prefix
- export the helper and cover its behaviour with unit tests to guard against regressions

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d158fc9284832e9b7d3415829dc5c4