### PR TITLE
Remove hardcoded Vite base path

### DIFF
--- a/resources/js/__tests__/vite-config.test.ts
+++ b/resources/js/__tests__/vite-config.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const configPath = resolve(currentDir, '../../..', 'vite.config.ts');
+const viteConfigSource = readFileSync(configPath, 'utf8');
+
+describe('vite configuration', () => {
+    it('avoids hardcoding the /ernie base path', () => {
+        expect(viteConfigSource).not.toMatch(/base\s*:\s*['\"]\/ernie\//);
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-    base: '/ernie/',
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],


### PR DESCRIPTION
This pull request removes the hardcoded `/ernie/` base path from the `vite.config.ts` configuration and adds a test to ensure that the base path is not reintroduced in the future. This helps improve the flexibility and maintainability of the Vite configuration.

Configuration improvements:

* Removed the hardcoded `base: '/ernie/'` property from `vite.config.ts` to make the configuration more generic.

Testing enhancements:

* Added a new test in `resources/js/__tests__/vite-config.test.ts` that checks the Vite configuration source and asserts that the `/ernie/` base path is not present.