### PR TITLE
Fix Vite base path for subdirectory deploy

### DIFF
--- a/resources/js/__tests__/vite-config-base.test.ts
+++ b/resources/js/__tests__/vite-config-base.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBasePath } from '../lib/vite-base';
+
+describe('resolveBasePath', () => {
+    it('returns /build/ for build command', () => {
+        expect(resolveBasePath('build')).toBe('/build/');
+    });
+
+    it('returns root path for non-build commands', () => {
+        expect(resolveBasePath('serve')).toBe('/');
+        expect(resolveBasePath('test')).toBe('/');
+    });
+});

--- a/resources/js/lib/vite-base.ts
+++ b/resources/js/lib/vite-base.ts
@@ -1,0 +1,2 @@
+export const resolveBasePath = (command: string): string =>
+    command === 'build' ? '/build/' : '/';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,11 @@ import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
+import { resolveBasePath } from './resources/js/lib/vite-base';
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({
-    base: '/ernie/',
+export default defineConfig(({ command }) => ({
+    base: resolveBasePath(command),
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
@@ -38,4 +39,4 @@ export default defineConfig({
             ],
         },
     },
-});
+}));


### PR DESCRIPTION
This pull request refactors how the Vite `base` path is determined in the build configuration. Instead of hardcoding the base path, it now uses a helper function to set the base path dynamically based on the command being run. Additionally, unit tests have been added for this new helper function.

Configuration improvements:

* Refactored `vite.config.ts` to use the new `resolveBasePath` helper, which sets the `base` path to `/build/` for the `build` command and `/` for other commands, improving flexibility and maintainability. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR5-R9) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL41-R42)
* Added the `resolveBasePath` function in `resources/js/lib/vite-base.ts` to encapsulate the logic for determining the base path.

Testing:

* Added unit tests for `resolveBasePath` in `resources/js/__tests__/vite-config-base.test.ts` to ensure correct behavior for different Vite commands.