### PR TITLE
Adjust Vite base path to include build directory

### DIFF
--- a/resources/js/__tests__/vite-base.test.ts
+++ b/resources/js/__tests__/vite-base.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAssetBase, resolveViteBase } from '../lib/vite-base';
+
+describe('normalizeAssetBase', () => {
+    it('returns an empty string when no asset url is provided', () => {
+        expect(normalizeAssetBase(undefined)).toBe('');
+        expect(normalizeAssetBase(null)).toBe('');
+    });
+
+    it('removes a trailing slash from the provided asset url', () => {
+        expect(normalizeAssetBase('https://example.com/ernie/')).toBe('https://example.com/ernie');
+    });
+});
+
+describe('resolveViteBase', () => {
+    it('falls back to the build directory when no asset url is set', () => {
+        expect(resolveViteBase(undefined)).toBe('/build/');
+    });
+
+    it('uses the normalized asset url with build suffix', () => {
+        expect(resolveViteBase('https://example.com/ernie/')).toBe('https://example.com/ernie/build/');
+    });
+});

--- a/resources/js/lib/vite-base.ts
+++ b/resources/js/lib/vite-base.ts
@@ -1,0 +1,13 @@
+export function normalizeAssetBase(assetUrl?: string | null): string {
+    if (!assetUrl) {
+        return '';
+    }
+
+    return assetUrl.replace(/\/$/, '');
+}
+
+export function resolveViteBase(assetUrl?: string | null): string {
+    const normalized = normalizeAssetBase(assetUrl);
+
+    return normalized ? `${normalized}/build/` : '/build/';
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,14 +3,18 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
+import { resolveViteBase } from './resources/js/lib/vite-base';
+
+const base = resolveViteBase(process.env.ASSET_URL);
 
 export default defineConfig({
-    base: '/ernie/',
+    base,
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
             ssr: 'resources/js/ssr.tsx',
             refresh: true,
+            buildDirectory: 'build',
         }),
         react(),
         tailwindcss(),


### PR DESCRIPTION
This pull request introduces helper functions to manage asset URLs for Vite builds and updates the Vite configuration to use these helpers. It also adds tests to ensure the helpers work as expected. The main goal is to make the base URL for assets more flexible and robust, especially when an external asset URL is provided.

**Asset URL normalization and resolution:**

* Added `normalizeAssetBase` and `resolveViteBase` helper functions in `vite-base.ts` to standardize and resolve the asset base URL for builds. (`resources/js/lib/vite-base.ts`)

**Testing:**

* Added unit tests for the new helper functions to verify correct behavior for various input scenarios. (`resources/js/__tests__/vite-base.test.ts`)

**Vite configuration update:**

* Updated `vite.config.ts` to use the new `resolveViteBase` helper for the `base` option, allowing dynamic configuration based on the `ASSET_URL` environment variable. Also explicitly set the `buildDirectory` to `build` in the Laravel Vite plugin config. (`vite.config.ts`)