### PR TITLE
Configure Vite build output for Traefik prefix

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Vite::useBuildDirectory('assets');
     }
 }

--- a/tests/Feature/ViteAssetsTest.php
+++ b/tests/Feature/ViteAssetsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
+use function Pest\Laravel\withVite;
+
+it('renders asset tags that point to the /ernie/assets base path', function () {
+    config()->set('app.url', 'https://env.rz-vm182.gfz.de/ernie');
+    withVite();
+
+    $manifestPath = public_path('assets/manifest.json');
+    $manifestDirectory = dirname($manifestPath);
+
+    if (! File::exists($manifestDirectory)) {
+        File::makeDirectory($manifestDirectory, 0755, true);
+    }
+
+    $originalManifest = File::exists($manifestPath)
+        ? File::get($manifestPath)
+        : null;
+
+    $manifest = [
+        'resources/js/app.tsx' => [
+            'src' => 'resources/js/app.tsx',
+            'file' => 'app-12345.js',
+            'isEntry' => true,
+            'css' => ['app-12345.css'],
+        ],
+        'resources/js/pages/welcome.tsx' => [
+            'src' => 'resources/js/pages/welcome.tsx',
+            'file' => 'welcome-67890.js',
+            'isEntry' => true,
+        ],
+    ];
+
+    File::put($manifestPath, json_encode($manifest));
+
+    try {
+        $html = Blade::render("@vite(['resources/js/app.tsx', 'resources/js/pages/welcome.tsx'])");
+
+        expect($html)->toContain('/ernie/assets/app-12345.js');
+        expect($html)->toContain('/ernie/assets/app-12345.css');
+        expect($html)->toContain('/ernie/assets/welcome-67890.js');
+    } finally {
+        if ($originalManifest !== null) {
+            File::put($manifestPath, $originalManifest);
+        } else {
+            File::delete($manifestPath);
+        }
+    }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
             ssr: 'resources/js/ssr.tsx',
             refresh: true,
+            buildDirectory: 'assets',
         }),
         react(),
         tailwindcss(),
@@ -20,6 +21,12 @@ export default defineConfig({
     ],
     esbuild: {
         jsx: 'automatic',
+    },
+    build: {
+        outDir: 'public/assets',
+        assetsDir: '',
+        manifest: 'manifest.json',
+        emptyOutDir: true,
     },
     test: {
         environment: 'jsdom',


### PR DESCRIPTION
This pull request updates the Vite build setup to ensure that all built frontend assets are output to a dedicated `assets` directory, and updates the application to serve those assets correctly. It also adds a feature test to verify that asset URLs are generated with the correct base path.

**Vite build output and asset serving changes:**

* Updated `vite.config.ts` to set the Vite build output directory to `public/assets`, use an empty `assetsDir`, and output the manifest as `manifest.json`. Also, set the `buildDirectory` option in the Vite Laravel plugin to `assets`. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR14) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR25-R30)
* In `AppServiceProvider.php`, configured Laravel Vite integration to use the `assets` build directory, ensuring asset URLs are generated relative to `/assets`. [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR5) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL22-R23)

**Testing and verification:**

* Added a new feature test `ViteAssetsTest.php` to verify that the generated asset tags reference the `/ernie/assets` base path, ensuring correct asset loading when the app is hosted in a subdirectory.