### PR TITLE
Remove manual Vite base configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-    base: '/ernie/',
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],


### PR DESCRIPTION
This pull request makes a small configuration change by removing the `base: '/ernie/'` property from the Vite configuration. This will affect how assets are resolved and served, defaulting to the root path instead of `/ernie/`.