### PR TITLE
Adjust Vite build output and add subpath smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bootstrap/ssr
 /node_modules
 /public/build
+/public/assets
 /public/hot
 /public/storage
 /resources/js/actions

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Vite::useBuildDirectory('assets');
     }
 }

--- a/e2e/welcome-no-404.spec.ts
+++ b/e2e/welcome-no-404.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+// Ensures the welcome page works when hosted behind a sub-path and that all
+// console messages stay free of 404 errors, preventing regressions when the
+// asset build directory changes.
+test('welcome page behind sub-path loads without 404s', async ({ page }) => {
+    const consoleMessages: string[] = [];
+
+    page.on('console', (message) => {
+        const text = message.text();
+        if (text.includes('404')) {
+            consoleMessages.push(text);
+        }
+    });
+
+    const response = await page.goto('/ernie', { waitUntil: 'networkidle' });
+    expect(response?.status() ?? 0).toBeLessThan(400);
+
+    await expect(page.locator('#app')).toHaveAttribute('data-page', /"component":"welcome"/);
+
+    expect(consoleMessages).toEqual([]);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,10 @@ Route::get('/', function () {
     return Inertia::render('welcome');
 })->name('home');
 
+Route::get('/ernie', function () {
+    return Inertia::render('welcome');
+})->name('home.subpath');
+
 Route::get('/about', function () {
     return Inertia::render('about');
 })->name('about');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],
             ssr: 'resources/js/ssr.tsx',
             refresh: true,
+            buildDirectory: 'assets',
         }),
         react(),
         tailwindcss(),


### PR DESCRIPTION
This pull request updates the asset build directory configuration to use a custom directory and ensures the application works correctly when hosted behind a sub-path. It also adds end-to-end test coverage to prevent regressions related to asset loading and 404 errors.

**Asset Build Directory Configuration:**

* Configured Vite to use the `assets` directory for built files in both the Vite config (`vite.config.ts`) and at runtime via `Vite::useBuildDirectory('assets')` in `AppServiceProvider.php`. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR14) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR5) [[3]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL22-R23)

**Routing Updates:**

* Added a new `/ernie` route rendering the `welcome` page to simulate hosting behind a sub-path.

**Testing Improvements:**

* Added an end-to-end Playwright test (`e2e/welcome-no-404.spec.ts`) to verify that the welcome page loads without 404 errors when accessed via a sub-path, ensuring asset loading works correctly with the new build directory.