### PR TITLE
Handle base path for prefixed deployments

### DIFF
--- a/resources/js/__tests__/base-path.test.ts
+++ b/resources/js/__tests__/base-path.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { applyBasePathToRoutes, withBasePath, __testing as basePathTesting } from '@/lib/base-path';
+
+describe('withBasePath', () => {
+    beforeEach(() => {
+        document.head.innerHTML = '';
+        basePathTesting.resetBasePathCache();
+    });
+
+    it('returns the original path when no base path is configured', () => {
+        expect(withBasePath('/docs')).toBe('/docs');
+    });
+
+    it('prefixes the provided path with the base path meta value', () => {
+        basePathTesting.setMetaBasePath('/ernie');
+        expect(withBasePath('/docs')).toBe('/ernie/docs');
+    });
+
+    it('does not double prefix paths that already include the base path', () => {
+        basePathTesting.setMetaBasePath('/ernie');
+        expect(withBasePath('/ernie/docs')).toBe('/ernie/docs');
+    });
+});
+
+describe('applyBasePathToRoutes', () => {
+    beforeEach(() => {
+        document.head.innerHTML = '';
+        basePathTesting.resetBasePathCache();
+    });
+
+    it('updates route definitions using the configured base path', () => {
+        const route = Object.assign(
+            () => ({ url: '/docs', method: 'get' }),
+            {
+                definition: { url: '/docs' },
+            },
+        );
+
+        applyBasePathToRoutes({ route });
+        expect(route.definition.url).toBe('/docs');
+
+        basePathTesting.setMetaBasePath('/ernie');
+        basePathTesting.resetBasePathCache();
+        applyBasePathToRoutes({ route });
+        expect(route.definition.url).toBe('/ernie/docs');
+
+        applyBasePathToRoutes({ route });
+        expect(route.definition.url).toBe('/ernie/docs');
+    });
+});

--- a/resources/js/components/__tests__/app-footer.test.tsx
+++ b/resources/js/components/__tests__/app-footer.test.tsx
@@ -2,20 +2,42 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import AppFooter from '../app-footer';
 import { latestVersion } from '@/lib/version';
-import { describe, expect, it, vi } from 'vitest';
+import { __testing as basePathTesting } from '@/lib/base-path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@inertiajs/react', () => ({
-    Link: ({ href, children, ...props }: { href: string; children?: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-        <a href={href} {...props}>
-            {children}
-        </a>
-    ),
+    Link: ({ href, children, ...props }: { href: unknown; children?: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+        const resolvedHref =
+            typeof href === 'string'
+                ? href
+                : href && typeof href === 'object' && 'url' in (href as Record<string, unknown>)
+                  ? String((href as { url: string }).url)
+                  : '';
+
+        return (
+            <a href={resolvedHref} {...props}>
+                {children}
+            </a>
+        );
+    },
 }));
 
-vi.mock('@/routes', () => ({
-    about: () => '/about',
-    legalNotice: () => '/legal-notice',
-}));
+vi.mock('@/routes', async () => {
+    const { withBasePath } = await import('@/lib/base-path');
+
+    const makeRoute = (path: string) => ({ url: withBasePath(path) });
+
+    return {
+        about: () => makeRoute('/about'),
+        legalNotice: () => makeRoute('/legal-notice'),
+        changelog: () => makeRoute('/changelog'),
+    };
+});
+
+afterEach(() => {
+    document.head.innerHTML = '';
+    basePathTesting.resetBasePathCache();
+});
 
 describe('AppFooter', () => {
     it('displays version and navigation links', () => {
@@ -27,6 +49,17 @@ describe('AppFooter', () => {
         expect(versionLink).toHaveAttribute('href', '/changelog');
         expect(screen.getByRole('link', { name: /about/i })).toHaveAttribute('href', '/about');
         expect(screen.getByRole('link', { name: /legal notice/i })).toHaveAttribute('href', '/legal-notice');
+    });
+
+    it('prefixes links with the configured base path', () => {
+        basePathTesting.setMetaBasePath('/ernie');
+        render(<AppFooter />);
+        const versionLink = screen.getByRole('link', {
+            name: new RegExp(`view changelog for version ${latestVersion}`, 'i'),
+        });
+        expect(versionLink).toHaveAttribute('href', '/ernie/changelog');
+        expect(screen.getByRole('link', { name: /about/i })).toHaveAttribute('href', '/ernie/about');
+        expect(screen.getByRole('link', { name: /legal notice/i })).toHaveAttribute('href', '/ernie/legal-notice');
     });
 });
 

--- a/resources/js/components/app-footer.tsx
+++ b/resources/js/components/app-footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@inertiajs/react';
-import { about, legalNotice } from '@/routes';
+import { about, changelog as changelogRoute, legalNotice } from '@/routes';
 import { latestVersion } from '@/lib/version';
 
 export function AppFooter() {
@@ -7,17 +7,17 @@ export function AppFooter() {
         <footer className="border-t py-4 text-sm text-neutral-600 dark:text-neutral-300">
             <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-2 px-4 md:flex-row">
                 <Link
-                    href="/changelog"
+                    href={changelogRoute().url}
                     className="hover:underline"
                     aria-label={`View changelog for version ${latestVersion}`}
                 >
                     ERNIE v{latestVersion}
                 </Link>
                 <div className="flex gap-4">
-                    <Link href={about()} className="hover:underline">
+                    <Link href={about().url} className="hover:underline">
                         About
                     </Link>
-                    <Link href={legalNotice()} className="hover:underline">
+                    <Link href={legalNotice().url} className="hover:underline">
                         Legal Notice
                     </Link>
                 </div>

--- a/resources/js/components/breadcrumbs.tsx
+++ b/resources/js/components/breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
+import { withBasePath } from '@/lib/base-path';
 import { type BreadcrumbItem as BreadcrumbItemType } from '@/types';
 import { Link } from '@inertiajs/react';
 import { Fragment } from 'react';
@@ -18,7 +19,7 @@ export function Breadcrumbs({ breadcrumbs }: { breadcrumbs: BreadcrumbItemType[]
                                             <BreadcrumbPage>{item.title}</BreadcrumbPage>
                                         ) : (
                                             <BreadcrumbLink asChild>
-                                                <Link href={item.href}>{item.title}</Link>
+                                                <Link href={withBasePath(item.href)}>{item.title}</Link>
                                             </BreadcrumbLink>
                                         )}
                                     </BreadcrumbItem>

--- a/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
+++ b/resources/js/layouts/auth/__tests__/auth-simple-layout.test.tsx
@@ -3,16 +3,35 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import AuthSimpleLayout from '../auth-simple-layout';
 
+function resolveHref(href: unknown): string {
+    if (typeof href === 'string') {
+        return href;
+    }
+
+    if (href && typeof href === 'object' && 'url' in href && typeof (href as { url?: unknown }).url === 'string') {
+        return (href as { url: string }).url;
+    }
+
+    return '';
+}
+
 vi.mock('@inertiajs/react', () => ({
-    Link: ({ href, children }: { href: string; children?: React.ReactNode }) => (
-        <a href={href}>{children}</a>
+    Link: ({ href, children }: { href: unknown; children?: React.ReactNode }) => (
+        <a href={resolveHref(href)}>{children}</a>
     ),
 }));
 
+function createRoute(path: string) {
+    const routeFn = () => ({ url: path });
+    routeFn.url = () => path;
+    return routeFn;
+}
+
 vi.mock('@/routes', () => ({
-    home: () => '/',
-    about: () => '/about',
-    legalNotice: () => '/legal-notice',
+    home: createRoute('/'),
+    about: createRoute('/about'),
+    legalNotice: createRoute('/legal-notice'),
+    changelog: createRoute('/changelog'),
 }));
 
 describe('AuthSimpleLayout', () => {

--- a/resources/js/lib/base-path.ts
+++ b/resources/js/lib/base-path.ts
@@ -1,0 +1,147 @@
+const BASE_PATH_META_NAME = 'app-base-path';
+const ORIGINAL_URL_SYMBOL = Symbol('originalUrl');
+let cachedBasePath: string | undefined;
+
+const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.+-]*:|\/\/)/i;
+
+const isWindowDefined = () => typeof window !== 'undefined';
+
+const normalizeBasePath = (value: string): string => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        return '';
+    }
+
+    const prefixed = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+    const withoutTrailingSlash = prefixed.length > 1 && prefixed.endsWith('/')
+        ? prefixed.slice(0, -1)
+        : prefixed;
+
+    return withoutTrailingSlash === '/' ? '' : withoutTrailingSlash;
+};
+
+const readMetaBasePath = (): string => {
+    if (typeof document === 'undefined') {
+        return '';
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>(
+        `meta[name="${BASE_PATH_META_NAME}"]`,
+    );
+
+    return meta?.content ?? '';
+};
+
+export const getBasePath = (): string => {
+    if (typeof cachedBasePath !== 'undefined') {
+        return cachedBasePath;
+    }
+
+    let basePath = '';
+
+    // Prefer build-time configuration when available (SSR, tests)
+    if (typeof import.meta !== 'undefined' && import.meta.env) {
+        basePath =
+            import.meta.env.VITE_APP_BASE_PATH ||
+            import.meta.env.APP_BASE_PATH ||
+            '';
+    }
+
+    if (!basePath && typeof process !== 'undefined') {
+        basePath =
+            (process.env?.VITE_APP_BASE_PATH as string | undefined) ||
+            (process.env?.APP_BASE_PATH as string | undefined) ||
+            '';
+    }
+
+    if (!basePath) {
+        basePath = readMetaBasePath();
+    }
+
+    cachedBasePath = normalizeBasePath(basePath);
+
+    return cachedBasePath;
+};
+
+const alreadyPrefixed = (path: string, basePath: string) =>
+    basePath && (path === basePath || path.startsWith(`${basePath}/`));
+
+export const withBasePath = (path: string): string => {
+    if (!path) {
+        return path;
+    }
+
+    const basePath = getBasePath();
+
+    if (!basePath) {
+        return path;
+    }
+
+    if (ABSOLUTE_URL_REGEX.test(path) || path.startsWith('#')) {
+        return path;
+    }
+
+    if (alreadyPrefixed(path, basePath)) {
+        return path;
+    }
+
+    if (path.startsWith('/')) {
+        return `${basePath}${path}`;
+    }
+
+    return `${basePath}/${path}`;
+};
+
+type RouteWithDefinition = {
+    definition?: {
+        url: string;
+        [ORIGINAL_URL_SYMBOL]?: string;
+    };
+};
+
+export const applyBasePathToRoutes = (
+    routes: Record<string, RouteWithDefinition | undefined>,
+): void => {
+    const basePath = getBasePath();
+
+    Object.values(routes).forEach((route) => {
+        if (!route?.definition || typeof route.definition.url !== 'string') {
+            return;
+        }
+
+        const definition = route.definition as RouteWithDefinition['definition'];
+        const originalUrl = definition?.[ORIGINAL_URL_SYMBOL] ?? route.definition.url;
+
+        if (definition) {
+            definition[ORIGINAL_URL_SYMBOL] = originalUrl;
+            definition.url = basePath ? withBasePath(originalUrl) : originalUrl;
+        }
+    });
+};
+
+export const __testing = {
+    resetBasePathCache: () => {
+        cachedBasePath = undefined;
+    },
+    setMetaBasePath: (value: string) => {
+        if (!isWindowDefined()) {
+            return;
+        }
+
+        let meta = document.querySelector<HTMLMetaElement>(
+            `meta[name="${BASE_PATH_META_NAME}"]`,
+        );
+
+        if (!meta) {
+            meta = document.createElement('meta');
+            meta.setAttribute('name', BASE_PATH_META_NAME);
+            document.head.appendChild(meta);
+        }
+
+        meta.content = value;
+        cachedBasePath = undefined;
+    },
+};
+
+export default withBasePath;

--- a/resources/js/pages/__tests__/dashboard.integration.test.tsx
+++ b/resources/js/pages/__tests__/dashboard.integration.test.tsx
@@ -6,6 +6,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const usePageMock = vi.fn();
 const routerMock = vi.hoisted(() => ({ get: vi.fn() }));
 
+function resolveHref(href: unknown): string {
+    if (typeof href === 'string') {
+        return href;
+    }
+
+    if (href && typeof href === 'object' && 'url' in href && typeof (href as { url?: unknown }).url === 'string') {
+        return (href as { url: string }).url;
+    }
+
+    return '';
+}
+
 vi.mock('@inertiajs/react', () => ({
     Head: ({ title, children }: { title?: string; children?: React.ReactNode }) => {
         if (title) document.title = title;
@@ -13,8 +25,8 @@ vi.mock('@inertiajs/react', () => ({
     },
     usePage: () => usePageMock(),
     router: routerMock,
-    Link: ({ href, children, ...props }: { href: string; children?: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-        <a href={href} {...props}>
+    Link: ({ href, children, ...props }: { href: unknown; children?: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={resolveHref(href)} {...props}>
             {children}
         </a>
     ),
@@ -24,8 +36,15 @@ vi.mock('@/layouts/app-layout', () => ({
     default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
 
+function createRoute(path: string) {
+    const routeFn = () => ({ url: path });
+    routeFn.url = () => path;
+    return routeFn;
+}
+
 vi.mock('@/routes', () => ({
-    dashboard: () => ({ url: '/dashboard' }),
+    dashboard: createRoute('/dashboard'),
+    changelog: createRoute('/changelog'),
 }));
 
 describe('Dashboard integration', () => {

--- a/resources/js/pages/__tests__/docs.test.tsx
+++ b/resources/js/pages/__tests__/docs.test.tsx
@@ -1,7 +1,8 @@
 import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import Docs from '../docs';
-import { describe, expect, it, vi } from 'vitest';
+import { __testing as basePathTesting } from '@/lib/base-path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -12,6 +13,11 @@ vi.mock('@/layouts/app-layout', () => ({
 }));
 
 describe('Docs page', () => {
+    afterEach(() => {
+        document.head.innerHTML = '';
+        basePathTesting.resetBasePathCache();
+    });
+
     it('renders collapsible triggers', () => {
         render(<Docs />);
         expect(screen.getByText('For Users')).toBeInTheDocument();
@@ -42,6 +48,15 @@ describe('Docs page', () => {
         fireEvent.click(screen.getByText('For Developers'));
         const link = screen.getByText('View the API documentation');
         expect(link).toHaveAttribute('href', '/api/v1/doc');
+    });
+
+    it('applies the base path to documentation links when configured', () => {
+        basePathTesting.setMetaBasePath('/ernie');
+        render(<Docs />);
+        fireEvent.click(screen.getByText('For Users'));
+        expect(screen.getByText('Go to the user documentation')).toHaveAttribute('href', '/ernie/docs/users');
+        fireEvent.click(screen.getByText('For Developers'));
+        expect(screen.getByText('View the API documentation')).toHaveAttribute('href', '/ernie/api/v1/doc');
     });
 });
 

--- a/resources/js/pages/auth/__tests__/forgot-password.test.tsx
+++ b/resources/js/pages/auth/__tests__/forgot-password.test.tsx
@@ -6,12 +6,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 let formErrors: { email?: string };
 let formProcessing: boolean;
 
+function resolveHref(href: unknown): string {
+    if (typeof href === 'string') {
+        return href;
+    }
+
+    if (href && typeof href === 'object' && 'url' in href && typeof (href as { url?: unknown }).url === 'string') {
+        return (href as { url: string }).url;
+    }
+
+    return '';
+}
+
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     Form: ({ children }: { children: (args: { processing: boolean; errors: typeof formErrors }) => React.ReactNode }) => (
         <form>{children({ processing: formProcessing, errors: formErrors })}</form>
     ),
-    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+    Link: ({ children, href }: { children?: React.ReactNode; href: unknown }) => (
+        <a href={resolveHref(href)}>{children}</a>
+    ),
 }));
 
 vi.mock('@/actions/App/Http/Controllers/Auth/PasswordResetLinkController', () => ({
@@ -22,11 +36,18 @@ vi.mock('@/actions/App/Http/Controllers/Auth/PasswordResetLinkController', () =>
     },
 }));
 
+function createRoute(path: string) {
+    const routeFn = () => ({ url: path });
+    routeFn.url = () => path;
+    return routeFn;
+}
+
 vi.mock('@/routes', () => ({
-    login: () => '/login',
-    home: () => '/',
-    about: () => '/about',
-    legalNotice: () => '/legal-notice',
+    login: createRoute('/login'),
+    home: createRoute('/'),
+    about: createRoute('/about'),
+    legalNotice: createRoute('/legal-notice'),
+    changelog: createRoute('/changelog'),
 }));
 
 describe('ForgotPassword page', () => {

--- a/resources/js/pages/auth/__tests__/verify-email.test.tsx
+++ b/resources/js/pages/auth/__tests__/verify-email.test.tsx
@@ -5,12 +5,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let formProcessing: boolean;
 
+function resolveHref(href: unknown): string {
+    if (typeof href === 'string') {
+        return href;
+    }
+
+    if (href && typeof href === 'object' && 'url' in href && typeof (href as { url?: unknown }).url === 'string') {
+        return (href as { url: string }).url;
+    }
+
+    return '';
+}
+
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     Form: ({ children }: { children: (args: { processing: boolean }) => React.ReactNode }) => (
         <form>{children({ processing: formProcessing })}</form>
     ),
-    Link: ({ children, href }: { children?: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+    Link: ({ children, href }: { children?: React.ReactNode; href: unknown }) => (
+        <a href={resolveHref(href)}>{children}</a>
+    ),
 }));
 
 vi.mock('@/actions/App/Http/Controllers/Auth/EmailVerificationNotificationController', () => ({
@@ -21,11 +35,18 @@ vi.mock('@/actions/App/Http/Controllers/Auth/EmailVerificationNotificationContro
     },
 }));
 
+function createRoute(path: string) {
+    const routeFn = () => ({ url: path });
+    routeFn.url = () => path;
+    return routeFn;
+}
+
 vi.mock('@/routes', () => ({
-    logout: () => '/logout',
-    home: () => '/',
-    about: () => '/about',
-    legalNotice: () => '/legal-notice',
+    logout: createRoute('/logout'),
+    home: createRoute('/'),
+    about: createRoute('/about'),
+    legalNotice: createRoute('/legal-notice'),
+    changelog: createRoute('/changelog'),
 }));
 
 describe('VerifyEmail page', () => {

--- a/resources/js/pages/changelog.tsx
+++ b/resources/js/pages/changelog.tsx
@@ -1,4 +1,5 @@
 import PublicLayout from '@/layouts/public-layout';
+import { withBasePath } from '@/lib/base-path';
 import { Head } from '@inertiajs/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
@@ -28,7 +29,7 @@ export default function Changelog() {
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        fetch('/api/changelog')
+        fetch(withBasePath('/api/changelog'))
             .then((res) => {
                 if (!res.ok) {
                     throw new Error('Network response was not ok');

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -1,5 +1,7 @@
 import AppLayout from '@/layouts/app-layout';
 import DataCiteForm from '@/components/curation/datacite-form';
+import { curation } from '@/routes';
+import { withBasePath } from '@/lib/base-path';
 import { Head } from '@inertiajs/react';
 import { useEffect, useState } from 'react';
 import {
@@ -9,13 +11,6 @@ import {
     type License,
     type Language,
 } from '@/types';
-
-const breadcrumbs: BreadcrumbItem[] = [
-    {
-        title: 'Curation',
-        href: '/curation',
-    },
-];
 
 interface CurationProps {
     maxTitles: number;
@@ -46,12 +41,19 @@ export default function Curation({
     const [languages, setLanguages] = useState<Language[] | null>(null);
     const [error, setError] = useState(false);
 
+    const breadcrumbs: BreadcrumbItem[] = [
+        {
+            title: 'Curation',
+            href: curation().url,
+        },
+    ];
+
     useEffect(() => {
         Promise.all([
-            fetch('/api/v1/resource-types/ernie'),
-            fetch('/api/v1/title-types/ernie'),
-            fetch('/api/v1/licenses/ernie'),
-            fetch('/api/v1/languages/ernie'),
+            fetch(withBasePath('/api/v1/resource-types/ernie')),
+            fetch(withBasePath('/api/v1/title-types/ernie')),
+            fetch(withBasePath('/api/v1/licenses/ernie')),
+            fetch(withBasePath('/api/v1/languages/ernie')),
         ])
             .then(async ([resTypes, titleRes, licenseRes, languageRes]) => {
                 if (!resTypes.ok || !titleRes.ok || !licenseRes.ok || !languageRes.ok)

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,5 +1,6 @@
 import AppLayout from '@/layouts/app-layout';
-import { dashboard } from '@/routes';
+import { curation as curationRoute, dashboard, changelog as changelogRoute } from '@/routes';
+import { uploadXml as uploadXmlRoute } from '@/routes/dashboard';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -21,7 +22,7 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
     formData.append('file', files[0]);
 
     try {
-        const response = await fetch('/dashboard/upload-xml', {
+        const response = await fetch(uploadXmlRoute.url(), {
             method: 'POST',
             body: formData,
             headers: {
@@ -64,7 +65,7 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
                 query[`licenses[${i}]`] = l;
             });
         }
-        router.get('/curation', query);
+        router.get(curationRoute().url, query);
     } catch (error) {
         console.error('XML upload failed', error);
         if (error instanceof Error) {
@@ -175,7 +176,7 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles }: DashboardProp
                                         <td className="py-1">ERNIE Version</td>
                                         <td className="py-1 text-right">
                                             <Link
-                                                href="/changelog"
+                                                href={changelogRoute().url}
                                                 aria-label={`View changelog for version ${latestVersion}`}
                                             >
                                                 <Badge className="w-14 bg-[#003da6] text-white">

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1,4 +1,5 @@
 import AppLayout from '@/layouts/app-layout';
+import { withBasePath } from '@/lib/base-path';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 import {
@@ -8,14 +9,14 @@ import {
 } from '@/components/ui/collapsible';
 import { ChevronDown } from 'lucide-react';
 
-const breadcrumbs: BreadcrumbItem[] = [
+export default function Docs() {
+    const breadcrumbs: BreadcrumbItem[] = [
         {
             title: 'Documentation',
-            href: '/docs',
+            href: withBasePath('/docs'),
         },
-];
+    ];
 
-export default function Docs() {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Documentation" />
@@ -30,7 +31,7 @@ export default function Docs() {
                     >
                         <p>Read guides for using the system.</p>
                         <p>
-                            <a href="/docs/users" className="underline">
+                            <a href={withBasePath('/docs/users')} className="underline">
                                 Go to the user documentation
                             </a>
                         </p>
@@ -74,7 +75,7 @@ export default function Docs() {
                     >
                         <p>Explore the REST API for integrating with the platform.</p>
                         <p>
-                            <a href="/api/v1/doc" className="underline">
+                            <a href={withBasePath('/api/v1/doc')} className="underline">
                                 View the API documentation
                             </a>
                         </p>

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1,4 +1,5 @@
 import PublicLayout from '@/layouts/public-layout';
+import { withBasePath } from '@/lib/base-path';
 import { Head, Link } from '@inertiajs/react';
 
 export default function Welcome() {
@@ -14,7 +15,7 @@ export default function Welcome() {
                 </p>
                 <p className="mt-6">
                     <Link
-                        href="/api/v1/doc"
+                        href={withBasePath('/api/v1/doc')}
                         className="rounded-sm border px-5 py-1.5 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                         API Documentation

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta name="app-base-path" content="{{ parse_url(config('app.url'), PHP_URL_PATH) ?? '' }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>


### PR DESCRIPTION
This pull request introduces a robust base path handling utility to support deployments under a configurable sub-path, and systematically integrates it throughout the application and its test suite. The changes ensure that all internal links, routes, and API requests are correctly prefixed with the configured base path, both at runtime and in tests. Additionally, the test infrastructure is updated to mock and verify base path behavior.

**Base path handling utility:**

- Added a new `withBasePath` function and related helpers in `lib/base-path.ts` to determine and apply a configurable base path to URLs, supporting environment variables and `<meta>` tags. Includes utilities for testing and route patching.

**Integration into application components:**

- Updated navigation and routing in components like `app-footer.tsx` and `breadcrumbs.tsx` to use `withBasePath`, ensuring links are correctly prefixed. [[1]](diffhunk://#diff-233d44c2b6c6c9081ca15631cc407a6bd75ad001cc867a42717c5ae173fe849dL2-R20) [[2]](diffhunk://#diff-4acdc1ec30d8e78814ea92204274f6aacc5302767f32d420993a00b988278c4dR2) [[3]](diffhunk://#diff-4acdc1ec30d8e78814ea92204274f6aacc5302767f32d420993a00b988278c4dL21-R22)

**Test infrastructure improvements:**

- Refactored test mocks for `@/routes` and `@inertiajs/react`'s `Link` to work with route objects containing `.url` and to utilize `withBasePath`, ensuring test coverage for base path logic. [[1]](diffhunk://#diff-f82f9166bc53f725fbe88db82aa4dcc42d2413e617cbf8fd0c432e532b4a587eL5-R40) [[2]](diffhunk://#diff-4745369a7f1e7eb063f4e760643f89220e2eaea3b836061faa3fc9a4577659deR6-R34) [[3]](diffhunk://#diff-da6f059ab4afac8885d24a8dfecaab9b84e911c2511cd9326cac8d3f783bbdc8R9-R29) [[4]](diffhunk://#diff-da6f059ab4afac8885d24a8dfecaab9b84e911c2511cd9326cac8d3f783bbdc8R39-R47) [[5]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL5-R7) [[6]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cL15-R61)
- Added and enhanced tests for base path handling, including new unit tests for `base-path.ts`, and integration tests that verify correct URL generation and API requests when a base path is configured. [[1]](diffhunk://#diff-c72e80601fd669542a202e0d360dc0b9134d044bd4528a8f488db0802cd52dafR1-R50) [[2]](diffhunk://#diff-f82f9166bc53f725fbe88db82aa4dcc42d2413e617cbf8fd0c432e532b4a587eR53-R63) [[3]](diffhunk://#diff-0a0c1e1f10fb8e1cb7b260364f965f3c5d742637956fc75fa25f6eeeeb335fc5L4-R6) [[4]](diffhunk://#diff-0a0c1e1f10fb8e1cb7b260364f965f3c5d742637956fc75fa25f6eeeeb335fc5R73-R77) [[5]](diffhunk://#diff-0a0c1e1f10fb8e1cb7b260364f965f3c5d742637956fc75fa25f6eeeeb335fc5R109-R119) [[6]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR138-R140) [[7]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR300-R328) [[8]](diffhunk://#diff-cf8de5389d60157c373c3e0904c33f1e2c5696c65fd1866956ddbf38896b78dbL4-R5)

**Test cleanup and reset logic:**

- Ensured tests clean up and reset the base path configuration and meta tags after each run to avoid cross-test contamination. [[1]](diffhunk://#diff-f82f9166bc53f725fbe88db82aa4dcc42d2413e617cbf8fd0c432e532b4a587eL5-R40) [[2]](diffhunk://#diff-0a0c1e1f10fb8e1cb7b260364f965f3c5d742637956fc75fa25f6eeeeb335fc5R73-R77) [[3]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR138-R140)

These changes collectively ensure that the application is compatible with deployments under an arbitrary base path, and that this behavior is thoroughly tested and reliable.