### PR TITLE
Add support for path prefix and asset URL behind proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . /var/www/html
 
 RUN composer install --no-interaction --no-plugins --no-scripts \
     && npm install \
-    && npm run build
+    && NODE_ENV=production npm run build
 
 EXPOSE 9000
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,27 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Set the asset URL for production when behind a proxy with path prefix
+        if (config('app.env') === 'production' && config('app.url')) {
+            $this->configureUrlGeneration();
+        }
+    }
+
+    /**
+     * Configure URL generation for production with path prefix
+     */
+    private function configureUrlGeneration(): void
+    {
+        // Force the asset URL to include the path prefix
+        if ($assetUrl = config('app.asset_url')) {
+            URL::forceRootUrl($assetUrl);
+        } else {
+            URL::forceRootUrl(config('app.url'));
+        }
+
+        // Ensure HTTPS is used if the app URL uses HTTPS
+        if (str_starts_with(config('app.url'), 'https://')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Asset URL
+    |--------------------------------------------------------------------------
+    |
+    | The asset URL is used to generate URLs for assets when the application
+    | is running behind a reverse proxy or load balancer that may change the
+    | public URL structure.
+    |
+    */
+
+    'asset_url' => env('ASSET_URL'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,15 @@ import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    base: process.env.NODE_ENV === 'production' ? '/ernie/' : '/',
+    build: {
+        assetsDir: 'assets',
+        rollupOptions: {
+            output: {
+                manualChunks: undefined
+            }
+        }
+    },
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],


### PR DESCRIPTION
This pull request introduces several improvements to support deployments behind a reverse proxy (such as Traefik) with a path prefix, particularly in production environments. The main changes ensure that URL and asset generation are correct when the application is served from a sub-path, and that HTTPS is enforced when appropriate. Additionally, the frontend build and asset paths are updated to match the backend configuration.

**Production URL and asset handling improvements:**

* Added logic in `SetUrlRoot` middleware to use the `X-Forwarded-Prefix` header if available, and otherwise fall back to a production-specific configuration that sets the root URL and enforces HTTPS based on `app.url` when running behind Traefik.
* In `AppServiceProvider`, added logic to set the asset URL (using `app.asset_url` or `app.url`) and enforce HTTPS for URL generation in production, ensuring all generated URLs include the correct path prefix.
* Registered the `URL` facade in `AppServiceProvider` to support the above URL manipulations.
* Added the `asset_url` configuration option to `config/app.php`, allowing the asset base URL to be set via the `ASSET_URL` environment variable.

**Frontend build and asset path adjustments:**

* Updated `vite.config.ts` to set the base path to `/ernie/` in production, ensuring that frontend assets are served from the correct sub-path, and configured the output directory for assets.
* Modified the Docker build process to set `NODE_ENV=production` during the frontend build step, ensuring the correct base path is used in production builds.