### PR TITLE
Ensure generated routes always honor base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,11 @@
 /public/hot
 /public/storage
 /resources/js/actions
-/resources/js/routes
+/resources/js/routes/*
+!/resources/js/routes/*.ts
+!/resources/js/routes/**/*.ts
+/resources/js/routes/index.ts
+/resources/js/routes/**/index.ts
 /resources/js/wayfinder
 /storage/*.key
 /storage/pail

--- a/resources/js/__tests__/routes.test.ts
+++ b/resources/js/__tests__/routes.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { home, logout } from '../routes/index';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { __testing as basePathTesting } from '@/lib/base-path';
 
 describe('generated routes', () => {
-  it('generates home route definitions', () => {
+  afterEach(() => {
+    basePathTesting.setMetaBasePath('');
+    basePathTesting.resetBasePathCache();
+    vi.resetModules();
+  });
+
+  it('generates home route definitions', async () => {
+    const routes = await import('@/routes');
+    const { home } = routes;
+
     expect(home()).toEqual({ url: '/', method: 'get' });
     expect(home.url()).toBe('/');
     expect(home.url({ query: { page: 1 } })).toBe('/?page=1');
@@ -19,10 +28,35 @@ describe('generated routes', () => {
     window.history.replaceState({}, '', '/');
   });
 
-  it('generates logout route definitions', () => {
+  it('generates logout route definitions', async () => {
+    const routes = await import('@/routes');
+    const { logout } = routes;
+
     expect(logout()).toEqual({ url: '/logout', method: 'post' });
     expect(logout.url({ query: { ref: 'x' } })).toBe('/logout?ref=x');
     expect(logout.form.post({ query: { token: 'abc' } })).toEqual({ action: '/logout?token=abc', method: 'post' });
+  });
+
+  it('applies the configured base path to generated routes', async () => {
+    basePathTesting.setMetaBasePath('/ernie');
+    basePathTesting.resetBasePathCache();
+    vi.resetModules();
+
+    const routes = await import('@/routes');
+    expect(routes.home.url()).toBe('/ernie/');
+    expect(routes.logout.url()).toBe('/ernie/logout');
+  });
+
+  it('updates route URLs when the base path meta changes after initial load', async () => {
+    basePathTesting.setMetaBasePath('');
+    basePathTesting.resetBasePathCache();
+    vi.resetModules();
+
+    const routes = await import('@/routes');
+    expect(routes.home.url()).toBe('/');
+
+    basePathTesting.setMetaBasePath('/ernie');
+    expect(routes.home.url()).toBe('/ernie/');
   });
 });
 

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -8,6 +8,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/co
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { UserMenuContent } from '@/components/user-menu-content';
 import { useInitials } from '@/hooks/use-initials';
+import { withBasePath } from '@/lib/base-path';
 import { cn } from '@/lib/utils';
 import { dashboard, settings } from '@/routes';
 import { type BreadcrumbItem, type NavItem, type SharedData } from '@/types';
@@ -24,7 +25,7 @@ const mainNavItems: NavItem[] = [
     },
     {
         title: 'Curation',
-        href: '/curation',
+        href: withBasePath('/curation'),
         icon: Database,
     },
 ];
@@ -37,17 +38,17 @@ const rightNavItems: NavItem[] = [
     },
     {
         title: 'Changelog',
-        href: '/changelog',
+        href: withBasePath('/changelog'),
         icon: History,
     },
     {
         title: 'Documentation',
-        href: '/docs',
+        href: withBasePath('/docs'),
         icon: BookOpen,
     },
     {
         title: 'API Documentation',
-        href: '/api/v1/doc',
+        href: withBasePath('/api/v1/doc'),
         icon: FileText,
     },
 ];

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { withBasePath } from '@/lib/base-path';
 import { dashboard, settings } from '@/routes';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
@@ -16,7 +17,7 @@ const mainNavItems: NavItem[] = [
     },
     {
         title: 'Curation',
-        href: '/curation',
+        href: withBasePath('/curation'),
         icon: Database,
     },
 ];
@@ -29,12 +30,12 @@ const footerNavItems: NavItem[] = [
     },
     {
         title: 'Changelog',
-        href: '/changelog',
+        href: withBasePath('/changelog'),
         icon: History,
     },
     {
         title: 'Documentation',
-        href: '/docs',
+        href: withBasePath('/docs'),
         icon: BookOpen,
     },
 ];

--- a/resources/js/pages/__tests__/docs-users.test.tsx
+++ b/resources/js/pages/__tests__/docs-users.test.tsx
@@ -1,22 +1,64 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
-import DocsUsers from '../docs-users';
-import { describe, expect, it, vi } from 'vitest';
+import { __testing as basePathTesting } from '@/lib/base-path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
+const AppLayoutMock = vi.fn(
+    ({ breadcrumbs, children }: { breadcrumbs: unknown; children?: React.ReactNode }) => (
+        <div data-breadcrumbs={JSON.stringify(breadcrumbs)}>{children}</div>
+    ),
+);
+
 vi.mock('@/layouts/app-layout', () => ({
-    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    default: AppLayoutMock,
 }));
 
 describe('User docs page', () => {
-    it('renders curator instructions', () => {
+    afterEach(() => {
+        basePathTesting.setMetaBasePath('');
+        basePathTesting.resetBasePathCache();
+        AppLayoutMock.mockClear();
+        vi.resetModules();
+    });
+
+    it('renders curator instructions', async () => {
+        const DocsUsers = (await import('../docs-users')).default;
+
         render(<DocsUsers />);
         expect(screen.getByText('Add new curators')).toBeInTheDocument();
         expect(
             screen.getByText(/ehrmann@gfz.de/)
         ).toBeInTheDocument();
+        const container = screen.getByText('Add new curators').closest('[data-breadcrumbs]');
+        expect(container).toHaveAttribute(
+            'data-breadcrumbs',
+            JSON.stringify([
+                { title: 'Documentation', href: '/docs' },
+                { title: 'User guide', href: '/docs/users' },
+            ]),
+        );
+    });
+
+    it('includes the base path in breadcrumb links when configured', async () => {
+        basePathTesting.setMetaBasePath('/ernie');
+        basePathTesting.resetBasePathCache();
+
+        vi.resetModules();
+        const DocsUsers = (await import('../docs-users')).default;
+
+        render(<DocsUsers />);
+
+        const container = screen.getByText('Add new curators').closest('[data-breadcrumbs]');
+        expect(container).toHaveAttribute(
+            'data-breadcrumbs',
+            JSON.stringify([
+                { title: 'Documentation', href: '/ernie/docs' },
+                { title: 'User guide', href: '/ernie/docs/users' },
+            ]),
+        );
     });
 });

--- a/resources/js/pages/docs-users.tsx
+++ b/resources/js/pages/docs-users.tsx
@@ -1,10 +1,11 @@
+import { withBasePath } from '@/lib/base-path';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Documentation', href: '/docs' },
-    { title: 'User guide', href: '/docs/users' },
+    { title: 'Documentation', href: withBasePath('/docs') },
+    { title: 'User guide', href: withBasePath('/docs/users') },
 ];
 
 export default function DocsUsers() {

--- a/resources/js/routes-wrappers/dashboard.ts
+++ b/resources/js/routes-wrappers/dashboard.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/dashboard/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/dashboard/index';

--- a/resources/js/routes-wrappers/docs.ts
+++ b/resources/js/routes-wrappers/docs.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/docs/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/docs/index';

--- a/resources/js/routes-wrappers/login.ts
+++ b/resources/js/routes-wrappers/login.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/login/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/login/index';

--- a/resources/js/routes-wrappers/password.ts
+++ b/resources/js/routes-wrappers/password.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/password/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/password/index';

--- a/resources/js/routes-wrappers/profile.ts
+++ b/resources/js/routes-wrappers/profile.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/profile/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/profile/index';

--- a/resources/js/routes-wrappers/settings.ts
+++ b/resources/js/routes-wrappers/settings.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/settings/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/settings/index';

--- a/resources/js/routes-wrappers/storage.ts
+++ b/resources/js/routes-wrappers/storage.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/storage/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/storage/index';

--- a/resources/js/routes-wrappers/verification.ts
+++ b/resources/js/routes-wrappers/verification.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from '../routes/verification/index';
+import { applyBasePathToRoutes } from '../lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from '../routes/verification/index';

--- a/resources/js/routes.ts
+++ b/resources/js/routes.ts
@@ -1,0 +1,8 @@
+import * as generatedRoutes from './routes/index';
+import { applyBasePathToRoutes } from './lib/base-path';
+
+type RouteModule = Record<string, unknown>;
+
+applyBasePathToRoutes(generatedRoutes as RouteModule);
+
+export * from './routes/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -109,7 +109,9 @@
         "skipLibCheck": true /* Skip type checking all .d.ts files. */,
         "baseUrl": ".",
         "paths": {
-            "@/*": ["./resources/js/*"]
+            "@/*": ["./resources/js/*"],
+            "@/routes": ["./resources/js/routes.ts"],
+            "@/routes/*": ["./resources/js/routes-wrappers/*"]
         },
         "jsx": "react-jsx"
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,13 @@ import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    resolve: {
+        alias: [
+            { find: '@', replacement: '/resources/js' },
+            { find: '@/routes/', replacement: '/resources/js/routes-wrappers/' },
+            { find: '@/routes', replacement: '/resources/js/routes.ts' },
+        ],
+    },
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.tsx', 'resources/js/swagger.tsx'],


### PR DESCRIPTION
This pull request enhances base path support throughout the application, ensuring that all navigation links, route definitions, and breadcrumbs consistently respect the configured base path. It also improves the test suites to verify this behavior and refactors how base paths are applied to route definitions.

**Base Path Handling and Route Refactoring**

* Ensured that navigation links and breadcrumbs use the configured base path by updating all usage of static URLs to use the `withBasePath` utility in `app-header.tsx`, `app-sidebar.tsx`, and `docs-users.tsx`. [[1]](diffhunk://#diff-e93188a864f7af449d4b29df16b91db77b206f891eef34b28856d7b5565e537dL27-R28) [[2]](diffhunk://#diff-e93188a864f7af449d4b29df16b91db77b206f891eef34b28856d7b5565e537dL40-R51) [[3]](diffhunk://#diff-09845d63b8044b16b013decdd5cc20a182793c1ad93ea10fdbea68d41d4643ecL19-R20) [[4]](diffhunk://#diff-09845d63b8044b16b013decdd5cc20a182793c1ad93ea10fdbea68d41d4643ecL32-R38) [[5]](diffhunk://#diff-97e2bbb3c67f662d716cfcbabb4550a9d10a49626c9a03c1214a79baa9959aa9R1-R8)
* Refactored the route base path application logic: `applyBasePathToRoutes` now uses a property descriptor to wrap route definitions, so URLs dynamically reflect changes in the base path.
* Added a new wrapper to apply base path logic to dashboard routes.

**Test Improvements**

* Updated and expanded tests for `AppHeader`, `AppSidebar`, and `docs-users` to verify that navigation links and breadcrumbs update correctly when the base path is set or changed, including after dynamic updates. [[1]](diffhunk://#diff-6ac759d3adc008639bbccdaaf5d1fdafa0f7ca7d9b8361441daf38e260ab3776L82-R98) [[2]](diffhunk://#diff-6ac759d3adc008639bbccdaaf5d1fdafa0f7ca7d9b8361441daf38e260ab3776L110-R119) [[3]](diffhunk://#diff-6ac759d3adc008639bbccdaaf5d1fdafa0f7ca7d9b8361441daf38e260ab3776R134-R167) [[4]](diffhunk://#diff-ad7a3d8bd56f6ae670679d87e3433cbee43c72b730af2edd2b1dca28684a5d4bL56-R76) [[5]](diffhunk://#diff-ad7a3d8bd56f6ae670679d87e3433cbee43c72b730af2edd2b1dca28684a5d4bL92-R126) [[6]](diffhunk://#diff-1a13bb9416fefd52cc2b38bde525ce23a5bc69828564d10b27de176553f2a935L3-R62)
* Improved route definition tests to check that generated route URLs respect the base path and update after changes. [[1]](diffhunk://#diff-1591ddd499b606ce388b7edc1dba32a15ffd28220e525d21346830caa4e040ccL1-R14) [[2]](diffhunk://#diff-1591ddd499b606ce388b7edc1dba32a15ffd28220e525d21346830caa4e040ccL22-R60)

**Base Path Utility Enhancements**

* Modified the `getBasePath` utility to re-read and update the cached base path if the meta tag changes, ensuring route URLs stay in sync with runtime changes.