### PR TITLE
Adjust settings bento grid layout to two columns

### DIFF
--- a/resources/js/components/ui/__tests__/bento-grid.test.tsx
+++ b/resources/js/components/ui/__tests__/bento-grid.test.tsx
@@ -18,6 +18,7 @@ describe('BentoGrid', () => {
     const first = screen.getByText('One')
     expect(first).toHaveAttribute('data-slot', 'bento-grid-item')
     expect(first).toHaveClass('self-start')
-    expect(grid).toHaveClass('grid', 'gap-4', 'md:grid-cols-2', 'lg:grid-cols-3')
+    expect(grid).toHaveClass('grid', 'gap-4', 'md:grid-cols-2')
+    expect(grid).not.toHaveClass('lg:grid-cols-3')
   })
 })

--- a/resources/js/components/ui/bento-grid.tsx
+++ b/resources/js/components/ui/bento-grid.tsx
@@ -7,7 +7,7 @@ function BentoGrid({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="bento-grid"
       className={cn(
-        "grid gap-4 md:grid-cols-2 lg:grid-cols-3",
+        "grid gap-4 md:grid-cols-2",
         className
       )}
       {...props}

--- a/resources/js/pages/__tests__/settings.test.tsx
+++ b/resources/js/pages/__tests__/settings.test.tsx
@@ -80,6 +80,33 @@ describe('EditorSettings page', () => {
         expect(elmoCell).toHaveClass('text-center');
     });
 
+    it('uses a two-column layout with Title Types and Limits in the second column', () => {
+        render(
+            <EditorSettings
+                resourceTypes={[
+                    { id: 1, name: 'Dataset', active: true, elmo_active: false },
+                ]}
+                titleTypes={[
+                    { id: 1, name: 'Article', slug: 'article', active: true, elmo_active: false },
+                ]}
+                licenses={[]}
+                languages={[]}
+                maxTitles={5}
+                maxLicenses={10}
+            />,
+        );
+
+        const grid = screen.getByTestId('bento-grid');
+        expect(grid).toHaveClass('md:grid-cols-2');
+        expect(grid).not.toHaveClass('lg:grid-cols-3');
+
+        const titleTypesRegion = screen.getByRole('region', { name: 'Title Types' });
+        expect(titleTypesRegion).toHaveClass('md:col-start-2');
+
+        const limitsRegion = screen.getByRole('region', { name: 'Limits' });
+        expect(limitsRegion).toHaveClass('md:col-start-2');
+    });
+
     it('updates ERNIE active when toggled', () => {
         const resourceTypes = [
             { id: 1, name: 'Dataset', active: false, elmo_active: false },

--- a/resources/js/pages/settings/__tests__/editor.test.tsx
+++ b/resources/js/pages/settings/__tests__/editor.test.tsx
@@ -52,7 +52,8 @@ describe('EditorSettings page', () => {
         );
         const grid = screen.getByTestId('bento-grid');
         expect(grid).toBeInTheDocument();
-        expect(grid).toHaveClass('md:grid-cols-2', 'lg:grid-cols-3');
+        expect(grid).toHaveClass('md:grid-cols-2');
+        expect(grid).not.toHaveClass('lg:grid-cols-3');
         const items = grid.querySelectorAll('[data-slot="bento-grid-item"]');
         expect(items).toHaveLength(5);
         items.forEach((item) => expect(item).toHaveClass('self-start'));

--- a/resources/js/pages/settings/index.tsx
+++ b/resources/js/pages/settings/index.tsx
@@ -285,7 +285,7 @@ export default function EditorSettings({ resourceTypes, titleTypes, licenses, la
                         </div>
                     </BentoGridItem>
 
-                    <BentoGridItem aria-labelledby="title-types-heading">
+                    <BentoGridItem aria-labelledby="title-types-heading" className="md:col-start-2">
                         <h2 id="title-types-heading" className="text-lg font-semibold">
                             Title Types
                         </h2>
@@ -415,7 +415,7 @@ export default function EditorSettings({ resourceTypes, titleTypes, licenses, la
                         </div>
                     </BentoGridItem>
 
-                    <BentoGridItem aria-labelledby="limits-heading">
+                    <BentoGridItem aria-labelledby="limits-heading" className="md:col-start-2">
                         <h2 id="limits-heading" className="text-lg font-semibold">
                             Limits
                         </h2>


### PR DESCRIPTION
This pull request updates the `BentoGrid` layout and its usage in the Editor Settings page to consistently use a two-column grid on medium screens and above, removing the previous three-column layout on large screens. It also ensures that the "Title Types" and "Limits" sections always appear in the second column. Tests have been updated to reflect these layout changes.

**BentoGrid layout changes:**

* The `BentoGrid` component now uses a two-column layout (`md:grid-cols-2`) and no longer applies a three-column layout on large screens (`lg:grid-cols-3`). (`resources/js/components/ui/bento-grid.tsx`, [resources/js/components/ui/bento-grid.tsxL10-R10](diffhunk://#diff-c2c59647105b074b83c6e5fe8d3b742e42baf28ea1e663be176b170cfc5b8979L10-R10))
* Corresponding tests for `BentoGrid` have been updated to check for the absence of the three-column layout. (`resources/js/components/ui/__tests__/bento-grid.test.tsx`, [resources/js/components/ui/__tests__/bento-grid.test.tsxL21-R22](diffhunk://#diff-ccc9c2bde40e1287a3e89e32462af84ad9123746966477098652415b5d9e46a5L21-R22))

**Editor Settings layout and tests:**

* The "Title Types" and "Limits" sections in the Editor Settings page are now explicitly placed in the second column using the `md:col-start-2` class. (`resources/js/pages/settings/index.tsx`, [[1]](diffhunk://#diff-38fbf189fb47a9ea661c35fc32eb12d880633a202344baa50240409d77f29577L288-R288) [[2]](diffhunk://#diff-38fbf189fb47a9ea661c35fc32eb12d880633a202344baa50240409d77f29577L418-R418)
* Tests for the Editor Settings page have been updated and expanded to verify the two-column layout and the correct placement of "Title Types" and "Limits" in the second column. (`resources/js/pages/__tests__/settings.test.tsx`, [[1]](diffhunk://#diff-b7b448886b8ee79b3a8a8c7cf1fce5c19628bafed625f56392c14f8b350697e1R83-R109); `resources/js/pages/settings/__tests__/editor.test.tsx`, [[2]](diffhunk://#diff-5fcecd37b0141b59e438b89cc5877e035324421ffa8c5e40660f06bbb5d4069aL55-R56)