### PR TITLE
Increase dropdown menu Vitest coverage

### DIFF
--- a/resources/js/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/resources/js/components/ui/__tests__/dropdown-menu.test.tsx
@@ -7,6 +7,16 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from '../dropdown-menu';
 
 describe('DropdownMenu', () => {
@@ -40,5 +50,75 @@ describe('DropdownMenu', () => {
     const item = await screen.findByText('Delete');
     expect(item).toHaveAttribute('data-inset', 'true');
     expect(item).toHaveAttribute('data-variant', 'destructive');
+  });
+
+  it('renders the full dropdown structure with checkbox, radio and sub menus', () => {
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>Advanced</DropdownMenuTrigger>
+        <DropdownMenuContent className="custom-content" forceMount>
+          <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+          <DropdownMenuGroup>
+            <DropdownMenuCheckboxItem checked>
+              Show hidden files
+            </DropdownMenuCheckboxItem>
+            <DropdownMenuRadioGroup value="system" onValueChange={() => {}}>
+              <DropdownMenuRadioItem value="light">
+                Light
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="system">
+                System
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>
+            Save
+            <DropdownMenuShortcut>⌘S</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuSub defaultOpen>
+            <DropdownMenuSubTrigger inset>More options</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="custom-sub" forceMount>
+              <DropdownMenuItem>Export</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    const content = document.querySelector(
+      '[data-slot="dropdown-menu-content"]'
+    );
+    expect(content).toHaveClass('custom-content');
+
+    const label = screen.getByText('Appearance');
+    expect(label).toHaveAttribute('data-slot', 'dropdown-menu-label');
+
+    const checkbox = screen.getByRole('menuitemcheckbox', {
+      name: 'Show hidden files',
+    });
+    expect(checkbox).toHaveAttribute('data-slot', 'dropdown-menu-checkbox-item');
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+    const radioItems = screen.getAllByRole('menuitemradio');
+    expect(radioItems).toHaveLength(2);
+    expect(radioItems[1]).toHaveAttribute('aria-checked', 'true');
+
+    const separator = document.querySelector(
+      '[data-slot="dropdown-menu-separator"]'
+    );
+    expect(separator).toBeInTheDocument();
+
+    const shortcut = screen.getByText('⌘S');
+    expect(shortcut).toHaveAttribute('data-slot', 'dropdown-menu-shortcut');
+
+    const subTrigger = screen.getByText('More options');
+    expect(subTrigger).toHaveAttribute('data-inset', 'true');
+
+    const subContent = document.querySelector(
+      '[data-slot="dropdown-menu-sub-content"]'
+    );
+    expect(subContent).toHaveClass('custom-sub');
+    expect(screen.getByText('Export')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- expand the dropdown menu Vitest suite to exercise checkbox, radio, shortcut, and sub-menu helpers
- assert data-slot attributes and custom class support to keep styling and accessibility hooks covered

## Testing
- npx vitest run resources/js/components/ui/__tests__/dropdown-menu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7e93eefc0832e9310070e234156b4