### PR TITLE
Fix: Improve CSRF/session handling and XML upload robustness

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies as Middleware;
+use Illuminate\Http\Request;
+
+class TrustProxies extends Middleware
+{
+    /**
+     * The trusted proxies for this application.
+     *
+     * @var array<int, string>|string|null
+     */
+    protected $proxies = '*';
+
+    /**
+     * The headers that should be used to detect proxies.
+     *
+     * @var int
+     */
+    protected $headers =
+        Request::HEADER_X_FORWARDED_FOR |
+        Request::HEADER_X_FORWARDED_HOST |
+        Request::HEADER_X_FORWARDED_PORT |
+        Request::HEADER_X_FORWARDED_PROTO |
+        Request::HEADER_X_FORWARDED_AWS_ELB;
+}

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -37,6 +37,12 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+        
+        # Proxy headers for proper session handling
+        fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_param HTTP_HOST $http_host;
+        fastcgi_param HTTP_X_REAL_IP $remote_addr;
     }
 
     location ~ /\.(?!well-known).* {

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,11 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
 
+// CSRF cookie route for AJAX requests
+Route::get('/csrf-token', function () {
+    return response()->json(['token' => csrf_token()]);
+})->middleware('web');
+
 Route::get('/health', function () {
     return response()->json([
         'status' => 'ok',

--- a/stack.env
+++ b/stack.env
@@ -5,6 +5,17 @@ APP_URL=https://env.rz-vm182.gfz.de/ernie
 APP_PORT=8084
 LARAVEL_PORT_NUMBER=80
 
+# Session configuration for /ernie subpath
+SESSION_PATH=/ernie
+SESSION_DOMAIN=env.rz-vm182.gfz.de
+SESSION_SECURE_COOKIE=true
+SESSION_HTTP_ONLY=true
+SESSION_SAME_SITE=lax
+
+# CSRF configuration
+CSRF_COOKIE_NAME=XSRF-TOKEN
+CSRF_COOKIE_PATH=/ernie
+
 # Database connection for Laravel
 DB_CONNECTION=mysql
 DB_HOST=db

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,19 +28,12 @@ export default defineConfig(() => {
             }
         },
         esbuild: {
-            jsx: 'automatic' as const,
-        },
-        define: {
-            global: 'globalThis',
+            jsx: 'automatic',
         },
         resolve: {
             alias: {
                 '@': '/resources/js',
             },
-        },
-        optimizeDeps: {
-            exclude: ['swagger-ui-react'],
-            include: ['react', 'react-dom'],
         },
         test: {
             environment: 'jsdom',
@@ -52,7 +45,7 @@ export default defineConfig(() => {
                 APP_URL: '',
             },
             coverage: {
-                provider: 'v8' as const,
+                provider: 'v8',
                 reporter: ['text', 'json-summary'],
                 reportsDirectory: 'coverage',
                 include: ['resources/js/**/*.{js,ts,jsx,tsx}'],


### PR DESCRIPTION
This pull request introduces several improvements focused on better handling of proxy headers, CSRF/session management, and error handling for XML uploads. Key changes include enhanced proxy and session configuration, improved CSRF token refresh logic in the frontend, and the addition of a dedicated route for retrieving CSRF tokens via AJAX.

**Proxy and Session Handling:**

* Added a new `TrustProxies` middleware (`app/Http/Middleware/TrustProxies.php`) to trust all proxies and correctly handle forwarded headers, improving security and compatibility with reverse proxies.
* Updated Nginx configuration to forward proxy-related headers to the application, ensuring proper session and request handling behind proxies (`docker/nginx/conf.d/default.conf`).
* Added session and CSRF cookie configuration for subpath deployments to `.env` (`stack.env`).

**CSRF Token and Error Handling Improvements:**

* Enhanced the XML upload logic in `dashboard.tsx` to automatically detect CSRF token mismatches (HTTP 419), refresh the token via a HEAD request, and retry the upload once. Improved error messaging for both JSON and HTML error responses. [[1]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR16) [[2]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR31-R81) [[3]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR91) [[4]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR110-R120)
* Added a new `/csrf-token` route to allow AJAX clients to fetch the CSRF token as JSON, supporting more robust frontend CSRF handling (`routes/web.php`).

**Build and Test Configuration:**

* Minor cleanup in `vite.config.ts` to simplify type assertions and remove unused dependency optimization settings. [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL31-L44) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL55-R48)