### PR TITLE
Add tests for old datasets feature

### DIFF
--- a/e2e/old-datasets.spec.ts
+++ b/e2e/old-datasets.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from './constants';
+
+test.describe('Old datasets overview', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel('Email address').fill(TEST_USER_EMAIL);
+    await page.getByLabel('Password').fill(TEST_USER_PASSWORD);
+    await page.getByRole('button', { name: 'Log in' }).click();
+
+    await page.waitForURL(/\/dashboard/, { timeout: 15_000 });
+  });
+
+  test('surfaces an accessible error state when the legacy source is unavailable', async ({ page }) => {
+    await page.goto('/old-datasets');
+
+    await expect(page).toHaveURL(/\/old-datasets$/);
+    await expect(page.getByRole('heading', { name: 'Old Datasets' })).toBeVisible();
+
+    const alert = page.getByRole('alert');
+    await expect(alert).toContainText('Datenbankverbindung fehlgeschlagen');
+
+    await expect(page.getByText('No datasets available. Please check the database connection.')).toBeVisible();
+    await expect(page.getByText('Overview of legacy resources from the SUMARIOPMD database')).toBeVisible();
+
+    await expect(page.getByRole('main')).toContainText('Old Datasets');
+  });
+});

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -1,0 +1,293 @@
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OldDatasets from '../old-datasets';
+import axios from 'axios';
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
+
+vi.mock('axios', () => {
+    const get = vi.fn();
+    return {
+        default: { get },
+        get,
+    };
+});
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => (
+        <div data-testid="mock-app-layout">{children}</div>
+    ),
+}));
+
+type AxiosMock = {
+    get: ReturnType<typeof vi.fn>;
+};
+
+const mockedAxios = axios as unknown as AxiosMock;
+
+const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+const intersectionObserverHandlers = {
+    observe: (target: Element) => {},
+    disconnect: () => {},
+    unobserve: (target: Element) => {},
+    takeRecords: () => [] as IntersectionObserverEntry[],
+};
+
+let activeIntersectionCallback: IntersectionObserverCallback = () => undefined;
+
+class GlobalMockIntersectionObserver implements IntersectionObserver {
+    readonly root: Element | Document | null = null;
+    readonly rootMargin = '';
+    readonly thresholds: ReadonlyArray<number> = [];
+
+    constructor(callback: IntersectionObserverCallback) {
+        activeIntersectionCallback = callback;
+    }
+
+    observe(target: Element): void {
+        intersectionObserverHandlers.observe(target);
+    }
+
+    disconnect(): void {
+        intersectionObserverHandlers.disconnect();
+    }
+
+    unobserve(target: Element): void {
+        intersectionObserverHandlers.unobserve(target);
+    }
+
+    takeRecords(): IntersectionObserverEntry[] {
+        return intersectionObserverHandlers.takeRecords();
+    }
+}
+
+if (typeof globalThis.IntersectionObserver === 'undefined') {
+    const mockObserver = GlobalMockIntersectionObserver as unknown as typeof IntersectionObserver;
+    (globalThis as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver = mockObserver;
+    if (typeof window !== 'undefined') {
+        (window as unknown as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver = mockObserver;
+    }
+}
+
+describe('OldDatasets page', () => {
+    let observeSpy: ReturnType<typeof vi.fn>;
+    let disconnectSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        mockedAxios.get.mockReset();
+
+        observeSpy = vi.fn();
+        disconnectSpy = vi.fn();
+        intersectionObserverHandlers.observe = (target: Element) => observeSpy(target);
+        intersectionObserverHandlers.disconnect = () => disconnectSpy();
+        intersectionObserverHandlers.unobserve = () => {};
+        intersectionObserverHandlers.takeRecords = () => [];
+        activeIntersectionCallback = () => undefined;
+
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (originalIntersectionObserver) {
+            globalThis.IntersectionObserver = originalIntersectionObserver;
+            if (typeof window !== 'undefined') {
+                (window as unknown as { IntersectionObserver?: typeof IntersectionObserver }).IntersectionObserver =
+                    originalIntersectionObserver;
+            }
+        }
+    });
+
+    const baseProps = {
+        datasets: [
+            {
+                id: 1,
+                identifier: '10.1234/example-one',
+                title: 'A dataset title that is long enough to demonstrate truncation when rendered in the table body with additional descriptive context to push it well beyond the truncation threshold for the component',
+                resourcetypegeneral: 'Dataset',
+                curator: 'Alice',
+                created_at: '2024-01-01T10:00:00Z',
+                updated_at: '2024-01-02T10:00:00Z',
+                publicstatus: 'review',
+                publisher: 'Example Publisher',
+                publicationyear: 2024,
+            },
+            {
+                id: 2,
+                identifier: '10.1234/example-two',
+                title: 'Concise dataset title',
+                resourcetypegeneral: 'Image',
+                curator: 'Bob',
+                created_at: '2024-02-01T12:00:00Z',
+                updated_at: '2024-02-02T12:00:00Z',
+                publicstatus: 'published',
+                publisher: 'Example Publisher',
+                publicationyear: 2023,
+            },
+        ],
+        pagination: {
+            current_page: 1,
+            last_page: 3,
+            per_page: 20,
+            total: 60,
+            from: 1,
+            to: 20,
+            has_more: true,
+        },
+        error: undefined,
+    } as const;
+
+    it('renders the legacy dataset overview with accessible labelling', () => {
+        render(<OldDatasets {...baseProps} />);
+
+        expect(screen.getAllByText('Old Datasets')[0]).toBeVisible();
+        expect(screen.getByText('Overview of legacy resources from the SUMARIOPMD database')).toBeVisible();
+
+        const badge = screen.getByText(/1-2 of 60 datasets/i);
+        expect(badge).toBeVisible();
+
+        const table = screen.getByRole('table');
+        expect(table).toBeVisible();
+
+        const headerRow = within(table).getAllByRole('row')[0];
+        expect(within(headerRow).getByText('Identifier (DOI)')).toBeVisible();
+        expect(within(headerRow).getByText('Created Date')).toBeVisible();
+
+        const bodyRows = within(table).getAllByRole('row').slice(1);
+        expect(bodyRows).toHaveLength(2);
+
+        const [firstRow, secondRow] = bodyRows;
+        expect(within(firstRow).getByText('1')).toBeVisible();
+        expect(within(firstRow).getByText(/10\.1234\/example-one/)).toBeVisible();
+        expect(within(firstRow).getByText('Under Review')).toBeVisible();
+        expect(within(firstRow).getByText(/01\/01\/2024/)).toBeVisible();
+        expect(within(firstRow).getByText(/01\/02\/2024/)).toBeVisible();
+        expect(within(firstRow).getByText(/A dataset title that is long enough/)).toHaveTextContent(/\.\.\.$/);
+
+        expect(within(secondRow).getByText('2')).toBeVisible();
+        expect(within(secondRow).getByText('Published')).toBeVisible();
+
+        // Ensure the infinite scroll sentinel is observed for accessibility
+        expect(observeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('requests the next page when the sentinel row becomes visible', async () => {
+        mockedAxios.get.mockResolvedValueOnce({
+            data: {
+                datasets: [
+                    {
+                        id: 3,
+                        identifier: '10.5555/example-three',
+                        title: 'Recently ingested dataset',
+                        resourcetypegeneral: 'Text',
+                        curator: 'Charlie',
+                        created_at: '2024-03-01T09:30:00Z',
+                        updated_at: '2024-03-01T12:00:00Z',
+                        publicstatus: 'draft',
+                        publisher: 'Example Publisher',
+                        publicationyear: 2022,
+                    },
+                ],
+                pagination: {
+                    current_page: 2,
+                    last_page: 3,
+                    per_page: 20,
+                    total: 60,
+                    from: 21,
+                    to: 40,
+                    has_more: true,
+                },
+            },
+        });
+
+        render(<OldDatasets {...baseProps} />);
+
+        const table = screen.getByRole('table');
+        const bodyRows = within(table).getAllByRole('row').slice(1);
+        const sentinelRow = bodyRows[bodyRows.length - 1];
+
+        expect(observeSpy).toHaveBeenCalledWith(sentinelRow);
+
+        activeIntersectionCallback([
+            {
+                isIntersecting: true,
+                target: sentinelRow,
+            } as IntersectionObserverEntry,
+        ], {} as IntersectionObserver);
+
+        await waitFor(() => {
+            expect(mockedAxios.get).toHaveBeenCalledWith('/old-datasets/load-more', {
+                params: { page: 2, per_page: 20 },
+            });
+        });
+
+        await screen.findByText('Recently ingested dataset');
+        expect(screen.getByText(/1-3 of 60 datasets/i)).toBeVisible();
+    });
+
+    it('shows an inline retry affordance when loading additional pages fails', async () => {
+        mockedAxios.get
+            .mockRejectedValueOnce(new Error('network down'))
+            .mockResolvedValueOnce({
+                data: {
+                    datasets: [
+                        {
+                            id: 3,
+                            identifier: '10.5555/example-three',
+                            title: 'Recovered dataset',
+                            resourcetypegeneral: 'Software',
+                            curator: 'Charlie',
+                            created_at: '2024-03-01T09:30:00Z',
+                            updated_at: '2024-03-01T12:00:00Z',
+                            publicstatus: 'draft',
+                            publisher: 'Example Publisher',
+                            publicationyear: 2022,
+                        },
+                    ],
+                    pagination: {
+                        current_page: 2,
+                        last_page: 2,
+                        per_page: 20,
+                        total: 3,
+                        from: 21,
+                        to: 21,
+                        has_more: false,
+                    },
+                },
+            });
+
+        const user = userEvent.setup();
+
+        render(<OldDatasets {...baseProps} />);
+
+        const table = screen.getByRole('table');
+        const bodyRows = within(table).getAllByRole('row').slice(1);
+        const sentinelRow = bodyRows[bodyRows.length - 1];
+
+        activeIntersectionCallback([
+            {
+                isIntersecting: true,
+                target: sentinelRow,
+            } as IntersectionObserverEntry,
+        ], {} as IntersectionObserver);
+
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveTextContent('Failed to load more datasets. Please try again.');
+        const retryButton = within(alert).getByRole('button', { name: /retry/i });
+
+        await user.click(retryButton);
+
+        await screen.findByText('Recovered dataset');
+
+        await waitFor(() => {
+            expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+        });
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(screen.getByText(/All datasets have been loaded/i)).toBeVisible();
+    });
+});

--- a/tests/Feature/OldDatasetControllerTest.php
+++ b/tests/Feature/OldDatasetControllerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use App\Models\OldDataset;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Inertia\Testing\AssertableInertia as Assert;
+use Mockery as MockeryAlias;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+afterEach(function (): void {
+    MockeryAlias::close();
+});
+
+beforeEach(function (): void {
+    $this->withoutVite();
+    actingAs(User::factory()->create([
+        'email_verified_at' => now(),
+    ]));
+});
+
+it('renders the old datasets page with paginated data', function (): void {
+    $datasets = [
+        [
+            'id' => 1,
+            'identifier' => '10.1234/example-one',
+            'resourcetypegeneral' => 'Dataset',
+            'curator' => 'Alice',
+            'title' => 'Example dataset number one',
+            'created_at' => '2024-01-01 10:00:00',
+            'updated_at' => '2024-01-05 12:00:00',
+            'publicstatus' => 'published',
+            'publisher' => 'Example Publisher',
+            'publicationyear' => 2024,
+        ],
+        [
+            'id' => 2,
+            'identifier' => '10.1234/example-two',
+            'resourcetypegeneral' => 'Dataset',
+            'curator' => 'Bob',
+            'title' => 'Example dataset number two',
+            'created_at' => '2024-02-02 14:30:00',
+            'updated_at' => '2024-02-05 09:15:00',
+            'publicstatus' => 'review',
+            'publisher' => 'Example Publisher',
+            'publicationyear' => 2023,
+        ],
+    ];
+
+    $paginator = new LengthAwarePaginator(
+        $datasets,
+        total: 2,
+        perPage: 50,
+        currentPage: 1,
+        options: ['path' => '/old-datasets']
+    );
+
+    MockeryAlias::mock('alias:' . OldDataset::class)
+        ->shouldReceive('getPaginatedOrderedByCreatedDate')
+        ->once()
+        ->with(1, 50)
+        ->andReturn($paginator);
+
+    get(route('old-datasets'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('old-datasets')
+            ->where('datasets', $datasets)
+            ->where('pagination', [
+                'current_page' => 1,
+                'last_page' => 1,
+                'per_page' => 50,
+                'total' => 2,
+                'from' => 1,
+                'to' => 2,
+                'has_more' => false,
+            ])
+            ->missing('error')
+        );
+});
+
+it('sanitises pagination parameters before fetching datasets', function (): void {
+    $paginator = new LengthAwarePaginator(
+        [],
+        total: 0,
+        perPage: 200,
+        currentPage: 1,
+        options: ['path' => '/old-datasets']
+    );
+
+    MockeryAlias::mock('alias:' . OldDataset::class)
+        ->shouldReceive('getPaginatedOrderedByCreatedDate')
+        ->once()
+        ->with(1, 200)
+        ->andReturn($paginator);
+
+    get('/old-datasets?page=0&per_page=999')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('old-datasets')
+            ->where('datasets', [])
+            ->where('pagination', [
+                'current_page' => 1,
+                'last_page' => 1,
+                'per_page' => 200,
+                'total' => 0,
+                'from' => null,
+                'to' => null,
+                'has_more' => false,
+            ])
+        );
+});
+
+it('returns JSON payload for the load-more endpoint', function (): void {
+    $datasets = [
+        [
+            'id' => 3,
+            'identifier' => '10.1234/example-three',
+            'resourcetypegeneral' => 'Image',
+            'curator' => 'Carol',
+            'title' => 'Example dataset number three',
+            'created_at' => '2024-03-01 08:00:00',
+            'updated_at' => '2024-03-02 09:00:00',
+            'publicstatus' => 'draft',
+            'publisher' => 'Example Publisher',
+            'publicationyear' => 2022,
+        ],
+    ];
+
+    $paginator = new LengthAwarePaginator(
+        $datasets,
+        total: 21,
+        perPage: 20,
+        currentPage: 2,
+        options: ['path' => '/old-datasets/load-more']
+    );
+
+    MockeryAlias::mock('alias:' . OldDataset::class)
+        ->shouldReceive('getPaginatedOrderedByCreatedDate')
+        ->once()
+        ->with(2, 20)
+        ->andReturn($paginator);
+
+    get('/old-datasets/load-more?page=2&per_page=20')
+        ->assertOk()
+        ->assertJson([
+            'datasets' => $datasets,
+            'pagination' => [
+                'current_page' => 2,
+                'last_page' => 2,
+                'per_page' => 20,
+                'total' => 21,
+                'from' => 21,
+                'to' => 21,
+                'has_more' => false,
+            ],
+        ]);
+});
+
+it('exposes a helpful error state when the listing cannot be loaded', function (): void {
+    $exception = new RuntimeException('database unavailable');
+
+    MockeryAlias::mock('alias:' . OldDataset::class)
+        ->shouldReceive('getPaginatedOrderedByCreatedDate')
+        ->once()
+        ->withAnyArgs()
+        ->andThrow($exception);
+
+    get(route('old-datasets'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('old-datasets')
+            ->where('datasets', [])
+            ->where('pagination', [
+                'current_page' => 1,
+                'last_page' => 1,
+                'per_page' => 50,
+                'total' => 0,
+                'from' => 0,
+                'to' => 0,
+                'has_more' => false,
+            ])
+            ->where('error', 'SUMARIOPMD-Datenbankverbindung fehlgeschlagen: ' . $exception->getMessage())
+        );
+});
+
+it('returns an error response when the load-more endpoint fails', function (): void {
+    MockeryAlias::mock('alias:' . OldDataset::class)
+        ->shouldReceive('getPaginatedOrderedByCreatedDate')
+        ->once()
+        ->withAnyArgs()
+        ->andThrow(new RuntimeException('timeout while contacting replica'));
+
+    get('/old-datasets/load-more')
+        ->assertStatus(500)
+        ->assertJson([
+            'error' => 'Error loading datasets:ss timeout while contacting replica',
+        ]);
+});


### PR DESCRIPTION
This pull request introduces comprehensive automated tests for the legacy datasets feature, covering both frontend and backend behavior. The new tests ensure that the old datasets overview page is robust, accessible, and correctly handles pagination, error states, and infinite scrolling. The tests also verify that the backend endpoints respond appropriately under normal and failure conditions.

**Frontend/end-to-end and component testing:**

- Added an end-to-end Playwright test (`e2e/old-datasets.spec.ts`) that verifies the old datasets overview page correctly displays an accessible error state when the legacy data source is unavailable, including appropriate headings, alerts, and descriptive text.
- Introduced a comprehensive React component test suite (`resources/js/pages/__tests__/old-datasets.test.tsx`) for the `OldDatasets` page, covering:
  - Proper rendering and accessibility of the datasets table and labels.
  - Infinite scroll behavior, including requesting additional pages when the sentinel row becomes visible.
  - Inline retry affordance and error handling when loading more datasets fails.

**Backend/feature testing:**

- Added feature tests for the `OldDatasetController` (`tests/Feature/OldDatasetControllerTest.php`) to verify:
  - Paginated data is rendered correctly on the main page.
  - Pagination parameters are sanitized before fetching datasets.
  - The `/load-more` endpoint returns the correct JSON payload for pagination.
  - Helpful error states are exposed when the listing cannot be loaded, both on the main page and the `/load-more` endpoint.