### PR TITLE
Ensure old datasets heading is accessible

### DIFF
--- a/resources/js/components/ui/__tests__/card.test.tsx
+++ b/resources/js/components/ui/__tests__/card.test.tsx
@@ -18,10 +18,27 @@ describe('Card', () => {
 
         const card = container.querySelector('[data-slot="card"]');
         expect(card).toBeInTheDocument();
-        expect(screen.getByText('Title')).toHaveAttribute('data-slot', 'card-title');
+        const cardTitle = screen.getByText('Title');
+        expect(cardTitle).toHaveAttribute('data-slot', 'card-title');
+        expect(cardTitle.tagName).toBe('H3');
         expect(screen.getByText('Description')).toHaveAttribute('data-slot', 'card-description');
         expect(screen.getByText('Content')).toHaveAttribute('data-slot', 'card-content');
         expect(screen.getByText('Footer')).toHaveAttribute('data-slot', 'card-footer');
+    });
+
+    it('allows rendering the title as a custom heading level for accessibility', () => {
+        render(
+            <Card>
+                <CardHeader>
+                    <CardTitle asChild>
+                        <h2>Accessible Title</h2>
+                    </CardTitle>
+                </CardHeader>
+            </Card>,
+        );
+
+        const heading = screen.getByRole('heading', { name: 'Accessible Title', level: 2 });
+        expect(heading).toHaveAttribute('data-slot', 'card-title');
     });
 });
 

--- a/resources/js/components/ui/card.tsx
+++ b/resources/js/components/ui/card.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
 
 import { cn } from "@/lib/utils"
 
@@ -25,11 +26,17 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+type CardTitleProps = React.ComponentProps<"h3"> & {
+  asChild?: boolean
+}
+
+function CardTitle({ className, asChild = false, ...props }: CardTitleProps) {
+  const Comp = asChild ? Slot : "h3"
+
   return (
-    <div
+    <Comp
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("font-semibold leading-none tracking-tight", className)}
       {...props}
     />
   )

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -31,9 +31,13 @@ const mockedAxios = axios as unknown as AxiosMock;
 const originalIntersectionObserver = globalThis.IntersectionObserver;
 
 const intersectionObserverHandlers = {
-    observe: (target: Element) => {},
+    observe: (target: Element) => {
+        void target;
+    },
     disconnect: () => {},
-    unobserve: (target: Element) => {},
+    unobserve: (target: Element) => {
+        void target;
+    },
     takeRecords: () => [] as IntersectionObserverEntry[],
 };
 

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -144,7 +144,7 @@ describe('OldDatasets page', () => {
     it('renders the legacy dataset overview with accessible labelling', () => {
         render(<OldDatasets {...baseProps} />);
 
-        expect(screen.getAllByText('Old Datasets')[0]).toBeVisible();
+        expect(screen.getByRole('heading', { name: 'Old Datasets', level: 1 })).toBeVisible();
         expect(screen.getByText('Overview of legacy resources from the SUMARIOPMD database')).toBeVisible();
 
         const badge = screen.getByText(/1-2 of 60 datasets/i);

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -200,7 +200,9 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
                 <Card>
                     <CardHeader>
-                        <CardTitle>Old Datasets</CardTitle>
+                        <CardTitle asChild>
+                            <h1 className="text-2xl font-semibold tracking-tight">Old Datasets</h1>
+                        </CardTitle>
                         <CardDescription>
                             Overview of legacy resources from the SUMARIOPMD database
                         </CardDescription>


### PR DESCRIPTION
This pull request improves accessibility and flexibility in the Card component and its usage, particularly around heading levels for better semantic HTML. It also updates related tests to use more accessible queries and improves clarity in mock implementations.

**Accessibility and Semantic HTML Improvements:**

* Updated the `CardTitle` component in `card.tsx` to accept an `asChild` prop, allowing consumers to render the title as a custom heading level (e.g., `<h1>`, `<h2>`) for improved accessibility. Internally, it uses the `Slot` component from `@radix-ui/react-slot` to support this flexibility. [[1]](diffhunk://#diff-029968afe791cb8ce4660db10655280f01ff6ffd26fc9b323963e022ae1c0293R2) [[2]](diffhunk://#diff-029968afe791cb8ce4660db10655280f01ff6ffd26fc9b323963e022ae1c0293L28-R39)
* Modified the `OldDatasets` page to render the card title as an `<h1>` when appropriate, ensuring correct heading hierarchy for screen readers.

**Test Enhancements for Accessibility:**

* Added and updated tests in `card.test.tsx` to verify that `CardTitle` renders with the correct heading level and remains accessible.
* Updated the `old-datasets.test.tsx` test to assert the presence of the "Old Datasets" heading using an accessible query (`getByRole` with heading level), rather than by text alone.

**Test Mock Improvements:**

* Improved the IntersectionObserver mocks in `old-datasets.test.tsx` to explicitly reference unused parameters, clarifying intent and avoiding unused variable warnings.