### PR TITLE
Add ERNIE actions for old datasets and support dataset detail API

### DIFF
--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -14,7 +14,7 @@ class ResourceTypeController extends Controller
     {
         $types = ResourceType::query()
             ->orderByName()
-            ->get(['id', 'name']);
+            ->get(['id', 'name', 'slug']);
 
         return response()->json($types);
     }
@@ -28,7 +28,7 @@ class ResourceTypeController extends Controller
             ->active()
             ->elmoActive()
             ->orderByName()
-            ->get(['id', 'name']);
+            ->get(['id', 'name', 'slug']);
 
         return response()->json($types);
     }
@@ -41,7 +41,7 @@ class ResourceTypeController extends Controller
         $types = ResourceType::query()
             ->active()
             ->orderByName()
-            ->get(['id', 'name']);
+            ->get(['id', 'name', 'slug']);
 
         return response()->json($types);
     }

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -86,6 +86,8 @@ class OldDataset extends Model
                 'resource.publicstatus',
                 'resource.publisher',
                 'resource.publicationyear',
+                'resource.version',
+                'resource.language',
                 'title.title'
             ])
             ->leftJoin('title', 'resource.id', '=', 'title.resource_id')
@@ -112,6 +114,8 @@ class OldDataset extends Model
                 'resource.publicstatus',
                 'resource.publisher',
                 'resource.publicationyear',
+                'resource.version',
+                'resource.language',
                 'title.title'
             ])
             ->leftJoin('title', 'resource.id', '=', 'title.resource_id')

--- a/app/Models/OldDatasetTitle.php
+++ b/app/Models/OldDatasetTitle.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OldDatasetTitle extends Model
+{
+    use HasFactory;
+
+    /**
+     * The connection name for the model.
+     */
+    protected $connection = 'metaworks';
+
+    /**
+     * The table associated with the model.
+     */
+    protected $table = 'title';
+
+    /**
+     * Indicates if the model should be timestamped.
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'resource_id',
+        'title',
+        'titleType',
+        'titletype',
+    ];
+}
+

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -14,7 +14,7 @@ describe('DataCiteForm', () => {
         Element.prototype.scrollIntoView = () => {};
     });
 
-    const resourceTypes: ResourceType[] = [{ id: 1, name: 'Dataset' }];
+    const resourceTypes: ResourceType[] = [{ id: 1, name: 'Dataset', slug: 'dataset' }];
 
     const titleTypes: TitleType[] = [
         { id: 1, name: 'Main Title', slug: 'main-title' },

--- a/resources/js/pages/__tests__/curation.test.tsx
+++ b/resources/js/pages/__tests__/curation.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import Curation from '../curation';
 import type { ResourceType, TitleType, License, Language } from '@/types';
 
-const resourceTypes: ResourceType[] = [{ id: 1, name: 'Dataset' }];
+const resourceTypes: ResourceType[] = [{ id: 1, name: 'Dataset', slug: 'dataset' }];
 const titleTypes: TitleType[] = [
     { id: 1, name: 'Main Title', slug: 'main-title' },
 ];
@@ -169,6 +169,22 @@ describe('Curation page', () => {
                 resourceType="1"
             />,
         );
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialResourceType: '1' }),
+            ),
+        );
+    });
+
+    it('derives the resource type from the slug when an id is not provided', async () => {
+        render(
+            <Curation
+                maxTitles={99}
+                maxLicenses={99}
+                resourceTypeSlug="Dataset"
+            />,
+        );
+
         await waitFor(() =>
             expect(renderForm).toHaveBeenCalledWith(
                 expect.objectContaining({ initialResourceType: '1' }),

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -20,6 +20,7 @@ interface CurationProps {
     version?: string;
     language?: string;
     resourceType?: string;
+    resourceTypeSlug?: string;
     titles?: { title: string; titleType: string }[];
     initialLicenses?: string[];
 }
@@ -32,9 +33,18 @@ export default function Curation({
     version = '',
     language = '',
     resourceType = '',
+    resourceTypeSlug = '',
     titles = [],
     initialLicenses = [],
 }: CurationProps) {
+    const toSlug = (value: string): string =>
+        value
+            .normalize('NFD')
+            .replace(/\p{Diacritic}/gu, '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/(^-|-$)+/g, '');
+
     const [resourceTypes, setResourceTypes] = useState<ResourceType[] | null>(null);
     const [titleTypes, setTitleTypes] = useState<TitleType[] | null>(null);
     const [licenses, setLicenses] = useState<License[] | null>(null);
@@ -71,6 +81,20 @@ export default function Curation({
             })
             .catch(() => setError(true));
     }, []);
+
+    const resolvedResourceType =
+        resourceType ||
+        (resourceTypeSlug && resourceTypes
+            ? (() => {
+                  const normalisedSlug = toSlug(resourceTypeSlug);
+                  const matchedType = resourceTypes.find(
+                      (type) =>
+                          toSlug(type.slug) === normalisedSlug ||
+                          toSlug(type.name) === normalisedSlug,
+                  );
+                  return matchedType ? String(matchedType.id) : '';
+              })()
+            : '');
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -110,7 +134,7 @@ export default function Curation({
                         initialYear={year}
                         initialVersion={version}
                         initialLanguage={language}
-                        initialResourceType={resourceType}
+                        initialResourceType={resolvedResourceType}
                         initialTitles={titles}
                         initialLicenses={initialLicenses}
                     />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -44,6 +44,7 @@ export interface User {
 export interface ResourceType {
     id: number;
     name: string;
+    slug: string;
 }
 
 export interface TitleType {

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,9 +47,13 @@ Route::get('/changelog', function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('old-datasets', [OldDatasetController::class, 'index'])
         ->name('old-datasets');
-    
+
     Route::get('old-datasets/load-more', [OldDatasetController::class, 'loadMore'])
         ->name('old-datasets.load-more');
+
+    Route::get('old-datasets/{dataset}', [OldDatasetController::class, 'show'])
+        ->whereNumber('dataset')
+        ->name('old-datasets.show');
 
     Route::post('dashboard/upload-xml', UploadXmlController::class)
         ->name('dashboard.upload-xml');
@@ -75,6 +79,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'version' => $request->query('version'),
             'language' => $request->query('language'),
             'resourceType' => $request->query('resourceType'),
+            'resourceTypeSlug' => $request->query('resourceTypeSlug'),
             'titles' => $request->query('titles', []),
             'initialLicenses' => $request->query('licenses', []),
         ]);

--- a/tests/Feature/AllResourceTypeApiTest.php
+++ b/tests/Feature/AllResourceTypeApiTest.php
@@ -24,12 +24,12 @@ test('returns all resource types', function () {
 
     $response->assertJsonCount(ResourceType::count());
     $response->assertJsonStructure([
-        '*' => ['id', 'name'],
+        '*' => ['id', 'name', 'slug'],
     ]);
     $response->assertJsonFragment([
         'id' => $typeB->id,
         'name' => 'Type B',
+        'slug' => 'type-b',
     ]);
-    $response->assertJsonMissingPath('0.slug');
 });
 

--- a/tests/Feature/ElmoResourceTypeApiTest.php
+++ b/tests/Feature/ElmoResourceTypeApiTest.php
@@ -27,5 +27,5 @@ it('returns only resource types enabled for ELMO', function () {
         ->assertJsonCount(1);
 
     expect($response->json('0'))
-        ->toBe(['id' => $enabled->id, 'name' => 'Type A']);
+        ->toBe(['id' => $enabled->id, 'name' => 'Type A', 'slug' => 'type-a']);
 });

--- a/tests/Feature/ResourceTypeApiTest.php
+++ b/tests/Feature/ResourceTypeApiTest.php
@@ -14,7 +14,6 @@ test('returns active resource types for Ernie', function () {
 
     $response->assertJsonCount(ResourceType::where('active', true)->count());
     $response->assertJsonStructure([
-        '*' => ['id', 'name'],
+        '*' => ['id', 'name', 'slug'],
     ]);
-    $response->assertJsonMissingPath('0.slug');
 });

--- a/tests/Feature/ResourceTypeControllerTest.php
+++ b/tests/Feature/ResourceTypeControllerTest.php
@@ -21,6 +21,12 @@ test('returns all resource types ordered by name', function () {
         'Charlie',
         'Delta',
     ]);
+    expect(array_column($response->json(), 'slug'))->toBe([
+        'alpha',
+        'bravo',
+        'charlie',
+        'delta',
+    ]);
 });
 
 test('returns only active resource types for Ernie', function () {
@@ -30,6 +36,10 @@ test('returns only active resource types for Ernie', function () {
         'Alpha',
         'Bravo',
     ]);
+    expect(array_column($response->json(), 'slug'))->toBe([
+        'alpha',
+        'bravo',
+    ]);
 });
 
 test('returns only active and elmo-active resource types', function () {
@@ -37,5 +47,8 @@ test('returns only active and elmo-active resource types', function () {
     expect($response->json())->toHaveCount(1);
     expect(array_column($response->json(), 'name'))->toBe([
         'Alpha',
+    ]);
+    expect(array_column($response->json(), 'slug'))->toBe([
+        'alpha',
     ]);
 });


### PR DESCRIPTION
## Summary
- add an "Open with ERNIE" action to each row in the old datasets table and expose a dataset detail endpoint
- preload all dataset titles and metadata into the curation form, resolving resource type slugs automatically
- return resource type slugs from the API and cover the new behavior with frontend and feature tests

## Testing
- npx vitest run resources/js/pages/__tests__/old-datasets.test.tsx resources/js/pages/__tests__/curation.test.tsx resources/js/components/curation/__tests__/datacite-form.test.tsx
- ./vendor/bin/pest tests/Feature/OldDatasetControllerTest.php tests/Feature/ResourceTypeControllerTest.php tests/Feature/ResourceTypeApiTest.php tests/Feature/AllResourceTypeApiTest.php tests/Feature/ElmoResourceTypeApiTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d8c76b6290832eaf58367215de7a71