### PR TITLE
Fix PHPStan typing for old dataset detail endpoint

### DIFF
--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -5,6 +5,19 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int $id
+ * @property string|null $identifier
+ * @property string|null $resourcetypegeneral
+ * @property string|null $curator
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property string|null $publicstatus
+ * @property string|null $publisher
+ * @property int|null $publicationyear
+ * @property string|null $version
+ * @property string|null $language
+ */
 class OldDataset extends Model
 {
     use HasFactory;

--- a/app/Models/OldDatasetTitle.php
+++ b/app/Models/OldDatasetTitle.php
@@ -5,6 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int $id
+ * @property int $resource_id
+ * @property string|null $title
+ * @property string|null $titleType
+ * @property string|null $titletype
+ */
 class OldDatasetTitle extends Model
 {
     use HasFactory;


### PR DESCRIPTION
This pull request improves type safety and code clarity in the dataset-related models and controller. The most significant changes are the addition of PHPDoc property annotations to the `OldDataset` and `OldDatasetTitle` models, and a refactor of the logic for processing dataset titles in the `OldDatasetController`.

**Model property annotations:**

* Added detailed PHPDoc property annotations to the `OldDataset` model, specifying the types and names of its properties for better IDE support and static analysis.
* Added PHPDoc property annotations to the `OldDatasetTitle` model, documenting its properties and their types.

**Controller logic improvements:**

* Refactored the title extraction logic in the `show` method of `OldDatasetController` to use explicit type annotations and a more readable loop, improving type safety and filtering out empty titles more clearly.