### PR TITLE
Combine date columns in old datasets table

### DIFF
--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -179,7 +179,7 @@ describe('OldDatasets page', () => {
 
         const headerRow = within(table).getAllByRole('row')[0];
         expect(within(headerRow).getByText('Identifier (DOI)')).toBeVisible();
-        expect(within(headerRow).getByText('Created Date')).toBeVisible();
+        expect(within(headerRow).getByText('Created / Updated')).toBeVisible();
 
         const bodyRows = within(table).getAllByRole('row').slice(1);
         expect(bodyRows).toHaveLength(2);
@@ -188,9 +188,23 @@ describe('OldDatasets page', () => {
         expect(within(firstRow).getByText('1')).toBeVisible();
         expect(within(firstRow).getByText(/10\.1234\/example-one/)).toBeVisible();
         expect(within(firstRow).getByText('Under Review')).toBeVisible();
-        expect(within(firstRow).getByText(/01\/01\/2024/)).toBeVisible();
-        expect(within(firstRow).getByText(/01\/02\/2024/)).toBeVisible();
-        expect(within(firstRow).getByText(/A dataset title that is long enough/)).toHaveTextContent(/\.\.\.$/);
+        const titleCell = within(firstRow).getAllByRole('cell')[2];
+        expect(titleCell).toHaveTextContent(baseProps.datasets[0].title);
+        expect(titleCell).toHaveClass('whitespace-normal');
+        expect(titleCell).toHaveClass('break-words');
+
+        const createdUpdatedCell = within(firstRow).getAllByRole('cell')[5];
+        const createdUpdatedRows = createdUpdatedCell.querySelectorAll(':scope > div > div');
+        expect(createdUpdatedRows).toHaveLength(2);
+        expect(createdUpdatedRows[0]).toHaveTextContent('Created');
+        expect(createdUpdatedRows[0]).toHaveTextContent('01/01/2024');
+        expect(createdUpdatedRows[1]).toHaveTextContent('Updated');
+        expect(createdUpdatedRows[1]).toHaveTextContent('01/02/2024');
+
+        const timeElements = createdUpdatedCell.querySelectorAll('time');
+        expect(timeElements).toHaveLength(2);
+        expect(timeElements[0]).toHaveAttribute('dateTime', '2024-01-01T10:00:00.000Z');
+        expect(timeElements[1]).toHaveAttribute('dateTime', '2024-01-02T10:00:00.000Z');
 
         expect(within(secondRow).getByText('2')).toBeVisible();
         expect(within(secondRow).getByText('Published')).toBeVisible();

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -361,6 +361,29 @@ describe('OldDatasets page', () => {
         expect(within(labelledContainer as HTMLElement).getByText('Invalid date')).toBeVisible();
     });
 
+    it('falls back to N/A when a dataset field is missing', () => {
+        render(
+            <OldDatasets
+                {...baseProps}
+                datasets={[
+                    {
+                        id: 9,
+                        identifier: '10.0000/missing-curator',
+                        title: 'Dataset missing curator metadata',
+                        resourcetypegeneral: 'Dataset',
+                        publicstatus: 'draft',
+                    },
+                ]}
+            />,
+        );
+
+        const table = screen.getByRole('table');
+        const bodyRow = within(table).getAllByRole('row')[1];
+        const curatorCell = within(bodyRow).getAllByRole('cell')[4];
+
+        expect(curatorCell).toHaveTextContent('N/A');
+    });
+
     it('logs the server-provided diagnostics when the initial page load fails', () => {
         render(<OldDatasets
             datasets={[]}

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -200,6 +200,7 @@ describe('OldDatasets page', () => {
         expect(createdUpdatedRows[0]).toHaveTextContent('01/01/2024');
         expect(createdUpdatedRows[1]).toHaveTextContent('Updated');
         expect(createdUpdatedRows[1]).toHaveTextContent('01/02/2024');
+        expect(createdUpdatedCell.querySelector(':scope > div')).toHaveAttribute('aria-label', 'Created on 01/01/2024. Updated on 01/02/2024');
 
         const timeElements = createdUpdatedCell.querySelectorAll('time');
         expect(timeElements).toHaveLength(2);
@@ -327,6 +328,37 @@ describe('OldDatasets page', () => {
 
         expect(screen.queryByRole('alert')).not.toBeInTheDocument();
         expect(screen.getByText(/All datasets have been loaded/i)).toBeVisible();
+    });
+
+    it('announces missing and invalid dates with meaningful aria labels', () => {
+        render(
+            <OldDatasets
+                {...baseProps}
+                datasets={[
+                    {
+                        id: 7,
+                        identifier: '10.0000/no-created-date',
+                        title: 'Dataset without a created timestamp',
+                        resourcetypegeneral: 'Dataset',
+                        curator: 'Dana',
+                        updated_at: 'invalid-date',
+                        publicstatus: 'draft',
+                    },
+                ]}
+            />,
+        );
+
+        const table = screen.getByRole('table');
+        const bodyRow = within(table).getAllByRole('row')[1];
+        const createdUpdatedCell = within(bodyRow).getAllByRole('cell')[5];
+        const labelledContainer = createdUpdatedCell.querySelector(':scope > div');
+
+        expect(labelledContainer).toHaveAttribute(
+            'aria-label',
+            'Created date not available. Updated date is invalid',
+        );
+        expect(within(labelledContainer as HTMLElement).getByText('Updated')).toBeVisible();
+        expect(within(labelledContainer as HTMLElement).getByText('Invalid date')).toBeVisible();
     });
 
     it('logs the server-provided diagnostics when the initial page load fails', () => {

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -52,6 +52,29 @@ const TITLE_COLUMN_WIDTH_CLASSES = 'min-w-[20rem] lg:min-w-[28rem] xl:min-w-[32r
 const TITLE_COLUMN_CELL_CLASSES = 'whitespace-normal break-words text-gray-900 dark:text-gray-100 leading-relaxed align-top';
 const DATE_COLUMN_CONTAINER_CLASSES = 'flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300';
 
+type DateType = 'Created' | 'Updated';
+
+const describeDate = (
+    label: string,
+    iso: string | null,
+    rawValue: string | undefined,
+    dateType: DateType,
+): string | null => {
+    if (iso) {
+        return `${dateType} on ${label}`;
+    }
+
+    if (!rawValue) {
+        return `${dateType} date not available`;
+    }
+
+    if (label === 'Invalid date') {
+        return `${dateType} date is invalid`;
+    }
+
+    return null;
+};
+
 export default function OldDatasets({ datasets: initialDatasets, pagination: initialPagination, error, debug }: DatasetsProps) {
     const [datasets, setDatasets] = useState<Dataset[]>(initialDatasets);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -223,31 +246,10 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                 const createdDetails = getDateDetails(dataset.created_at ?? null);
                 const updatedDetails = getDateDetails(dataset.updated_at ?? null);
 
-                const describeDate = (
-                    label: string,
-                    iso: string | null,
-                    rawValue: string | undefined,
-                    dateType: 'Created' | 'Updated',
-                ): string | null => {
-                    if (iso) {
-                        return `${dateType} on ${label}`;
-                    }
-
-                    if (!rawValue) {
-                        return `${dateType} date not available`;
-                    }
-
-                    if (label === 'Invalid date') {
-                        return `${dateType} date is invalid`;
-                    }
-
-                    return null;
-                };
-
                 const ariaLabelParts = [
                     describeDate(createdDetails.label, createdDetails.iso, dataset.created_at, 'Created'),
                     describeDate(updatedDetails.label, updatedDetails.iso, dataset.updated_at, 'Updated'),
-                ].filter((part): part is string => Boolean(part));
+                ].filter((part): part is string => part !== null);
 
                 const dateColumnAriaLabel = ariaLabelParts.length > 0 ? ariaLabelParts.join('. ') : undefined;
 

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -40,6 +40,14 @@ interface DatasetsProps {
     debug?: Record<string, unknown>;
 }
 
+interface DatasetColumn {
+    key: string;
+    label: string;
+    widthClass: string;
+    cellClassName?: string;
+    render?: (dataset: Dataset) => React.ReactNode;
+}
+
 export default function OldDatasets({ datasets: initialDatasets, pagination: initialPagination, error, debug }: DatasetsProps) {
     const [datasets, setDatasets] = useState<Dataset[]>(initialDatasets);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -130,65 +138,39 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
     }, [loading, pagination.has_more, loadMoreDatasets]);
 
     // Loading skeleton component
-    const LoadingSkeleton = () => (
-        <>
-            {[...Array(5)].map((_, index) => (
-                <tr key={`skeleton-${index}`} className="animate-pulse">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-8"></div>
-                    </td>
-                    {getDatasetKeys().map((key) => (
-                        <td key={key} className={`px-6 py-4 ${getColumnWidth(key)}`}>
-                            <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded"></div>
-                        </td>
-                    ))}
-                </tr>
-            ))}
-        </>
-    );
+    const getDateDetails = (dateString: string | null) => {
+        if (!dateString) {
+            return { label: 'Not available', iso: null };
+        }
 
-    const formatDate = (dateString: string | null): string => {
-        if (!dateString) return 'Not available';
         try {
             const date = new Date(dateString);
-            return date.toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-            });
+            if (Number.isNaN(date.getTime())) {
+                return { label: 'Invalid date', iso: null };
+            }
+
+            return {
+                label: date.toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                }),
+                iso: date.toISOString(),
+            };
         } catch {
-            return 'Invalid date';
+            return { label: 'Invalid date', iso: null };
         }
     };
 
-    const formatKeyName = (key: string): string => {
-        const keyMappings: { [key: string]: string } = {
-            'id': 'ID',
-            'identifier': 'Identifier (DOI)',
-            'resourcetypegeneral': 'Resource Type',
-            'curator': 'Curator',
-            'title': 'Title',
-            'created_at': 'Created Date',
-            'updated_at': 'Updated Date',
-            'publicstatus': 'Publication Status',
-            'publisher': 'Publisher',
-            'publicationyear': 'Publication Year',
-        };
-
-        return keyMappings[key] || key
-            .replace(/_/g, ' ')
-            .replace(/\b\w/g, (letter) => letter.toUpperCase());
+    const formatDate = (dateString: string | null): string => {
+        return getDateDetails(dateString).label;
     };
 
     const formatValue = (key: string, value: unknown): string => {
         if (value === null || value === undefined) return 'N/A';
-        
+
         if (key.includes('_at') || key.includes('date')) {
             return formatDate(value as string);
-        }
-        
-        if (key === 'title' && typeof value === 'string' && value.length > 110) {
-            return value.substring(0, 107) + '...';
         }
         
         if (key === 'publicstatus') {
@@ -203,34 +185,96 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
         
         return String(value);
     };
+    const datasetColumns: DatasetColumn[] = [
+        {
+            key: 'identifier',
+            label: 'Identifier (DOI)',
+            widthClass: 'min-w-[8rem]',
+            cellClassName: 'whitespace-nowrap',
+        },
+        {
+            key: 'title',
+            label: 'Title',
+            widthClass: 'min-w-[20rem] lg:min-w-[28rem] xl:min-w-[32rem]',
+            cellClassName: 'whitespace-normal break-words text-gray-900 dark:text-gray-100 leading-relaxed align-top',
+        },
+        {
+            key: 'resourcetypegeneral',
+            label: 'Resource Type',
+            widthClass: 'min-w-[10rem]',
+            cellClassName: 'whitespace-nowrap',
+        },
+        {
+            key: 'curator',
+            label: 'Curator',
+            widthClass: 'min-w-[7rem]',
+            cellClassName: 'whitespace-nowrap',
+        },
+        {
+            key: 'created_updated',
+            label: 'Created / Updated',
+            widthClass: 'min-w-[12rem]',
+            cellClassName: 'whitespace-normal align-top',
+            render: (dataset: Dataset) => {
+                const createdDetails = getDateDetails(dataset.created_at ?? null);
+                const updatedDetails = getDateDetails(dataset.updated_at ?? null);
 
-    const getDatasetKeys = (): string[] => {
-        // Define the desired column order
-        return [
-            'identifier',
-            'title', 
-            'resourcetypegeneral',
-            'curator',
-            'created_at',
-            'updated_at',
-            'publicstatus'
-        ];
-    };
+                return (
+                    <div
+                        className="flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300"
+                        aria-label={`Dataset created on ${createdDetails.label} and updated on ${updatedDetails.label}`}
+                    >
+                        <div>
+                            <span className="font-medium text-gray-700 dark:text-gray-200">Created</span>{' '}
+                            {createdDetails.iso ? (
+                                <time dateTime={createdDetails.iso}>{createdDetails.label}</time>
+                            ) : (
+                                <span>{createdDetails.label}</span>
+                            )}
+                        </div>
+                        <div>
+                            <span className="font-medium text-gray-700 dark:text-gray-200">Updated</span>{' '}
+                            {updatedDetails.iso ? (
+                                <time dateTime={updatedDetails.iso}>{updatedDetails.label}</time>
+                            ) : (
+                                <span>{updatedDetails.label}</span>
+                            )}
+                        </div>
+                    </div>
+                );
+            },
+        },
+        {
+            key: 'publicstatus',
+            label: 'Publication Status',
+            widthClass: 'min-w-[10rem]',
+            cellClassName: 'whitespace-nowrap',
+        },
+    ];
 
-    const getColumnWidth = (key: string): string => {
-        const widthMap: { [key: string]: string } = {
-            'identifier': 'w-20', // Even smaller width for DOI
-            'title': 'w-96', // Even wider for title
-            'resourcetypegeneral': 'w-40',
-            'curator': 'w-24', // Half width for curator (first names only)
-            'created_at': 'w-32',
-            'updated_at': 'w-32',
-            'publicstatus': 'w-28'
-        };
-        return widthMap[key] || 'w-32';
-    };
-
-    const keys = getDatasetKeys();
+    const LoadingSkeleton = () => (
+        <>
+            {[...Array(5)].map((_, index) => (
+                <tr key={`skeleton-${index}`} className="animate-pulse">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="h-4 w-8 rounded bg-gray-200 dark:bg-gray-700"></div>
+                    </td>
+                    {datasetColumns.map((column) => (
+                        <td key={column.key} className={`px-6 py-4 ${column.widthClass} ${column.cellClassName ?? ''}`}>
+                            {column.key === 'created_updated' ? (
+                                <div className="flex flex-col gap-2">
+                                    <div className="h-4 w-28 rounded bg-gray-200 dark:bg-gray-700"></div>
+                                    <div className="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
+                                </div>
+                            ) : (
+                                <div className="h-4 w-3/4 rounded bg-gray-200 dark:bg-gray-700"></div>
+                            )}
+                        </td>
+                    ))}
+                </tr>
+            ))}
+        </>
+    );
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -276,9 +320,12 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider w-16">
                                                     ID
                                                 </th>
-                                                {keys.map((key: string) => (
-                                                    <th key={key} className={`px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider ${getColumnWidth(key)}`}>
-                                                        {formatKeyName(key)}
+                                                {datasetColumns.map((column) => (
+                                                    <th
+                                                        key={column.key}
+                                                        className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300 ${column.widthClass}`}
+                                                    >
+                                                        {column.label}
                                                     </th>
                                                 ))}
                                             </tr>
@@ -287,17 +334,22 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                                             {datasets.map((dataset, index) => {
                                                 const isLast = index === datasets.length - 1;
                                                 return (
-                                                    <tr 
-                                                        key={dataset.id} 
+                                                    <tr
+                                                        key={dataset.id}
                                                         className="hover:bg-gray-50 dark:hover:bg-gray-800"
                                                         ref={isLast ? lastDatasetElementRef : null}
                                                     >
                                                         <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100 w-16">
                                                             {dataset.id}
                                                         </td>
-                                                        {keys.map((key: string) => (
-                                                            <td key={key} className={`px-6 py-4 text-sm text-gray-500 dark:text-gray-300 ${getColumnWidth(key)} ${key === 'title' ? '' : 'whitespace-nowrap'}`}>
-                                                                {formatValue(key, dataset[key])}
+                                                        {datasetColumns.map((column) => (
+                                                            <td
+                                                                key={column.key}
+                                                                className={`px-6 py-4 text-sm text-gray-500 dark:text-gray-300 ${column.widthClass} ${column.cellClassName ?? ''}`}
+                                                            >
+                                                                {column.render
+                                                                    ? column.render(dataset)
+                                                                    : formatValue(column.key, dataset[column.key])}
                                                             </td>
                                                         ))}
                                                     </tr>

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -48,6 +48,10 @@ interface DatasetColumn {
     render?: (dataset: Dataset) => React.ReactNode;
 }
 
+const TITLE_COLUMN_WIDTH_CLASSES = 'min-w-[20rem] lg:min-w-[28rem] xl:min-w-[32rem]';
+const TITLE_COLUMN_CELL_CLASSES = 'whitespace-normal break-words text-gray-900 dark:text-gray-100 leading-relaxed align-top';
+const DATE_COLUMN_CONTAINER_CLASSES = 'flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300';
+
 export default function OldDatasets({ datasets: initialDatasets, pagination: initialPagination, error, debug }: DatasetsProps) {
     const [datasets, setDatasets] = useState<Dataset[]>(initialDatasets);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -195,8 +199,8 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
         {
             key: 'title',
             label: 'Title',
-            widthClass: 'min-w-[20rem] lg:min-w-[28rem] xl:min-w-[32rem]',
-            cellClassName: 'whitespace-normal break-words text-gray-900 dark:text-gray-100 leading-relaxed align-top',
+            widthClass: TITLE_COLUMN_WIDTH_CLASSES,
+            cellClassName: TITLE_COLUMN_CELL_CLASSES,
         },
         {
             key: 'resourcetypegeneral',
@@ -219,10 +223,38 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                 const createdDetails = getDateDetails(dataset.created_at ?? null);
                 const updatedDetails = getDateDetails(dataset.updated_at ?? null);
 
+                const describeDate = (
+                    label: string,
+                    iso: string | null,
+                    rawValue: string | undefined,
+                    dateType: 'Created' | 'Updated',
+                ): string | null => {
+                    if (iso) {
+                        return `${dateType} on ${label}`;
+                    }
+
+                    if (!rawValue) {
+                        return `${dateType} date not available`;
+                    }
+
+                    if (label === 'Invalid date') {
+                        return `${dateType} date is invalid`;
+                    }
+
+                    return null;
+                };
+
+                const ariaLabelParts = [
+                    describeDate(createdDetails.label, createdDetails.iso, dataset.created_at, 'Created'),
+                    describeDate(updatedDetails.label, updatedDetails.iso, dataset.updated_at, 'Updated'),
+                ].filter((part): part is string => Boolean(part));
+
+                const dateColumnAriaLabel = ariaLabelParts.length > 0 ? ariaLabelParts.join('. ') : undefined;
+
                 return (
                     <div
-                        className="flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300"
-                        aria-label={`Dataset created on ${createdDetails.label} and updated on ${updatedDetails.label}`}
+                        className={DATE_COLUMN_CONTAINER_CLASSES}
+                        aria-label={dateColumnAriaLabel}
                     >
                         <div>
                             <span className="font-medium text-gray-700 dark:text-gray-200">Created</span>{' '}

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -189,17 +189,9 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
         }
     };
 
-    const formatDate = (dateString: string | null): string => {
-        return getDateDetails(dateString).label;
-    };
-
     const formatValue = (key: string, value: unknown): string => {
         if (value === null || value === undefined) return 'N/A';
 
-        if (key.includes('_at') || key.includes('date')) {
-            return formatDate(value as string);
-        }
-        
         if (key === 'publicstatus') {
             const statusMap: { [key: string]: string } = {
                 'published': 'Published',


### PR DESCRIPTION
This pull request refactors the `OldDatasets` page to improve accessibility, code maintainability, and UI consistency for displaying dataset information, especially for date fields. The changes introduce a new column configuration system, enhance the handling and display of created/updated dates (including invalid or missing data), and update related tests to reflect the new logic.

**Accessibility and Date Handling Improvements:**

* Added a new "Created / Updated" column that combines created and updated dates, displays both values with clear labels, and provides meaningful `aria-label` attributes for screen readers, including cases where dates are missing or invalid. [[1]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eR215-R311) [[2]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eL133-R193)
* Improved date parsing and formatting logic to handle invalid or missing dates gracefully, with fallback text and accessibility labels.

**UI and Code Structure Enhancements:**

* Refactored table column definitions into a `datasetColumns` array, allowing for easier configuration of column order, labels, widths, and custom rendering logic.
* Updated table header and row rendering to use the new column configuration, ensuring consistent styling and layout, especially for long titles and date cells. [[1]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eL279-R362) [[2]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eL298-R386)
* Modified the loading skeleton to match the new column structure for a more accurate loading state representation.

**Test Updates:**

* Updated tests to check for the new "Created / Updated" column, verify correct rendering of date labels, accessibility attributes, and handling of invalid/missing dates. [[1]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4L182-R182) [[2]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4L191-R208) [[3]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4R333-R363)