### PR TITLE
Add curation actions to old datasets table

### DIFF
--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -544,7 +544,7 @@ describe('deriveDatasetRowKey', () => {
         const firstKey = deriveDatasetRowKey(dataset);
         const secondKey = deriveDatasetRowKey({ ...dataset });
 
-        expect(firstKey).toMatch(/^dataset-/);
+        expect(firstKey).toMatch(/^dataset-[a-z0-9]+-[a-z0-9-]+$/);
         expect(secondKey).toBe(firstKey);
     });
 
@@ -554,5 +554,31 @@ describe('deriveDatasetRowKey', () => {
 
         expect(deriveDatasetRowKey(datasetWithId)).toBe('id-987');
         expect(deriveDatasetRowKey(datasetWithIdentifier)).toBe('doi-10.1234/example');
+    });
+
+    it('normalises fallback serialisation ordering to avoid collisions from object key order', () => {
+        const firstDataset: DatasetLike = {
+            extras: {
+                zebra: 'last',
+                alpha: 'first',
+            },
+        };
+
+        const secondDataset: DatasetLike = {
+            extras: {
+                alpha: 'first',
+                zebra: 'last',
+            },
+        };
+
+        expect(deriveDatasetRowKey(firstDataset)).toBe(deriveDatasetRowKey(secondDataset));
+    });
+
+    it('includes a deterministic suffix in the derived key so collisions can be avoided client-side', () => {
+        const dataset: DatasetLike = {
+            curator: 'Alicia',
+        };
+
+        expect(deriveDatasetRowKey(dataset)).toMatch(/^dataset-[a-z0-9]+-[a-z0-9-]+$/);
     });
 });

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -4,6 +4,10 @@ import OldDatasets from '../old-datasets';
 import axios from 'axios';
 import { vi, beforeEach, afterEach, describe, it, expect, type MockInstance } from 'vitest';
 
+const inertiaMocks = vi.hoisted(() => ({
+    routerGet: vi.fn(),
+}));
+
 vi.mock('axios', () => {
     const get = vi.fn();
     const isAxiosError = (value: unknown): value is { isAxiosError: true } => {
@@ -18,7 +22,12 @@ vi.mock('axios', () => {
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    router: {
+        get: inertiaMocks.routerGet,
+    },
 }));
+
+const routerGetSpy = inertiaMocks.routerGet;
 
 vi.mock('@/layouts/app-layout', () => ({
     default: ({ children }: { children?: React.ReactNode }) => (
@@ -91,6 +100,7 @@ describe('OldDatasets page', () => {
 
     beforeEach(() => {
         mockedAxios.get.mockReset();
+        routerGetSpy.mockReset();
 
         observeSpy = vi.fn();
         disconnectSpy = vi.fn();
@@ -139,6 +149,16 @@ describe('OldDatasets page', () => {
                 publicstatus: 'review',
                 publisher: 'Example Publisher',
                 publicationyear: 2024,
+                titles: [
+                    { title: 'Subtitle Title', titleType: 'subtitle' },
+                    { title: 'Provided Main Title', titleType: 'main-title' },
+                    { title: 'Translated Title', titleType: 'Translated Title' },
+                ],
+                licenses: ['CC-BY-4.0', { rightsIdentifier: 'MIT' }],
+                license: 'GPL-3.0',
+                version: '1.2.0',
+                language: 'en',
+                resourcetype: '1',
             },
             {
                 id: 2,
@@ -220,6 +240,43 @@ describe('OldDatasets page', () => {
 
         // Ensure the infinite scroll sentinel is observed for accessibility
         expect(observeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('provides accessible actions for opening datasets in the curation form', async () => {
+        const user = userEvent.setup();
+
+        render(<OldDatasets {...baseProps} />);
+
+        const buttons = screen.getAllByRole('button', { name: /open dataset/i });
+        expect(buttons).toHaveLength(2);
+        expect(buttons[0]).toHaveAccessibleName('Open dataset 10.1234/example-one in curation form');
+
+        await user.click(buttons[0]);
+
+        expect(routerGetSpy).toHaveBeenCalledTimes(1);
+
+        const params = new URLSearchParams();
+        params.set('doi', '10.1234/example-one');
+        params.set('year', '2024');
+        params.set('version', '1.2.0');
+        params.set('language', 'en');
+        params.set('resourceType', '1');
+        params.append('titles[0][title]', 'Provided Main Title');
+        params.append('titles[0][titleType]', 'main-title');
+        params.append(
+            'titles[1][title]',
+            'A dataset title that is long enough to demonstrate truncation when rendered in the table body with additional descriptive context to push it well beyond the truncation threshold for the component',
+        );
+        params.append('titles[1][titleType]', 'main-title');
+        params.append('titles[2][title]', 'Subtitle Title');
+        params.append('titles[2][titleType]', 'subtitle');
+        params.append('titles[3][title]', 'Translated Title');
+        params.append('titles[3][titleType]', 'translated-title');
+        params.append('licenses[0]', 'CC-BY-4.0');
+        params.append('licenses[1]', 'MIT');
+        params.append('licenses[2]', 'GPL-3.0');
+
+        expect(routerGetSpy).toHaveBeenCalledWith(`/curation?${params.toString()}`);
     });
 
     it('requests the next page when the sentinel row becomes visible', async () => {

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -279,6 +279,34 @@ describe('OldDatasets page', () => {
         expect(routerGetSpy).toHaveBeenCalledWith(`/curation?${params.toString()}`);
     });
 
+    it('omits the resource type when the identifier contains non-digit characters', async () => {
+        const user = userEvent.setup();
+
+        render(
+            <OldDatasets
+                {...baseProps}
+                datasets={[
+                    {
+                        ...baseProps.datasets[0],
+                        resourcetype: 'type123',
+                    },
+                ]}
+            />,
+        );
+
+        const button = screen.getByRole('button', {
+            name: /open dataset 10\.1234\/example-one in curation form/i,
+        });
+
+        await user.click(button);
+
+        expect(routerGetSpy).toHaveBeenCalledTimes(1);
+        const [requestedUrl] = routerGetSpy.mock.calls[0] as [string];
+        const params = new URLSearchParams(requestedUrl.split('?')[1] ?? '');
+
+        expect(params.has('resourceType')).toBe(false);
+    });
+
     it('requests the next page when the sentinel row becomes visible', async () => {
         mockedAxios.get.mockResolvedValueOnce({
             data: {

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -4,9 +4,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Head } from '@inertiajs/react';
+import { curation as curationRoute } from '@/routes';
+import { Head, router } from '@inertiajs/react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import type { ReactNode } from 'react';
+import { ArrowUpRight } from 'lucide-react';
 import axios, { isAxiosError } from 'axios';
 
 interface Dataset {
@@ -15,6 +17,17 @@ interface Dataset {
     resourcetypegeneral?: string;
     curator?: string;
     title?: string;
+    titleType?: string;
+    title_type?: string;
+    titles?: { title?: string | null; titleType?: string | null; title_type?: string | null }[];
+    licenses?: (string | { identifier?: string | null; rightsIdentifier?: string | null; license?: string | null })[];
+    license?: string;
+    version?: string;
+    language?: string;
+    resourcetype?: string | number;
+    resourcetypeid?: string | number;
+    resource_type_id?: string | number;
+    resourceTypeId?: string | number;
     created_at?: string;
     updated_at?: string;
     publicstatus?: string;
@@ -58,9 +71,180 @@ const DATE_COLUMN_HEADER_LABEL = (
         <span>Updated</span>
     </span>
 );
+const ACTIONS_COLUMN_WIDTH_CLASSES = 'w-24 min-w-[6rem]';
 
 type DateType = 'Created' | 'Updated';
 type DateDetails = { label: string; iso: string | null };
+
+interface NormalisedTitle {
+    title: string;
+    titleType: string;
+}
+
+const NORMALISED_MAIN_TITLE = 'main-title';
+
+const normaliseTitleType = (value: string | null | undefined): string => {
+    if (!value) {
+        return NORMALISED_MAIN_TITLE;
+    }
+
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+        return NORMALISED_MAIN_TITLE;
+    }
+
+    return trimmed
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/gi, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-');
+};
+
+const normaliseTitles = (dataset: Dataset): NormalisedTitle[] => {
+    const titles: NormalisedTitle[] = [];
+
+    if (Array.isArray(dataset.titles)) {
+        dataset.titles.forEach((raw) => {
+            if (typeof raw === 'string') {
+                const text = raw.trim();
+                if (text) {
+                    titles.push({ title: text, titleType: NORMALISED_MAIN_TITLE });
+                }
+                return;
+            }
+
+            if (!raw) return;
+
+            const value = raw.title ?? null;
+            const titleText = typeof value === 'string' ? value.trim() : '';
+
+            if (!titleText) return;
+
+            const typeValue = normaliseTitleType(raw.titleType ?? raw.title_type ?? null);
+            titles.push({ title: titleText, titleType: typeValue });
+        });
+    }
+
+    const fallbackTitle = typeof dataset.title === 'string' ? dataset.title.trim() : '';
+
+    if (fallbackTitle) {
+        const fallbackType = normaliseTitleType(dataset.titleType ?? dataset.title_type ?? null);
+        titles.push({ title: fallbackTitle, titleType: fallbackType });
+    }
+
+    const mainTitles = titles.filter((entry) => entry.titleType === NORMALISED_MAIN_TITLE);
+    const secondaryTitles = titles.filter((entry) => entry.titleType !== NORMALISED_MAIN_TITLE);
+
+    return [...mainTitles, ...secondaryTitles];
+};
+
+const normaliseLicenses = (dataset: Dataset): string[] => {
+    const licenses: string[] = [];
+
+    const appendLicense = (value: unknown) => {
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                licenses.push(trimmed);
+            }
+            return;
+        }
+
+        if (typeof value === 'object' && value !== null) {
+            const candidate =
+                'identifier' in value
+                    ? value.identifier
+                    : 'rightsIdentifier' in value
+                        ? value.rightsIdentifier
+                        : 'license' in value
+                            ? value.license
+                            : null;
+
+            if (typeof candidate === 'string') {
+                const trimmed = candidate.trim();
+                if (trimmed) {
+                    licenses.push(trimmed);
+                }
+            }
+        }
+    };
+
+    if (Array.isArray(dataset.licenses)) {
+        dataset.licenses.forEach(appendLicense);
+    }
+
+    appendLicense(dataset.license ?? null);
+
+    return licenses;
+};
+
+const getResourceTypeIdentifier = (dataset: Dataset): string | null => {
+    const candidates = [
+        dataset.resourceTypeId,
+        dataset.resource_type_id,
+        dataset.resourcetypeid,
+        dataset.resourcetype,
+    ];
+
+    for (const candidate of candidates) {
+        if (candidate === null || candidate === undefined) {
+            continue;
+        }
+
+        if (typeof candidate === 'number') {
+            return String(candidate);
+        }
+
+        if (typeof candidate === 'string') {
+            const trimmed = candidate.trim();
+            if (!trimmed) continue;
+            if (/^\d+$/.test(trimmed)) {
+                return trimmed;
+            }
+        }
+    }
+
+    return null;
+};
+
+const buildCurationQuery = (dataset: Dataset): Record<string, string> => {
+    const query: Record<string, string> = {};
+
+    if (dataset.identifier) {
+        query.doi = dataset.identifier;
+    }
+
+    if (dataset.publicationyear !== undefined && dataset.publicationyear !== null) {
+        query.year = String(dataset.publicationyear);
+    }
+
+    if (dataset.version) {
+        query.version = dataset.version;
+    }
+
+    if (dataset.language) {
+        query.language = dataset.language;
+    }
+
+    const resourceType = getResourceTypeIdentifier(dataset);
+    if (resourceType) {
+        query.resourceType = resourceType;
+    }
+
+    const titles = normaliseTitles(dataset);
+    titles.forEach((title, index) => {
+        query[`titles[${index}][title]`] = title.title;
+        query[`titles[${index}][titleType]`] = title.titleType;
+    });
+
+    const licenses = normaliseLicenses(dataset);
+    licenses.forEach((license, index) => {
+        query[`licenses[${index}]`] = license;
+    });
+
+    return query;
+};
 
 const renderDateContent = (details: DateDetails): ReactNode => {
     if (details.iso) {
@@ -101,6 +285,11 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
     const [loading, setLoading] = useState(false);
     const [loadingError, setLoadingError] = useState<string>('');
     const observer = useRef<IntersectionObserver | null>(null);
+
+    const handleOpenInCuration = useCallback((dataset: Dataset) => {
+        const query = buildCurationQuery(dataset);
+        router.get(curationRoute({ query }).url);
+    }, []);
 
     const logDebugInformation = useCallback((source: string, message: string | undefined, payload?: Record<string, unknown>) => {
         if (!payload || Object.keys(payload).length === 0) {
@@ -303,6 +492,9 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                             )}
                         </td>
                     ))}
+                    <td className={`px-6 py-4 ${ACTIONS_COLUMN_WIDTH_CLASSES}`}>
+                        <div className="size-9 rounded-full bg-gray-200 dark:bg-gray-700" />
+                    </td>
                 </tr>
             ))}
         </>
@@ -360,14 +552,23 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                                                         {column.label}
                                                     </th>
                                                 ))}
+                                                <th
+                                                    className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300 ${ACTIONS_COLUMN_WIDTH_CLASSES}`}
+                                                >
+                                                    Actions
+                                                </th>
                                             </tr>
                                         </thead>
                                         <tbody className="bg-white divide-y divide-gray-200 dark:bg-gray-900 dark:divide-gray-700">
                                             {datasets.map((dataset, index) => {
                                                 const isLast = index === datasets.length - 1;
+                                                const datasetLabel =
+                                                    dataset.identifier ??
+                                                    dataset.title ??
+                                                    (dataset.id !== undefined ? `#${dataset.id}` : 'entry');
                                                 return (
                                                     <tr
-                                                        key={dataset.id}
+                                                        key={dataset.id ?? dataset.identifier ?? `dataset-${index}`}
                                                         className="hover:bg-gray-50 dark:hover:bg-gray-800"
                                                         ref={isLast ? lastDatasetElementRef : null}
                                                     >
@@ -384,6 +585,18 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
                                                                     : formatValue(column.key, dataset[column.key])}
                                                             </td>
                                                         ))}
+                                                        <td className={`px-6 py-4 text-sm text-gray-500 dark:text-gray-300 ${ACTIONS_COLUMN_WIDTH_CLASSES}`}>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                onClick={() => handleOpenInCuration(dataset)}
+                                                                aria-label={`Open dataset ${datasetLabel} in curation form`}
+                                                                title={`Open dataset ${datasetLabel} in curation form`}
+                                                            >
+                                                                <ArrowUpRight aria-hidden="true" className="size-4" />
+                                                            </Button>
+                                                        </td>
                                                     </tr>
                                                 );
                                             })}

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -101,6 +101,10 @@ const normaliseTitleType = (value: string | null | undefined): string => {
         .replace(/-+/g, '-');
 };
 
+/**
+ * 64-bit FNV-1a constants sourced from the Fowler–Noll–Vo hash specification.
+ * See: http://www.isthe.com/chongo/tech/comp/fnv/
+ */
 const FNV_OFFSET_BASIS_64 = BigInt('0xcbf29ce484222325');
 const FNV_PRIME_64 = BigInt('0x100000001b3');
 const FNV_64_MASK = BigInt('0xffffffffffffffff');
@@ -305,8 +309,9 @@ const normaliseLicenses = (dataset: Dataset): string[] => {
  *
  * The backend expects this identifier to be numeric. The helper therefore
  * accepts string and number inputs but intentionally filters out values that contain
- * non-digit characters so that we never forward invalid identifiers to the
- * curation form.
+ * non-digit characters. Only purely numeric strings (for example, "123") are forwarded,
+ * while mixed alphanumeric values such as "type123" or "12abc" are rejected so the
+ * curation form never receives invalid identifiers.
  */
 const getResourceTypeIdentifier = (dataset: Dataset): string | null => {
     const candidates = [


### PR DESCRIPTION
This pull request adds robust support for dataset row key generation and accessible curation actions to the `OldDatasets` page, improving stability, accessibility, and test coverage. Key changes include a new deterministic key derivation function for datasets, enhanced logic for building curation form query parameters, and new tests to ensure correct behavior for these features.

**Dataset key generation and normalization:**

* Added the `deriveDatasetRowKey` function to generate stable, collision-resistant keys for dataset rows, preferring `id` and `identifier` when present, and falling back to a hash-based approach for legacy or incomplete data. This includes deterministic serialization and normalization to avoid key collisions. (`resources/js/pages/old-datasets.tsx`, `resources/js/pages/__tests__/old-datasets.test.tsx`) [[1]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eR74-R382) [[2]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4R555-R612)
* Updated the dataset table to use `deriveDatasetRowKey` for the React `key` prop, ensuring row stability even when structural identifiers are missing. (`resources/js/pages/old-datasets.tsx`) (F08247fbL686)

**Curation form integration and accessibility:**

* Implemented the `buildCurationQuery` helper to construct query parameters for opening datasets in the curation form, including normalized titles and licenses, and only passing valid numeric resource type identifiers. (`resources/js/pages/old-datasets.tsx`)
* Added an "Actions" column to the dataset table with an accessible button to open each dataset in the curation form, using the new query builder and providing descriptive ARIA labels. (`resources/js/pages/old-datasets.tsx`) (F08247fbL686, F08247fbL719)

**Testing improvements:**

* Added comprehensive tests for `deriveDatasetRowKey`, covering fallback behavior, normalization, and collision avoidance. (`resources/js/pages/__tests__/old-datasets.test.tsx`)
* Added tests for accessible curation actions, verifying correct query parameter construction and resource type handling. (`resources/js/pages/__tests__/old-datasets.test.tsx`)

**Mocking and setup enhancements:**

* Improved test setup by mocking the Inertia router and resetting spies between tests to ensure isolation and reliability. (`resources/js/pages/__tests__/old-datasets.test.tsx`) [[1]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4L3-R10) [[2]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4R25-R31) [[3]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4R103)

**Dataset model extension:**

* Extended the `Dataset` interface to support additional metadata fields required for normalization and query construction, including multiple title and license formats. (`resources/js/pages/old-datasets.tsx`) (F08247fbL17)

These changes collectively improve the reliability, accessibility, and maintainability of the dataset table and its integration with the curation workflow.