### PR TITLE
Fix: Mapping for resource types and licenses to ERNIE IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+clover.xml
 
 # Playwright
 node_modules/

--- a/app/Http/Controllers/OldDatasetController.php
+++ b/app/Http/Controllers/OldDatasetController.php
@@ -33,8 +33,14 @@ class OldDatasetController extends Controller
             // Resources aus der SUMARIOPMD-Datenbank abrufen (paginiert)
             $paginatedDatasets = OldDataset::getPaginatedOrderedByCreatedDate($page, $perPage);
 
+            // Load licenses for each dataset
+            $datasetsWithLicenses = $paginatedDatasets->items();
+            foreach ($datasetsWithLicenses as $dataset) {
+                $dataset->licenses = $dataset->getLicenses();
+            }
+
             return Inertia::render('old-datasets', [
-                'datasets' => $paginatedDatasets->items(),
+                'datasets' => $datasetsWithLicenses,
                 'pagination' => [
                     'current_page' => $paginatedDatasets->currentPage(),
                     'last_page' => $paginatedDatasets->lastPage(),
@@ -87,8 +93,14 @@ class OldDatasetController extends Controller
             
             $paginatedDatasets = OldDataset::getPaginatedOrderedByCreatedDate($page, $perPage);
 
+            // Load licenses for each dataset
+            $datasetsWithLicenses = $paginatedDatasets->items();
+            foreach ($datasetsWithLicenses as $dataset) {
+                $dataset->licenses = $dataset->getLicenses();
+            }
+
             return response()->json([
-                'datasets' => $paginatedDatasets->items(),
+                'datasets' => $datasetsWithLicenses,
                 'pagination' => [
                     'current_page' => $paginatedDatasets->currentPage(),
                     'last_page' => $paginatedDatasets->lastPage(),

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
+/**
+ * @property array<string>|null $licenses
+ */
 class OldDataset extends Model
 {
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -115,10 +115,28 @@ class OldDataset extends Model
                 'resource.publicstatus',
                 'resource.publisher',
                 'resource.publicationyear',
+                'resource.version',
+                'resource.language',
                 'title.title'
             ])
             ->leftJoin('title', 'resource.id', '=', 'title.resource_id')
             ->orderBy('resource.created_at', 'desc')
             ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    /**
+     * Get licenses for this resource from the license table.
+     *
+     * @return array<string>
+     */
+    public function getLicenses(): array
+    {
+        $licenses = \Illuminate\Support\Facades\DB::connection($this->connection)
+            ->table('license')
+            ->where('resource_id', $this->id)
+            ->pluck('name')
+            ->toArray();
+
+        return array_values(array_unique($licenses));
     }
 }

--- a/resources/js/pages/__tests__/old-datasets.test.tsx
+++ b/resources/js/pages/__tests__/old-datasets.test.tsx
@@ -316,7 +316,7 @@ describe('OldDatasets page', () => {
                 datasets={[
                     {
                         ...baseProps.datasets[0],
-                        resourcetype: 'type123',
+                        resourcetypegeneral: 'type123',
                     },
                 ]}
             />,

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -342,7 +342,139 @@ const getResourceTypeIdentifier = (dataset: Dataset): string | null => {
     return null;
 };
 
-const buildCurationQuery = (dataset: Dataset): Record<string, string> => {
+// Cache for resource types and licenses to avoid repeated API calls
+let resourceTypesCache: { id: number; name: string; slug: string }[] | null = null;
+let licensesCache: { id: number; identifier: string; name: string }[] | null = null;
+
+/**
+ * Fetch and cache resource types from ERNIE API
+ */
+const getResourceTypes = async (): Promise<{ id: number; name: string; slug: string }[]> => {
+    if (resourceTypesCache) {
+        return resourceTypesCache;
+    }
+
+    try {
+        const response = await fetch('/api/v1/resource-types/ernie');
+        if (!response.ok) return [];
+        resourceTypesCache = await response.json();
+        return resourceTypesCache || [];
+    } catch (error) {
+        console.error('Error fetching resource types:', error);
+        return [];
+    }
+};
+
+/**
+ * Fetch and cache licenses from ERNIE API
+ */
+const getLicenses = async (): Promise<{ id: number; identifier: string; name: string }[]> => {
+    if (licensesCache) {
+        return licensesCache;
+    }
+
+    try {
+        const response = await fetch('/api/v1/licenses/ernie');
+        if (!response.ok) return [];
+        licensesCache = await response.json();
+        return licensesCache || [];
+    } catch (error) {
+        console.error('Error fetching licenses:', error);
+        return [];
+    }
+};
+
+/**
+ * Map old database resource type general strings to ERNIE resource type IDs.
+ * The mapping is based on the resource type names in ERNIE's resource_types table.
+ */
+const mapResourceTypeToId = async (resourceTypeGeneral?: string): Promise<string | null> => {
+    if (!resourceTypeGeneral) return null;
+
+    // Normalize the input
+    const normalized = resourceTypeGeneral.trim();
+    if (!normalized) return null;
+
+    try {
+        const resourceTypes = await getResourceTypes();
+
+        // Try to find a matching resource type by name (case-insensitive)
+        const match = resourceTypes.find(
+            (type) => type.name.toLowerCase() === normalized.toLowerCase()
+        );
+
+        if (match) {
+            return String(match.id);
+        }
+
+        // Try to match by slug for some special cases
+        const slugMatch = resourceTypes.find(
+            (type) => type.slug === normalized.toLowerCase().replace(/\s+/g, '-')
+        );
+
+        if (slugMatch) {
+            return String(slugMatch.id);
+        }
+
+        return null;
+    } catch (error) {
+        console.error('Error mapping resource type:', error);
+        return null;
+    }
+};
+
+/**
+ * Map old database license names to ERNIE license identifiers.
+ * This is a best-effort mapping based on common license name patterns.
+ */
+const mapLicenseToIdentifier = async (licenseName: string): Promise<string | null> => {
+    if (!licenseName) return null;
+
+    const normalized = licenseName.trim();
+    if (!normalized) return null;
+
+    try {
+        const licenses = await getLicenses();
+
+        // First, try exact match on identifier (e.g., "CC-BY-4.0")
+        const exactMatch = licenses.find(
+            (lic) => lic.identifier.toLowerCase() === normalized.toLowerCase()
+        );
+        if (exactMatch) {
+            return exactMatch.identifier;
+        }
+
+        // Try to match by name
+        const nameMatch = licenses.find(
+            (lic) => lic.name.toLowerCase() === normalized.toLowerCase()
+        );
+        if (nameMatch) {
+            return nameMatch.identifier;
+        }
+
+        // Try partial matching for common CC licenses
+        const ccMatch = normalized.match(/CC[\s-]*(BY|BY-SA|BY-NC|BY-ND|BY-NC-SA|BY-NC-ND)[\s-]*(\d\.\d)?/i);
+        if (ccMatch) {
+            const licenseType = ccMatch[1].toUpperCase();
+            const version = ccMatch[2] || '4.0';
+            const ccIdentifier = `CC-${licenseType}-${version}`;
+            
+            const found = licenses.find(
+                (lic) => lic.identifier.toLowerCase() === ccIdentifier.toLowerCase()
+            );
+            if (found) {
+                return found.identifier;
+            }
+        }
+
+        return null;
+    } catch (error) {
+        console.error('Error mapping license:', error);
+        return null;
+    }
+};
+
+const buildCurationQuery = async (dataset: Dataset): Promise<Record<string, string>> => {
     const query: Record<string, string> = {};
 
     if (dataset.identifier) {
@@ -361,9 +493,12 @@ const buildCurationQuery = (dataset: Dataset): Record<string, string> => {
         query.language = dataset.language;
     }
 
-    const resourceType = getResourceTypeIdentifier(dataset);
-    if (resourceType) {
-        query.resourceType = resourceType;
+    // Map resource type from old DB string to ERNIE ID
+    if (dataset.resourcetypegeneral) {
+        const resourceTypeId = await mapResourceTypeToId(dataset.resourcetypegeneral);
+        if (resourceTypeId) {
+            query.resourceType = resourceTypeId;
+        }
     }
 
     const titles = normaliseTitles(dataset);
@@ -372,8 +507,16 @@ const buildCurationQuery = (dataset: Dataset): Record<string, string> => {
         query[`titles[${index}][titleType]`] = title.titleType;
     });
 
+    // Map licenses from old DB to ERNIE identifiers
     const licenses = normaliseLicenses(dataset);
-    licenses.forEach((license, index) => {
+    const mappedLicenses = await Promise.all(
+        licenses.map(async (license) => {
+            const identifier = await mapLicenseToIdentifier(license);
+            return identifier || license; // Fallback to original if no mapping found
+        })
+    );
+    
+    mappedLicenses.forEach((license, index) => {
         query[`licenses[${index}]`] = license;
     });
 
@@ -420,8 +563,8 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
     const [loadingError, setLoadingError] = useState<string>('');
     const observer = useRef<IntersectionObserver | null>(null);
 
-    const handleOpenInCuration = useCallback((dataset: Dataset) => {
-        const query = buildCurationQuery(dataset);
+    const handleOpenInCuration = useCallback(async (dataset: Dataset) => {
+        const query = await buildCurationQuery(dataset);
         router.get(curationRoute({ query }).url);
     }, []);
 
@@ -454,6 +597,12 @@ export default function OldDatasets({ datasets: initialDatasets, pagination: ini
             logDebugInformation('initial page load', error, debug);
         }
     }, [debug, error, logDebugInformation]);
+
+    // Preload resource types and licenses on component mount
+    useEffect(() => {
+        getResourceTypes();
+        getLicenses();
+    }, []);
     
     const breadcrumbs: BreadcrumbItem[] = [
         {

--- a/resources/js/pages/old-datasets.tsx
+++ b/resources/js/pages/old-datasets.tsx
@@ -347,7 +347,18 @@ let resourceTypesCache: { id: number; name: string; slug: string }[] | null = nu
 let licensesCache: { id: number; identifier: string; name: string }[] | null = null;
 
 /**
- * Fetch and cache resource types from ERNIE API
+ * Fetch and cache resource types from ERNIE API.
+ * 
+ * This function retrieves the list of resource types available in ERNIE and caches
+ * the result to avoid repeated API calls. The cache persists for the lifetime of
+ * the page session.
+ * 
+ * @returns {Promise<Array<{id: number, name: string, slug: string}>>} Array of resource types with their IDs, names, and slugs
+ * @throws Returns empty array if the API call fails
+ * 
+ * @example
+ * const types = await getResourceTypes();
+ * // [{id: 1, name: 'Dataset', slug: 'dataset'}, ...]
  */
 const getResourceTypes = async (): Promise<{ id: number; name: string; slug: string }[]> => {
     if (resourceTypesCache) {
@@ -366,7 +377,18 @@ const getResourceTypes = async (): Promise<{ id: number; name: string; slug: str
 };
 
 /**
- * Fetch and cache licenses from ERNIE API
+ * Fetch and cache licenses from ERNIE API.
+ * 
+ * This function retrieves the list of licenses available in ERNIE and caches
+ * the result to avoid repeated API calls. The cache persists for the lifetime of
+ * the page session.
+ * 
+ * @returns {Promise<Array<{id: number, identifier: string, name: string}>>} Array of licenses with their IDs, identifiers, and names
+ * @throws Returns empty array if the API call fails
+ * 
+ * @example
+ * const licenses = await getLicenses();
+ * // [{id: 1, identifier: 'CC-BY-4.0', name: 'Creative Commons Attribution 4.0'}, ...]
  */
 const getLicenses = async (): Promise<{ id: number; identifier: string; name: string }[]> => {
     if (licensesCache) {

--- a/tests/Feature/OldDatasetControllerTest.php
+++ b/tests/Feature/OldDatasetControllerTest.php
@@ -25,32 +25,76 @@ beforeEach(function (): void {
 });
 
 it('renders the old datasets page with paginated data', function (): void {
-    $datasets = [
-        [
-            'id' => 1,
-            'identifier' => '10.1234/example-one',
-            'resourcetypegeneral' => 'Dataset',
-            'curator' => 'Alice',
-            'title' => 'Example dataset number one',
-            'created_at' => '2024-01-01 10:00:00',
-            'updated_at' => '2024-01-05 12:00:00',
-            'publicstatus' => 'published',
-            'publisher' => 'Example Publisher',
-            'publicationyear' => 2024,
-        ],
-        [
-            'id' => 2,
-            'identifier' => '10.1234/example-two',
-            'resourcetypegeneral' => 'Dataset',
-            'curator' => 'Bob',
-            'title' => 'Example dataset number two',
-            'created_at' => '2024-02-02 14:30:00',
-            'updated_at' => '2024-02-05 09:15:00',
-            'publicstatus' => 'review',
-            'publisher' => 'Example Publisher',
-            'publicationyear' => 2023,
-        ],
-    ];
+    // Create mock OldDataset objects that behave like real models
+    $dataset1 = new class {
+        public $id = 1;
+        public $identifier = '10.1234/example-one';
+        public $resourcetypegeneral = 'Dataset';
+        public $curator = 'Alice';
+        public $title = 'Example dataset number one';
+        public $created_at = '2024-01-01 10:00:00';
+        public $updated_at = '2024-01-05 12:00:00';
+        public $publicstatus = 'published';
+        public $publisher = 'Example Publisher';
+        public $publicationyear = 2024;
+        public $licenses;
+        
+        public function getLicenses(): array {
+            return [];
+        }
+        
+        public function jsonSerialize(): array {
+            return [
+                'id' => $this->id,
+                'identifier' => $this->identifier,
+                'resourcetypegeneral' => $this->resourcetypegeneral,
+                'curator' => $this->curator,
+                'title' => $this->title,
+                'created_at' => $this->created_at,
+                'updated_at' => $this->updated_at,
+                'publicstatus' => $this->publicstatus,
+                'publisher' => $this->publisher,
+                'publicationyear' => $this->publicationyear,
+                'licenses' => $this->licenses ?? [],
+            ];
+        }
+    };
+
+    $dataset2 = new class {
+        public $id = 2;
+        public $identifier = '10.1234/example-two';
+        public $resourcetypegeneral = 'Dataset';
+        public $curator = 'Bob';
+        public $title = 'Example dataset number two';
+        public $created_at = '2024-02-02 14:30:00';
+        public $updated_at = '2024-02-05 09:15:00';
+        public $publicstatus = 'review';
+        public $publisher = 'Example Publisher';
+        public $publicationyear = 2023;
+        public $licenses;
+        
+        public function getLicenses(): array {
+            return [];
+        }
+        
+        public function jsonSerialize(): array {
+            return [
+                'id' => $this->id,
+                'identifier' => $this->identifier,
+                'resourcetypegeneral' => $this->resourcetypegeneral,
+                'curator' => $this->curator,
+                'title' => $this->title,
+                'created_at' => $this->created_at,
+                'updated_at' => $this->updated_at,
+                'publicstatus' => $this->publicstatus,
+                'publisher' => $this->publisher,
+                'publicationyear' => $this->publicationyear,
+                'licenses' => $this->licenses ?? [],
+            ];
+        }
+    };
+
+    $datasets = [$dataset1, $dataset2];
 
     $paginator = new LengthAwarePaginator(
         $datasets,
@@ -66,11 +110,41 @@ it('renders the old datasets page with paginated data', function (): void {
         ->with(1, 50)
         ->andReturn($paginator);
 
+    // Expected datasets with licenses added
+    $expectedDatasets = [
+        [
+            'id' => 1,
+            'identifier' => '10.1234/example-one',
+            'resourcetypegeneral' => 'Dataset',
+            'curator' => 'Alice',
+            'title' => 'Example dataset number one',
+            'created_at' => '2024-01-01 10:00:00',
+            'updated_at' => '2024-01-05 12:00:00',
+            'publicstatus' => 'published',
+            'publisher' => 'Example Publisher',
+            'publicationyear' => 2024,
+            'licenses' => [],
+        ],
+        [
+            'id' => 2,
+            'identifier' => '10.1234/example-two',
+            'resourcetypegeneral' => 'Dataset',
+            'curator' => 'Bob',
+            'title' => 'Example dataset number two',
+            'created_at' => '2024-02-02 14:30:00',
+            'updated_at' => '2024-02-05 09:15:00',
+            'publicstatus' => 'review',
+            'publisher' => 'Example Publisher',
+            'publicationyear' => 2023,
+            'licenses' => [],
+        ],
+    ];
+
     get(route('old-datasets'))
         ->assertOk()
         ->assertInertia(fn (Assert $page): Assert => $page
             ->component('old-datasets')
-            ->where('datasets', $datasets)
+            ->where('datasets', $expectedDatasets)
             ->where('pagination', [
                 'current_page' => 1,
                 'last_page' => 1,
@@ -118,20 +192,42 @@ it('sanitises pagination parameters before fetching datasets', function (): void
 });
 
 it('returns JSON payload for the load-more endpoint', function (): void {
-    $datasets = [
-        [
-            'id' => 3,
-            'identifier' => '10.1234/example-three',
-            'resourcetypegeneral' => 'Image',
-            'curator' => 'Carol',
-            'title' => 'Example dataset number three',
-            'created_at' => '2024-03-01 08:00:00',
-            'updated_at' => '2024-03-02 09:00:00',
-            'publicstatus' => 'draft',
-            'publisher' => 'Example Publisher',
-            'publicationyear' => 2022,
-        ],
-    ];
+    // Create mock OldDataset object
+    $dataset3 = new class {
+        public $id = 3;
+        public $identifier = '10.1234/example-three';
+        public $resourcetypegeneral = 'Image';
+        public $curator = 'Carol';
+        public $title = 'Example dataset number three';
+        public $created_at = '2024-03-01 08:00:00';
+        public $updated_at = '2024-03-02 09:00:00';
+        public $publicstatus = 'draft';
+        public $publisher = 'Example Publisher';
+        public $publicationyear = 2022;
+        public $licenses;
+        
+        public function getLicenses(): array {
+            return [];
+        }
+        
+        public function jsonSerialize(): array {
+            return [
+                'id' => $this->id,
+                'identifier' => $this->identifier,
+                'resourcetypegeneral' => $this->resourcetypegeneral,
+                'curator' => $this->curator,
+                'title' => $this->title,
+                'created_at' => $this->created_at,
+                'updated_at' => $this->updated_at,
+                'publicstatus' => $this->publicstatus,
+                'publisher' => $this->publisher,
+                'publicationyear' => $this->publicationyear,
+                'licenses' => $this->licenses ?? [],
+            ];
+        }
+    };
+
+    $datasets = [$dataset3];
 
     $paginator = new LengthAwarePaginator(
         $datasets,
@@ -147,10 +243,27 @@ it('returns JSON payload for the load-more endpoint', function (): void {
         ->with(2, 20)
         ->andReturn($paginator);
 
+    // Expected datasets with licenses added
+    $expectedDatasets = [
+        [
+            'id' => 3,
+            'identifier' => '10.1234/example-three',
+            'resourcetypegeneral' => 'Image',
+            'curator' => 'Carol',
+            'title' => 'Example dataset number three',
+            'created_at' => '2024-03-01 08:00:00',
+            'updated_at' => '2024-03-02 09:00:00',
+            'publicstatus' => 'draft',
+            'publisher' => 'Example Publisher',
+            'publicationyear' => 2022,
+            'licenses' => [],
+        ],
+    ];
+
     get('/old-datasets/load-more?page=2&per_page=20')
         ->assertOk()
         ->assertJson([
-            'datasets' => $datasets,
+            'datasets' => $expectedDatasets,
             'pagination' => [
                 'current_page' => 2,
                 'last_page' => 2,

--- a/tests/Feature/OldDatasetControllerTest.php
+++ b/tests/Feature/OldDatasetControllerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Log;
 use Inertia\Testing\AssertableInertia as Assert;
 use Mockery as MockeryAlias;
+use Tests\Helpers\OldDatasetMockFactory;
 
 use function Pest\Laravel\get;
 use function Pest\Laravel\actingAs;
@@ -25,74 +26,33 @@ beforeEach(function (): void {
 });
 
 it('renders the old datasets page with paginated data', function (): void {
-    // Create mock OldDataset objects that behave like real models
-    $dataset1 = new class {
-        public $id = 1;
-        public $identifier = '10.1234/example-one';
-        public $resourcetypegeneral = 'Dataset';
-        public $curator = 'Alice';
-        public $title = 'Example dataset number one';
-        public $created_at = '2024-01-01 10:00:00';
-        public $updated_at = '2024-01-05 12:00:00';
-        public $publicstatus = 'published';
-        public $publisher = 'Example Publisher';
-        public $publicationyear = 2024;
-        public $licenses;
-        
-        public function getLicenses(): array {
-            return [];
-        }
-        
-        public function jsonSerialize(): array {
-            return [
-                'id' => $this->id,
-                'identifier' => $this->identifier,
-                'resourcetypegeneral' => $this->resourcetypegeneral,
-                'curator' => $this->curator,
-                'title' => $this->title,
-                'created_at' => $this->created_at,
-                'updated_at' => $this->updated_at,
-                'publicstatus' => $this->publicstatus,
-                'publisher' => $this->publisher,
-                'publicationyear' => $this->publicationyear,
-                'licenses' => $this->licenses ?? [],
-            ];
-        }
-    };
+    $dataset1 = OldDatasetMockFactory::make([
+        'id' => 1,
+        'identifier' => '10.1234/example-one',
+        'resourcetypegeneral' => 'Dataset',
+        'curator' => 'Alice',
+        'title' => 'Example dataset number one',
+        'created_at' => '2024-01-01 10:00:00',
+        'updated_at' => '2024-01-05 12:00:00',
+        'publicstatus' => 'published',
+        'publisher' => 'Example Publisher',
+        'publicationyear' => 2024,
+        'licenses' => [],
+    ]);
 
-    $dataset2 = new class {
-        public $id = 2;
-        public $identifier = '10.1234/example-two';
-        public $resourcetypegeneral = 'Dataset';
-        public $curator = 'Bob';
-        public $title = 'Example dataset number two';
-        public $created_at = '2024-02-02 14:30:00';
-        public $updated_at = '2024-02-05 09:15:00';
-        public $publicstatus = 'review';
-        public $publisher = 'Example Publisher';
-        public $publicationyear = 2023;
-        public $licenses;
-        
-        public function getLicenses(): array {
-            return [];
-        }
-        
-        public function jsonSerialize(): array {
-            return [
-                'id' => $this->id,
-                'identifier' => $this->identifier,
-                'resourcetypegeneral' => $this->resourcetypegeneral,
-                'curator' => $this->curator,
-                'title' => $this->title,
-                'created_at' => $this->created_at,
-                'updated_at' => $this->updated_at,
-                'publicstatus' => $this->publicstatus,
-                'publisher' => $this->publisher,
-                'publicationyear' => $this->publicationyear,
-                'licenses' => $this->licenses ?? [],
-            ];
-        }
-    };
+    $dataset2 = OldDatasetMockFactory::make([
+        'id' => 2,
+        'identifier' => '10.1234/example-two',
+        'resourcetypegeneral' => 'Dataset',
+        'curator' => 'Bob',
+        'title' => 'Example dataset number two',
+        'created_at' => '2024-02-02 14:30:00',
+        'updated_at' => '2024-02-05 09:15:00',
+        'publicstatus' => 'review',
+        'publisher' => 'Example Publisher',
+        'publicationyear' => 2023,
+        'licenses' => [],
+    ]);
 
     $datasets = [$dataset1, $dataset2];
 
@@ -192,40 +152,19 @@ it('sanitises pagination parameters before fetching datasets', function (): void
 });
 
 it('returns JSON payload for the load-more endpoint', function (): void {
-    // Create mock OldDataset object
-    $dataset3 = new class {
-        public $id = 3;
-        public $identifier = '10.1234/example-three';
-        public $resourcetypegeneral = 'Image';
-        public $curator = 'Carol';
-        public $title = 'Example dataset number three';
-        public $created_at = '2024-03-01 08:00:00';
-        public $updated_at = '2024-03-02 09:00:00';
-        public $publicstatus = 'draft';
-        public $publisher = 'Example Publisher';
-        public $publicationyear = 2022;
-        public $licenses;
-        
-        public function getLicenses(): array {
-            return [];
-        }
-        
-        public function jsonSerialize(): array {
-            return [
-                'id' => $this->id,
-                'identifier' => $this->identifier,
-                'resourcetypegeneral' => $this->resourcetypegeneral,
-                'curator' => $this->curator,
-                'title' => $this->title,
-                'created_at' => $this->created_at,
-                'updated_at' => $this->updated_at,
-                'publicstatus' => $this->publicstatus,
-                'publisher' => $this->publisher,
-                'publicationyear' => $this->publicationyear,
-                'licenses' => $this->licenses ?? [],
-            ];
-        }
-    };
+    $dataset3 = OldDatasetMockFactory::make([
+        'id' => 3,
+        'identifier' => '10.1234/example-three',
+        'resourcetypegeneral' => 'Image',
+        'curator' => 'Carol',
+        'title' => 'Example dataset number three',
+        'created_at' => '2024-03-01 08:00:00',
+        'updated_at' => '2024-03-02 09:00:00',
+        'publicstatus' => 'draft',
+        'publisher' => 'Example Publisher',
+        'publicationyear' => 2022,
+        'licenses' => [],
+    ]);
 
     $datasets = [$dataset3];
 

--- a/tests/Helpers/OldDatasetMockFactory.php
+++ b/tests/Helpers/OldDatasetMockFactory.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Helpers;
+
+/**
+ * Factory class for creating mock OldDataset objects for testing.
+ * 
+ * This class provides a reusable way to create mock dataset objects
+ * that behave like real OldDataset models without requiring database access.
+ */
+class OldDatasetMockFactory
+{
+    /**
+     * Create a mock OldDataset object with the given attributes.
+     *
+     * @param array<string, mixed> $attributes
+     * @return object
+     */
+    public static function make(array $attributes = []): object
+    {
+        return new class($attributes) implements \JsonSerializable {
+            public int $id;
+            public string $identifier;
+            public string $resourcetypegeneral;
+            public string $curator;
+            public string $title;
+            public string $created_at;
+            public string $updated_at;
+            public string $publicstatus;
+            public string $publisher;
+            public int $publicationyear;
+            public ?array $licenses = null;
+
+            public function __construct(array $attributes)
+            {
+                $defaults = [
+                    'id' => 1,
+                    'identifier' => '10.1234/example',
+                    'resourcetypegeneral' => 'Dataset',
+                    'curator' => 'Test Curator',
+                    'title' => 'Test Dataset',
+                    'created_at' => '2024-01-01 10:00:00',
+                    'updated_at' => '2024-01-01 10:00:00',
+                    'publicstatus' => 'published',
+                    'publisher' => 'Test Publisher',
+                    'publicationyear' => 2024,
+                ];
+
+                $merged = array_merge($defaults, $attributes);
+
+                foreach ($merged as $key => $value) {
+                    $this->$key = $value;
+                }
+            }
+
+            public function getLicenses(): array
+            {
+                return $this->licenses ?? [];
+            }
+
+            public function jsonSerialize(): array
+            {
+                return [
+                    'id' => $this->id,
+                    'identifier' => $this->identifier,
+                    'resourcetypegeneral' => $this->resourcetypegeneral,
+                    'curator' => $this->curator,
+                    'title' => $this->title,
+                    'created_at' => $this->created_at,
+                    'updated_at' => $this->updated_at,
+                    'publicstatus' => $this->publicstatus,
+                    'publisher' => $this->publisher,
+                    'publicationyear' => $this->publicationyear,
+                    'licenses' => $this->licenses ?? [],
+                ];
+            }
+        };
+    }
+
+    /**
+     * Create multiple mock OldDataset objects.
+     *
+     * @param int $count
+     * @param array<string, mixed> $attributes
+     * @return array<object>
+     */
+    public static function makeMany(int $count, array $attributes = []): array
+    {
+        $datasets = [];
+        for ($i = 0; $i < $count; $i++) {
+            $datasets[] = self::make(array_merge($attributes, [
+                'id' => ($attributes['id'] ?? 1) + $i,
+            ]));
+        }
+        return $datasets;
+    }
+}


### PR DESCRIPTION
This pull request enhances how old datasets are handled and curated by introducing robust mapping and enrichment of resource types and licenses from the legacy database to the ERNIE system. It improves both backend data enrichment and frontend mapping logic, and updates tests to reflect these changes.

**Backend data enrichment:**

* Each dataset returned by `OldDatasetController` now includes a `licenses` property, populated by querying the license table for each resource. This ensures licenses are available for downstream processing and UI display. [[1]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49R36-R43) [[2]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49R96-R103) [[3]](diffhunk://#diff-8c93c3df47ab824fe7841f40c203c0e7fa795151cba9461161edfbf0ab43f7faR10-R12) [[4]](diffhunk://#diff-8c93c3df47ab824fe7841f40c203c0e7fa795151cba9461161edfbf0ab43f7faR121-R144)

**Frontend mapping and API integration:**

* Added async functions `getResourceTypes` and `getLicenses` to fetch and cache ERNIE resource types and licenses, minimizing repeated API calls. These are preloaded on page mount for efficiency. [[1]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eL345-R499) [[2]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eR623-R628)
* Implemented robust mapping functions (`mapResourceTypeToId`, `mapLicenseToIdentifier`) to convert legacy resource type strings and license names into ERNIE-compatible identifiers for curation queries.
* Refactored `buildCurationQuery` to use the new mapping logic, ensuring resource type and license fields are correctly mapped for curation routing. [[1]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eL364-R523) [[2]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eR532-R541) [[3]](diffhunk://#diff-19ec52e4ebf5106e3f9d15745396d8d0adab8297d90304f47864cac3b5510b2eL423-R589)

**Testing improvements:**

* Updated feature tests to expect datasets with the new `licenses` property, ensuring test coverage for enriched dataset payloads. [[1]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0L28-R29) [[2]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0L40-R43) [[3]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0L52-R57) [[4]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0R73-R107) [[5]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0L121-R155) [[6]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0L133-R169) [[7]](diffhunk://#diff-0a43e9d11c6fb3959ba10fae91cfe32063ed1c2f820c278c2b48b8363865e4d0R185-R205)
* Enhanced frontend tests to mock fetch calls for resource types and licenses, and validated correct mapping of resource type IDs in curation queries. [[1]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4R126-R150) [[2]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4R281-R291) [[3]](diffhunk://#diff-3ed989a2c15604b277d16ddf5abfab8d6a732b7042581cd5b8fa7ac207be11f4L291-R319)

These changes ensure that old datasets are correctly enriched and mapped to ERNIE standards, improving both backend data quality and frontend curation workflows.