### PR TITLE
Default curation language to English

### DIFF
--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -31,6 +31,7 @@ describe('DataCiteForm', () => {
     const languages: Language[] = [
         { id: 1, code: 'en', name: 'English' },
         { id: 2, code: 'de', name: 'German' },
+        { id: 3, code: 'fr', name: 'French' },
     ];
 
     it('renders fields, title options and supports adding/removing titles', async () => {
@@ -223,7 +224,7 @@ describe('DataCiteForm', () => {
         ).toBe(true);
     });
 
-    it('prefills Language when initialLanguage is provided', () => {
+    it('prefills Language when initialLanguage code is provided', () => {
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
@@ -235,6 +236,50 @@ describe('DataCiteForm', () => {
         );
         expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
             'German',
+        );
+    });
+
+    it('defaults Language to English when initialLanguage is missing', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={languages}
+            />,
+        );
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'English',
+        );
+    });
+
+    it('prefills Language when initialLanguage name is provided', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={languages}
+                initialLanguage="German"
+            />,
+        );
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'German',
+        );
+    });
+
+    it('prefills French when initialLanguage indicates French', () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={languages}
+                initialLanguage="French"
+            />,
+        );
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'French',
         );
     });
 

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -253,6 +253,27 @@ describe('DataCiteForm', () => {
         );
     });
 
+    it('defaults Language to English even when English is not the first option', () => {
+        const shuffledLanguages: Language[] = [
+            { id: 2, code: 'de', name: 'German' },
+            { id: 3, code: 'fr', name: 'French' },
+            { id: 1, code: 'en', name: 'English' },
+        ];
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={shuffledLanguages}
+            />,
+        );
+
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'English',
+        );
+    });
+
     it('prefills Language when initialLanguage name is provided', () => {
         render(
             <DataCiteForm
@@ -280,6 +301,26 @@ describe('DataCiteForm', () => {
         );
         expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
             'French',
+        );
+    });
+
+    it('falls back to the first language with a code when English is unavailable', () => {
+        const limitedLanguages = [
+            { id: 4, code: null, name: null },
+            { id: 5, code: 'de', name: 'German' },
+        ] as unknown as Language[];
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={limitedLanguages}
+            />,
+        );
+
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'German',
         );
     });
 

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -283,6 +283,29 @@ describe('DataCiteForm', () => {
         );
     });
 
+    it('defaults to English when languages include incomplete entries', () => {
+        const incompleteLanguages = [
+            { id: 1, code: null, name: null },
+            { id: 2, code: 'en', name: 'English' },
+            { id: 3, code: 'de', name: 'German' },
+        ] as unknown as Language[];
+
+        expect(() =>
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    licenses={licenses}
+                    languages={incompleteLanguages}
+                />,
+            ),
+        ).not.toThrow();
+
+        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+            'English',
+        );
+    });
+
     it('prefills Resource Type when initialResourceType is provided', () => {
         render(
             <DataCiteForm

--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -306,9 +306,9 @@ describe('DataCiteForm', () => {
 
     it('falls back to the first language with a code when English is unavailable', () => {
         const limitedLanguages = [
-            { id: 4, code: null, name: null },
-            { id: 5, code: 'de', name: 'German' },
-        ] as unknown as Language[];
+            { id: 4, code: 'de', name: 'German' },
+            { id: 5, code: 'fr', name: 'French' },
+        ] satisfies Language[];
 
         render(
             <DataCiteForm
@@ -326,21 +326,19 @@ describe('DataCiteForm', () => {
 
     it('defaults to English when languages include incomplete entries', () => {
         const incompleteLanguages = [
-            { id: 1, code: null, name: null },
+            { id: 1, code: ' ', name: ' ' },
             { id: 2, code: 'en', name: 'English' },
             { id: 3, code: 'de', name: 'German' },
-        ] as unknown as Language[];
+        ] satisfies Language[];
 
-        expect(() =>
-            render(
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    licenses={licenses}
-                    languages={incompleteLanguages}
-                />,
-            ),
-        ).not.toThrow();
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={incompleteLanguages}
+            />,
+        );
 
         expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
             'English',

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -3,6 +3,7 @@ import InputField from './fields/input-field';
 import { SelectField } from './fields/select-field';
 import TitleField from './fields/title-field';
 import LicenseField from './fields/license-field';
+import { resolveInitialLanguageCode } from './utils/language-resolver';
 import {
     Accordion,
     AccordionContent,
@@ -82,72 +83,12 @@ export default function DataCiteForm({
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
-    const resolveInitialLanguage = () => {
-        const normalize = (value?: string | null) => value?.trim().toLowerCase() ?? '';
-
-        const expandCandidate = (value?: string | null) => {
-            const normalized = normalize(value);
-            if (!normalized) {
-                return [] as string[];
-            }
-
-            const base = normalized.split('-')[0];
-            const candidates = new Set<string>([normalized]);
-
-            if (base && base !== normalized) {
-                candidates.add(base);
-            }
-
-            return [...candidates];
-        };
-
-        const findLanguageCode = (
-            ...rawCandidates: (string | null | undefined)[]
-        ): string => {
-            const candidates = new Set(
-                rawCandidates.flatMap((candidate) => expandCandidate(candidate)),
-            );
-
-            if (!candidates.size) {
-                return '';
-            }
-
-            return (
-                languages.find((lang) => {
-                    const code = normalize(lang.code);
-                    const name = normalize(lang.name);
-
-                    return (
-                        (!!code && candidates.has(code)) || (!!name && candidates.has(name))
-                    );
-                })?.code ?? ''
-            );
-        };
-
-        const initialMatch = findLanguageCode(initialLanguage);
-        if (initialMatch) {
-            return initialMatch;
-        }
-
-        const englishMatch = findLanguageCode('english', 'en');
-        if (englishMatch) {
-            return englishMatch;
-        }
-
-        const firstWithCode = languages.find((lang) => normalize(lang.code))?.code;
-        if (firstWithCode) {
-            return firstWithCode;
-        }
-
-        return languages.find((lang) => normalize(lang.name))?.code ?? '';
-    };
-
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
         year: initialYear,
         resourceType: initialResourceType,
         version: initialVersion,
-        language: resolveInitialLanguage(),
+        language: resolveInitialLanguageCode(languages, initialLanguage),
     });
 
     const [titles, setTitles] = useState<TitleEntry[]>(

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -82,12 +82,43 @@ export default function DataCiteForm({
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
+    const resolveInitialLanguage = () => {
+        const normalize = (value: string) => value.trim().toLowerCase();
+        const findCode = (...candidates: string[]) => {
+            const normalized = candidates.map(normalize);
+            return (
+                languages.find((lang) => {
+                    const code = normalize(lang.code);
+                    const name = normalize(lang.name);
+                    return normalized.includes(code) || normalized.includes(name);
+                })?.code ?? ''
+            );
+        };
+
+        const normalizedInitial = normalize(initialLanguage);
+        const englishCode = findCode('english', 'en') || languages[0]?.code || '';
+
+        if (['german', 'de'].includes(normalizedInitial)) {
+            return findCode('german', 'de') || englishCode;
+        }
+
+        if (['french', 'fr'].includes(normalizedInitial)) {
+            return findCode('french', 'fr') || englishCode;
+        }
+
+        if (['english', 'en'].includes(normalizedInitial)) {
+            return englishCode;
+        }
+
+        return englishCode;
+    };
+
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
         year: initialYear,
         resourceType: initialResourceType,
         version: initialVersion,
-        language: initialLanguage,
+        language: resolveInitialLanguage(),
     });
 
     const [titles, setTitles] = useState<TitleEntry[]>(

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -83,14 +83,17 @@ export default function DataCiteForm({
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
     const resolveInitialLanguage = () => {
-        const normalize = (value: string) => value.trim().toLowerCase();
+        const normalize = (value?: string | null) => value?.trim().toLowerCase() ?? '';
         const findCode = (...candidates: string[]) => {
             const normalized = candidates.map(normalize);
             return (
                 languages.find((lang) => {
                     const code = normalize(lang.code);
                     const name = normalize(lang.name);
-                    return normalized.includes(code) || normalized.includes(name);
+                    return (
+                        (!!code && normalized.includes(code)) ||
+                        (!!name && normalized.includes(name))
+                    );
                 })?.code ?? ''
             );
         };

--- a/resources/js/components/curation/utils/__tests__/language-resolver.test.ts
+++ b/resources/js/components/curation/utils/__tests__/language-resolver.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInitialLanguageCode, type LanguageOption } from '../language-resolver';
+
+const baseLanguages: LanguageOption[] = [
+    { code: 'en', name: 'English' },
+    { code: 'de', name: 'German' },
+    { code: 'fr', name: 'French' },
+];
+
+describe('resolveInitialLanguageCode', () => {
+    it('returns the initial language when provided', () => {
+        expect(resolveInitialLanguageCode(baseLanguages, 'de')).toBe('de');
+        expect(resolveInitialLanguageCode(baseLanguages, 'German')).toBe('de');
+    });
+
+    it('falls back to English when no initial language is provided', () => {
+        expect(resolveInitialLanguageCode(baseLanguages, undefined)).toBe('en');
+        expect(resolveInitialLanguageCode(baseLanguages, '')).toBe('en');
+    });
+
+    it('matches initial codes with hyphenated variants', () => {
+        const languages: LanguageOption[] = [
+            { code: 'en-US', name: 'English (US)' },
+            { code: 'en-GB', name: 'English (UK)' },
+        ];
+
+        expect(resolveInitialLanguageCode(languages, 'en-gb')).toBe('en-GB');
+        expect(resolveInitialLanguageCode(languages, 'en')).toBe('en-US');
+    });
+
+    it('prefers English even if it is not the first language', () => {
+        const shuffled: LanguageOption[] = [
+            { code: 'de', name: 'German' },
+            { code: 'fr', name: 'French' },
+            { code: 'en', name: 'English' },
+        ];
+
+        expect(resolveInitialLanguageCode(shuffled)).toBe('en');
+    });
+
+    it('returns the first language with a code when English is unavailable', () => {
+        const languages: LanguageOption[] = [
+            { code: '', name: '' },
+            { code: 'de', name: 'German' },
+        ];
+
+        expect(resolveInitialLanguageCode(languages)).toBe('de');
+    });
+
+    it('falls back to an empty string when no codes are present', () => {
+        const languages: LanguageOption[] = [
+            { code: '', name: '' },
+            { code: null, name: 'Français' },
+        ];
+
+        expect(resolveInitialLanguageCode(languages)).toBe('');
+    });
+});

--- a/resources/js/components/curation/utils/language-resolver.ts
+++ b/resources/js/components/curation/utils/language-resolver.ts
@@ -1,0 +1,69 @@
+export interface LanguageOption {
+    code?: string | null;
+    name?: string | null;
+}
+
+const normalize = (value?: string | null) => value?.trim().toLowerCase() ?? '';
+
+const expandCandidate = (value?: string | null): string[] => {
+    const normalized = normalize(value);
+
+    if (!normalized) {
+        return [];
+    }
+
+    const base = normalized.split('-')[0];
+    const candidates = new Set<string>([normalized]);
+
+    if (base && base !== normalized) {
+        candidates.add(base);
+    }
+
+    return [...candidates];
+};
+
+const findLanguageCode = (
+    languages: LanguageOption[],
+    ...rawCandidates: (string | null | undefined)[]
+): string => {
+    const candidates = new Set(
+        rawCandidates.flatMap((candidate) => expandCandidate(candidate)),
+    );
+
+    if (!candidates.size) {
+        return '';
+    }
+
+    return (
+        languages.find((lang) => {
+            const code = normalize(lang.code);
+            const name = normalize(lang.name);
+
+            return (
+                (!!code && candidates.has(code)) || (!!name && candidates.has(name))
+            );
+        })?.code ?? ''
+    );
+};
+
+export function resolveInitialLanguageCode(
+    languages: LanguageOption[],
+    initialLanguage?: string | null,
+): string {
+    const initialMatch = findLanguageCode(languages, initialLanguage);
+    if (initialMatch) {
+        return initialMatch;
+    }
+
+    const englishMatch = findLanguageCode(languages, 'english', 'en');
+    if (englishMatch) {
+        return englishMatch;
+    }
+
+    const firstWithCode = languages.find((lang) => normalize(lang.code))?.code;
+    if (firstWithCode) {
+        return firstWithCode;
+    }
+
+    return languages.find((lang) => normalize(lang.name))?.code ?? '';
+}


### PR DESCRIPTION
This pull request improves how the `DataCiteForm` component determines and displays the initial language selection, ensuring more robust and user-friendly defaults. The main change is the introduction of a new utility function to resolve the initial language code, along with comprehensive tests and updates to the form and its test suite.

**Language selection logic improvements:**

* Added a new utility function `resolveInitialLanguageCode` in `utils/language-resolver.ts` to robustly determine the initial language code based on the provided language list and initial value, with sensible fallbacks (e.g., preferring English, handling incomplete entries, and supporting both code and name matches).
* Updated `DataCiteForm` in `datacite-form.tsx` to use `resolveInitialLanguageCode` for setting the initial language state, replacing the previous direct assignment. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R6) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L90-R91)

**Testing enhancements:**

* Added a comprehensive test suite for `resolveInitialLanguageCode` in `utils/__tests__/language-resolver.test.ts`, covering various scenarios (hyphenated codes, missing English, incomplete entries, etc.).
* Expanded the test coverage in `datacite-form.test.tsx` to verify all new language selection behaviors, including fallback logic and handling of shuffled or incomplete language lists. [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R34) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L226-R227) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R242-R347)