### PR TITLE
Mark language field as required in DataCite form

### DIFF
--- a/resources/js/components/curation/__tests__/datacite-form.test.tsx
+++ b/resources/js/components/curation/__tests__/datacite-form.test.tsx
@@ -83,7 +83,15 @@ describe('DataCiteForm', () => {
         ).toBeInTheDocument();
 
         // language options
-        const languageTrigger = screen.getByLabelText('Language of Data');
+        const languageTrigger = screen.getByLabelText('Language of Data', {
+            exact: false,
+        });
+        expect(languageTrigger).toHaveAttribute('aria-required', 'true');
+        const languageLabel = languageTrigger.closest('div')?.querySelector('label');
+        if (!languageLabel) {
+            throw new Error('Language label not found');
+        }
+        expect(languageLabel).toHaveTextContent('*');
         await user.click(languageTrigger);
         for (const option of languages) {
             expect(
@@ -245,7 +253,9 @@ describe('DataCiteForm', () => {
                 initialLanguage="de"
             />,
         );
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'German',
         );
     });
@@ -259,7 +269,9 @@ describe('DataCiteForm', () => {
                 languages={languages}
             />,
         );
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'English',
         );
     });
@@ -280,7 +292,9 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'English',
         );
     });
@@ -295,7 +309,9 @@ describe('DataCiteForm', () => {
                 initialLanguage="German"
             />,
         );
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'German',
         );
     });
@@ -310,7 +326,9 @@ describe('DataCiteForm', () => {
                 initialLanguage="French"
             />,
         );
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'French',
         );
     });
@@ -330,7 +348,9 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'German',
         );
     });
@@ -351,7 +371,9 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Language of Data')).toHaveTextContent(
+        expect(
+            screen.getByLabelText('Language of Data', { exact: false }),
+        ).toHaveTextContent(
             'English',
         );
     });

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -339,6 +339,7 @@ export default function DataCiteForm({
                                     label: l.name,
                                 }))}
                                 className="md:col-span-2"
+                                required
                             />
                         </div>
                         <div className="space-y-4 mt-3">

--- a/resources/js/components/curation/fields/select-field.tsx
+++ b/resources/js/components/curation/fields/select-field.tsx
@@ -43,7 +43,7 @@ export function SelectField({
                 {required && <span className="text-destructive ml-1">*</span>}
             </Label>
             <Select value={value} onValueChange={onValueChange} required={required}>
-                <SelectTrigger id={id}>
+                <SelectTrigger id={id} aria-required={required || undefined}>
                     <SelectValue placeholder={placeholder} />
                 </SelectTrigger>
                 <SelectContent>


### PR DESCRIPTION
## Summary
- mark the Language of Data selection as required in the curation form
- propagate required state to the select trigger for better accessibility
- extend DataCite form tests to cover the required indicator and updated accessible names

## Testing
- npm test -- --run resources/js/components/curation/__tests__/datacite-form.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dfe6e72668832eab915250f069fdfb