### PR TITLE
Fix CSRF handling under prefixed deployments

### DIFF
--- a/resources/js/lib/__tests__/csrf-token.test.ts
+++ b/resources/js/lib/__tests__/csrf-token.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildCsrfHeaders, getXsrfTokenFromCookie } from '../csrf-token';
+
+const clearCookies = () => {
+    const cookies = document.cookie ? document.cookie.split(';') : [];
+
+    for (const cookie of cookies) {
+        const [rawName] = cookie.split('=');
+        const name = rawName?.trim();
+
+        if (name) {
+            document.cookie = `${name}=;expires=${new Date(0).toUTCString()};path=/`;
+        }
+    }
+};
+
+beforeEach(() => {
+    clearCookies();
+    document.head.innerHTML = '';
+});
+
+afterEach(() => {
+    clearCookies();
+    document.head.innerHTML = '';
+});
+
+describe('getXsrfTokenFromCookie', () => {
+    it('returns decoded values when the cookie is URI encoded', () => {
+        document.cookie = `XSRF-TOKEN=${encodeURIComponent('token with spaces')}`;
+
+        expect(getXsrfTokenFromCookie()).toBe('token with spaces');
+    });
+
+    it('falls back to the raw value when decoding fails', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        document.cookie = 'XSRF-TOKEN=test%';
+
+        expect(getXsrfTokenFromCookie()).toBe('test%');
+        expect(warnSpy).toHaveBeenCalledWith(
+            'Failed to decode CSRF cookie value.',
+            expect.any(Error),
+        );
+
+        warnSpy.mockRestore();
+    });
+});
+
+describe('buildCsrfHeaders', () => {
+    it('prefers meta tokens for X-CSRF-TOKEN while still setting the cookie header', () => {
+        document.head.innerHTML = '<meta name="csrf-token" content="meta-token">';
+        document.cookie = 'XSRF-TOKEN=cookie-token';
+
+        expect(buildCsrfHeaders()).toEqual({
+            'X-CSRF-TOKEN': 'meta-token',
+            'X-XSRF-TOKEN': 'cookie-token',
+        });
+    });
+
+    it('falls back to the cookie token when no meta tag exists', () => {
+        document.cookie = 'XSRF-TOKEN=cookie-token';
+
+        expect(buildCsrfHeaders()).toEqual({
+            'X-CSRF-TOKEN': 'cookie-token',
+            'X-XSRF-TOKEN': 'cookie-token',
+        });
+    });
+});

--- a/resources/js/lib/csrf-token.ts
+++ b/resources/js/lib/csrf-token.ts
@@ -1,0 +1,85 @@
+const CSRF_META_SELECTOR = 'meta[name="csrf-token"]';
+const XSRF_COOKIE_NAME = 'XSRF-TOKEN';
+
+const isBrowser = () => typeof document !== 'undefined';
+
+const safeTrim = (value?: string | null): string | null => {
+    if (!value) {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+};
+
+const safeDecode = (value: string): string => {
+    try {
+        return decodeURIComponent(value);
+    } catch (error) {
+        console.warn('Failed to decode CSRF cookie value.', error);
+        return value;
+    }
+};
+
+const readCookie = (name: string): string | null => {
+    if (!isBrowser()) {
+        return null;
+    }
+
+    const cookies = document.cookie ? document.cookie.split(';') : [];
+
+    for (const rawCookie of cookies) {
+        const cookie = rawCookie.trim();
+        if (cookie.startsWith(`${name}=`)) {
+            const value = cookie.substring(name.length + 1);
+            return value ? safeDecode(value) : null;
+        }
+    }
+
+    return null;
+};
+
+export const getMetaCsrfToken = (): string | null => {
+    if (!isBrowser()) {
+        return null;
+    }
+
+    const meta = document.querySelector<HTMLMetaElement>(CSRF_META_SELECTOR);
+    return safeTrim(meta?.content ?? null);
+};
+
+export const getXsrfTokenFromCookie = (): string | null => readCookie(XSRF_COOKIE_NAME);
+
+export const getCsrfToken = (): string | null => {
+    return getMetaCsrfToken() ?? getXsrfTokenFromCookie();
+};
+
+export const ensureCsrfToken = (): string => {
+    const token = getCsrfToken();
+
+    if (!token) {
+        throw new Error('CSRF token not found');
+    }
+
+    return token;
+};
+
+export const buildCsrfHeaders = (): Record<string, string> => {
+    const headers: Record<string, string> = {};
+    const metaToken = getMetaCsrfToken();
+    const cookieToken = getXsrfTokenFromCookie();
+
+    if (metaToken) {
+        headers['X-CSRF-TOKEN'] = metaToken;
+    }
+
+    if (cookieToken) {
+        headers['X-XSRF-TOKEN'] = cookieToken;
+
+        if (!headers['X-CSRF-TOKEN']) {
+            headers['X-CSRF-TOKEN'] = cookieToken;
+        }
+    }
+
+    return headers;
+};

--- a/resources/js/lib/csrf-token.ts
+++ b/resources/js/lib/csrf-token.ts
@@ -12,6 +12,15 @@ const safeTrim = (value?: string | null): string | null => {
     return trimmed.length > 0 ? trimmed : null;
 };
 
+/**
+ * Safely decodes URI-encoded cookie values while tolerating malformed input.
+ *
+ * The browser may persist cookie values that are not valid percent-encoded
+ * strings (for example when set by non-URI-aware tooling). Because
+ * `decodeURIComponent` throws on malformed input, this helper falls back to
+ * returning the original value when decoding fails so that consumers can still
+ * read the cookie.
+ */
 const safeDecode = (value: string): string => {
     try {
         return decodeURIComponent(value);
@@ -64,6 +73,16 @@ export const ensureCsrfToken = (): string => {
     return token;
 };
 
+/**
+ * Builds CSRF headers prioritising the meta tag token for `X-CSRF-TOKEN` while
+ * always sending the cookie token when available.
+ *
+ * Some middleware validates `X-CSRF-TOKEN`, which should mirror the meta tag
+ * value when present, while others expect `X-XSRF-TOKEN` sourced from the
+ * cookie. Sending both ensures compatibility across deployments that rely on
+ * either header, with meta tokens taking precedence over cookie fallbacks for
+ * `X-CSRF-TOKEN`.
+ */
 export const buildCsrfHeaders = (): Record<string, string> => {
     const headers: Record<string, string> = {};
     const metaToken = getMetaCsrfToken();

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -9,11 +9,14 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { useRef, useState } from 'react';
 import { latestVersion } from '@/lib/version';
+import { buildCsrfHeaders } from '@/lib/csrf-token';
 
 export const handleXmlFiles = async (files: File[]): Promise<void> => {
     if (!files.length) return;
 
-    const token = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content;
+    const csrfHeaders = buildCsrfHeaders();
+    const token = csrfHeaders['X-CSRF-TOKEN'];
+
     if (!token) {
         throw new Error('CSRF token not found');
     }
@@ -25,9 +28,7 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
         const response = await fetch(uploadXmlRoute.url(), {
             method: 'POST',
             body: formData,
-            headers: {
-                'X-CSRF-TOKEN': token,
-            },
+            headers: csrfHeaders,
         });
         if (!response.ok) {
             let message = 'Upload failed';


### PR DESCRIPTION
This pull request introduces a robust and unified approach to handling CSRF tokens across the frontend codebase. The main improvement is the addition of a new utility, `buildCsrfHeaders`, which reliably sources CSRF tokens from either the meta tag or the XSRF cookie, ensuring compatibility with various server-side CSRF validation strategies. The changes refactor all CSRF handling logic in both application and test code to use this utility, improving security and maintainability.

**CSRF Token Handling Improvements**

* Added `resources/js/lib/csrf-token.ts` with helpers to read CSRF tokens from meta tags and cookies, safely decode cookie values, and build appropriate headers for all requests. (`buildCsrfHeaders`, `getMetaCsrfToken`, `getXsrfTokenFromCookie`, etc.)
* Refactored CSRF token usage in `resources/js/app.tsx`, `resources/js/components/curation/datacite-form.tsx`, and `resources/js/pages/dashboard.tsx` to use `buildCsrfHeaders`, ensuring both `X-CSRF-TOKEN` and `X-XSRF-TOKEN` are sent when available, and falling back to the cookie if the meta tag is missing. [[1]](diffhunk://#diff-73c3ce87ef6d4a353a310891da96365277faeae46286373a05698552b76d214cR9-R40) [[2]](diffhunk://#diff-73c3ce87ef6d4a353a310891da96365277faeae46286373a05698552b76d214cL76-R88) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R17) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L25-L34) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R213-R230) [[6]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR12-R19) [[7]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL28-R31)

**Testing Enhancements**

* Added comprehensive unit tests for CSRF token extraction and header-building logic in `resources/js/lib/__tests__/csrf-token.test.ts`, including edge cases for malformed cookies and preference order.
* Updated and expanded frontend tests for CSRF scenarios in `resources/js/components/curation/__tests__/datacite-form.test.tsx` and `resources/js/pages/__tests__/dashboard.test.tsx`, covering meta tag fallback, cookie fallback, and error handling when no token is present. [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L4-R14) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R26-R38) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R634-R641) [[4]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R659-R719) [[5]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R758-R764) [[6]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR153) [[7]](diffhunk://#diff-4345b7a64a46e0f2bf8e834b3faa5e86b226fb65058dec6dc92eedfc257c5e1cR191-R217)

These changes make CSRF protection more reliable and easier to maintain, and ensure that both manual and automated tests cover all critical scenarios.