### PR TITLE
Disable saving until required fields are filled

### DIFF
--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -128,6 +128,23 @@ export default function DataCiteForm({
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
+    const areRequiredFieldsFilled = useMemo(() => {
+        const mainTitleEntry = titles.find((entry) => entry.titleType === 'main-title');
+        const mainTitleFilled = Boolean(mainTitleEntry?.title.trim());
+        const yearFilled = Boolean(form.year?.trim());
+        const resourceTypeSelected = Boolean(form.resourceType);
+        const languageSelected = Boolean(form.language);
+        const primaryLicenseFilled = Boolean(licenseEntries[0]?.license?.trim());
+
+        return (
+            mainTitleFilled &&
+            yearFilled &&
+            resourceTypeSelected &&
+            languageSelected &&
+            primaryLicenseFilled
+        );
+    }, [form.language, form.resourceType, form.year, licenseEntries, titles]);
+
     const handleChange = (field: keyof DataCiteFormData, value: string) => {
         setForm((prev) => ({ ...prev, [field]: value }));
     };
@@ -408,8 +425,9 @@ export default function DataCiteForm({
             <div className="flex justify-end">
                 <Button
                     type="submit"
-                    disabled={isSaving}
+                    disabled={isSaving || !areRequiredFieldsFilled}
                     aria-busy={isSaving}
+                    aria-disabled={isSaving || !areRequiredFieldsFilled}
                 >
                     {isSaving ? 'Saving…' : 'Save to database'}
                 </Button>


### PR DESCRIPTION
This pull request improves the validation logic and user experience of the `DataCiteForm` component by ensuring that the "Save to database" button is disabled until all required fields are filled. It also updates related tests to verify the new behavior and corrects test data to better reflect real-world scenarios.

**Validation and form behavior improvements:**

* Added a new `areRequiredFieldsFilled` check in `datacite-form.tsx` to ensure the main title, year, resource type, language, and primary license are all provided before enabling the save button. The button is now disabled and marked as `aria-disabled` until these fields are filled. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R131-R147) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L411-R430)

**Test coverage enhancements:**

* Added a new test to verify that saving is disabled until all required fields are entered, using realistic user interactions.

**Test data corrections and improvements:**

* Updated test cases to provide `initialLicenses` and ensure that the main title is included in `initialTitles` when required, improving the accuracy of the tests. [[1]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R720) [[2]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R747) [[3]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0L747-R790) [[4]](diffhunk://#diff-413082fe5e82a4de7b922fbccdaa30f965b8a4a0e96f9dfb55da031cc46a03d0R812-R815)