### PR TITLE
feat: add resources page

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -6,13 +6,96 @@ use App\Http\Requests\StoreResourceRequest;
 use App\Models\Language;
 use App\Models\License;
 use App\Models\Resource;
+use App\Models\ResourceTitle;
 use App\Models\TitleType;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response;
 use Throwable;
 
 class ResourceController extends Controller
 {
+    private const DEFAULT_PER_PAGE = 25;
+
+    private const MIN_PER_PAGE = 5;
+
+    private const MAX_PER_PAGE = 100;
+
+    public function index(Request $request): Response
+    {
+        $page = max(1, (int) $request->query('page', 1));
+        $perPage = (int) $request->query('per_page', self::DEFAULT_PER_PAGE);
+
+        $perPage = max(self::MIN_PER_PAGE, min(self::MAX_PER_PAGE, $perPage));
+
+        $resources = Resource::query()
+            ->with([
+                'resourceType:id,name,slug',
+                'language:id,code,name',
+                'titles' => function ($query): void {
+                    $query->select(['id', 'resource_id', 'title', 'title_type_id'])
+                        ->with(['titleType:id,name,slug']);
+                },
+                'licenses:id,identifier,name',
+            ])
+            ->latest('created_at')
+            ->paginate($perPage, ['*'], 'page', $page)
+            ->through(static function (Resource $resource): array {
+                return [
+                    'id' => $resource->id,
+                    'doi' => $resource->doi,
+                    'year' => $resource->year,
+                    'version' => $resource->version,
+                    'created_at' => $resource->created_at?->toIso8601String(),
+                    'updated_at' => $resource->updated_at?->toIso8601String(),
+                    'resource_type' => $resource->resourceType ? [
+                        'name' => $resource->resourceType->name,
+                        'slug' => $resource->resourceType->slug,
+                    ] : null,
+                    'language' => $resource->language ? [
+                        'code' => $resource->language->code,
+                        'name' => $resource->language->name,
+                    ] : null,
+                    'titles' => $resource->titles
+                        ->map(static function (ResourceTitle $title): array {
+                            return [
+                                'title' => $title->title,
+                                'title_type' => $title->titleType ? [
+                                    'name' => $title->titleType->name,
+                                    'slug' => $title->titleType->slug,
+                                ] : null,
+                            ];
+                        })
+                        ->values()
+                        ->all(),
+                    'licenses' => $resource->licenses
+                        ->map(static function (License $license): array {
+                            return [
+                                'identifier' => $license->identifier,
+                                'name' => $license->name,
+                            ];
+                        })
+                        ->values()
+                        ->all(),
+                ];
+            });
+
+        return Inertia::render('resources', [
+            'resources' => $resources->items(),
+            'pagination' => [
+                'current_page' => $resources->currentPage(),
+                'last_page' => $resources->lastPage(),
+                'per_page' => $resources->perPage(),
+                'total' => $resources->total(),
+                'from' => $resources->firstItem(),
+                'to' => $resources->lastItem(),
+                'has_more' => $resources->hasMorePages(),
+            ],
+        ]);
+    }
+
     public function store(StoreResourceRequest $request): JsonResponse
     {
         try {

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -6,7 +6,7 @@ import { withBasePath } from '@/lib/base-path';
 import { dashboard, settings } from '@/routes';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, LayoutGrid, Database, History, Settings, FileText } from 'lucide-react';
+import { BookOpen, LayoutGrid, Database, History, Settings, FileText, Layers } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -24,6 +24,11 @@ const mainNavItems: NavItem[] = [
         title: 'Old Datasets',
         href: withBasePath('/old-datasets'),
         icon: Database,
+    },
+    {
+        title: 'Resources',
+        href: withBasePath('/resources'),
+        icon: Layers,
     },
 ];
 

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1,0 +1,412 @@
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, router } from '@inertiajs/react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { withBasePath } from '@/lib/base-path';
+import { useMemo } from 'react';
+
+interface ResourceTitleType {
+    name: string | null;
+    slug: string | null;
+}
+
+interface ResourceTitle {
+    title: string;
+    title_type: ResourceTitleType | null;
+}
+
+interface ResourceLicense {
+    identifier: string | null;
+    name: string | null;
+}
+
+interface ResourceTypeSummary {
+    name: string | null;
+    slug: string | null;
+}
+
+interface ResourceLanguageSummary {
+    code: string | null;
+    name: string | null;
+}
+
+interface ResourceListItem {
+    id: number;
+    doi: string | null;
+    year: number;
+    version: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+    resource_type: ResourceTypeSummary | null;
+    language: ResourceLanguageSummary | null;
+    titles: ResourceTitle[];
+    licenses: ResourceLicense[];
+}
+
+interface PaginationInfo {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+    has_more: boolean;
+}
+
+interface ResourcesPageProps {
+    resources: ResourceListItem[];
+    pagination: PaginationInfo;
+}
+
+const PAGE_TITLE = 'Resources';
+const MAIN_TITLE_SLUG = 'main-title';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: PAGE_TITLE,
+        href: '/resources',
+    },
+];
+
+const getPrimaryTitle = (titles: ResourceTitle[]): string => {
+    if (titles.length === 0) {
+        return 'Untitled resource';
+    }
+
+    const mainTitle = titles.find((entry) => entry.title_type?.slug === MAIN_TITLE_SLUG);
+
+    return (mainTitle ?? titles[0]).title || 'Untitled resource';
+};
+
+const getAdditionalTitles = (titles: ResourceTitle[]): ResourceTitle[] => {
+    if (titles.length <= 1) {
+        return [];
+    }
+
+    const primarySlug = titles.find((entry) => entry.title_type?.slug === MAIN_TITLE_SLUG)?.title_type?.slug;
+
+    return titles.filter((entry) => {
+        if (primarySlug) {
+            return entry.title_type?.slug !== primarySlug;
+        }
+
+        return entry !== titles[0];
+    });
+};
+
+const buildDoiUrl = (doi: string | null): string | null => {
+    if (!doi) {
+        return null;
+    }
+
+    const trimmed = doi.trim();
+
+    if (!trimmed) {
+        return null;
+    }
+
+    return `https://doi.org/${trimmed}`;
+};
+
+const formatDateTime = (isoString: string | null): { label: string; iso?: string } => {
+    if (!isoString) {
+        return { label: 'Not available' };
+    }
+
+    const date = new Date(isoString);
+
+    if (Number.isNaN(date.getTime())) {
+        return { label: 'Not available' };
+    }
+
+    const formatter = new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+
+    return { label: formatter.format(date), iso: date.toISOString() };
+};
+
+const describeLanguage = (language: ResourceLanguageSummary | null): string => {
+    if (!language) {
+        return 'Not specified';
+    }
+
+    if (language.name && language.code) {
+        return `${language.name} (${language.code.toUpperCase()})`;
+    }
+
+    return language.name ?? language.code ?? 'Not specified';
+};
+
+const describeResourceType = (resourceType: ResourceTypeSummary | null): string =>
+    resourceType?.name ?? 'Not classified';
+
+const describeLicense = (license: ResourceLicense): string =>
+    license.name ?? license.identifier ?? 'Unlabelled license';
+
+const ResourcesPage = ({ resources, pagination }: ResourcesPageProps) => {
+    const hasResources = resources.length > 0;
+
+    const summaryLabel = useMemo(() => {
+        if (!hasResources) {
+            return 'No resources available yet.';
+        }
+
+        const from = pagination.from ?? 0;
+        const to = pagination.to ?? resources.length;
+        const total = pagination.total;
+
+        return `Showing ${from.toLocaleString()}–${to.toLocaleString()} of ${total.toLocaleString()} resources`;
+    }, [hasResources, pagination.from, pagination.to, pagination.total, resources.length]);
+
+    const handlePageChange = (page: number) => {
+        router.get(
+            withBasePath('/resources'),
+            {
+                page,
+                per_page: pagination.per_page,
+            },
+            {
+                preserveScroll: true,
+                preserveState: true,
+            },
+        );
+    };
+
+    const isFirstPage = pagination.current_page <= 1;
+    const isLastPage = !pagination.has_more;
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={PAGE_TITLE} />
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-hidden rounded-xl p-4">
+                <Card>
+                    <CardHeader className="space-y-2">
+                        <CardTitle asChild>
+                            <h1 className="text-2xl font-semibold tracking-tight">{PAGE_TITLE}</h1>
+                        </CardTitle>
+                        <CardDescription className="text-base">
+                            Browse and review the curated resources stored in ERNIE.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-6">
+                        <p className="text-sm text-muted-foreground" role="status" aria-live="polite">
+                            {summaryLabel}
+                        </p>
+
+                        {!hasResources ? (
+                            <Alert role="status">
+                                <AlertTitle>No resources found</AlertTitle>
+                                <AlertDescription>
+                                    Once new resources are added through the curation workflow, they will appear in this list.
+                                </AlertDescription>
+                            </Alert>
+                        ) : (
+                            <>
+                                <div className="overflow-x-auto">
+                                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                        <caption className="sr-only">
+                                            Detailed list of curated resources including titles, identifiers, classifications, and lifecycle
+                                            information.
+                                        </caption>
+                                        <thead className="bg-muted/60">
+                                            <tr>
+                                                <th
+                                                    scope="col"
+                                                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                    Title
+                                                </th>
+                                                <th
+                                                    scope="col"
+                                                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                    Identifiers
+                                                </th>
+                                                <th
+                                                    scope="col"
+                                                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                    Classification
+                                                </th>
+                                                <th
+                                                    scope="col"
+                                                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                    Licenses
+                                                </th>
+                                                <th
+                                                    scope="col"
+                                                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                    Lifecycle
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody className="divide-y divide-gray-200 bg-background text-sm dark:divide-gray-700">
+                                            {resources.map((resource) => {
+                                                const primaryTitle = getPrimaryTitle(resource.titles);
+                                                const additionalTitles = getAdditionalTitles(resource.titles);
+                                                const doiUrl = buildDoiUrl(resource.doi);
+                                                const createdAt = formatDateTime(resource.created_at);
+                                                const updatedAt = formatDateTime(resource.updated_at);
+
+                                                return (
+                                                    <tr
+                                                        key={resource.id}
+                                                        className="transition-colors hover:bg-muted/40 focus-within:bg-muted/50"
+                                                    >
+                                                        <td className="px-6 py-4 align-top">
+                                                            <div className="flex flex-col gap-2">
+                                                                <div className="flex flex-wrap items-center gap-3">
+                                                                    <span className="text-base font-semibold text-foreground">{primaryTitle}</span>
+                                                                    <Badge variant="outline" className="rounded-full px-3 text-xs">
+                                                                        {resource.year}
+                                                                    </Badge>
+                                                                </div>
+                                                                {additionalTitles.length > 0 ? (
+                                                                    <details className="group rounded-md text-sm text-muted-foreground">
+                                                                        <summary className="cursor-pointer rounded-md px-1 py-0.5 font-medium text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                                                                            Show additional titles
+                                                                        </summary>
+                                                                        <ul className="mt-2 list-disc space-y-1 pl-5">
+                                                                            {additionalTitles.map((title, index) => (
+                                                                                <li key={`${resource.id}-title-${index}`} className="leading-relaxed">
+                                                                                    {title.title}
+                                                                                    {title.title_type?.name ? (
+                                                                                        <span className="ml-2 text-xs uppercase tracking-wide text-muted-foreground">
+                                                                                            {title.title_type.name}
+                                                                                        </span>
+                                                                                    ) : null}
+                                                                                </li>
+                                                                            ))}
+                                                                        </ul>
+                                                                    </details>
+                                                                ) : null}
+                                                            </div>
+                                                        </td>
+                                                        <td className="px-6 py-4 align-top">
+                                                            <dl className="space-y-2 text-sm">
+                                                                <div>
+                                                                    <dt className="font-medium text-muted-foreground">DOI</dt>
+                                                                    <dd>
+                                                                        {doiUrl ? (
+                                                                            <a
+                                                                                className="inline-flex items-center gap-2 text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                                                href={doiUrl}
+                                                                                target="_blank"
+                                                                                rel="noopener noreferrer"
+                                                                            >
+                                                                                {resource.doi}
+                                                                                <span className="sr-only">(opens in a new tab)</span>
+                                                                            </a>
+                                                                        ) : (
+                                                                            <span className="text-muted-foreground">Not provided</span>
+                                                                        )}
+                                                                    </dd>
+                                                                </div>
+                                                                <div>
+                                                                    <dt className="font-medium text-muted-foreground">Version</dt>
+                                                                    <dd>{resource.version ?? <span className="text-muted-foreground">Not provided</span>}</dd>
+                                                                </div>
+                                                            </dl>
+                                                        </td>
+                                                        <td className="px-6 py-4 align-top">
+                                                            <dl className="space-y-2 text-sm">
+                                                                <div>
+                                                                    <dt className="font-medium text-muted-foreground">Resource type</dt>
+                                                                    <dd>{describeResourceType(resource.resource_type)}</dd>
+                                                                </div>
+                                                                <div>
+                                                                    <dt className="font-medium text-muted-foreground">Language</dt>
+                                                                    <dd>{describeLanguage(resource.language)}</dd>
+                                                                </div>
+                                                            </dl>
+                                                        </td>
+                                                        <td className="px-6 py-4 align-top">
+                                                            {resource.licenses.length > 0 ? (
+                                                                <ul className="flex flex-wrap gap-2" aria-label="Licenses">
+                                                                    {resource.licenses.map((license, index) => (
+                                                                        <li key={`${resource.id}-license-${index}`}>
+                                                                            <Badge variant="secondary" className="rounded-full px-3 py-1 text-xs">
+                                                                                {describeLicense(license)}
+                                                                            </Badge>
+                                                                        </li>
+                                                                    ))}
+                                                                </ul>
+                                                            ) : (
+                                                                <span className="text-sm text-muted-foreground">No licenses linked</span>
+                                                            )}
+                                                        </td>
+                                                        <td className="px-6 py-4 align-top">
+                                                            <dl className="space-y-2 text-sm">
+                                                                <div>
+                                                                    <dt className="font-medium text-muted-foreground">Created</dt>
+                                                                    <dd>
+                                                                        {createdAt.iso ? (
+                                                                            <time dateTime={createdAt.iso}>{createdAt.label}</time>
+                                                                        ) : (
+                                                                            <span className="text-muted-foreground">{createdAt.label}</span>
+                                                                        )}
+                                                                    </dd>
+                                                                </div>
+                                                                <div>
+                                                                    <dt className="font-medium text-muted-foreground">Updated</dt>
+                                                                    <dd>
+                                                                        {updatedAt.iso ? (
+                                                                            <time dateTime={updatedAt.iso}>{updatedAt.label}</time>
+                                                                        ) : (
+                                                                            <span className="text-muted-foreground">{updatedAt.label}</span>
+                                                                        )}
+                                                                    </dd>
+                                                                </div>
+                                                            </dl>
+                                                        </td>
+                                                    </tr>
+                                                );
+                                            })}
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <nav
+                                    aria-label="Resources pagination"
+                                    className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between"
+                                >
+                                    <div className="text-sm text-muted-foreground">
+                                        Page {pagination.current_page.toLocaleString()} of {pagination.last_page.toLocaleString()}
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            disabled={isFirstPage}
+                                            onClick={() => handlePageChange(pagination.current_page - 1)}
+                                        >
+                                            Previous
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            disabled={isLastPage}
+                                            onClick={() => handlePageChange(pagination.current_page + 1)}
+                                        >
+                                            Next
+                                        </Button>
+                                    </div>
+                                </nav>
+                            </>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+};
+
+export default ResourcesPage;
+
+export { getPrimaryTitle, getAdditionalTitles, buildDoiUrl, formatDateTime, describeLanguage, describeResourceType, describeLicense };

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,9 +48,12 @@ Route::get('/changelog', function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('old-datasets', [OldDatasetController::class, 'index'])
         ->name('old-datasets');
-    
+
     Route::get('old-datasets/load-more', [OldDatasetController::class, 'loadMore'])
         ->name('old-datasets.load-more');
+
+    Route::get('resources', [ResourceController::class, 'index'])
+        ->name('resources');
 
     Route::post('dashboard/upload-xml', UploadXmlController::class)
         ->name('dashboard.upload-xml');

--- a/tests/pest/Feature/ResourceControllerTest.php
+++ b/tests/pest/Feature/ResourceControllerTest.php
@@ -3,108 +3,187 @@
 use App\Models\Language;
 use App\Models\License;
 use App\Models\Resource;
+use App\Models\ResourceTitle;
 use App\Models\ResourceType;
 use App\Models\TitleType;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Inertia\Testing\AssertableInertia as Assert;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
 
 uses(RefreshDatabase::class);
 
-function createCurationDependencies(): array
-{
-    $resourceType = ResourceType::create([
+beforeEach(function (): void {
+    $this->withoutVite();
+
+    actingAs(User::factory()->create([
+        'email_verified_at' => now(),
+    ]));
+});
+
+it('renders the resources index with paginated data', function (): void {
+    $resourceType = ResourceType::query()->create([
         'name' => 'Dataset',
         'slug' => 'dataset',
-        'active' => true,
-        'elmo_active' => true,
     ]);
 
-    $mainTitleType = TitleType::create([
-        'name' => 'Main Title',
-        'slug' => 'main-title',
-        'active' => true,
-        'elmo_active' => true,
-    ]);
-
-    $subtitleType = TitleType::create([
-        'name' => 'Subtitle',
-        'slug' => 'subtitle',
-        'active' => true,
-        'elmo_active' => true,
-    ]);
-
-    $license = License::create([
-        'identifier' => 'MIT',
-        'name' => 'MIT License',
-        'active' => true,
-        'elmo_active' => true,
-    ]);
-
-    $language = Language::create([
+    $language = Language::query()->create([
         'code' => 'en',
         'name' => 'English',
         'active' => true,
         'elmo_active' => true,
     ]);
 
-    return compact('resourceType', 'mainTitleType', 'subtitleType', 'license', 'language');
-}
+    $mainTitleType = TitleType::query()->create([
+        'name' => 'Main Title',
+        'slug' => 'main-title',
+    ]);
 
-test('authenticated users can store resources from the curation form', function () {
-    actingAs(User::factory()->create());
+    $alternateTitleType = TitleType::query()->create([
+        'name' => 'Subtitle',
+        'slug' => 'subtitle',
+    ]);
 
-    $dependencies = createCurationDependencies();
+    $license = License::query()->create([
+        'identifier' => 'cc-by-4',
+        'name' => 'Creative Commons Attribution 4.0',
+    ]);
 
-    $response = $this->postJson(route('curation.resources.store'), [
-        'doi' => '10.1234/example',
+    $resource = Resource::query()->create([
+        'doi' => '10.1234/example-one',
         'year' => 2024,
-        'resourceType' => $dependencies['resourceType']->id,
-        'version' => '1.0',
-        'language' => $dependencies['language']->code,
-        'titles' => [
-            ['title' => 'Primary Resource', 'titleType' => 'main-title'],
-            ['title' => 'Secondary Title', 'titleType' => 'subtitle'],
-        ],
-        'licenses' => [$dependencies['license']->identifier],
+        'resource_type_id' => $resourceType->id,
+        'version' => '1.2.0',
+        'language_id' => $language->id,
     ]);
 
-    $response->assertCreated()->assertJson([
-        'message' => 'Successfully saved resource.',
+    Resource::query()->whereKey($resource->id)->update([
+        'created_at' => Carbon::parse('2024-03-10 09:30:00'),
+        'updated_at' => Carbon::parse('2024-03-12 15:00:00'),
     ]);
 
-    $resource = Resource::with(['titles', 'licenses'])->first();
+    $resource->refresh();
 
-    expect($resource)->not->toBeNull();
-    expect($resource->year)->toBe(2024);
-    expect($resource->resource_type_id)->toBe($dependencies['resourceType']->id);
-    expect($resource->language_id)->toBe($dependencies['language']->id);
-    expect($resource->titles)->toHaveCount(2);
-    expect($resource->titles->firstWhere('title_type_id', $dependencies['mainTitleType']->id)?->title)
-        ->toBe('Primary Resource');
-    expect($resource->licenses)->toHaveCount(1);
-    expect($resource->licenses->first()->identifier)->toBe($dependencies['license']->identifier);
+    ResourceTitle::query()->create([
+        'resource_id' => $resource->id,
+        'title' => 'Exploring metadata interoperability',
+        'title_type_id' => $mainTitleType->id,
+    ]);
+
+    ResourceTitle::query()->create([
+        'resource_id' => $resource->id,
+        'title' => 'A practical subtitle',
+        'title_type_id' => $alternateTitleType->id,
+    ]);
+
+    $resource->licenses()->attach($license->id);
+
+    $secondaryResourceType = ResourceType::query()->create([
+        'name' => 'Text',
+        'slug' => 'text',
+    ]);
+
+    $secondaryResource = Resource::query()->create([
+        'doi' => null,
+        'year' => 2023,
+        'resource_type_id' => $secondaryResourceType->id,
+        'version' => null,
+        'language_id' => null,
+    ]);
+
+    Resource::query()->whereKey($secondaryResource->id)->update([
+        'created_at' => Carbon::parse('2023-12-24 11:00:00'),
+        'updated_at' => Carbon::parse('2023-12-24 11:00:00'),
+    ]);
+
+    $secondaryResource->refresh();
+
+    ResourceTitle::query()->create([
+        'resource_id' => $secondaryResource->id,
+        'title' => 'Second resource title',
+        'title_type_id' => $mainTitleType->id,
+    ]);
+
+    get(route('resources'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('resources')
+            ->has('resources', 2)
+            ->where('resources.0.id', $resource->id)
+            ->where('resources.0.doi', $resource->doi)
+            ->where('resources.0.year', 2024)
+            ->where('resources.0.version', '1.2.0')
+            ->where('resources.0.resource_type.name', 'Dataset')
+            ->where('resources.0.language.code', 'en')
+            ->where('resources.0.titles', fn ($titles) => count($titles) === 2)
+            ->where('resources.0.licenses', fn ($licenses) => count($licenses) === 1)
+            ->where('resources.0.created_at', $resource->created_at?->toIso8601String())
+            ->where('resources.0.updated_at', $resource->updated_at?->toIso8601String())
+            ->where('resources.1.id', $secondaryResource->id)
+            ->where('resources.1.doi', null)
+            ->where('resources.1.year', 2023)
+            ->where('resources.1.resource_type.name', 'Text')
+            ->where('resources.1.titles', fn ($titles) => count($titles) === 1)
+            ->where('resources.1.licenses', fn ($licenses) => count($licenses) === 0)
+            ->where('resources.1.language', null)
+            ->where('resources.1.created_at', $secondaryResource->created_at?->toIso8601String())
+            ->where('resources.1.updated_at', $secondaryResource->updated_at?->toIso8601String())
+            ->where('pagination', [
+                'current_page' => 1,
+                'last_page' => 1,
+                'per_page' => 25,
+                'total' => 2,
+                'from' => 1,
+                'to' => 2,
+                'has_more' => false,
+            ])
+        );
 });
 
-test('validation errors are returned when the resource payload is invalid', function () {
-    actingAs(User::factory()->create());
-
-    $dependencies = createCurationDependencies();
-
-    $response = $this->postJson(route('curation.resources.store'), [
-        'year' => 2024,
-        'resourceType' => $dependencies['resourceType']->id,
-        'language' => $dependencies['language']->code,
-        'titles' => [
-            ['title' => 'Only Subtitle', 'titleType' => 'subtitle'],
-        ],
-        'licenses' => [$dependencies['license']->identifier],
+it('caps the per page parameter to protect performance', function (): void {
+    $resourceType = ResourceType::query()->create([
+        'name' => 'Dataset',
+        'slug' => 'dataset',
     ]);
 
-    $response
-        ->assertUnprocessable()
-        ->assertJsonValidationErrors(['titles']);
+    $mainTitleType = TitleType::query()->create([
+        'name' => 'Main Title',
+        'slug' => 'main-title',
+    ]);
 
-    expect(Resource::count())->toBe(0);
+    $startDate = Carbon::parse('2024-01-01 00:00:00');
+
+    for ($index = 0; $index < 105; $index++) {
+        $resource = Resource::query()->create([
+            'doi' => sprintf('10.5555/example-%03d', $index),
+            'year' => 2020 + ($index % 5),
+            'resource_type_id' => $resourceType->id,
+            'version' => null,
+            'language_id' => null,
+        ]);
+
+        Resource::query()->whereKey($resource->id)->update([
+            'created_at' => $startDate->copy()->addMinutes($index),
+            'updated_at' => $startDate->copy()->addMinutes($index),
+        ]);
+
+        ResourceTitle::query()->create([
+            'resource_id' => $resource->id,
+            'title' => sprintf('Example resource %d', $index + 1),
+            'title_type_id' => $mainTitleType->id,
+        ]);
+    }
+
+    get(route('resources', ['per_page' => 500, 'page' => -3]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('resources')
+            ->has('resources', 100)
+            ->where('pagination.per_page', 100)
+            ->where('pagination.current_page', 1)
+            ->where('pagination.has_more', true)
+        );
 });

--- a/tests/vitest/components/__tests__/app-sidebar.test.tsx
+++ b/tests/vitest/components/__tests__/app-sidebar.test.tsx
@@ -78,11 +78,15 @@ describe('AppSidebar', () => {
         const oldDatasetsLink = screen.getByRole('link', { name: /old datasets/i });
         expect(oldDatasetsLink).toHaveAttribute('href', withBasePath('/old-datasets'));
 
+        const resourcesLink = screen.getByRole('link', { name: /resources/i });
+        expect(resourcesLink).toHaveAttribute('href', withBasePath('/resources'));
+
         const mainArgs = NavMainMock.mock.calls[0][0];
         expect(mainArgs.items.map((i: NavItem) => i.title)).toEqual([
             'Dashboard',
             'Curation',
             'Old Datasets',
+            'Resources',
         ]);
 
         const footerArgs = NavFooterMock.mock.calls[0][0];
@@ -125,6 +129,7 @@ describe('AppSidebar', () => {
         expect(screen.getByRole('link', { name: /dashboard/i })).toHaveAttribute('href', '/ernie/dashboard');
         expect(screen.getByRole('link', { name: /curation/i })).toHaveAttribute('href', '/ernie/curation');
         expect(screen.getByRole('link', { name: /old datasets/i })).toHaveAttribute('href', '/ernie/old-datasets');
+        expect(screen.getByRole('link', { name: /resources/i })).toHaveAttribute('href', '/ernie/resources');
         expect(screen.getByRole('link', { name: /changelog/i })).toHaveAttribute('href', '/ernie/changelog');
         expect(screen.getByRole('link', { name: /documentation/i })).toHaveAttribute('href', '/ernie/docs');
         expect(screen.getByRole('link', { name: /editor settings/i })).toHaveAttribute('href', '/ernie/settings');

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -1,0 +1,197 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import ResourcesPage, {
+    buildDoiUrl,
+    describeLanguage,
+    describeLicense,
+    describeResourceType,
+    formatDateTime,
+    getAdditionalTitles,
+    getPrimaryTitle,
+} from '@/pages/resources';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const routerMock = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    router: routerMock,
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div data-testid="app-layout">{children}</div>,
+}));
+
+describe('resource helper utilities', () => {
+    it('selects the main title when available and falls back otherwise', () => {
+        const titles = [
+            { title: 'Secondary title', title_type: { name: 'Subtitle', slug: 'subtitle' } },
+            { title: 'Primary', title_type: { name: 'Main Title', slug: 'main-title' } },
+        ];
+
+        expect(getPrimaryTitle(titles as never)).toBe('Primary');
+        expect(getPrimaryTitle([{ title: 'Only title', title_type: null }] as never)).toBe('Only title');
+        expect(getPrimaryTitle([] as never)).toBe('Untitled resource');
+    });
+
+    it('derives additional titles by excluding the primary entry', () => {
+        const titles = [
+            { title: 'Main', title_type: { name: 'Main', slug: 'main-title' } },
+            { title: 'Alt', title_type: { name: 'Alternate', slug: 'alternative-title' } },
+        ];
+
+        const extras = getAdditionalTitles(titles as never);
+        expect(extras).toHaveLength(1);
+        expect(extras[0]?.title).toBe('Alt');
+        expect(getAdditionalTitles([{ title: 'Single', title_type: null }] as never)).toHaveLength(0);
+    });
+
+    it('builds DOI URLs safely', () => {
+        expect(buildDoiUrl('10.1234/abc')).toBe('https://doi.org/10.1234/abc');
+        expect(buildDoiUrl('  ')).toBeNull();
+        expect(buildDoiUrl(null)).toBeNull();
+    });
+
+    it('formats date time information with ISO output', () => {
+        const result = formatDateTime('2024-01-01T10:00:00Z');
+        expect(result.iso).toBe('2024-01-01T10:00:00.000Z');
+        expect(result.label).toBeTruthy();
+        expect(formatDateTime(null).label).toBe('Not available');
+    });
+
+    it('describes metadata fields for accessibility', () => {
+        expect(describeLanguage({ name: 'English', code: 'en' })).toBe('English (EN)');
+        expect(describeLanguage({ name: null, code: 'fr' })).toBe('fr');
+        expect(describeLanguage(null)).toBe('Not specified');
+
+        expect(describeResourceType({ name: 'Dataset', slug: 'dataset' })).toBe('Dataset');
+        expect(describeResourceType(null)).toBe('Not classified');
+
+        expect(describeLicense({ name: 'CC-BY', identifier: 'cc-by' })).toBe('CC-BY');
+        expect(describeLicense({ name: null, identifier: 'cc0' })).toBe('cc0');
+    });
+});
+
+describe('ResourcesPage', () => {
+    beforeEach(() => {
+        routerMock.get.mockClear();
+    });
+
+    afterEach(() => {
+        document.head.innerHTML = '';
+    });
+
+    it('renders a table with resource information and accessibility enhancements', () => {
+        const props = {
+            resources: [
+                {
+                    id: 1,
+                    doi: '10.9999/example',
+                    year: 2024,
+                    version: '2.0',
+                    created_at: '2024-04-01T09:00:00Z',
+                    updated_at: '2024-04-02T10:00:00Z',
+                    resource_type: { name: 'Dataset', slug: 'dataset' },
+                    language: { name: 'English', code: 'en' },
+                    titles: [
+                        { title: 'Primary title', title_type: { name: 'Main', slug: 'main-title' } },
+                        { title: 'Alternate', title_type: { name: 'Subtitle', slug: 'subtitle' } },
+                    ],
+                    licenses: [
+                        { name: 'CC-BY 4.0', identifier: 'cc-by-4.0' },
+                    ],
+                },
+            ],
+            pagination: {
+                current_page: 1,
+                last_page: 3,
+                per_page: 25,
+                total: 60,
+                from: 1,
+                to: 25,
+                has_more: true,
+            },
+        } as const;
+
+        render(<ResourcesPage {...props} />);
+
+        expect(screen.getByTestId('app-layout')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 1, name: /resources/i })).toBeInTheDocument();
+        expect(screen.getByText(/showing 1–25 of 60 resources/i)).toBeInTheDocument();
+
+        const table = screen.getByRole('table');
+        expect(table).toBeInTheDocument();
+        expect(within(table).getByText('Primary title')).toBeInTheDocument();
+        const summary = within(table).getByText(/show additional titles/i);
+        expect(summary.tagName).toBe('SUMMARY');
+        expect(within(table).getByText('Dataset')).toBeInTheDocument();
+        expect(within(table).getByText('English (EN)')).toBeInTheDocument();
+        expect(within(table).getByText('CC-BY 4.0')).toBeInTheDocument();
+
+        const timeElements = within(table).getAllByText((_, element) => element?.tagName === 'TIME');
+        expect(timeElements[0]).toHaveAttribute('dateTime', '2024-04-01T09:00:00.000Z');
+        expect(timeElements[1]).toHaveAttribute('dateTime', '2024-04-02T10:00:00.000Z');
+    });
+
+    it('shows a friendly empty state when there are no resources', () => {
+        render(
+            <ResourcesPage
+                resources={[]}
+                pagination={{ current_page: 1, last_page: 1, per_page: 25, total: 0, from: null, to: null, has_more: false }}
+            />,
+        );
+
+        expect(screen.getByText(/no resources found/i)).toBeInTheDocument();
+        expect(screen.getByText(/will appear in this list/i)).toBeInTheDocument();
+    });
+
+    it('navigates between pages using inertia router', () => {
+        const props = {
+            resources: [
+                {
+                    id: 1,
+                    doi: null,
+                    year: 2024,
+                    version: null,
+                    created_at: null,
+                    updated_at: null,
+                    resource_type: null,
+                    language: null,
+                    titles: [{ title: 'Untitled', title_type: null }],
+                    licenses: [],
+                },
+            ],
+            pagination: {
+                current_page: 2,
+                last_page: 4,
+                per_page: 25,
+                total: 80,
+                from: 26,
+                to: 50,
+                has_more: true,
+            },
+        } as const;
+
+        render(<ResourcesPage {...props} />);
+
+        const previousButton = screen.getByRole('button', { name: /previous/i });
+        const nextButton = screen.getByRole('button', { name: /next/i });
+
+        expect(previousButton).toBeEnabled();
+        expect(nextButton).toBeEnabled();
+
+        fireEvent.click(nextButton);
+        expect(routerMock.get).toHaveBeenCalledWith(
+            '/resources',
+            { page: 3, per_page: 25 },
+            expect.objectContaining({ preserveScroll: true, preserveState: true }),
+        );
+
+        fireEvent.click(previousButton);
+        expect(routerMock.get).toHaveBeenCalledWith(
+            '/resources',
+            { page: 1, per_page: 25 },
+            expect.objectContaining({ preserveScroll: true, preserveState: true }),
+        );
+    });
+});


### PR DESCRIPTION
This pull request introduces a new paginated resources index page to the application, including backend, frontend, and test updates. The main changes add a new route and controller method for serving resource data, update the sidebar navigation to include the new page, and provide comprehensive tests for both backend pagination and frontend rendering and navigation.

### Backend: Resource Index Implementation

* Added a new `index` method to `ResourceController` that returns a paginated list of resources, including related types, languages, titles, and licenses, with performance safeguards for pagination parameters. The data is returned via Inertia for frontend rendering.
* Registered the new route `/resources` in `routes/web.php` to point to the resource index controller method.

### Frontend: Navigation and Page

* Updated the sidebar (`app-sidebar.tsx`) to include a "Resources" link with the appropriate icon, making the new page accessible from the main navigation. [[1]](diffhunk://#diff-09845d63b8044b16b013decdd5cc20a182793c1ad93ea10fdbea68d41d4643ecL9-R9) [[2]](diffhunk://#diff-09845d63b8044b16b013decdd5cc20a182793c1ad93ea10fdbea68d41d4643ecR28-R32)
* Added and tested a new resources page component (`resources.test.tsx`), including utility functions for displaying resource metadata and handling pagination.

### Testing: Backend and Frontend Coverage

* Replaced and expanded backend tests for `ResourceController` to cover resource index rendering, pagination limits, and data structure validation.
* Updated frontend sidebar tests to verify the presence and correct routing of the new "Resources" navigation item. [[1]](diffhunk://#diff-c10fdbe7b2260b895fb215d186c93c52d4614711d2da639ff78a5f48894057b4R81-R89) [[2]](diffhunk://#diff-c10fdbe7b2260b895fb215d186c93c52d4614711d2da639ff78a5f48894057b4R132)
* Added comprehensive frontend tests for the resources page, verifying correct rendering, empty states, accessibility, and pagination navigation.