### PR TITLE
feat: display resource count in dashboard statistics

### DIFF
--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -91,11 +91,17 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
+type DashboardPageProps = SharedData & {
+    resourceCount?: number;
+};
+
 export default function Dashboard({ onXmlFiles = handleXmlFiles }: DashboardProps = {}) {
-    const { auth } = usePage<SharedData>().props;
+    const { auth, resourceCount } = usePage<DashboardPageProps>().props;
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [isDragging, setIsDragging] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const datasetCount = typeof resourceCount === 'number' ? resourceCount : 0;
 
     async function uploadXml(files: File[]) {
         try {
@@ -163,7 +169,8 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles }: DashboardProp
                             <CardTitle>Statistics</CardTitle>
                         </CardHeader>
                         <CardContent className="text-sm text-muted-foreground">
-                            x datasets from y data centers of z institutions
+                            <strong className="font-semibold text-foreground">{datasetCount}</strong>{' '}
+                            datasets from y data centers of z institutions
                         </CardContent>
                     </Card>
                     <Card>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -27,6 +27,7 @@ export interface SharedData {
     quote: { message: string; author: string };
     auth: Auth;
     sidebarOpen: boolean;
+    resourceCount?: number;
     [key: string]: unknown;
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ResourceController;
 use App\Http\Controllers\OldDatasetController;
 use App\Http\Controllers\UploadXmlController;
 use App\Models\License;
+use App\Models\Resource;
 use App\Models\Setting;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\DB;
@@ -59,7 +60,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('dashboard.upload-xml');
 
     Route::get('dashboard', function () {
-        return Inertia::render('dashboard');
+        return Inertia::render('dashboard', [
+            'resourceCount' => Resource::count(),
+        ]);
     })->name('dashboard');
 
     Route::get('docs', function () {

--- a/tests/pest/Feature/DashboardTest.php
+++ b/tests/pest/Feature/DashboardTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Models\Resource;
+use App\Models\ResourceType;
 use App\Models\User;
+use Inertia\Testing\AssertableInertia;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -12,4 +15,29 @@ test('authenticated users can visit the dashboard', function () {
     $this->actingAs($user = User::factory()->create());
 
     $this->get(route('dashboard'))->assertOk();
+});
+
+test('dashboard view receives the resource count', function () {
+    $this->actingAs(User::factory()->create());
+
+    $resourceType = ResourceType::create([
+        'name' => 'Dataset',
+        'slug' => 'dataset',
+    ]);
+
+    Resource::create([
+        'year' => 2024,
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    Resource::create([
+        'year' => 2025,
+        'resource_type_id' => $resourceType->id,
+    ]);
+
+    $this->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->where('resourceCount', 2)
+        );
 });


### PR DESCRIPTION
This pull request enhances the dashboard page by displaying the total count of datasets (resources) in the statistics card. It introduces backend and frontend changes to fetch and render the resource count, along with comprehensive tests to ensure correct behavior and fallback handling.

**Dashboard statistics improvements:**

* The backend now passes the total resource count to the dashboard view by adding `resourceCount` to the Inertia render call in `routes/web.php`. (`[routes/web.phpL62-R65](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL62-R65)`)
* The frontend dashboard component (`dashboard.tsx`) reads `resourceCount` from props, displays it in the statistics card, and falls back to zero if the count is unavailable. (`[[1]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR94-R105)`, `[[2]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL166-R173)`)

**Testing enhancements:**

* Added a feature test to verify that the dashboard view receives and correctly renders the resource count from the backend. (`[tests/pest/Feature/DashboardTest.phpR19-R43](diffhunk://#diff-e669e13c10043b53923c6deb0d4ae55fd527c277024df3cfc64cbd629cd77f8bR19-R43)`)
* Updated and expanded Vitest tests to check that the dashboard displays the correct resource count, uses a fallback of zero, and renders the count with the expected styling. (`[[1]](diffhunk://#diff-7c5b5cbe16c434291ac7dba43cb1ef3920fb44a07a9b021b55b7c654bd713af2L65-R65)`, `[[2]](diffhunk://#diff-7c5b5cbe16c434291ac7dba43cb1ef3920fb44a07a9b021b55b7c654bd713af2R79-R95)`)

**Codebase maintenance:**

* Minor imports added for new models and testing utilities to support the above changes. (`[[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR7)`, `[[2]](diffhunk://#diff-e669e13c10043b53923c6deb0d4ae55fd527c277024df3cfc64cbd629cd77f8bR3-R6)`, `[[3]](diffhunk://#diff-7c5b5cbe16c434291ac7dba43cb1ef3920fb44a07a9b021b55b7c654bd713af2L2-R2)`)