### PR TITLE
Add edit action column to resources page

### DIFF
--- a/resources/js/lib/curation-query.ts
+++ b/resources/js/lib/curation-query.ts
@@ -1,0 +1,196 @@
+import { withBasePath } from '@/lib/base-path';
+
+interface ResourceTypeReference {
+    id: number;
+    name: string;
+}
+
+interface ResourceTitleTypeSummary {
+    slug: string | null;
+}
+
+interface ResourceTitleSummary {
+    title: string;
+    title_type: ResourceTitleTypeSummary | null;
+}
+
+interface ResourceLicenseSummary {
+    identifier: string | null;
+}
+
+interface ResourceLanguageSummary {
+    code: string | null;
+}
+
+interface ResourceTypeSummary {
+    name: string | null;
+}
+
+export interface ResourceForCuration {
+    doi: string | null;
+    year: number;
+    version: string | null;
+    resource_type: ResourceTypeSummary | null;
+    language: ResourceLanguageSummary | null;
+    titles: ResourceTitleSummary[];
+    licenses: ResourceLicenseSummary[];
+}
+
+let resourceTypesCache: ResourceTypeReference[] | null = null;
+
+const fetchResourceTypes = async (): Promise<ResourceTypeReference[]> => {
+    if (resourceTypesCache) {
+        return resourceTypesCache;
+    }
+
+    try {
+        const response = await fetch(withBasePath('/api/v1/resource-types/ernie'));
+
+        if (!response.ok) {
+            return [];
+        }
+
+        const data = (await response.json()) as ResourceTypeReference[];
+        resourceTypesCache = Array.isArray(data) ? data : [];
+
+        return resourceTypesCache;
+    } catch (error) {
+        console.error('Failed to fetch resource types for curation.', error);
+        return [];
+    }
+};
+
+const mapResourceTypeNameToId = async (name: string | null): Promise<string | null> => {
+    if (!name) {
+        return null;
+    }
+
+    const trimmed = name.trim();
+
+    if (!trimmed) {
+        return null;
+    }
+
+    const resourceTypes = await fetchResourceTypes();
+    const normalised = trimmed.toLowerCase();
+
+    const match = resourceTypes.find((type) => type.name.trim().toLowerCase() === normalised);
+
+    if (!match) {
+        return null;
+    }
+
+    return String(match.id);
+};
+
+const normaliseTitles = (titles: ResourceTitleSummary[]): { title: string; titleType: string }[] => {
+    const cleaned = titles
+        .map((entry) => {
+            const text = entry.title?.trim();
+
+            if (!text) {
+                return null;
+            }
+
+            const slug = entry.title_type?.slug?.trim() ?? '';
+
+            return {
+                title: text,
+                titleType: slug,
+            };
+        })
+        .filter(Boolean) as { title: string; titleType: string }[];
+
+    if (cleaned.length === 0) {
+        return [];
+    }
+
+    let hasMainTitle = cleaned.some((entry) => entry.titleType === 'main-title');
+
+    const resolved = cleaned.map((entry, index) => {
+        if (entry.titleType === 'main-title') {
+            hasMainTitle = true;
+            return entry;
+        }
+
+        if (!entry.titleType) {
+            if (!hasMainTitle) {
+                hasMainTitle = true;
+                return { ...entry, titleType: 'main-title' };
+            }
+
+            return { ...entry, titleType: 'alternative-title' };
+        }
+
+        return entry;
+    });
+
+    if (!hasMainTitle && resolved.length > 0) {
+        const [first, ...rest] = resolved;
+        return [{ ...first, titleType: 'main-title' }, ...rest];
+    }
+
+    const mainTitles = resolved.filter((entry) => entry.titleType === 'main-title');
+    const secondaryTitles = resolved.filter((entry) => entry.titleType !== 'main-title');
+
+    return [...mainTitles, ...secondaryTitles];
+};
+
+const normaliseLicenses = (licenses: ResourceLicenseSummary[]): string[] =>
+    licenses
+        .map((license) => license.identifier?.trim())
+        .filter((identifier): identifier is string => Boolean(identifier));
+
+export const buildCurationQueryFromResource = async (
+    resource: ResourceForCuration,
+): Promise<Record<string, string>> => {
+    const query: Record<string, string> = {};
+
+    const doi = resource.doi?.trim();
+
+    if (doi) {
+        query.doi = doi;
+    }
+
+    if (Number.isFinite(resource.year)) {
+        query.year = String(resource.year);
+    }
+
+    const version = resource.version?.trim();
+
+    if (version) {
+        query.version = version;
+    }
+
+    const languageCode = resource.language?.code?.trim();
+
+    if (languageCode) {
+        query.language = languageCode;
+    }
+
+    const resourceTypeName = resource.resource_type?.name;
+    const resourceTypeId = await mapResourceTypeNameToId(resourceTypeName ?? null);
+
+    if (resourceTypeId) {
+        query.resourceType = resourceTypeId;
+    }
+
+    const titles = normaliseTitles(resource.titles);
+    titles.forEach((title, index) => {
+        query[`titles[${index}][title]`] = title.title;
+        query[`titles[${index}][titleType]`] = title.titleType;
+    });
+
+    const licenses = normaliseLicenses(resource.licenses);
+    licenses.forEach((identifier, index) => {
+        query[`licenses[${index}]`] = identifier;
+    });
+
+    return query;
+};
+
+export const __testing = {
+    resetResourceTypeCache: () => {
+        resourceTypesCache = null;
+    },
+};

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -6,7 +6,10 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { withBasePath } from '@/lib/base-path';
-import { useMemo } from 'react';
+import { buildCurationQueryFromResource } from '@/lib/curation-query';
+import { useCallback, useMemo } from 'react';
+import { PencilLine } from 'lucide-react';
+import { curation as curationRoute } from '@/routes';
 
 interface ResourceTitleType {
     name: string | null;
@@ -177,6 +180,16 @@ const ResourcesPage = ({ resources, pagination }: ResourcesPageProps) => {
         );
     };
 
+    const handleEditResource = useCallback(async (resource: ResourceListItem) => {
+        try {
+            const query = await buildCurationQueryFromResource(resource);
+            router.get(curationRoute({ query }).url);
+        } catch (error) {
+            console.error('Unable to open resource in curation.', error);
+            router.get(curationRoute().url);
+        }
+    }, []);
+
     const isFirstPage = pagination.current_page <= 1;
     const isLastPage = !pagination.has_more;
 
@@ -244,6 +257,12 @@ const ResourcesPage = ({ resources, pagination }: ResourcesPageProps) => {
                                                     className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
                                                 >
                                                     Lifecycle
+                                                </th>
+                                                <th
+                                                    scope="col"
+                                                    className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                                                >
+                                                    Actions
                                                 </th>
                                             </tr>
                                         </thead>
@@ -365,6 +384,20 @@ const ResourcesPage = ({ resources, pagination }: ResourcesPageProps) => {
                                                                     </dd>
                                                                 </div>
                                                             </dl>
+                                                        </td>
+                                                        <td className="px-6 py-4 align-top">
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                onClick={() => {
+                                                                    void handleEditResource(resource);
+                                                                }}
+                                                                aria-label={`Edit ${primaryTitle} in the curation editor`}
+                                                                title={`Edit ${primaryTitle} in the curation editor`}
+                                                            >
+                                                                <PencilLine aria-hidden="true" className="size-4" />
+                                                            </Button>
                                                         </td>
                                                     </tr>
                                                 );

--- a/tests/vitest/lib/curation-query.test.ts
+++ b/tests/vitest/lib/curation-query.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildCurationQueryFromResource, __testing } from '@/lib/curation-query';
+
+const originalFetch = globalThis.fetch;
+
+describe('buildCurationQueryFromResource', () => {
+    beforeEach(() => {
+        __testing.resetResourceTypeCache();
+    });
+
+    afterEach(() => {
+        __testing.resetResourceTypeCache();
+        if (originalFetch) {
+            globalThis.fetch = originalFetch;
+        }
+        vi.restoreAllMocks();
+    });
+
+    it('constructs a query string using available metadata and mapped resource type identifiers', async () => {
+        const fetchMock = vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve([{ id: 7, name: 'Dataset' }]),
+            } as unknown as Response),
+        );
+
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        const query = await buildCurationQueryFromResource({
+            doi: ' 10.1234/example ',
+            year: 2023,
+            version: ' 1.0 ',
+            resource_type: { name: 'Dataset', slug: 'dataset' },
+            language: { code: 'en', name: 'English' },
+            titles: [
+                { title: 'Primary Title', title_type: { slug: 'main-title' } },
+                { title: ' Secondary Title ', title_type: { slug: null } },
+            ],
+            licenses: [
+                { identifier: 'CC-BY-4.0' },
+                { identifier: null },
+            ],
+        });
+
+        expect(query).toEqual({
+            doi: '10.1234/example',
+            year: '2023',
+            version: '1.0',
+            language: 'en',
+            resourceType: '7',
+            'titles[0][title]': 'Primary Title',
+            'titles[0][titleType]': 'main-title',
+            'titles[1][title]': 'Secondary Title',
+            'titles[1][titleType]': 'alternative-title',
+            'licenses[0]': 'CC-BY-4.0',
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('/api/v1/resource-types/ernie');
+    });
+
+    it('reuses cached resource type data across multiple invocations', async () => {
+        const fetchMock = vi.fn(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve([{ id: 3, name: 'Dataset' }]),
+            } as unknown as Response),
+        );
+
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        const resource = {
+            doi: '10.0000/example',
+            year: 2024,
+            version: null,
+            resource_type: { name: 'Dataset', slug: 'dataset' },
+            language: { code: null, name: null },
+            titles: [{ title: 'Title', title_type: { slug: 'main-title' } }],
+            licenses: [],
+        } as const;
+
+        await buildCurationQueryFromResource(resource);
+        await buildCurationQueryFromResource(resource);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits resource type information when lookup fails gracefully', async () => {
+        const error = new Error('network down');
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const fetchMock = vi.fn(() => Promise.reject(error));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        const query = await buildCurationQueryFromResource({
+            doi: null,
+            year: 2022,
+            version: null,
+            resource_type: { name: 'Unknown', slug: 'unknown' },
+            language: { code: 'de', name: 'German' },
+            titles: [],
+            licenses: [],
+        });
+
+        expect(query).toEqual({
+            year: '2022',
+            language: 'de',
+        });
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch resource types for curation.', error);
+    });
+});

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { render, screen, within, fireEvent, act } from '@testing-library/react';
 import ResourcesPage, {
     buildDoiUrl,
     describeLanguage,
@@ -12,10 +12,30 @@ import ResourcesPage, {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const routerMock = vi.hoisted(() => ({ get: vi.fn() }));
+const buildCurationQueryFromResourceMock = vi.hoisted(() => vi.fn());
+const curationRouteMock = vi.hoisted(
+    () =>
+        vi.fn(
+            ({ query }: { query?: Record<string, string> } = {}) => ({
+                url: query
+                    ? `/curation?${new URLSearchParams(query).toString()}`
+                    : '/curation',
+                method: 'get',
+            }),
+        ),
+);
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     router: routerMock,
+}));
+
+vi.mock('@/lib/curation-query', () => ({
+    buildCurationQueryFromResource: buildCurationQueryFromResourceMock,
+}));
+
+vi.mock('@/routes', () => ({
+    curation: curationRouteMock,
 }));
 
 vi.mock('@/layouts/app-layout', () => ({
@@ -75,6 +95,9 @@ describe('resource helper utilities', () => {
 describe('ResourcesPage', () => {
     beforeEach(() => {
         routerMock.get.mockClear();
+        buildCurationQueryFromResourceMock.mockReset();
+        buildCurationQueryFromResourceMock.mockResolvedValue({});
+        curationRouteMock.mockClear();
     });
 
     afterEach(() => {
@@ -113,6 +136,8 @@ describe('ResourcesPage', () => {
             },
         } as const;
 
+        buildCurationQueryFromResourceMock.mockResolvedValue({ doi: '10.9999/example' });
+
         render(<ResourcesPage {...props} />);
 
         expect(screen.getByTestId('app-layout')).toBeInTheDocument();
@@ -127,6 +152,10 @@ describe('ResourcesPage', () => {
         expect(within(table).getByText('Dataset')).toBeInTheDocument();
         expect(within(table).getByText('English (EN)')).toBeInTheDocument();
         expect(within(table).getByText('CC-BY 4.0')).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /actions/i })).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /edit primary title in the curation editor/i }),
+        ).toBeInTheDocument();
 
         const timeElements = within(table).getAllByText((_, element) => element?.tagName === 'TIME');
         expect(timeElements[0]).toHaveAttribute('dateTime', '2024-04-01T09:00:00.000Z');
@@ -193,5 +222,53 @@ describe('ResourcesPage', () => {
             { page: 1, per_page: 25 },
             expect.objectContaining({ preserveScroll: true, preserveState: true }),
         );
+    });
+
+    it('opens the curation editor with prefilled metadata when the action is triggered', async () => {
+        const resource = {
+            id: 1,
+            doi: '10.9999/example',
+            year: 2024,
+            version: '2.0',
+            created_at: '2024-04-01T09:00:00Z',
+            updated_at: '2024-04-02T10:00:00Z',
+            resource_type: { name: 'Dataset', slug: 'dataset' },
+            language: { name: 'English', code: 'en' },
+            titles: [
+                { title: 'Primary title', title_type: { name: 'Main', slug: 'main-title' } },
+            ],
+            licenses: [{ name: 'CC-BY 4.0', identifier: 'cc-by-4.0' }],
+        } as const;
+
+        buildCurationQueryFromResourceMock.mockResolvedValue({ doi: resource.doi });
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 25,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+            />,
+        );
+
+        const editButton = screen.getByRole('button', {
+            name: /edit primary title in the curation editor/i,
+        });
+
+        await act(async () => {
+            fireEvent.click(editButton);
+            await Promise.resolve();
+        });
+
+        expect(buildCurationQueryFromResourceMock).toHaveBeenCalledWith(resource);
+        expect(curationRouteMock).toHaveBeenCalledWith({ query: { doi: resource.doi } });
+        const lastCall = routerMock.get.mock.calls.at(-1);
+        expect(lastCall?.[0]).toBe('/curation?doi=10.9999%2Fexample');
     });
 });


### PR DESCRIPTION
## Summary
- add a helper to construct curation query parameters from an existing resource entry
- render an Actions column with an accessible edit control that opens the resource in the curation editor
- cover the new helper and UI behaviour with dedicated Vitest suites

## Testing
- npm test -- --run tests/vitest/lib/curation-query.test.ts tests/vitest/pages/__tests__/resources.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1526fc9a0832ea49310e6acbd7390