### PR TITLE
Add deletion controls to resources management

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -9,6 +9,7 @@ use App\Models\Resource;
 use App\Models\ResourceTitle;
 use App\Models\TitleType;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
@@ -185,5 +186,14 @@ class ResourceController extends Controller
                 'id' => $resource->id,
             ],
         ], $status);
+    }
+
+    public function destroy(Resource $resource): RedirectResponse
+    {
+        $resource->delete();
+
+        return redirect()
+            ->route('resources')
+            ->with('success', 'Resource deleted successfully.');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('resources', [ResourceController::class, 'index'])
         ->name('resources');
 
+    Route::delete('resources/{resource}', [ResourceController::class, 'destroy'])
+        ->name('resources.destroy');
+
     Route::post('dashboard/upload-xml', UploadXmlController::class)
         ->name('dashboard.upload-xml');
 


### PR DESCRIPTION
This pull request adds support for deleting resources from the ERNIE app, including both backend and frontend functionality. It introduces a new controller action and route for resource deletion, updates the resources page to provide a user-friendly confirmation dialog for destructive actions, and adds comprehensive tests to ensure correct behavior and data cleanup.

**Backend functionality:**

* Added a new `destroy` method to `ResourceController` to handle resource deletion and redirect with a success message.
* Registered a new `DELETE` route for resource deletion in `routes/web.php`.

**Frontend enhancements:**

* Updated `resources.tsx` to add a "Delete" button for each resource, show a confirmation dialog before deletion, and handle UI states for pending/ongoing deletions. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R158-R170) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R207-R239) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R323-R325) [[4]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R439) [[5]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R449-R468) [[6]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R506-R557)

**Testing and validation:**

* Added a feature test to verify that deleting a resource also removes its related metadata and license associations.
* Enhanced Vitest tests to cover the presence of the delete button and the confirmation dialog workflow, including UI and router interactions. [[1]](diffhunk://#diff-5809bb7f17b87658ea64212ec03769ca87f5123e6b1b042c41b59f69732c0aa6L14-R14) [[2]](diffhunk://#diff-5809bb7f17b87658ea64212ec03769ca87f5123e6b1b042c41b59f69732c0aa6R98) [[3]](diffhunk://#diff-5809bb7f17b87658ea64212ec03769ca87f5123e6b1b042c41b59f69732c0aa6R163-R165) [[4]](diffhunk://#diff-5809bb7f17b87658ea64212ec03769ca87f5123e6b1b042c41b59f69732c0aa6R286-R362)