### PR TITLE
Update changelog and latest release expansion

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "0.1.0",
-    "date": "2025-09-12",
+    "date": "2025-10-05",
     "features": [
       {
         "title": "Resources workspace",

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,8 +4,12 @@
     "date": "2025-09-12",
     "features": [
       {
-        "title": "Dashboard",
-        "description": "Added a dashboard for quick access to key features."
+        "title": "Resources workspace",
+        "description": "Browse curated resources with metadata badges, DOI links, pagination details, and quick edit or delete actions."
+      },
+      {
+        "title": "Dashboard overview",
+        "description": "Surface key statistics like the total resource count alongside shortcuts to curation and documentation."
       },
       {
         "title": "Resource Information form group",
@@ -52,6 +56,14 @@
       {
         "title": "Registration closed",
         "description": "Closed registration so only admins can add new users."
+      },
+      {
+        "title": "Resource table layout",
+        "description": "Streamlined the resources list with clearer spacing, responsive formatting, and accessible typography."
+      },
+      {
+        "title": "Deletion confirmations",
+        "description": "Added confirm dialogs and loading states so resource removals stay intentional and transparent."
       }
     ]
   }

--- a/resources/js/pages/changelog.tsx
+++ b/resources/js/pages/changelog.tsx
@@ -36,7 +36,10 @@ export default function Changelog() {
                 }
                 return res.json();
             })
-            .then((data: Release[]) => setReleases(data))
+            .then((data: Release[]) => {
+                setReleases(data);
+                setActive(data.length > 0 ? 0 : null);
+            })
             .catch(() => setError('Unable to load changelog.'));
     }, []);
 
@@ -55,18 +58,20 @@ export default function Changelog() {
                 >
                     {releases.map((release, index) => {
                         const isOpen = active === index;
+                        const buttonId = `release-trigger-${index}`;
+                        const panelId = `release-${index}`;
                         const prev = releases[index - 1];
                         const [currMajor, currMinor] = release.version.split('.').map(Number);
-                    const [prevMajor, prevMinor] = prev
-                        ? prev.version.split('.').map(Number)
-                        : [currMajor, currMinor];
-                    const ringColor = (() => {
-                        if (!prev) return 'ring-green-500';
-                        if (currMajor !== prevMajor) return 'ring-green-500';
-                        if (currMinor !== prevMinor) return 'ring-blue-500';
-                        return 'ring-red-500';
-                    })();
-                    return (
+                        const [prevMajor, prevMinor] = prev
+                            ? prev.version.split('.').map(Number)
+                            : [currMajor, currMinor];
+                        const ringColor = (() => {
+                            if (!prev) return 'ring-green-500';
+                            if (currMajor !== prevMajor) return 'ring-green-500';
+                            if (currMinor !== prevMinor) return 'ring-blue-500';
+                            return 'ring-red-500';
+                        })();
+                        return (
                         <li key={release.version} className="relative">
                             <span
                                 aria-hidden="true"
@@ -76,8 +81,11 @@ export default function Changelog() {
                             <motion.button
                                 whileHover={{ scale: 1.01 }}
                                 onClick={() => setActive(isOpen ? null : index)}
+                                id={buttonId}
                                 aria-expanded={isOpen}
+                                aria-controls={panelId}
                                 className="flex w-full items-center rounded p-2 text-left focus:outline-none focus:ring"
+                                type="button"
                             >
                                 <span className="flex-1 font-medium">Version {release.version}</span>
                                 <span className="ml-4 text-sm text-gray-600">{release.date}</span>
@@ -85,12 +93,14 @@ export default function Changelog() {
                             <AnimatePresence initial={false}>
                                 {isOpen && (
                                     <motion.div
-                                        id={`release-${index}`}
+                                        id={panelId}
                                         initial={{ height: 0, opacity: 0 }}
                                         animate={{ height: 'auto', opacity: 1 }}
                                         exit={{ height: 0, opacity: 0 }}
                                         transition={{ duration: 0.3 }}
                                         className="ml-5 mt-2 border-l pl-4 text-sm text-gray-700"
+                                        role="region"
+                                        aria-labelledby={buttonId}
                                     >
                                         {(
                                             Object.keys(sectionConfig) as Array<keyof typeof sectionConfig>

--- a/tests/pest/Feature/ChangelogApiTest.php
+++ b/tests/pest/Feature/ChangelogApiTest.php
@@ -10,10 +10,10 @@ it('returns changelog data grouped by release', function () {
             'version' => '0.1.0',
         ])
         ->assertJsonFragment([
-            'title' => 'Resource Information form group',
+            'title' => 'Resources workspace',
         ])
         ->assertJsonFragment([
-            'title' => 'License and Rights form group',
+            'title' => 'Dashboard overview',
         ]);
 });
 

--- a/tests/vitest/pages/__tests__/changelog.test.tsx
+++ b/tests/vitest/pages/__tests__/changelog.test.tsx
@@ -14,57 +14,47 @@ vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
-const sanitizeButtonMotionProps = (
-    props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
-        whileHover?: unknown;
+type MotionButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    whileHover?: unknown;
+};
+
+type MotionDivProps = React.HTMLAttributes<HTMLDivElement> & {
+    initial?: unknown;
+    animate?: unknown;
+    exit?: unknown;
+    transition?: unknown;
+};
+
+const sanitizeButtonMotionProps = ({ whileHover, ...rest }: MotionButtonProps) => {
+    if (typeof whileHover !== 'undefined') {
+        // Motion-only prop intentionally dropped for DOM rendering in tests.
     }
-) => {
-    const rest = { ...props } as React.ButtonHTMLAttributes<HTMLButtonElement> & {
-        whileHover?: unknown;
-    };
-    delete rest.whileHover;
+
     return rest;
 };
 
-const sanitizeDivMotionProps = (
-    props: React.HTMLAttributes<HTMLDivElement> & {
-        initial?: unknown;
-        animate?: unknown;
-        exit?: unknown;
-        transition?: unknown;
+const sanitizeDivMotionProps = ({ initial, animate, exit, transition, ...rest }: MotionDivProps) => {
+    if (
+        typeof initial !== 'undefined' ||
+        typeof animate !== 'undefined' ||
+        typeof exit !== 'undefined' ||
+        typeof transition !== 'undefined'
+    ) {
+        // Motion-only props intentionally dropped for DOM rendering in tests.
     }
-) => {
-    const rest = { ...props } as React.HTMLAttributes<HTMLDivElement> & {
-        initial?: unknown;
-        animate?: unknown;
-        exit?: unknown;
-        transition?: unknown;
-    };
-    delete rest.initial;
-    delete rest.animate;
-    delete rest.exit;
-    delete rest.transition;
+
     return rest;
 };
 
 vi.mock('framer-motion', () => ({
     AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     motion: {
-        button: ({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) => {
-            const rest = sanitizeButtonMotionProps(
-                props as React.ButtonHTMLAttributes<HTMLButtonElement> & { whileHover?: unknown }
-            );
+        button: ({ children, ...props }: MotionButtonProps & { children?: React.ReactNode }) => {
+            const rest = sanitizeButtonMotionProps(props);
             return <button {...rest}>{children}</button>;
         },
-        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
-            const rest = sanitizeDivMotionProps(
-                props as React.HTMLAttributes<HTMLDivElement> & {
-                    initial?: unknown;
-                    animate?: unknown;
-                    exit?: unknown;
-                    transition?: unknown;
-                }
-            );
+        div: ({ children, ...props }: MotionDivProps & { children?: React.ReactNode }) => {
+            const rest = sanitizeDivMotionProps(props);
             return <div {...rest}>{children}</div>;
         },
     },

--- a/tests/vitest/pages/__tests__/changelog.test.tsx
+++ b/tests/vitest/pages/__tests__/changelog.test.tsx
@@ -25,24 +25,19 @@ type MotionDivProps = React.HTMLAttributes<HTMLDivElement> & {
     transition?: unknown;
 };
 
-const sanitizeButtonMotionProps = ({ whileHover, ...rest }: MotionButtonProps) => {
-    if (typeof whileHover !== 'undefined') {
-        // Motion-only prop intentionally dropped for DOM rendering in tests.
-    }
+const consumeMotionOnlyProps = (...values: unknown[]) => {
+    values.forEach(() => {
+        // Accessing via forEach keeps eslint satisfied without mutating output.
+    });
+};
 
+const sanitizeButtonMotionProps = ({ whileHover, ...rest }: MotionButtonProps) => {
+    consumeMotionOnlyProps(whileHover);
     return rest;
 };
 
 const sanitizeDivMotionProps = ({ initial, animate, exit, transition, ...rest }: MotionDivProps) => {
-    if (
-        typeof initial !== 'undefined' ||
-        typeof animate !== 'undefined' ||
-        typeof exit !== 'undefined' ||
-        typeof transition !== 'undefined'
-    ) {
-        // Motion-only props intentionally dropped for DOM rendering in tests.
-    }
-
+    consumeMotionOnlyProps(initial, animate, exit, transition);
     return rest;
 };
 

--- a/tests/vitest/pages/__tests__/changelog.test.tsx
+++ b/tests/vitest/pages/__tests__/changelog.test.tsx
@@ -18,19 +18,23 @@ vi.mock('framer-motion', () => ({
     AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     motion: {
         button: ({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) => {
-            const { whileHover: _whileHover, ...rest } = props as React.ButtonHTMLAttributes<HTMLButtonElement> & {
+            const { whileHover, ...rest } = props as React.ButtonHTMLAttributes<HTMLButtonElement> & {
                 whileHover?: unknown;
             };
+            void whileHover;
             return <button {...rest}>{children}</button>;
         },
         div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
-            const { initial: _initial, animate: _animate, exit: _exit, transition: _transition, ...rest } =
-                props as React.HTMLAttributes<HTMLDivElement> & {
-                    initial?: unknown;
-                    animate?: unknown;
-                    exit?: unknown;
-                    transition?: unknown;
-                };
+            const { initial, animate, exit, transition, ...rest } = props as React.HTMLAttributes<HTMLDivElement> & {
+                initial?: unknown;
+                animate?: unknown;
+                exit?: unknown;
+                transition?: unknown;
+            };
+            void initial;
+            void animate;
+            void exit;
+            void transition;
             return <div {...rest}>{children}</div>;
         },
     },

--- a/tests/vitest/pages/__tests__/changelog.test.tsx
+++ b/tests/vitest/pages/__tests__/changelog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach, afterEach, Mock } from 'vitest';
 import Changelog from '@/pages/changelog';
 import { __testing as basePathTesting } from '@/lib/base-path';
+import type React from 'react';
 
 vi.mock('@/layouts/public-layout', () => ({
     default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -16,10 +17,22 @@ vi.mock('@inertiajs/react', () => ({
 vi.mock('framer-motion', () => ({
     AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     motion: {
-        button: ({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) => (
-            <button {...props}>{children}</button>
-        ),
-        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+        button: ({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) => {
+            const { whileHover: _whileHover, ...rest } = props as React.ButtonHTMLAttributes<HTMLButtonElement> & {
+                whileHover?: unknown;
+            };
+            return <button {...rest}>{children}</button>;
+        },
+        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+            const { initial: _initial, animate: _animate, exit: _exit, transition: _transition, ...rest } =
+                props as React.HTMLAttributes<HTMLDivElement> & {
+                    initial?: unknown;
+                    animate?: unknown;
+                    exit?: unknown;
+                    transition?: unknown;
+                };
+            return <div {...rest}>{children}</div>;
+        },
     },
 }));
 
@@ -34,12 +47,12 @@ describe('Changelog', () => {
                         date: '2024-12-01',
                         features: [
                             {
-                                title: 'Resource Information form group',
-                                description: 'Add structured resource information section.',
+                                title: 'Resources workspace',
+                                description: 'Browse curated resources with metadata badges and quick actions.',
                             },
                             {
-                                title: 'License and Rights',
-                                description: 'Include license and rights details for resources.',
+                                title: 'Dashboard overview',
+                                description: 'Surface key statistics like the total resource count.',
                             },
                         ],
                     },
@@ -75,7 +88,7 @@ describe('Changelog', () => {
         basePathTesting.resetBasePathCache();
     });
 
-    it('renders releases on a timeline and toggles grouped details', async () => {
+    it('renders releases on a timeline, expands the latest by default, and toggles grouped details', async () => {
         const user = userEvent.setup();
         render(<Changelog />);
         const list = await screen.findByRole('list', { name: /changelog timeline/i });
@@ -84,12 +97,18 @@ describe('Changelog', () => {
         const lastButton = await screen.findByRole('button', { name: /version 0.2.0/i });
         expect(firstButton).toBeInTheDocument();
         expect(lastButton).toBeInTheDocument();
-        await user.click(firstButton);
-        expect(await screen.findByText(/Resource Information form group/i)).toBeInTheDocument();
-        expect(screen.getByText('License and Rights')).toBeInTheDocument();
+        expect(firstButton).toHaveAttribute('aria-expanded', 'true');
+        expect(await screen.findByText(/Resources workspace/i)).toBeInTheDocument();
+        expect(screen.getByText(/Dashboard overview/i)).toBeInTheDocument();
         await user.click(lastButton);
+        expect(lastButton).toHaveAttribute('aria-expanded', 'true');
+        expect(firstButton).toHaveAttribute('aria-expanded', 'false');
         expect(await screen.findByText(/Minor improvements/i)).toBeInTheDocument();
         expect(screen.getByText(/UI enhancements/i)).toBeInTheDocument();
+        await user.click(lastButton);
+        await vi.waitFor(() => {
+            expect(screen.queryByText(/Minor improvements/i)).not.toBeInTheDocument();
+        });
     });
 
     it('colors anchors based on version changes', async () => {
@@ -112,6 +131,8 @@ describe('Changelog', () => {
         const fetchSpy = global.fetch as unknown as Mock;
 
         render(<Changelog />);
+
+        await screen.findByRole('list', { name: /changelog timeline/i });
 
         await vi.waitFor(() => {
             expect(fetchSpy).toHaveBeenCalledWith('/ernie/api/changelog');

--- a/tests/vitest/pages/__tests__/changelog.test.tsx
+++ b/tests/vitest/pages/__tests__/changelog.test.tsx
@@ -14,27 +14,57 @@ vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
+const sanitizeButtonMotionProps = (
+    props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+        whileHover?: unknown;
+    }
+) => {
+    const rest = { ...props } as React.ButtonHTMLAttributes<HTMLButtonElement> & {
+        whileHover?: unknown;
+    };
+    delete rest.whileHover;
+    return rest;
+};
+
+const sanitizeDivMotionProps = (
+    props: React.HTMLAttributes<HTMLDivElement> & {
+        initial?: unknown;
+        animate?: unknown;
+        exit?: unknown;
+        transition?: unknown;
+    }
+) => {
+    const rest = { ...props } as React.HTMLAttributes<HTMLDivElement> & {
+        initial?: unknown;
+        animate?: unknown;
+        exit?: unknown;
+        transition?: unknown;
+    };
+    delete rest.initial;
+    delete rest.animate;
+    delete rest.exit;
+    delete rest.transition;
+    return rest;
+};
+
 vi.mock('framer-motion', () => ({
     AnimatePresence: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     motion: {
         button: ({ children, ...props }: React.HTMLAttributes<HTMLButtonElement>) => {
-            const { whileHover, ...rest } = props as React.ButtonHTMLAttributes<HTMLButtonElement> & {
-                whileHover?: unknown;
-            };
-            void whileHover;
+            const rest = sanitizeButtonMotionProps(
+                props as React.ButtonHTMLAttributes<HTMLButtonElement> & { whileHover?: unknown }
+            );
             return <button {...rest}>{children}</button>;
         },
         div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
-            const { initial, animate, exit, transition, ...rest } = props as React.HTMLAttributes<HTMLDivElement> & {
-                initial?: unknown;
-                animate?: unknown;
-                exit?: unknown;
-                transition?: unknown;
-            };
-            void initial;
-            void animate;
-            void exit;
-            void transition;
+            const rest = sanitizeDivMotionProps(
+                props as React.HTMLAttributes<HTMLDivElement> & {
+                    initial?: unknown;
+                    animate?: unknown;
+                    exit?: unknown;
+                    transition?: unknown;
+                }
+            );
             return <div {...rest}>{children}</div>;
         },
     },


### PR DESCRIPTION
This pull request updates the changelog feature to improve clarity, accessibility, and test coverage. The main changes include updating the changelog data to reflect new features, enhancing the accessibility of the changelog UI, and revising tests to match the new changelog content and behavior.

**Changelog data updates:**

* Updated `resources/data/changelog.json` to replace "Dashboard" and "Resource Information form group" with "Resources workspace" and "Dashboard overview", and added new entries for resource table layout and deletion confirmations. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R12) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR59-R66)

**Accessibility and UI improvements:**

* In `resources/js/pages/changelog.tsx`, added accessible attributes (`aria-controls`, `aria-expanded`, `role="region"`, and proper `id`s) to changelog buttons and panels, and set the latest release to expand by default for better user experience. [[1]](diffhunk://#diff-4b8dd37df23c47fa47be184dbd30b84cab83d7b9a24d2aee1ed68bfe0672fdbbL39-R42) [[2]](diffhunk://#diff-4b8dd37df23c47fa47be184dbd30b84cab83d7b9a24d2aee1ed68bfe0672fdbbR61-R62) [[3]](diffhunk://#diff-4b8dd37df23c47fa47be184dbd30b84cab83d7b9a24d2aee1ed68bfe0672fdbbR84-R103)

**Testing updates:**

* Updated feature test in `tests/pest/Feature/ChangelogApiTest.php` to expect new changelog entries.
* Improved mock components and props handling in `tests/vitest/pages/__tests__/changelog.test.tsx` for `framer-motion`, and updated test data and assertions to match the new changelog content and expanded-by-default behavior. [[1]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aR7) [[2]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aR17-R54) [[3]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aL37-R74) [[4]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aL78-R110) [[5]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aL87-R130) [[6]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aR154-R155)