### PR TITLE
Increase timeout for DataCiteForm author management test

### DIFF
--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -547,7 +547,7 @@ describe('DataCiteForm', () => {
         const finalAffiliationField = screen.getByTestId('author-0-affiliations-field');
         expect(finalAffiliationField).toHaveTextContent('Institution X');
         expect(finalAffiliationField).toHaveTextContent('Institution Y');
-    });
+    }, 15000);
 
     it('applies responsive layout for author inputs', async () => {
         render(


### PR DESCRIPTION
This pull request makes a minor adjustment to the test suite for the `DataCiteForm` component. The change increases the timeout for a specific test to ensure it has enough time to complete.

* Increased the timeout of the test that verifies author affiliation fields from the default to 15 seconds by passing `15000` as the second argument to the test function in `datacite-form.test.tsx`.