### PR TITLE
Display ROR ID badges for matched affiliations

### DIFF
--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -216,9 +216,22 @@ class OldDataset extends Model
             ->groupBy('resourceagent_order')
             ->map(function ($affiliations) {
                 return $affiliations->map(function ($affiliation) {
+                    $identifier = $affiliation->identifier ?? null;
+                    
+                    // Normalize ROR identifier to full URL format
+                    if ($identifier && !empty(trim($identifier))) {
+                        // If it's already a full URL, keep it
+                        if (!str_starts_with($identifier, 'http')) {
+                            // Convert short ROR ID to full URL
+                            $identifier = 'https://ror.org/' . ltrim($identifier, '/');
+                        }
+                    } else {
+                        $identifier = null;
+                    }
+                    
                     return [
                         'value' => $affiliation->name,
-                        'rorId' => $affiliation->identifier ?? null,
+                        'rorId' => $identifier,
                     ];
                 })->toArray();
             })

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -217,7 +217,7 @@ class OldDataset extends Model
             ->map(function ($affiliations) {
                 return $affiliations->map(function ($affiliation) {
                     $identifier = $affiliation->identifier ?? null;
-                    
+
                     // Normalize ROR identifier to full URL format
                     if ($identifier && !empty(trim($identifier))) {
                         // If it's already a full URL, keep it
@@ -228,7 +228,7 @@ class OldDataset extends Model
                     } else {
                         $identifier = null;
                     }
-                    
+
                     return [
                         'value' => $affiliation->name,
                         'rorId' => $identifier,

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -99,24 +99,16 @@ export type InitialAuthor =
           institutionName?: string | null;
       });
 
-const DEBUG_AFFILIATIONS = true;
-
 const normaliseInitialAffiliations = (
     affiliations?: (InitialAffiliationInput | null | undefined)[] | null,
 ): AffiliationTag[] => {
     if (!affiliations || !Array.isArray(affiliations)) {
-        if (DEBUG_AFFILIATIONS) {
-            console.log('normaliseInitialAffiliations: No affiliations or not an array', affiliations);
-        }
         return [];
     }
 
-    const normalized = affiliations
-        .map((affiliation, index) => {
+    return affiliations
+        .map((affiliation) => {
             if (!affiliation || typeof affiliation !== 'object') {
-                if (DEBUG_AFFILIATIONS) {
-                    console.log(`normaliseInitialAffiliations: Affiliation ${index} is not an object`, affiliation);
-                }
                 return null;
             }
 
@@ -141,18 +133,7 @@ const normaliseInitialAffiliations = (
                 ).trim();
 
             if (!rawValue && !rawRorId) {
-                if (DEBUG_AFFILIATIONS) {
-                    console.log(`normaliseInitialAffiliations: Affiliation ${index} has no value or rorId`, affiliation);
-                }
                 return null;
-            }
-
-            if (DEBUG_AFFILIATIONS) {
-                console.log(`normaliseInitialAffiliations: Affiliation ${index}`, {
-                    input: affiliation,
-                    value: rawValue || rawRorId,
-                    rorId: rawRorId || null,
-                });
             }
 
             return {
@@ -161,11 +142,6 @@ const normaliseInitialAffiliations = (
             } satisfies AffiliationTag;
         })
         .filter((item): item is AffiliationTag => Boolean(item && item.value));
-
-    if (DEBUG_AFFILIATIONS) {
-        console.log('normaliseInitialAffiliations: Final result', { input: affiliations, output: normalized });
-    }
-    return normalized;
 };
 
 const mapInitialAuthorToEntry = (author: InitialAuthor): AuthorEntry | null => {

--- a/resources/js/components/curation/fields/author-field.tsx
+++ b/resources/js/components/curation/fields/author-field.tsx
@@ -289,16 +289,24 @@ export function AuthorField({
                                         <Badge
                                             key={`${affiliation.rorId}-${affiliation.value}`}
                                             variant="secondary"
-                                            className="gap-1 px-2 py-1 text-xs font-medium"
+                                            className="gap-1 px-2 py-1 text-xs font-medium hover:bg-secondary/80 transition-colors"
                                             role="listitem"
+                                            asChild
                                         >
-                                            <span aria-hidden="true">ROR:</span>
-                                            <span aria-hidden="true" className="font-mono">
-                                                {affiliation.rorId}
-                                            </span>
-                                            <span className="sr-only">
-                                                {`ROR identifier for ${affiliation.value}: ${affiliation.rorId}`}
-                                            </span>
+                                            <a
+                                                href={affiliation.rorId}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center gap-1"
+                                            >
+                                                <span aria-hidden="true">ROR:</span>
+                                                <span aria-hidden="true" className="font-mono">
+                                                    {affiliation.rorId}
+                                                </span>
+                                                <span className="sr-only">
+                                                    {`Open ROR identifier for ${affiliation.value}: ${affiliation.rorId} in new tab`}
+                                                </span>
+                                            </a>
                                         </Badge>
                                     ))}
                                 </div>

--- a/resources/js/components/curation/fields/author-field.tsx
+++ b/resources/js/components/curation/fields/author-field.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import InputField from './input-field';
 import { SelectField } from './select-field';
 import TagInputField from './tag-input-field';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -69,6 +70,24 @@ export function AuthorField({
 }: AuthorFieldProps) {
     const isPerson = author.type === 'person';
     const contactLabelTextId = `${author.id}-contact-label-text`;
+    const affiliationsWithRorId = useMemo(() => {
+        const seen = new Set<string>();
+
+        return author.affiliations.reduce<{ value: string; rorId: string }[]>((accumulator, affiliation) => {
+            const value = affiliation.value.trim();
+            const rorId = typeof affiliation.rorId === 'string' ? affiliation.rorId.trim() : '';
+
+            if (!value || !rorId || seen.has(rorId)) {
+                return accumulator;
+            }
+
+            seen.add(rorId);
+            accumulator.push({ value, rorId });
+            return accumulator;
+        }, []);
+    }, [author.affiliations]);
+    const affiliationsDescriptionId =
+        affiliationsWithRorId.length > 0 ? `${author.id}-affiliations-ror-description` : undefined;
 
     const tagifySettings = useMemo<Partial<TagifySettings<TagData>>>(() => {
         const whitelist = affiliationSuggestions.map((suggestion) => ({
@@ -249,7 +268,42 @@ export function AuthorField({
                             }}
                             data-testid={`author-${index}-affiliations-input`}
                             tagifySettings={tagifySettings}
+                            aria-describedby={affiliationsDescriptionId}
                         />
+                        {affiliationsWithRorId.length > 0 && (
+                            <div
+                                id={affiliationsDescriptionId}
+                                className="col-span-full flex flex-col gap-2 md:col-span-12"
+                                data-testid={`author-${index}-affiliations-ror-ids`}
+                                aria-live="polite"
+                            >
+                                <p className="text-sm font-medium text-muted-foreground">
+                                    Linked ROR IDs
+                                </p>
+                                <div
+                                    className="flex flex-wrap gap-2"
+                                    role="list"
+                                    aria-label="Selected ROR identifiers"
+                                >
+                                    {affiliationsWithRorId.map((affiliation) => (
+                                        <Badge
+                                            key={`${affiliation.rorId}-${affiliation.value}`}
+                                            variant="secondary"
+                                            className="gap-1 px-2 py-1 text-xs font-medium"
+                                            role="listitem"
+                                        >
+                                            <span aria-hidden="true">ROR:</span>
+                                            <span aria-hidden="true" className="font-mono">
+                                                {affiliation.rorId}
+                                            </span>
+                                            <span className="sr-only">
+                                                {`ROR identifier for ${affiliation.value}: ${affiliation.rorId}`}
+                                            </span>
+                                        </Badge>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                         {isPerson && author.isContact && (
                             <>
                                 <InputField

--- a/resources/js/components/curation/fields/tag-input-field.tsx
+++ b/resources/js/components/curation/fields/tag-input-field.tsx
@@ -108,7 +108,7 @@ export function TagInputField({
         const handleChange = (event: CustomEvent) => {
             const detail = event.detail as { value?: string; tagify: Tagify<TagData> };
             const rawValue = detail.value ?? '';
-            
+
             const tags: TagInputItem[] = detail.tagify.value
                 .map((item) => {
                     const trimmedValue = typeof item.value === 'string' ? item.value.trim() : '';
@@ -168,7 +168,7 @@ export function TagInputField({
         }
 
         tagify.whitelist = tagifySettings.whitelist;
-        
+
         // Update dropdown settings if provided
         // Defensive: settings can be undefined in test environments
         if (tagifySettings.dropdown && tagify.settings?.dropdown) {
@@ -190,12 +190,12 @@ export function TagInputField({
             .map((item) => {
                 const rawItem = item as Record<string, unknown>;
                 const data = rawItem.data as Record<string, unknown> | undefined;
-                
+
                 // Try to get rorId from item directly or from item.data
                 const directRorId = typeof rawItem.rorId === 'string' ? rawItem.rorId : null;
                 const dataRorId = data && typeof data.rorId === 'string' ? data.rorId : null;
                 const rorId = directRorId ?? dataRorId;
-                
+
                 return {
                     value: typeof item.value === 'string' ? item.value : '',
                     rorId,


### PR DESCRIPTION
This pull request improves how author affiliations and ROR (Research Organization Registry) identifiers are handled and displayed in the curation UI. The changes ensure that ROR IDs are normalized, affiliations are processed robustly, and linked ROR IDs are clearly shown to users. It also adds thorough tests to verify the new behavior. The most important changes are grouped below:

**Affiliation and ROR ID Normalization**

* The backend (`OldDataset.php`) now normalizes ROR identifiers to always use the full URL format (e.g., `https://ror.org/xxxxxx`), ensuring consistency for downstream usage.
* The frontend affiliation normalization function (`datacite-form.tsx`) is updated to handle multiple possible property names (`value`, `name`, `rorId`, `rorid`, `identifier`) and includes debug logging to aid troubleshooting.

**UI Improvements for ROR ID Display**

* The author field UI (`author-field.tsx`) now computes and displays badges for affiliations that include recognized ROR IDs, with accessible markup and links to ROR pages. Badges only appear for affiliations with valid ROR IDs. [[1]](diffhunk://#diff-94286373e70417ddf49bc2aec481c5ec80e3d651396bdaebb8f10da2755f7c0bR73-R90) [[2]](diffhunk://#diff-94286373e70417ddf49bc2aec481c5ec80e3d651396bdaebb8f10da2755f7c0bR271-R314)
* Tag input handling (`tag-input-field.tsx`) is enhanced to preserve and extract ROR IDs from tags, ensuring that the affiliation data structure remains consistent throughout user interactions. [[1]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fR83-R90) [[2]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL96-R111) [[3]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL180-R203)

**Testing**

* New tests verify that ROR badges are rendered for affiliations with ROR IDs, are not shown when missing, and work for both initial and user-added authors. This ensures the UI behaves as intended for all scenarios.