### PR TITLE
Docs: Changelog update for version bump 0.2.0

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,19 +1,83 @@
 [
   {
     "version": "0.2.0",
-    "date": "2025-10-08",
+    "date": "2025-10-06",
     "features": [
       {
-        "title": "New form group Authors",
-        "description": "Added structured authors section."
+        "title": "Authors Management in Curation Form",
+        "description": "Added comprehensive authors section with support for persons and institutions, ORCID input fields, contact person functionality, role and affiliation management using Tagify-based inputs, and extensive end-to-end tests with Playwright. Includes accessible implementation with optimized aria-label usage."
       },
       {
-        "title": "Autocomplete for Affiliations field",
-        "description": "Added autocomplete for Affiliations field with Tagify and ROR-IDs."
+        "title": "ROR Affiliation Synchronization",
+        "description": "Integrated Research Organization Registry (ROR) with automatic data synchronization, autocomplete functionality for affiliations with ROR IDs, support for ZIP archives containing ROR data, and a new data structure using prefLabel, rorId, and otherLabel fields. Includes comprehensive tests for ROR data fetching and processing."
       },
       {
-        "title": "Added statistic card on dashboard",
-        "description": "Show total datasets count on dashboard."
+        "title": "Import Authors from DataCite XML",
+        "description": "Automatically extract authors from uploaded DataCite XML files with proper handling of nested creator elements."
+      },
+      {
+        "title": "API for Old Dataset Authors",
+        "description": "New endpoint to fetch authors from legacy datasets with fuzzy matching for contact information and affiliations. Frontend integration automatically loads legacy authors into the curation form. Includes ORCID support, optimized queries to avoid N+1 problems, improved name normalization with diacritic removal, and comprehensive tests (Pest, Playwright, Vitest)."
+      },
+      {
+        "title": "ROR ID Badges for Affiliations",
+        "description": "Display ROR ID badges for matched affiliations with clickable links to ROR identifiers, improved normalization of affiliation data, and consistent formatting of ROR URLs."
+      },
+      {
+        "title": "Persistent Sorting for Old Datasets",
+        "description": "Added sorting controls for the old datasets table with lazy loading that respects server-side sorting and persistent storage of sort preferences."
+      },
+      {
+        "title": "Store Authors with Roles and Affiliations",
+        "description": "Complete persistence of author management data with form hydration using stored authors, support for ROR IDs for institutions, normalization of boolean values, and reuse of existing institutions."
+      },
+      {
+        "title": "API Key Authentication for ELMO Resource Types",
+        "description": "Protected ELMO endpoint with configurable API key using new ELMO_API_KEY environment variable. Configuration added to .env.example and stack.env with updated tests for consistent test environment."
+      },
+      {
+        "title": "Dashboard Statistics Card",
+        "description": "Show total datasets count on dashboard with new statistics card."
+      }
+    ],
+    "improvements": [
+      {
+        "title": "Test Timeout Adjustments",
+        "description": "Increased timeout for DataCiteForm author management tests to improve test reliability."
+      },
+      {
+        "title": "Layout and Accessibility Enhancements",
+        "description": "Improved layout and accessibility for author fields with optimized spacing and better screen reader support."
+      },
+      {
+        "title": "Query Optimization",
+        "description": "Optimized queries for contact information matching to reduce database load and improve performance."
+      },
+      {
+        "title": "Error Handling",
+        "description": "Enhanced error handling and messaging throughout the application for better user feedback."
+      }
+    ],
+    "fixes": [
+      {
+        "title": "DataCite Author Extraction",
+        "description": "Fixed DataCite author extraction to correctly ignore nested creator elements."
+      },
+      {
+        "title": "PHPStan Issues",
+        "description": "Resolved PHPStan issues for ROR synchronization and author affiliations."
+      },
+      {
+        "title": "JSON File Error Handling",
+        "description": "Improved error handling for JSON file read operations."
+      },
+      {
+        "title": "TagInputField Dropdown Settings",
+        "description": "Corrected dropdown settings merge in TagInputField component."
+      },
+      {
+        "title": "MockTagify Reset",
+        "description": "Fixed MockTagify removeAllTags method to correctly clear the value array."
       }
     ]
   },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -92,7 +92,6 @@ const createEmptyInstitutionAuthor = (): InstitutionAuthorEntry => ({
     id: crypto.randomUUID(),
     type: 'institution',
     institutionName: '',
-    rorId: '',
     affiliations: [] as AffiliationTag[],
     affiliationsInput: '',
 });
@@ -214,10 +213,6 @@ const mapInitialAuthorToEntry = (author: InitialAuthor): AuthorEntry | null => {
             institutionName:
                 typeof author.institutionName === 'string'
                     ? author.institutionName.trim()
-                    : '',
-            rorId:
-                typeof author.rorId === 'string'
-                    ? author.rorId.trim()
                     : '',
             affiliations,
             affiliationsInput,
@@ -462,18 +457,6 @@ export default function DataCiteForm({
         );
     };
 
-    const handleInstitutionRorIdChange = (authorId: string, value: string) => {
-        setAuthors((previous) =>
-            previous.map((author) => {
-                if (author.id !== authorId || author.type !== 'institution') {
-                    return author;
-                }
-
-                return { ...author, rorId: value } as InstitutionAuthorEntry;
-            }),
-        );
-    };
-
     const handleAuthorContactChange = (authorId: string, checked: boolean) => {
         setAuthors((previous) =>
             previous.map((author) => {
@@ -595,12 +578,13 @@ export default function DataCiteForm({
             }
 
             const institutionName = author.institutionName.trim();
-            const rorId = author.rorId.trim();
+            // Get ROR ID from first affiliation that has one
+            const rorId = author.affiliations.find((aff) => aff.rorId)?.rorId?.trim() || null;
 
             return {
                 type: 'institution',
                 institutionName,
-                rorId: rorId || null,
+                rorId,
                 affiliations,
                 position: index,
             } satisfies SerializedAuthor;
@@ -848,9 +832,6 @@ export default function DataCiteForm({
                                     }
                                     onInstitutionNameChange={(value) =>
                                         handleInstitutionNameChange(author.id, value)
-                                    }
-                                    onInstitutionRorIdChange={(value) =>
-                                        handleInstitutionRorIdChange(author.id, value)
                                     }
                                     onContactChange={(checked) =>
                                         handleAuthorContactChange(author.id, checked)

--- a/resources/js/components/curation/fields/author-field.tsx
+++ b/resources/js/components/curation/fields/author-field.tsx
@@ -32,7 +32,6 @@ export interface PersonAuthorEntry extends BaseAuthorEntry {
 export interface InstitutionAuthorEntry extends BaseAuthorEntry {
     type: 'institution';
     institutionName: string;
-    rorId: string;
 }
 
 export type AuthorEntry = PersonAuthorEntry | InstitutionAuthorEntry;
@@ -46,7 +45,6 @@ interface AuthorFieldProps {
         value: string,
     ) => void;
     onInstitutionNameChange: (value: string) => void;
-    onInstitutionRorIdChange: (value: string) => void;
     onContactChange: (checked: boolean) => void;
     onAffiliationsChange: (value: { raw: string; tags: AffiliationTag[] }) => void;
     onRemoveAuthor: () => void;
@@ -62,7 +60,6 @@ export function AuthorField({
     onTypeChange,
     onPersonFieldChange,
     onInstitutionNameChange,
-    onInstitutionRorIdChange,
     onContactChange,
     onAffiliationsChange,
     onRemoveAuthor,
@@ -233,25 +230,14 @@ export function AuthorField({
                                 </div>
                             </>
                         ) : (
-                            <>
-                                <InputField
-                                    id={`${author.id}-institution`}
-                                    label="Institution name"
-                                    value={author.institutionName}
-                                    onChange={(event) => onInstitutionNameChange(event.target.value)}
-                                    containerProps={{ className: 'md:col-span-7' }}
-                                    required
-                                />
-                                <InputField
-                                    id={`${author.id}-rorId`}
-                                    label="ROR ID"
-                                    value={author.rorId}
-                                    onChange={(event) => onInstitutionRorIdChange(event.target.value)}
-                                    placeholder="https://ror.org/"
-                                    inputMode="url"
-                                    containerProps={{ className: 'md:col-span-4' }}
-                                />
-                            </>
+                            <InputField
+                                id={`${author.id}-institution`}
+                                label="Institution name"
+                                value={author.institutionName}
+                                onChange={(event) => onInstitutionNameChange(event.target.value)}
+                                containerProps={{ className: 'md:col-span-11' }}
+                                required
+                            />
                         )}
                     </div>
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -649,10 +649,6 @@ describe('DataCiteForm', () => {
         const institutionInput = screen.getByRole('textbox', { name: /Institution name/i });
         await user.type(institutionInput, 'Test University');
 
-        const rorIdInput = screen.getByRole('textbox', { name: /ROR ID/i });
-        await user.type(rorIdInput, 'https://ror.org/01bj3aw27');
-        expect(rorIdInput).toHaveValue('https://ror.org/01bj3aw27');
-
         // Verify first and third are still persons
         expect(screen.getAllByRole('textbox', { name: /Last name/i })).toHaveLength(2);
         expect(screen.getAllByRole('textbox', { name: /Last name/i })[0]).toHaveValue('First Author');
@@ -1574,10 +1570,9 @@ describe('DataCiteForm', () => {
                     {
                         type: 'institution',
                         institutionName: 'Research Lab',
-                        rorId: 'https://ror.org/03yrm5c26',
                         affiliations: [
-                            { value: 'Parent Org', rorId: null },
-                            { value: 'Parent Org', rorId: null },
+                            { value: 'Parent Org', rorId: 'https://ror.org/03yrm5c26' },
+                            { value: 'Another Org', rorId: null },
                         ],
                     },
                 ]}
@@ -1611,7 +1606,10 @@ describe('DataCiteForm', () => {
                 type: 'institution',
                 institutionName: 'Research Lab',
                 rorId: 'https://ror.org/03yrm5c26',
-                affiliations: [{ value: 'Parent Org', rorId: null }],
+                affiliations: [
+                    { value: 'Parent Org', rorId: 'https://ror.org/03yrm5c26' },
+                    { value: 'Another Org', rorId: null },
+                ],
                 position: 1,
             },
         ]);


### PR DESCRIPTION
This pull request refactors the way ROR IDs are handled for institution authors in the curation form. Instead of storing a separate `rorId` field for each institution author, the ROR ID is now derived from the first affiliated organization that has a ROR ID. This change simplifies the data model and improves consistency between affiliations and ROR IDs. The update also removes the ROR ID input field from the institution author UI and adapts related tests and type definitions accordingly.

**Institution Author ROR ID Refactor**

* Removed the `rorId` field from the `InstitutionAuthorEntry` type and from all code paths that previously set or used it, including creation, mapping, and serialization logic in `datacite-form.tsx` and `author-field.tsx`. The ROR ID is now extracted from the first affiliation tag with a `rorId` value. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L95) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L218-L221) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L598-R587) [[4]](diffhunk://#diff-94286373e70417ddf49bc2aec481c5ec80e3d651396bdaebb8f10da2755f7c0bL35)
* Removed the institution ROR ID input field from the author entry UI, including its props, handlers, and rendering logic in `author-field.tsx`. The institution author UI now only shows the institution name field. [[1]](diffhunk://#diff-94286373e70417ddf49bc2aec481c5ec80e3d651396bdaebb8f10da2755f7c0bL49) [[2]](diffhunk://#diff-94286373e70417ddf49bc2aec481c5ec80e3d651396bdaebb8f10da2755f7c0bL65) [[3]](diffhunk://#diff-94286373e70417ddf49bc2aec481c5ec80e3d651396bdaebb8f10da2755f7c0bL236-L254) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L465-L476) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L852-L854)

**Test Updates**

* Updated Vitest tests for the curation form to remove direct ROR ID input for institution authors and to verify that ROR IDs are correctly derived from affiliation tags. Adjusted test data and assertions to match the new data structure. [[1]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9L652-L655) [[2]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9L1577-R1575) [[3]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9L1614-R1612)

**Changelog Update**

* Updated the changelog entry for version 0.2.0 to reflect the new ROR ID handling and affiliation synchronization, including improved normalization and formatting of affiliation data.