### PR TITLE
Populate contributors from XML uploads

### DIFF
--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -187,6 +187,23 @@ export type InitialAuthor =
           rorId?: string | null;
       });
 
+type BaseInitialContributor = {
+    affiliations?: (InitialAffiliationInput | null | undefined)[] | null;
+    roles?: (string | null | undefined)[] | Record<string, unknown> | string | null;
+};
+
+export type InitialContributor =
+    | (BaseInitialContributor & {
+          type?: 'person';
+          orcid?: string | null;
+          firstName?: string | null;
+          lastName?: string | null;
+      })
+    | (BaseInitialContributor & {
+          type: 'institution';
+          institutionName?: string | null;
+      });
+
 const normaliseInitialAffiliations = (
     affiliations?: (InitialAffiliationInput | null | undefined)[] | null,
 ): AffiliationTag[] => {
@@ -230,6 +247,78 @@ const normaliseInitialAffiliations = (
             } satisfies AffiliationTag;
         })
         .filter((item): item is AffiliationTag => Boolean(item && item.value));
+};
+
+const normaliseInitialContributorRoles = (
+    roles: BaseInitialContributor['roles'],
+): ContributorRoleTag[] => {
+    if (!roles) {
+        return [];
+    }
+
+    const rawRoles = Array.isArray(roles)
+        ? roles
+        : typeof roles === 'string'
+          ? [roles]
+          : typeof roles === 'object'
+            ? Object.values(roles)
+            : [];
+
+    const unique = new Set<string>();
+
+    return rawRoles
+        .map((role) => (typeof role === 'string' ? role.trim() : ''))
+        .filter((role) => role.length > 0)
+        .filter((role) => {
+            if (unique.has(role)) {
+                return false;
+            }
+            unique.add(role);
+            return true;
+        })
+        .map((role) => ({ value: role }));
+};
+
+const mapInitialContributorToEntry = (
+    contributor: InitialContributor,
+): ContributorEntry | null => {
+    if (!contributor || typeof contributor !== 'object') {
+        return null;
+    }
+
+    const affiliations = normaliseInitialAffiliations(contributor.affiliations ?? null);
+    const affiliationsInput = affiliations.map((item) => item.value).join(', ');
+    const roles = normaliseInitialContributorRoles(contributor.roles ?? null);
+    const rolesInput = roles.map((role) => role.value).join(', ');
+
+    if (contributor.type === 'institution') {
+        const base = createEmptyInstitutionContributor();
+
+        return {
+            ...base,
+            institutionName:
+                typeof contributor.institutionName === 'string'
+                    ? contributor.institutionName.trim()
+                    : '',
+            affiliations,
+            affiliationsInput,
+            roles,
+            rolesInput,
+        } satisfies InstitutionContributorEntry;
+    }
+
+    const base = createEmptyPersonContributor();
+
+    return {
+        ...base,
+        orcid: typeof contributor.orcid === 'string' ? contributor.orcid.trim() : '',
+        firstName: typeof contributor.firstName === 'string' ? contributor.firstName.trim() : '',
+        lastName: typeof contributor.lastName === 'string' ? contributor.lastName.trim() : '',
+        affiliations,
+        affiliationsInput,
+        roles,
+        rolesInput,
+    } satisfies PersonContributorEntry;
 };
 
 const mapInitialAuthorToEntry = (author: InitialAuthor): AuthorEntry | null => {
@@ -288,6 +377,7 @@ interface DataCiteFormProps {
     initialLicenses?: string[];
     initialResourceId?: string;
     initialAuthors?: InitialAuthor[];
+    initialContributors?: InitialContributor[];
 }
 
 export function canAddTitle(titles: TitleEntry[], maxTitles: number) {
@@ -328,6 +418,7 @@ export default function DataCiteForm({
     initialLicenses = [],
     initialResourceId,
     initialAuthors = [],
+    initialContributors = [],
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
@@ -372,9 +463,19 @@ export default function DataCiteForm({
 
         return [createEmptyAuthor()];
     });
-    const [contributors, setContributors] = useState<ContributorEntry[]>([
-        createEmptyContributor(),
-    ]);
+    const [contributors, setContributors] = useState<ContributorEntry[]>(() => {
+        if (initialContributors.length > 0) {
+            const mapped = initialContributors
+                .map((contributor) => mapInitialContributorToEntry(contributor))
+                .filter((contributor): contributor is ContributorEntry => Boolean(contributor));
+
+            if (mapped.length > 0) {
+                return mapped;
+            }
+        }
+
+        return [createEmptyContributor()];
+    });
     const contributorPersonRoleNames = useMemo(
         () => contributorPersonRoles.map((role) => role.name),
         [contributorPersonRoles],

--- a/resources/js/pages/curation.tsx
+++ b/resources/js/pages/curation.tsx
@@ -1,5 +1,8 @@
 import AppLayout from '@/layouts/app-layout';
-import DataCiteForm, { type InitialAuthor } from '@/components/curation/datacite-form';
+import DataCiteForm, {
+    type InitialAuthor,
+    type InitialContributor,
+} from '@/components/curation/datacite-form';
 import { curation } from '@/routes';
 import { withBasePath } from '@/lib/base-path';
 import { Head } from '@inertiajs/react';
@@ -25,6 +28,7 @@ interface CurationProps {
     initialLicenses?: string[];
     resourceId?: string;
     authors?: InitialAuthor[];
+    contributors?: InitialContributor[];
 }
 
 export default function Curation({
@@ -39,6 +43,7 @@ export default function Curation({
     initialLicenses = [],
     resourceId,
     authors = [],
+    contributors = [],
 }: CurationProps) {
     const [resourceTypes, setResourceTypes] = useState<ResourceType[] | null>(null);
     const [titleTypes, setTitleTypes] = useState<TitleType[] | null>(null);
@@ -172,6 +177,7 @@ export default function Curation({
                             initialLicenses={initialLicenses}
                             initialResourceId={resourceId}
                             initialAuthors={authors}
+                            initialContributors={contributors}
                         />
                     )}
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'titles' => $request->query('titles', []),
             'initialLicenses' => $request->query('licenses', []),
             'authors' => $request->query('authors', []),
+            'contributors' => $request->query('contributors', []),
         ]);
     })->name('curation');
 

--- a/tests/pest/Feature/UploadXmlControllerTest.php
+++ b/tests/pest/Feature/UploadXmlControllerTest.php
@@ -32,6 +32,48 @@ XML;
     $response->assertJsonPath('resourceType', (string) $type->id);
 });
 
+test('extracts contributors from uploaded XML', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <contributors>
+    <contributor contributorType="ContactPerson">
+      <contributorName nameType="Personal">ExampleFamilyName, ExampleGivenName</contributorName>
+      <givenName>ExampleGivenName</givenName>
+      <familyName>ExampleFamilyName</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0001-5727-2427</nameIdentifier>
+      <affiliation affiliationIdentifier="https://ror.org/04wxnsj81" affiliationIdentifierScheme="ROR" schemeURI="https://ror.org">ExampleAffiliation</affiliation>
+    </contributor>
+    <contributor contributorType="Distributor">
+      <contributorName nameType="Organizational">ExampleOrganization</contributorName>
+      <nameIdentifier nameIdentifierScheme="ROR" schemeURI="https://ror.org">https://ror.org/03yrm5c26</nameIdentifier>
+    </contributor>
+  </contributors>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('contributors.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertJsonPath('contributors.0.type', 'person');
+    $response->assertJsonPath('contributors.0.roles', ['ContactPerson']);
+    $response->assertJsonPath('contributors.0.orcid', 'https://orcid.org/0000-0001-5727-2427');
+    $response->assertJsonPath('contributors.0.firstName', 'ExampleGivenName');
+    $response->assertJsonPath('contributors.0.lastName', 'ExampleFamilyName');
+    $response->assertJsonPath('contributors.0.affiliations.0.value', 'ExampleAffiliation');
+    $response->assertJsonPath('contributors.0.affiliations.0.rorId', 'https://ror.org/04wxnsj81');
+
+    $response->assertJsonPath('contributors.1.type', 'institution');
+    $response->assertJsonPath('contributors.1.roles', ['Distributor']);
+    $response->assertJsonPath('contributors.1.institutionName', 'ExampleOrganization');
+    $response->assertJsonPath('contributors.1.affiliations.0.value', 'ExampleOrganization');
+    $response->assertJsonPath('contributors.1.affiliations.0.rorId', 'https://ror.org/03yrm5c26');
+});
+
 test('uploading a non-xml file returns validation errors', function () {
     $this->actingAs(User::factory()->create());
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom/vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, afterAll, afterEach, describe, it, expect, vi } from 'vitest';
 import DataCiteForm, { canAddLicense, canAddTitle } from '@/components/curation/datacite-form';
@@ -1146,6 +1146,94 @@ describe('DataCiteForm', () => {
 
         expect(screen.getAllByText('GFZ Data Services').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Independent Collaboration').length).toBeGreaterThan(0);
+    });
+
+    it('prefills contributors when initialContributors are provided', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialContributors={[
+                    {
+                        type: 'person',
+                        roles: ['ContactPerson'],
+                        orcid: 'https://orcid.org/0000-0001-5727-2427',
+                        firstName: 'Ada',
+                        lastName: 'Lovelace',
+                        affiliations: [
+                            { value: 'Example Affiliation', rorId: 'https://ror.org/04wxnsj81' },
+                        ],
+                    },
+                    {
+                        type: 'institution',
+                        roles: ['Distributor'],
+                        institutionName: 'Example Org',
+                        affiliations: [
+                            { value: 'Example Org', rorId: 'https://ror.org/03yrm5c26' },
+                        ],
+                    },
+                ]}
+            />,
+        );
+
+        await ensureContributorsOpen(user);
+
+        const contributorRoleInput = screen.getByTestId(
+            'contributor-0-roles-input',
+        ) as HTMLInputElement;
+        expect(contributorRoleInput.value).toBe('ContactPerson');
+
+        const contributorSection = screen
+            .getByRole('heading', { name: 'Contributor 1' })
+            .closest('section') as HTMLElement;
+
+        const contributorOrcidField = within(
+            screen.getByTestId('contributor-0-orcid-field'),
+        ).getByRole('textbox') as HTMLInputElement;
+        expect(contributorOrcidField.value).toBe('https://orcid.org/0000-0001-5727-2427');
+
+        const contributorFirstNameField = within(contributorSection).getByLabelText('First name', {
+            selector: 'input',
+        }) as HTMLInputElement;
+        expect(contributorFirstNameField.value).toBe('Ada');
+
+        const contributorLastNameField = contributorSection.querySelector<HTMLInputElement>(
+            'input[id$="-lastName"]',
+        );
+        expect(contributorLastNameField).not.toBeNull();
+        expect(contributorLastNameField!.value).toBe('Lovelace');
+
+        const contributorAffiliationsInput = screen.getByTestId(
+            'contributor-0-affiliations-input',
+        ) as HTMLInputElement;
+        expect(contributorAffiliationsInput.value).toBe('Example Affiliation');
+        expect(screen.getByTestId('contributor-0-affiliations-ror-ids')).toBeInTheDocument();
+
+        const institutionSection = screen
+            .getByRole('heading', { name: 'Contributor 2' })
+            .closest('section') as HTMLElement;
+
+        const institutionRolesInput = screen.getByTestId('contributor-1-roles-input') as HTMLInputElement;
+        expect(institutionRolesInput.value).toBe('Distributor');
+
+        const institutionNameInput = institutionSection.querySelector<HTMLInputElement>(
+            'input[id$="-institution"]',
+        );
+        expect(institutionNameInput).not.toBeNull();
+        expect(institutionNameInput!.value).toBe('Example Org');
+
+        const institutionAffiliationsInput = institutionSection.querySelector<HTMLInputElement>(
+            'input[data-testid="contributor-1-affiliations-input"]',
+        );
+        expect(institutionAffiliationsInput.value).toBe('Example Org');
+        expect(screen.getByTestId('contributor-1-affiliations-ror-ids')).toBeInTheDocument();
     });
 
     it('disables add license when entries list is empty', () => {


### PR DESCRIPTION
## Summary
- extract contributor entries (including roles, names, ORCID, and affiliations) from uploaded XML and return them in the upload response
- hydrate the curation form with initial contributors and display them in the contributor section
- propagate contributor data through the dashboard XML handler and cover the new flow with unit tests

## Testing
- ./vendor/bin/pest --filter=UploadXmlControllerTest
- npx vitest run tests/vitest/components/curation/__tests__/datacite-form.test.tsx tests/vitest/pages/__tests__/dashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e48f5854cc832ea9425c184d482600