### PR TITLE
Expand contributors section by default on the curation form

### DIFF
--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -1033,7 +1033,7 @@ export default function DataCiteForm({
             )}
             <Accordion
                 type="multiple"
-                defaultValue={['resource-info', 'authors', 'licenses-rights']}
+                defaultValue={['resource-info', 'authors', 'licenses-rights', 'contributors']}
                 className="w-full"
             >
                 <AccordionItem value="resource-info">


### PR DESCRIPTION
## Summary
- expand the contributors accordion panel by default when the curation form loads so it matches the other sections
- update DataCite form tests to expect the contributors section to be open initially and to fill required contributor fields when submitting
- add helper utilities so author-specific assertions only inspect author inputs despite the contributor section being visible

## Testing
- npm run test -- --run tests/vitest/components/curation/__tests__/datacite-form.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4b119af9c832e9083b57741760c7e