### PR TITLE
Feature: Add Dates form group frontend

### DIFF
--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -43,6 +43,9 @@ import { SelectField } from './fields/select-field';
 import TitleField from './fields/title-field';
 import { resolveInitialLanguageCode } from './utils/language-resolver';
 
+// Constants
+const REQUIRED_DATE_TYPE = 'created' as const;
+
 interface DataCiteFormData {
     doi: string;
     year: string;
@@ -512,7 +515,7 @@ export default function DataCiteForm({
             description: 'The date or date range in which the resource content was collected. To indicate precise or particular timeframes in which research was conducted.'
         },
         { 
-            value: 'created', 
+            value: REQUIRED_DATE_TYPE, 
             label: 'Created',
             description: 'The date the resource itself was put together; this could refer to a timeframe in ancient history, a date range, or a single date for a final component. Recommended for discovery.'
         },
@@ -604,7 +607,7 @@ export default function DataCiteForm({
     });
     const [descriptions, setDescriptions] = useState<DescriptionEntry[]>([]);
     const [dates, setDates] = useState<DateEntry[]>([
-        { id: crypto.randomUUID(), date: '', dateType: 'created' },
+        { id: crypto.randomUUID(), date: '', dateType: REQUIRED_DATE_TYPE },
     ]);
     
     const contributorPersonRoleNames = useMemo(
@@ -691,7 +694,7 @@ export default function DataCiteForm({
             (desc) => desc.type === 'Abstract' && desc.value.trim() !== '',
         );
         const dateCreatedFilled = dates.some(
-            (date) => date.dateType === 'created' && date.date.trim() !== '',
+            (date) => date.dateType === REQUIRED_DATE_TYPE && date.date.trim() !== '',
         );
 
         return (

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -35,6 +35,7 @@ import ContributorField, {
     type InstitutionContributorEntry,
     type PersonContributorEntry,
 } from './fields/contributor-field';
+import DateField from './fields/date-field';
 import DescriptionField, { type DescriptionEntry } from './fields/description-field';
 import InputField from './fields/input-field';
 import LicenseField from './fields/license-field';
@@ -59,6 +60,12 @@ interface TitleEntry {
 interface LicenseEntry {
     id: string;
     license: string;
+}
+
+interface DateEntry {
+    id: string;
+    date: string;
+    dateType: string;
 }
 
 interface SerializedAffiliation {
@@ -449,6 +456,14 @@ export function canAddLicense(
     );
 }
 
+export function canAddDate(dates: DateEntry[], maxDates: number) {
+    return (
+        dates.length < maxDates &&
+        dates.length > 0 &&
+        !!dates[dates.length - 1].date
+    );
+}
+
 export default function DataCiteForm({
     resourceTypes,
     titleTypes,
@@ -472,6 +487,24 @@ export default function DataCiteForm({
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
+    const MAX_DATES = 12;
+    
+    // Available date types according to DataCite schema
+    const dateTypes = [
+        { value: 'accepted', label: 'Accepted' },
+        { value: 'available', label: 'Available' },
+        { value: 'copyrighted', label: 'Copyrighted' },
+        { value: 'collected', label: 'Collected' },
+        { value: 'coverage', label: 'Coverage' },
+        { value: 'created', label: 'Created' },
+        { value: 'issued', label: 'Issued' },
+        { value: 'submitted', label: 'Submitted' },
+        { value: 'updated', label: 'Updated' },
+        { value: 'valid', label: 'Valid' },
+        { value: 'withdrawn', label: 'Withdrawn' },
+        { value: 'other', label: 'Other' },
+    ];
+    
     const errorRef = useRef<HTMLDivElement | null>(null);
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
@@ -527,6 +560,10 @@ export default function DataCiteForm({
         return [createEmptyContributor()];
     });
     const [descriptions, setDescriptions] = useState<DescriptionEntry[]>([]);
+    const [dates, setDates] = useState<DateEntry[]>([
+        { id: crypto.randomUUID(), date: '', dateType: 'created' },
+    ]);
+    
     const contributorPersonRoleNames = useMemo(
         () => contributorPersonRoles.map((role) => role.name),
         [contributorPersonRoles],
@@ -610,6 +647,9 @@ export default function DataCiteForm({
         const abstractFilled = descriptions.some(
             (desc) => desc.type === 'Abstract' && desc.value.trim() !== '',
         );
+        const dateCreatedFilled = dates.some(
+            (date) => date.dateType === 'created' && date.date.trim() !== '',
+        );
 
         return (
             mainTitleFilled &&
@@ -618,9 +658,10 @@ export default function DataCiteForm({
             languageSelected &&
             primaryLicenseFilled &&
             authorsValid &&
-            abstractFilled
+            abstractFilled &&
+            dateCreatedFilled
         );
-    }, [authors, descriptions, form.language, form.resourceType, form.year, licenseEntries, titles]);
+    }, [authors, descriptions, dates, form.language, form.resourceType, form.year, licenseEntries, titles]);
 
     const handleChange = (field: keyof DataCiteFormData, value: string) => {
         setForm((prev) => ({ ...prev, [field]: value }));
@@ -908,6 +949,33 @@ export default function DataCiteForm({
         setLicenseEntries((prev) => prev.filter((_, i) => i !== index));
     };
 
+    const handleDateChange = (
+        index: number,
+        field: keyof Omit<DateEntry, 'id'>,
+        value: string,
+    ) => {
+        setDates((prev) => {
+            const next = [...prev];
+            next[index] = { ...next[index], [field]: value };
+            return next;
+        });
+    };
+
+    const addDate = () => {
+        if (dates.length >= MAX_DATES) return;
+        // Find the first unused date type or default to 'other'
+        const usedTypes = new Set(dates.map((d) => d.dateType));
+        const availableType = dateTypes.find((dt) => !usedTypes.has(dt.value))?.value ?? 'other';
+        setDates((prev) => [
+            ...prev,
+            { id: crypto.randomUUID(), date: '', dateType: availableType },
+        ]);
+    };
+
+    const removeDate = (index: number) => {
+        setDates((prev) => prev.filter((_, i) => i !== index));
+    };
+
     useEffect(() => {
         if (errorMessage && errorRef.current) {
             errorRef.current.focus();
@@ -1029,6 +1097,7 @@ export default function DataCiteForm({
             authors: SerializedAuthor[];
             contributors: SerializedContributor[];
             descriptions: { descriptionType: string; description: string }[];
+            dates: { date: string; dateType: string }[];
             resourceId?: number;
         } = {
             doi: form.doi?.trim() || null,
@@ -1050,6 +1119,12 @@ export default function DataCiteForm({
                 .map((desc) => ({
                     descriptionType: desc.type,
                     description: desc.value.trim(),
+                })),
+            dates: dates
+                .filter((date) => date.date.trim() !== '')
+                .map((date) => ({
+                    date: date.date.trim(),
+                    dateType: date.dateType,
                 })),
         };
 
@@ -1135,7 +1210,7 @@ export default function DataCiteForm({
             )}
             <Accordion
                 type="multiple"
-                defaultValue={['resource-info', 'authors', 'licenses-rights', 'contributors', 'descriptions']}
+                defaultValue={['resource-info', 'authors', 'licenses-rights', 'contributors', 'descriptions', 'dates']}
                 className="w-full"
             >
                 <AccordionItem value="resource-info">
@@ -1355,6 +1430,36 @@ export default function DataCiteForm({
                             descriptions={descriptions}
                             onChange={setDescriptions}
                         />
+                    </AccordionContent>
+                </AccordionItem>
+                <AccordionItem value="dates">
+                    <AccordionTrigger>Dates</AccordionTrigger>
+                    <AccordionContent>
+                        <div className="space-y-4">
+                            {dates.map((entry, index) => (
+                                <DateField
+                                    key={entry.id}
+                                    id={entry.id}
+                                    date={entry.date}
+                                    dateType={entry.dateType}
+                                    options={dateTypes.filter(
+                                        (dt) =>
+                                            dt.value === entry.dateType ||
+                                            !dates.some((d) => d.dateType === dt.value),
+                                    )}
+                                    onDateChange={(val) =>
+                                        handleDateChange(index, 'date', val)
+                                    }
+                                    onTypeChange={(val) =>
+                                        handleDateChange(index, 'dateType', val)
+                                    }
+                                    onAdd={addDate}
+                                    onRemove={() => removeDate(index)}
+                                    isFirst={index === 0}
+                                    canAdd={canAddDate(dates, MAX_DATES)}
+                                />
+                            ))}
+                        </div>
                     </AccordionContent>
                 </AccordionItem>
             </Accordion>

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -487,22 +487,65 @@ export default function DataCiteForm({
 }: DataCiteFormProps) {
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
-    const MAX_DATES = 12;
+    const MAX_DATES = 11;
     
-    // Available date types according to DataCite schema
+    // Available date types according to DataCite schema with descriptions
     const dateTypes = [
-        { value: 'accepted', label: 'Accepted' },
-        { value: 'available', label: 'Available' },
-        { value: 'copyrighted', label: 'Copyrighted' },
-        { value: 'collected', label: 'Collected' },
-        { value: 'coverage', label: 'Coverage' },
-        { value: 'created', label: 'Created' },
-        { value: 'issued', label: 'Issued' },
-        { value: 'submitted', label: 'Submitted' },
-        { value: 'updated', label: 'Updated' },
-        { value: 'valid', label: 'Valid' },
-        { value: 'withdrawn', label: 'Withdrawn' },
-        { value: 'other', label: 'Other' },
+        { 
+            value: 'accepted', 
+            label: 'Accepted',
+            description: 'The date that the publisher accepted the resource into their system. To indicate the start of an embargo period, use Accepted or Submitted.'
+        },
+        { 
+            value: 'available', 
+            label: 'Available',
+            description: 'The date the resource is made publicly available. May be a range. To indicate the end of an embargo period, use Available.'
+        },
+        { 
+            value: 'copyrighted', 
+            label: 'Copyrighted',
+            description: 'The specific, documented date at which the resource receives a copyrighted status, if applicable.'
+        },
+        { 
+            value: 'collected', 
+            label: 'Collected',
+            description: 'The date or date range in which the resource content was collected. To indicate precise or particular timeframes in which research was conducted.'
+        },
+        { 
+            value: 'created', 
+            label: 'Created',
+            description: 'The date the resource itself was put together; this could refer to a timeframe in ancient history, a date range, or a single date for a final component. Recommended for discovery.'
+        },
+        { 
+            value: 'issued', 
+            label: 'Issued',
+            description: 'The date that the resource is published or distributed, e.g., to a data centre.'
+        },
+        { 
+            value: 'submitted', 
+            label: 'Submitted',
+            description: 'The date the creator submits the resource to the publisher. This could be different from Accepted if the publisher then applies a selection process. Recommended for discovery. To indicate the start of an embargo period, use Submitted or Accepted.'
+        },
+        { 
+            value: 'updated', 
+            label: 'Updated',
+            description: 'The date of the last update to the resource, when the resource is being added to. May be a range.'
+        },
+        { 
+            value: 'valid', 
+            label: 'Valid',
+            description: 'The date or date range during which the dataset or resource is accurate.'
+        },
+        { 
+            value: 'withdrawn', 
+            label: 'Withdrawn',
+            description: 'The date the resource is removed. It is good practice to include a Description that indicates the reason for the retraction or withdrawal.'
+        },
+        { 
+            value: 'other', 
+            label: 'Other',
+            description: 'Other date that does not fit into an existing category.'
+        },
     ];
     
     const errorRef = useRef<HTMLDivElement | null>(null);
@@ -1436,29 +1479,33 @@ export default function DataCiteForm({
                     <AccordionTrigger>Dates</AccordionTrigger>
                     <AccordionContent>
                         <div className="space-y-4">
-                            {dates.map((entry, index) => (
-                                <DateField
-                                    key={entry.id}
-                                    id={entry.id}
-                                    date={entry.date}
-                                    dateType={entry.dateType}
-                                    options={dateTypes.filter(
-                                        (dt) =>
-                                            dt.value === entry.dateType ||
-                                            !dates.some((d) => d.dateType === dt.value),
-                                    )}
-                                    onDateChange={(val) =>
-                                        handleDateChange(index, 'date', val)
-                                    }
-                                    onTypeChange={(val) =>
-                                        handleDateChange(index, 'dateType', val)
-                                    }
-                                    onAdd={addDate}
-                                    onRemove={() => removeDate(index)}
-                                    isFirst={index === 0}
-                                    canAdd={canAddDate(dates, MAX_DATES)}
-                                />
-                            ))}
+                            {dates.map((entry, index) => {
+                                const selectedDateType = dateTypes.find(dt => dt.value === entry.dateType);
+                                return (
+                                    <DateField
+                                        key={entry.id}
+                                        id={entry.id}
+                                        date={entry.date}
+                                        dateType={entry.dateType}
+                                        dateTypeDescription={selectedDateType?.description}
+                                        options={dateTypes.filter(
+                                            (dt) =>
+                                                dt.value === entry.dateType ||
+                                                !dates.some((d) => d.dateType === dt.value),
+                                        )}
+                                        onDateChange={(val) =>
+                                            handleDateChange(index, 'date', val)
+                                        }
+                                        onTypeChange={(val) =>
+                                            handleDateChange(index, 'dateType', val)
+                                        }
+                                        onAdd={addDate}
+                                        onRemove={() => removeDate(index)}
+                                        isFirst={index === 0}
+                                        canAdd={canAddDate(dates, MAX_DATES)}
+                                    />
+                                );
+                            })}
                         </div>
                     </AccordionContent>
                 </AccordionItem>

--- a/resources/js/components/curation/fields/date-field.tsx
+++ b/resources/js/components/curation/fields/date-field.tsx
@@ -9,6 +9,7 @@ import { SelectField } from './select-field';
 interface Option {
     value: string;
     label: string;
+    description?: string;
 }
 
 interface DateFieldProps {
@@ -16,6 +17,7 @@ interface DateFieldProps {
     date: string;
     dateType: string;
     options: Option[];
+    dateTypeDescription?: string;
     onDateChange: (value: string) => void;
     onTypeChange: (value: string) => void;
     onAdd: () => void;
@@ -30,6 +32,7 @@ export function DateField({
     date,
     dateType,
     options,
+    dateTypeDescription,
     onDateChange,
     onTypeChange,
     onAdd,
@@ -50,16 +53,22 @@ export function DateField({
                 className="md:col-span-8"
                 required={dateType === 'created'}
             />
-            <SelectField
-                id={`${id}-dateType`}
-                label="Date Type"
-                value={dateType}
-                onValueChange={onTypeChange}
-                options={options}
-                hideLabel={!isFirst}
-                className="md:col-span-3"
-                required
-            />
+            <div className="md:col-span-3">
+                <SelectField
+                    id={`${id}-dateType`}
+                    label="Date Type"
+                    value={dateType}
+                    onValueChange={onTypeChange}
+                    options={options}
+                    hideLabel={!isFirst}
+                    required
+                />
+                {dateTypeDescription && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                        {dateTypeDescription}
+                    </p>
+                )}
+            </div>
             <div className="flex items-end md:col-span-1">
                 {isFirst ? (
                     <Button

--- a/resources/js/components/curation/fields/date-field.tsx
+++ b/resources/js/components/curation/fields/date-field.tsx
@@ -1,0 +1,91 @@
+import { Minus, Plus } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+import InputField from './input-field';
+import { SelectField } from './select-field';
+
+interface Option {
+    value: string;
+    label: string;
+}
+
+interface DateFieldProps {
+    id: string;
+    date: string;
+    dateType: string;
+    options: Option[];
+    onDateChange: (value: string) => void;
+    onTypeChange: (value: string) => void;
+    onAdd: () => void;
+    onRemove: () => void;
+    isFirst: boolean;
+    canAdd?: boolean;
+    className?: string;
+}
+
+export function DateField({
+    id,
+    date,
+    dateType,
+    options,
+    onDateChange,
+    onTypeChange,
+    onAdd,
+    onRemove,
+    isFirst,
+    canAdd = true,
+    className,
+}: DateFieldProps) {
+    return (
+        <div className={cn('grid gap-4 md:grid-cols-12', className)}>
+            <InputField
+                id={`${id}-date`}
+                label="Date"
+                type="date"
+                value={date}
+                onChange={(e) => onDateChange(e.target.value)}
+                hideLabel={!isFirst}
+                className="md:col-span-8"
+                required={dateType === 'created'}
+            />
+            <SelectField
+                id={`${id}-dateType`}
+                label="Date Type"
+                value={dateType}
+                onValueChange={onTypeChange}
+                options={options}
+                hideLabel={!isFirst}
+                className="md:col-span-3"
+                required
+            />
+            <div className="flex items-end md:col-span-1">
+                {isFirst ? (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        aria-label="Add date"
+                        onClick={onAdd}
+                        disabled={!canAdd}
+                    >
+                        <Plus className="h-4 w-4" />
+                    </Button>
+                ) : (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        aria-label="Remove date"
+                        onClick={onRemove}
+                    >
+                        <Minus className="h-4 w-4" />
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default DateField;

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -162,9 +162,7 @@ describe('DataCiteForm', () => {
     const originalFetch = global.fetch;
 
     // Constants
-    // 'created' is the required date type - it must be filled for form submission
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const REQUIRED_DATE_TYPE = 'created';
+    // The label for the required date type (Date Created must be filled for form submission)
     const REQUIRED_DATE_TYPE_LABEL = 'Created';
 
     // Helper Functions

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2478,5 +2478,40 @@ describe('DataCiteForm', () => {
 
         expect(requestBody.descriptions[0].description).toBe('Test abstract with spaces');
     });
-    });
-});
+
+    describe('Dates Form Group', () => {
+        it('renders the Dates accordion section', () => {
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                />,
+            );
+
+            const datesTrigger = screen.getByRole('button', { name: 'Dates' });
+            expect(datesTrigger).toBeInTheDocument();
+            expect(datesTrigger).toHaveAttribute('aria-expanded', 'true');
+        });
+
+        it('renders a single Date Created field by default', () => {
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                />,
+            );
+
+            const dateInputs = screen.getAllByLabelText(/^Date$/);
+            expect(dateInputs).toHaveLength(1);
+            expect(dateInputs[0]).toHaveAttribute('type', 'date');
+            

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -250,15 +250,25 @@ describe('DataCiteForm', () => {
 
     const fillRequiredDateCreated = async (
         user: ReturnType<typeof userEvent.setup>,
-        date = '20240115',
+        date = '2024-01-15',
     ) => {
         await ensureDatesOpen(user);
         const dateInputs = screen.getAllByDisplayValue('').filter(input => 
             input.getAttribute('type') === 'date'
         );
+        if (dateInputs.length === 0) {
+            throw new Error('No date inputs found in the form');
+        }
         const dateCreatedInput = dateInputs[0] as HTMLInputElement;
-        await user.click(dateCreatedInput);
-        await user.keyboard(date);
+        
+        // Use type() instead of keyboard() for date inputs with the correct format
+        await user.clear(dateCreatedInput);
+        await user.type(dateCreatedInput, date);
+        
+        // Wait for the value to be set
+        await waitFor(() => {
+            expect(dateCreatedInput.value).toBe(date);
+        });
     };
 
     beforeAll(() => {
@@ -555,6 +565,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user, 'Doe');
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
 
         await waitFor(() => {
             expect(saveButton).toBeEnabled();
@@ -1112,6 +1123,7 @@ describe('DataCiteForm', () => {
 
         await user.type(emailInput, 'contact@example.org');
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
 
         await waitFor(() => {
             expect(saveButton).toBeEnabled();
@@ -1865,6 +1877,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await user.click(saveButton);
 
         expect(global.fetch).toHaveBeenCalledWith('/curation/resources', expect.objectContaining({
@@ -1946,6 +1959,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await user.click(saveButton);
 
         expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -2024,6 +2038,7 @@ describe('DataCiteForm', () => {
         const saveButton = screen.getByRole('button', { name: /save to database/i });
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await user.click(saveButton);
 
         expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -2093,6 +2108,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await user.click(saveButton);
 
         expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -2126,6 +2142,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await user.click(saveButton);
 
         expect(global.fetch).not.toHaveBeenCalled();
@@ -2176,6 +2193,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await user.click(saveButton);
 
         expect(global.fetch).toHaveBeenCalledWith('/curation/resources', expect.any(Object));
@@ -2236,6 +2254,7 @@ describe('DataCiteForm', () => {
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
+        await fillRequiredDateCreated(user);
         await waitFor(() => expect(saveButton).toBeEnabled());
         await user.click(saveButton);
 
@@ -2316,6 +2335,7 @@ describe('DataCiteForm', () => {
 
         await fillRequiredAuthor(user);
         await fillRequiredContributor(user);
+        await fillRequiredDateCreated(user);
 
         // Fill Abstract
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });


### PR DESCRIPTION
This pull request adds support for managing multiple date fields in the DataCite curation form, including enforcing a required "created" date, updating form validation, and ensuring correct serialization and UI integration. It also introduces a new reusable `DateField` component and updates the test suite to cover the new date logic.

**Form enhancements: Dates support**
* Added a new `DateField` component for date entry, supporting multiple date types and descriptions, and integrated it into the DataCite form UI. [[1]](diffhunk://#diff-140edc6d2018e18e1e089011d9e3f3d4ae29146b098a10e394ca69abce7211b9R1-R100) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R38-R48) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R1481-R1514)
* Updated the form state and validation logic to require a "created" date and allow up to 11 date entries, with clear handling for adding/removing dates and selecting date types with contextual descriptions. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R68-R73) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R493-R553) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R609-R612) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R696-R698) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L621-R710) [[6]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R462-R469) [[7]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R998-R1024)

**Data serialization**
* Modified form submission to serialize date entries, filtering out empty dates and including both the date value and type in the payload. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R1146) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R1169-R1174)

**UI/UX improvements**
* Added a "Dates" accordion section to the form for managing date entries, improving user navigation and clarity.

**Testing updates**
* Refactored and extended the test suite to require the "created" date for form submission, added helpers for date input interaction, and updated all relevant tests to include the new date logic. [[1]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R164-R184) [[2]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R261-R288) [[3]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R583) [[4]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R1141) [[5]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R1895) [[6]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R1977) [[7]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R2056) [[8]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R2126)