### PR TITLE
Feature: Load Descriptions and Dates from XML uploads

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -83,6 +83,7 @@ class UploadXmlController extends Controller
         );
         $authors = $this->extractAuthors($reader);
         $contributors = $this->extractContributors($reader);
+        $descriptions = $this->extractDescriptions($reader);
 
         $rightsElements = $reader
             ->xpathElement('//*[local-name()="rightsList"]/*[local-name()="rights"]')
@@ -140,6 +141,7 @@ class UploadXmlController extends Controller
             'licenses' => $licenses,
             'authors' => $authors,
             'contributors' => $contributors,
+            'descriptions' => $descriptions,
         ]);
     }
 
@@ -302,6 +304,34 @@ class UploadXmlController extends Controller
         }
 
         return $contributors;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function extractDescriptions(XmlReader $reader): array
+    {
+        $descriptionElements = $reader
+            ->xpathElement('/*[local-name()="resource"]/*[local-name()="descriptions"]/*[local-name()="description"]')
+            ->get();
+
+        $descriptions = [];
+
+        foreach ($descriptionElements as $element) {
+            $descriptionType = $element->getAttribute('descriptionType');
+            $description = $element->getContent();
+
+            if (! is_string($description) || trim($description) === '') {
+                continue;
+            }
+
+            $descriptions[] = [
+                'type' => $descriptionType ?? 'Other',
+                'description' => $description,
+            ];
+        }
+
+        return $descriptions;
     }
 
     /**

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -87,6 +87,7 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
             licenses?: string[] | null;
             authors?: (UploadedAuthor | null | undefined)[] | null;
             contributors?: (UploadedContributor | null | undefined)[] | null;
+            descriptions?: { type: string; description: string }[] | null;
         } = await response.json();
         const query: Record<string, string | number> = {};
         if (data.doi) query.doi = data.doi;
@@ -250,6 +251,24 @@ export const handleXmlFiles = async (files: File[]): Promise<void> => {
                             rorId;
                     }
                 });
+            });
+        }
+        if (data.descriptions && data.descriptions.length > 0) {
+            data.descriptions.forEach((desc, i) => {
+                if (!desc || typeof desc !== 'object') {
+                    return;
+                }
+
+                const type = typeof desc.type === 'string' ? desc.type.trim() : '';
+                const description =
+                    typeof desc.description === 'string' ? desc.description.trim() : '';
+
+                if (!type || !description) {
+                    return;
+                }
+
+                query[`descriptions[${i}][type]`] = type;
+                query[`descriptions[${i}][description]`] = description;
             });
         }
         router.get(curationRoute({ query }).url);


### PR DESCRIPTION
This pull request adds support for extracting, returning, and handling descriptions from uploaded XML files throughout the backend, frontend, and test suites. The main changes include implementing backend extraction logic, updating the API response, extending frontend handling, and enhancing both feature and integration tests to cover the new descriptions functionality.

**Backend extraction and API changes:**
* Added a new `extractDescriptions` method in `UploadXmlController.php` to parse descriptions from XML files, filtering out empty values and returning type/content pairs. [[1]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R86) [[2]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R309-R336)
* Updated the API response in `UploadXmlController.php` to include a `descriptions` field containing extracted descriptions.

**Frontend handling:**
* Extended the `handleXmlFiles` function in `dashboard.tsx` to process the new `descriptions` field, mapping each description's type and content into the curation form's query parameters. [[1]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR90) [[2]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bR256-R273)

**Automated tests:**
* Added comprehensive feature tests in `UploadXmlControllerTest.php` to verify correct extraction, handling of missing/empty descriptions, and response formatting for various XML inputs.
* Enhanced Playwright integration tests in `xml-upload.spec.ts` to check for descriptions in the URL parameters after upload and verify that expected description types and values are present in the curation form. [[1]](diffhunk://#diff-7041571a8a21073796bdccc522af830bff3b15571630d7aec3c9113936cb109cR112-R115) [[2]](diffhunk://#diff-7041571a8a21073796bdccc522af830bff3b15571630d7aec3c9113936cb109cR244-R302)