### PR TITLE
Feature: API for GCMD Science Keywords

### DIFF
--- a/app/Console/Commands/GetGcmdScienceKeywords.php
+++ b/app/Console/Commands/GetGcmdScienceKeywords.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Support\GcmdScienceKeywordsParser;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+class GetGcmdScienceKeywords extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'get-gcmd-science-keywords';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fetch GCMD Science Keywords from NASA KMS API and save as hierarchical JSON';
+
+    /**
+     * The NASA KMS API endpoint for GCMD Science Keywords
+     *
+     * @var string
+     */
+    protected const NASA_KMS_URL = 'https://cmr.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords?format=rdf';
+
+    /**
+     * The output file path (relative to storage/app)
+     *
+     * @var string
+     */
+    protected const OUTPUT_FILE = 'gcmd-science-keywords.json';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('Fetching GCMD Science Keywords from NASA KMS API...');
+        $this->line('URL: ' . self::NASA_KMS_URL);
+
+        try {
+            $allConcepts = [];
+            $pageNum = 1;
+            $pageSize = 2000;
+            $totalHits = null;
+
+            // Fetch all pages
+            do {
+                $url = self::NASA_KMS_URL . "&page_num={$pageNum}&page_size={$pageSize}";
+                $this->info("Fetching page {$pageNum}...");
+
+                $response = Http::timeout(60)
+                    ->accept('application/rdf+xml')
+                    ->get($url);
+
+                if (!$response->successful()) {
+                    $this->error('Failed to fetch data from NASA KMS API');
+                    $this->error('Status: ' . $response->status());
+                    return Command::FAILURE;
+                }
+
+                $rdfContent = $response->body();
+                
+                // Parse metadata from first page
+                if ($pageNum === 1) {
+                    $totalHits = $this->extractTotalHits($rdfContent);
+                    $this->info("Total concepts to fetch: {$totalHits}");
+                }
+
+                // Parse concepts from this page
+                $concepts = $this->extractConcepts($rdfContent);
+                $allConcepts = array_merge($allConcepts, $concepts);
+                
+                $this->info("Fetched " . count($concepts) . " concepts (total: " . count($allConcepts) . ")");
+
+                $pageNum++;
+
+            } while (count($allConcepts) < $totalHits);
+
+            $this->info('Successfully fetched all RDF data');
+
+            // Build hierarchical structure
+            $this->info('Building hierarchical structure...');
+            $parser = new GcmdScienceKeywordsParser();
+            $hierarchicalData = $parser->buildHierarchy($allConcepts);
+
+            // Count total concepts
+            $totalConcepts = $this->countConcepts($hierarchicalData['data']);
+            $this->info("Built hierarchy with {$totalConcepts} concepts");
+
+            // Save as JSON
+            $this->info('Saving to ' . self::OUTPUT_FILE . '...');
+            $json = json_encode($hierarchicalData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            
+            Storage::put(self::OUTPUT_FILE, $json);
+            
+            $filePath = Storage::path(self::OUTPUT_FILE);
+            $fileSize = Storage::size(self::OUTPUT_FILE);
+            
+            $this->newLine();
+            $this->components->twoColumnDetail(
+                '<fg=green>✓</fg=green> Successfully saved GCMD Science Keywords',
+                ''
+            );
+            $this->components->twoColumnDetail('File', $filePath);
+            $this->components->twoColumnDetail('Size', number_format($fileSize) . ' bytes');
+            $this->components->twoColumnDetail('Last Updated', $hierarchicalData['lastUpdated']);
+            $this->components->twoColumnDetail('Total Concepts', number_format($totalConcepts));
+
+            return Command::SUCCESS;
+
+        } catch (\Exception $e) {
+            $this->error('Error: ' . $e->getMessage());
+            $this->error('Trace: ' . $e->getTraceAsString());
+            return Command::FAILURE;
+        }
+    }
+
+    /**
+     * Extract total hits from RDF content
+     */
+    private function extractTotalHits(string $rdfContent): int
+    {
+        $xml = new \SimpleXMLElement($rdfContent);
+        $xml->registerXPathNamespace('gcmd', 'https://gcmd.earthdata.nasa.gov/kms#');
+        
+        $hits = $xml->xpath('//gcmd:gcmd/gcmd:hits');
+        
+        return $hits ? (int) $hits[0] : 0;
+    }
+
+    /**
+     * Extract concepts from RDF content
+     */
+    private function extractConcepts(string $rdfContent): array
+    {
+        $xml = new \SimpleXMLElement($rdfContent);
+        $xml->registerXPathNamespace('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+        $xml->registerXPathNamespace('skos', 'http://www.w3.org/2004/02/skos/core#');
+        $xml->registerXPathNamespace('dcterms', 'http://purl.org/dc/terms/');
+
+        $conceptElements = $xml->xpath('//skos:Concept');
+        $concepts = [];
+
+        foreach ($conceptElements as $concept) {
+            $rdfNs = $concept->attributes('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+            $id = (string) ($rdfNs['about'] ?? '');
+            
+            // Convert UUID to full URL if necessary
+            if ($id && !str_starts_with($id, 'http')) {
+                $id = 'https://gcmd.earthdata.nasa.gov/kms/concept/' . $id;
+            }
+            
+            $skosNs = $concept->children('http://www.w3.org/2004/02/skos/core#');
+            $prefLabel = (string) ($skosNs->prefLabel ?? '');
+            $definition = (string) ($skosNs->definition ?? '');
+            
+            // Get language (default to 'en')
+            $language = 'en';
+            if ($skosNs->prefLabel) {
+                $langAttr = $skosNs->prefLabel->attributes('http://www.w3.org/XML/1998/namespace');
+                if ($langAttr && isset($langAttr['lang'])) {
+                    $language = (string) $langAttr['lang'];
+                }
+            }
+
+            // Get broader relationship
+            $broaderId = null;
+            if ($skosNs->broader) {
+                $broaderAttr = $skosNs->broader->attributes('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+                $broaderId = (string) ($broaderAttr['resource'] ?? '');
+                
+                // Convert UUID to full URL if necessary
+                if ($broaderId && !str_starts_with($broaderId, 'http')) {
+                    $broaderId = 'https://gcmd.earthdata.nasa.gov/kms/concept/' . $broaderId;
+                }
+            }
+
+            $concepts[] = [
+                'id' => $id,
+                'text' => $prefLabel,
+                'language' => $language,
+                'description' => $definition,
+                'broaderId' => $broaderId,
+            ];
+        }
+
+        return $concepts;
+    }
+
+    /**
+     * Recursively count all concepts in the hierarchy
+     */
+    private function countConcepts(array $data): int
+    {
+        $count = count($data);
+        
+        foreach ($data as $item) {
+            if (isset($item['children']) && is_array($item['children']) && count($item['children']) > 0) {
+                $count += $this->countConcepts($item['children']);
+            }
+        }
+        
+        return $count;
+    }
+}

--- a/app/Support/GcmdScienceKeywordsParser.php
+++ b/app/Support/GcmdScienceKeywordsParser.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Support;
+
+class GcmdScienceKeywordsParser
+{
+    /**
+     * Build hierarchical structure from flat concept array
+     */
+    public function buildHierarchy(array $concepts): array
+    {
+        $schemeURI = 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords';
+        $schemeTitle = 'NASA/GCMD Earth Science Keywords';
+
+        $conceptsById = [];
+        $childrenMap = [];
+
+        // First pass: index all concepts
+        foreach ($concepts as $concept) {
+            $id = $concept['id'];
+            
+            $conceptsById[$id] = [
+                'id' => $id,
+                'text' => $concept['text'],
+                'language' => $concept['language'],
+                'scheme' => $schemeTitle,
+                'schemeURI' => $schemeURI,
+                'description' => $concept['description'],
+                'children' => [],
+            ];
+
+            // Build parent-child mapping
+            if ($concept['broaderId']) {
+                $broaderId = $concept['broaderId'];
+                if (!isset($childrenMap[$broaderId])) {
+                    $childrenMap[$broaderId] = [];
+                }
+                $childrenMap[$broaderId][] = $id;
+            }
+        }
+
+        // Second pass: build hierarchy
+        foreach ($childrenMap as $parentId => $childIds) {
+            if (isset($conceptsById[$parentId])) {
+                foreach ($childIds as $childId) {
+                    if (isset($conceptsById[$childId])) {
+                        $conceptsById[$parentId]['children'][] = $conceptsById[$childId];
+                    }
+                }
+            }
+        }
+
+        // Find root concepts (concepts with no parent)
+        $rootConcepts = [];
+        foreach ($conceptsById as $id => $concept) {
+            $hasParent = false;
+            foreach ($childrenMap as $parentId => $childIds) {
+                if (in_array($id, $childIds)) {
+                    $hasParent = true;
+                    break;
+                }
+            }
+            if (!$hasParent) {
+                $rootConcepts[] = $concept;
+            }
+        }
+
+        return [
+            'lastUpdated' => now()->format('Y-m-d H:i:s'),
+            'data' => $rootConcepts,
+        ];
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Laravel console command to fetch and process GCMD Science Keywords from NASA's KMS API, along with a supporting parser for building a hierarchical JSON structure. The command handles data retrieval, parsing, and storage, while the parser organizes the flat list of concepts into a parent-child hierarchy.

**New command for fetching and processing GCMD Science Keywords:**

* Added `GetGcmdScienceKeywords` console command (`app/Console/Commands/GetGcmdScienceKeywords.php`) that fetches paginated RDF data from NASA KMS API, parses it, builds a hierarchical structure, and saves it as JSON in storage.

**Hierarchical data processing:**

* Added `GcmdScienceKeywordsParser` class (`app/Support/GcmdScienceKeywordsParser.php`) to convert the flat array of concepts into a hierarchical parent-child structure, including scheme metadata and last updated timestamp.

**Data extraction and transformation:**

* Implemented methods in the command for extracting total hits and concept details from RDF/XML, handling concept relationships, and counting concepts recursively for reporting.

**Storage and reporting enhancements:**

* The command outputs details such as file path, size, last updated timestamp, and total concept count after saving the hierarchical JSON file.