### PR TITLE
Fix: 419 error when saving editor settings

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
       - APP_DEBUG=false
       - SESSION_DRIVER=file
       - SESSION_LIFETIME=120
-      - SESSION_PATH=/
+      - SESSION_PATH=/ernie
       - SESSION_DOMAIN=.env.rz-vm182.gfz.de
       - SESSION_SECURE_COOKIE=true
       - SESSION_SAME_SITE=lax


### PR DESCRIPTION
This pull request makes a minor configuration adjustment to the session path for the production environment. The change updates the session path to be more specific.

* Changed the value of `SESSION_PATH` in `docker-compose.prod.yml` from `/` to `/ernie`, which will scope session cookies to the `/ernie` path.