### PR TITLE
Fix: Loading resource to editor not working

### DIFF
--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -6,6 +6,15 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
+/**
+ * @property int $id
+ * @property string|null $orcid
+ * @property string|null $first_name
+ * @property string|null $last_name
+ * @property \Illuminate\Support\Carbon|null $orcid_verified_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
 class Person extends Model
 {
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
@@ -17,7 +26,20 @@ class Person extends Model
         'orcid',
         'first_name',
         'last_name',
+        'orcid_verified_at',
     ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'orcid_verified_at' => 'datetime',
+        ];
+    }
 
     /** @return MorphMany<ResourceAuthor, static> */
     public function resourceAuthors(): MorphMany

--- a/database/migrations/2025_10_21_053751_add_orcid_verified_at_to_persons_table.php
+++ b/database/migrations/2025_10_21_053751_add_orcid_verified_at_to_persons_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('persons', function (Blueprint $table) {
+            $table->timestamp('orcid_verified_at')->nullable()->after('orcid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('persons', function (Blueprint $table) {
+            $table->dropColumn('orcid_verified_at');
+        });
+    }
+};

--- a/tests/Feature/EditorResourceLoadingTest.php
+++ b/tests/Feature/EditorResourceLoadingTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use App\Models\Resource;
+use App\Models\ResourceType;
+use App\Models\Language;
+use App\Models\Person;
+use App\Models\ResourceAuthor;
+use App\Models\Role;
+use App\Models\ResourceTitle;
+use App\Models\TitleType;
+use App\Models\License;
+use App\Models\ResourceDescription;
+use App\Models\ResourceDate;
+use App\Models\ResourceKeyword;
+use App\Models\ResourceCoverage;
+use App\Models\RelatedIdentifier;
+use App\Models\ResourceFundingReference;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+beforeEach(function () {
+    // Create a test user
+    $this->user = User::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => bcrypt('password'),
+        'email_verified_at' => now(),
+    ]);
+
+    // Create required related records
+    $resourceType = ResourceType::create([
+        'name' => 'Dataset',
+        'slug' => 'dataset',
+    ]);
+    
+    $language = Language::create([
+        'code' => 'en',
+        'name' => 'English',
+    ]);
+
+    // Create a test resource
+    $this->resource = Resource::create([
+        'doi' => '10.5880/TEST.LOAD.001',
+        'year' => 2025,
+        'version' => '1.0',
+        'resource_type_id' => $resourceType->id,
+        'language_id' => $language->id,
+    ]);
+});
+
+test('editor loads resource titles correctly', function () {
+    $titleType = TitleType::create(['name' => 'Title', 'slug' => 'title']);
+    $subtitleType = TitleType::create(['name' => 'Subtitle', 'slug' => 'subtitle']);
+    
+    ResourceTitle::create([
+        'resource_id' => $this->resource->id,
+        'title' => 'Main Title',
+        'title_type_id' => $titleType->id,
+    ]);
+    
+    ResourceTitle::create([
+        'resource_id' => $this->resource->id,
+        'title' => 'Subtitle Text',
+        'title_type_id' => $subtitleType->id,
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=' . $this->resource->id)
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->has('initialData.titles', 2)
+            ->where('initialData.titles.0.title', 'Main Title')
+            ->where('initialData.titles.0.titleType', 'title')
+        );
+});
+
+test('editor loads authors with deduplication', function () {
+    $person = Person::create([
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'orcid' => '0000-0001-2345-6789',
+        'orcid_verified_at' => now(),
+    ]);
+
+    $authorRole = Role::create(['name' => 'Author', 'slug' => 'author']);
+    $contactRole = Role::create(['name' => 'Contact Person', 'slug' => 'contact-person']);
+
+    // Create two ResourceAuthor entries for the same person (author + contact)
+    $author1 = ResourceAuthor::create([
+        'resource_id' => $this->resource->id,
+        'authorable_type' => Person::class,
+        'authorable_id' => $person->id,
+        'position' => 1,
+    ]);
+    $author1->roles()->attach($authorRole);
+
+    $author2 = ResourceAuthor::create([
+        'resource_id' => $this->resource->id,
+        'authorable_type' => Person::class,
+        'authorable_id' => $person->id,
+        'position' => 1,
+    ]);
+    $author2->roles()->attach($contactRole);
+
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=' . $this->resource->id)
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->has('initialData.authors', 1) // Should be deduplicated to 1
+            ->where('initialData.authors.0.firstName', 'John')
+            ->where('initialData.authors.0.lastName', 'Doe')
+            ->where('initialData.authors.0.orcid', '0000-0001-2345-6789')
+            ->where('initialData.authors.0.isContact', true)
+            ->where('initialData.authors.0.orcidVerified', true)
+        );
+});
+
+test('editor loads descriptions with type mapping', function () {
+    ResourceDescription::create([
+        'resource_id' => $this->resource->id,
+        'description_type' => 'abstract',
+        'description' => 'This is an abstract.',
+    ]);
+
+    ResourceDescription::create([
+        'resource_id' => $this->resource->id,
+        'description_type' => 'methods',
+        'description' => 'These are the methods.',
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=' . $this->resource->id)
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->has('initialData.descriptions', 2)
+            ->where('initialData.descriptions.0.type', 'Abstract') // PascalCase
+            ->where('initialData.descriptions.1.type', 'Methods') // PascalCase
+        );
+});
+
+test('editor excludes coverage dates from dates array', function () {
+    ResourceDate::create([
+        'resource_id' => $this->resource->id,
+        'date_type' => 'created',
+        'start_date' => '2025-10-01',
+    ]);
+
+    ResourceDate::create([
+        'resource_id' => $this->resource->id,
+        'date_type' => 'coverage', // Should be excluded
+        'start_date' => '2025-10-05',
+        'end_date' => '2025-10-10',
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=' . $this->resource->id)
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->has('initialData.dates', 1) // Only non-coverage dates
+            ->where('initialData.dates.0.dateType', 'created')
+            ->where('initialData.dates.0.startDate', '2025-10-01')
+        );
+});
+
+test('editor loads coverages with date formatting', function () {
+    ResourceCoverage::create([
+        'resource_id' => $this->resource->id,
+        'lat_min' => 48.173685,
+        'lon_min' => 11.403433,
+        'start_date' => '2025-10-13',
+        'end_date' => '2025-10-19',
+        'timezone' => 'Europe/Berlin',
+        'description' => 'Test coverage',
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=' . $this->resource->id)
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->has('initialData.coverages', 1)
+            ->where('initialData.coverages.0.latMin', '48.173685')
+            ->where('initialData.coverages.0.lonMin', '11.403433')
+            ->where('initialData.coverages.0.startDate', '2025-10-13')
+            ->where('initialData.coverages.0.endDate', '2025-10-19')
+        );
+});
+
+test('editor handles zero coordinates correctly', function () {
+    // Coordinates with 0 values (equator/prime meridian) should not become empty strings
+    ResourceCoverage::create([
+        'resource_id' => $this->resource->id,
+        'lat_min' => 0.0, // Equator
+        'lon_min' => 0.0, // Prime meridian
+        'timezone' => 'UTC',
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=' . $this->resource->id)
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->has('initialData.coverages', 1)
+            ->where('initialData.coverages.0.latMin', '0')
+            ->where('initialData.coverages.0.lonMin', '0')
+        );
+});
+
+test('editor without resource id shows empty form', function () {
+    $this->actingAs($this->user)
+        ->get(route('editor'))
+        ->assertInertia(fn(Assert $page) => $page
+            ->component('editor')
+            ->missing('initialData')
+        );
+});
+
+test('editor with invalid resource id returns 404', function () {
+    $this->actingAs($this->user)
+        ->get(route('editor') . '?resourceId=99999')
+        ->assertNotFound();
+});


### PR DESCRIPTION
This pull request introduces support for tracking and exposing the ORCID verification status for persons, and significantly enhances the data transformation logic for loading existing resources into the editor. The main changes include adding a new `orcid_verified_at` field to the `persons` table and model, updating model casts and documentation, and refactoring the editor route to provide richer, more structured data to the frontend, especially for authors, contributors, and related entities.

**Database and Model Enhancements:**

* Added a new nullable `orcid_verified_at` timestamp column to the `persons` table, along with an associated migration.
* Updated the `Person` model to include the `orcid_verified_at` property in its PHPDoc, fillable attributes, and to cast it as a `datetime` for proper date handling. [[1]](diffhunk://#diff-117ca03fc11c334ca17f453c605ed81090c6c7c0076e0264d84b294c42ef2864R9-R17) [[2]](diffhunk://#diff-117ca03fc11c334ca17f453c605ed81090c6c7c0076e0264d84b294c42ef2864R29-R43)

**Editor Route Data Transformation Improvements:**

* Refactored the `/editor` route to:
  - Load and transform resource data when a `resourceId` is provided, grouping author and contributor data by their underlying person or institution and exposing ORCID verification status where applicable.
  - Structure authors and contributors with detailed information, including affiliations, roles, and ORCID verification, and sort them by position.
  - Transform and format related resource fields such as titles, licenses, descriptions, dates, keywords, coverages, related works, funding references, and MSL laboratories for frontend consumption.