### PR TITLE
Fix: Wrong DOI resolution response title

### DIFF
--- a/app/Http/Controllers/DoiValidationController.php
+++ b/app/Http/Controllers/DoiValidationController.php
@@ -103,7 +103,7 @@ class DoiValidationController extends Controller
                     'success' => true,
                     'source' => 'doi.org',
                     'metadata' => [
-                        'title' => 'DOI registered (not in DataCite)',
+                        'title' => 'DOI registered',
                     ],
                 ]);
             }


### PR DESCRIPTION
This pull request makes a minor update to the DOI validation response message in the `DoiValidationController`. The change simplifies the title shown when a DOI is registered but not found in DataCite. 

- Changed the `title` in the JSON response metadata from `'DOI registered (not in DataCite)'` to `'DOI registered'` in the `checkDoiOrgResolution` method of `DoiValidationController.php`.