### PR TITLE
Chore: Bump Node to 24 and add coverage badge fallback for coverage badge workflow

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -104,11 +104,11 @@ jobs:
             elif [ $COVERAGE -ge 70 ]; then COLOR=yellow
             elif [ $COVERAGE -ge 50 ]; then COLOR=orange
             fi
-            npx --yes badge-maker "Vitest Coverage" "$COVERAGE%" ":$COLOR" > output/vitest-coverage.svg
+            npx --yes --package=badge-maker@5.0.2 badge-maker "Vitest Coverage" "$COVERAGE%" ":$COLOR" > output/vitest-coverage.svg
             echo "Badge created with color: $COLOR"
           else
             echo "Creating fallback badge (N/A)"
-            npx --yes badge-maker "Vitest Coverage" "N/A" ":lightgrey" > output/vitest-coverage.svg
+            npx --yes --package=badge-maker@5.0.2 badge-maker "Vitest Coverage" "N/A" ":lightgrey" > output/vitest-coverage.svg
           fi
 
       - name: Git push to image-data branch


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for generating the Vitest coverage badge. The main improvements include upgrading Node.js, making the badge creation more robust when coverage is missing, and ensuring consistent badge generation.

**Workflow robustness and badge generation:**

* The Node.js version used in the workflow is updated from 22 to 24 for improved compatibility and support.
* The coverage check step now emits a warning instead of failing when the coverage report is missing, and proceeds to create a fallback badge instead of exiting early.
* Badge creation logic is updated to always run, generating either a coverage badge (when data exists) or a fallback "N/A" badge (when coverage is missing), ensuring a badge is always produced. [[1]](diffhunk://#diff-71c81a3ced3a77a7f29bbbbffa02cec47b4d3d22702a917c1d9b399b36b484e1L78-R90) [[2]](diffhunk://#diff-71c81a3ced3a77a7f29bbbbffa02cec47b4d3d22702a917c1d9b399b36b484e1L107-R112)
* The badge generation now explicitly uses `badge-maker@5.0.2` to ensure consistent output and avoid issues with package resolution.