### PR TITLE
Feature: OAI-PMH harvesting support

### DIFF
--- a/app/Console/Commands/PurgeExpiredOaiPmhTokens.php
+++ b/app/Console/Commands/PurgeExpiredOaiPmhTokens.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\OaiPmh\OaiPmhResumptionTokenService;
+use Illuminate\Console\Command;
+
+/**
+ * Purge expired OAI-PMH resumption tokens.
+ */
+class PurgeExpiredOaiPmhTokens extends Command
+{
+    protected $signature = 'oaipmh:purge-tokens';
+
+    protected $description = 'Purge expired OAI-PMH resumption tokens';
+
+    public function handle(OaiPmhResumptionTokenService $tokenService): int
+    {
+        $count = $tokenService->purgeExpired();
+
+        $this->info("Purged {$count} expired OAI-PMH resumption token(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/OaiPmh/OaiPmhController.php
+++ b/app/Http/Controllers/OaiPmh/OaiPmhController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\OaiPmh;
+
+use App\Http\Controllers\Controller;
+use App\Services\OaiPmh\OaiPmhService;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * OAI-PMH 2.0 harvesting endpoint.
+ *
+ * Single endpoint handling all 6 OAI-PMH verbs via the `verb` query parameter.
+ * Supports both GET and POST as required by the OAI-PMH specification.
+ *
+ * @see http://www.openarchives.org/OAI/openarchivesprotocol.html
+ */
+class OaiPmhController extends Controller
+{
+    public function __invoke(Request $request, OaiPmhService $service): Response
+    {
+        $xml = $service->handleRequest($request);
+
+        return response($xml, 200, [
+            'Content-Type' => 'text/xml; charset=utf-8',
+        ]);
+    }
+}

--- a/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
+++ b/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
@@ -39,6 +39,8 @@ class OaiPmhDocsController extends Controller
             'metadataFormats' => config('oaipmh.metadata_formats'),
             'resourceTypeSlugs' => $resourceTypeSlugs,
             'identifierPrefix' => config('oaipmh.identifier_prefix'),
+            'pageSize' => (int) config('oaipmh.page_size', 100),
+            'tokenTtlHours' => (int) round((int) config('oaipmh.resumption_token_ttl', 86400) / 3600),
         ]);
     }
 }

--- a/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
+++ b/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\OaiPmh;
+
+use App\Http\Controllers\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Serves the OAI-PMH harvester documentation page.
+ */
+class OaiPmhDocsController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('oai-pmh/docs', [
+            'baseUrl' => config('oaipmh.base_url'),
+            'adminEmail' => config('oaipmh.admin_email'),
+            'metadataFormats' => config('oaipmh.metadata_formats'),
+        ]);
+    }
+}

--- a/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
+++ b/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\OaiPmh;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -15,10 +16,16 @@ class OaiPmhDocsController extends Controller
 {
     public function index(): Response
     {
+        $resourceTypeSlugs = DB::table('resource_types')
+            ->orderBy('name')
+            ->pluck('slug')
+            ->all();
+
         return Inertia::render('oai-pmh/docs', [
             'baseUrl' => config('oaipmh.base_url'),
             'adminEmail' => config('oaipmh.admin_email'),
             'metadataFormats' => config('oaipmh.metadata_formats'),
+            'resourceTypeSlugs' => $resourceTypeSlugs,
         ]);
     }
 }

--- a/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
+++ b/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
@@ -26,6 +26,7 @@ class OaiPmhDocsController extends Controller
             'adminEmail' => config('oaipmh.admin_email'),
             'metadataFormats' => config('oaipmh.metadata_formats'),
             'resourceTypeSlugs' => $resourceTypeSlugs,
+            'identifierPrefix' => config('oaipmh.identifier_prefix'),
         ]);
     }
 }

--- a/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
+++ b/app/Http/Controllers/OaiPmh/OaiPmhDocsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\OaiPmh;
 
 use App\Http\Controllers\Controller;
+use App\Services\OaiPmh\OaiPmhSetService;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -14,12 +15,23 @@ use Inertia\Response;
  */
 class OaiPmhDocsController extends Controller
 {
-    public function index(): Response
+    public function index(OaiPmhSetService $setService): Response
     {
-        $resourceTypeSlugs = DB::table('resource_types')
-            ->orderBy('name')
-            ->pluck('slug')
+        $activeSets = $setService->listSets();
+
+        $resourceTypeSlugs = collect($activeSets)
+            ->filter(fn (array $set) => str_starts_with($set['spec'], 'resourcetype:'))
+            ->map(fn (array $set) => substr($set['spec'], strlen('resourcetype:')))
+            ->values()
             ->all();
+
+        // Fall back to all resource types when no published sets exist yet
+        if ($resourceTypeSlugs === []) {
+            $resourceTypeSlugs = DB::table('resource_types')
+                ->orderBy('name')
+                ->pluck('slug')
+                ->all();
+        }
 
         return Inertia::render('oai-pmh/docs', [
             'baseUrl' => config('oaipmh.base_url'),

--- a/app/Models/OaiPmhDeletedRecord.php
+++ b/app/Models/OaiPmhDeletedRecord.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Tracks deleted/depublished records for OAI-PMH persistent deletion support.
+ *
+ * When a published resource is deleted or its landing page is depublished,
+ * a record is created here so that OAI-PMH harvesters are informed via
+ * the status="deleted" header attribute.
+ *
+ * @property int $id
+ * @property string $oai_identifier OAI identifier (e.g., "oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001")
+ * @property string $doi Original DOI of the deleted resource
+ * @property \Illuminate\Support\Carbon $datestamp When the record was deleted/depublished
+ * @property array<int, string>|null $sets OAI sets the record belonged to
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class OaiPmhDeletedRecord extends Model
+{
+    /** @var list<string> */
+    protected $fillable = [
+        'oai_identifier',
+        'doi',
+        'datestamp',
+        'sets',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'datestamp' => 'datetime',
+            'sets' => 'array',
+        ];
+    }
+}

--- a/app/Models/OaiPmhResumptionToken.php
+++ b/app/Models/OaiPmhResumptionToken.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * OAI-PMH resumption token for cursor-based pagination.
+ *
+ * Tokens are generated when list responses exceed the configured page size.
+ * They store the query state to resume from where the previous response ended.
+ *
+ * @property int $id
+ * @property string $token Random 64-character token string
+ * @property string $verb OAI-PMH verb (ListRecords, ListIdentifiers, ListSets)
+ * @property string|null $metadata_prefix Metadata format prefix
+ * @property string|null $set_spec Set filter specification
+ * @property \Illuminate\Support\Carbon|null $from_date Date range start
+ * @property \Illuminate\Support\Carbon|null $until_date Date range end
+ * @property int $cursor Current offset position
+ * @property int $complete_list_size Total result count
+ * @property \Illuminate\Support\Carbon $expires_at Token expiration timestamp
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class OaiPmhResumptionToken extends Model
+{
+    protected $table = 'oai_pmh_resumption_tokens';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'token',
+        'verb',
+        'metadata_prefix',
+        'set_spec',
+        'from_date',
+        'until_date',
+        'cursor',
+        'complete_list_size',
+        'expires_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'from_date' => 'datetime',
+            'until_date' => 'datetime',
+            'expires_at' => 'datetime',
+            'cursor' => 'integer',
+            'complete_list_size' => 'integer',
+        ];
+    }
+}

--- a/app/Models/OaiPmhResumptionToken.php
+++ b/app/Models/OaiPmhResumptionToken.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @property int $id
  * @property string $token Random 64-character token string
- * @property string $verb OAI-PMH verb (ListRecords, ListIdentifiers, ListSets)
+ * @property string $verb OAI-PMH verb (ListRecords, ListIdentifiers)
  * @property string|null $metadata_prefix Metadata format prefix
  * @property string|null $set_spec Set filter specification
  * @property \Illuminate\Support\Carbon|null $from_date Date range start

--- a/app/Observers/LandingPageObserver.php
+++ b/app/Observers/LandingPageObserver.php
@@ -43,7 +43,7 @@ class LandingPageObserver
             $resource->loadMissing('resourceType');
             $sets = $this->oaiPmhSetService->getSetsForResource($resource);
 
-            OaiPmhDeletedRecord::firstOrCreate(
+            OaiPmhDeletedRecord::updateOrCreate(
                 ['oai_identifier' => $oaiIdentifier],
                 [
                     'doi' => $resource->doi,

--- a/app/Observers/LandingPageObserver.php
+++ b/app/Observers/LandingPageObserver.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\LandingPage;
+use App\Models\OaiPmhDeletedRecord;
+use App\Services\OaiPmh\OaiPmhSetService;
+
+/**
+ * Observer for LandingPage model to track publish/depublish events
+ * for OAI-PMH persistent deleted records support.
+ */
+class LandingPageObserver
+{
+    public function __construct(
+        private readonly OaiPmhSetService $oaiPmhSetService,
+    ) {}
+
+    /**
+     * Handle the LandingPage "updated" event.
+     *
+     * Tracks depublishing (is_published: true → false) as a deletion in OAI-PMH.
+     * Tracks republishing (is_published: false → true) by removing the deletion record.
+     */
+    public function updated(LandingPage $landingPage): void
+    {
+        if (! $landingPage->wasChanged('is_published')) {
+            return;
+        }
+
+        $resource = $landingPage->resource;
+
+        if ($resource->doi === null || $resource->doi === '') {
+            return;
+        }
+
+        $oaiIdentifier = config('oaipmh.identifier_prefix') . ':' . $resource->doi;
+
+        if (! $landingPage->is_published) {
+            // Depublished → track as deleted in OAI-PMH
+            if (! OaiPmhDeletedRecord::where('oai_identifier', $oaiIdentifier)->exists()) {
+                $resource->loadMissing('resourceType');
+                $sets = $this->oaiPmhSetService->getSetsForResource($resource);
+
+                OaiPmhDeletedRecord::create([
+                    'oai_identifier' => $oaiIdentifier,
+                    'doi' => $resource->doi,
+                    'datestamp' => now(),
+                    'sets' => $sets,
+                ]);
+            }
+        } else {
+            // Republished → remove from deleted records
+            OaiPmhDeletedRecord::where('oai_identifier', $oaiIdentifier)->delete();
+        }
+    }
+}

--- a/app/Observers/LandingPageObserver.php
+++ b/app/Observers/LandingPageObserver.php
@@ -39,18 +39,18 @@ class LandingPageObserver
         $oaiIdentifier = config('oaipmh.identifier_prefix') . ':' . $resource->doi;
 
         if (! $landingPage->is_published) {
-            // Depublished → track as deleted in OAI-PMH
-            if (! OaiPmhDeletedRecord::where('oai_identifier', $oaiIdentifier)->exists()) {
-                $resource->loadMissing('resourceType');
-                $sets = $this->oaiPmhSetService->getSetsForResource($resource);
+            // Depublished → track as deleted in OAI-PMH (concurrency-safe)
+            $resource->loadMissing('resourceType');
+            $sets = $this->oaiPmhSetService->getSetsForResource($resource);
 
-                OaiPmhDeletedRecord::create([
-                    'oai_identifier' => $oaiIdentifier,
+            OaiPmhDeletedRecord::firstOrCreate(
+                ['oai_identifier' => $oaiIdentifier],
+                [
                     'doi' => $resource->doi,
                     'datestamp' => now(),
                     'sets' => $sets,
-                ]);
-            }
+                ],
+            );
         } else {
             // Republished → remove from deleted records
             OaiPmhDeletedRecord::where('oai_identifier', $oaiIdentifier)->delete();

--- a/app/Observers/ResourceObserver.php
+++ b/app/Observers/ResourceObserver.php
@@ -229,7 +229,7 @@ class ResourceObserver
         $oaiIdentifier = config('oaipmh.identifier_prefix') . ':' . $resource->doi;
         $sets = $this->oaiPmhSetService->getSetsForResource($resource);
 
-        OaiPmhDeletedRecord::firstOrCreate(
+        OaiPmhDeletedRecord::updateOrCreate(
             ['oai_identifier' => $oaiIdentifier],
             [
                 'doi' => $resource->doi,

--- a/app/Observers/ResourceObserver.php
+++ b/app/Observers/ResourceObserver.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Observers;
 
+use App\Models\OaiPmhDeletedRecord;
 use App\Models\Resource;
 use App\Services\KeywordSuggestionService;
+use App\Services\OaiPmh\OaiPmhSetService;
 use App\Services\ResourceCacheService;
 use App\Support\Traits\ChecksCacheTagging;
 use Illuminate\Support\Facades\Cache;
@@ -25,6 +27,7 @@ class ResourceObserver
     public function __construct(
         private readonly ResourceCacheService $cacheService,
         private readonly KeywordSuggestionService $keywordService,
+        private readonly OaiPmhSetService $oaiPmhSetService,
     ) {}
 
     /**
@@ -173,13 +176,15 @@ class ResourceObserver
      * Handle the Resource "deleted" event.
      *
      * Invalidates all resource caches since the resource
-     * will be removed from list views.
+     * will be removed from list views. Also tracks the deletion
+     * for OAI-PMH persistent deleted records support.
      */
     public function deleted(Resource $resource): void
     {
         $this->cacheService->invalidateAllResourceCaches();
         $this->keywordService->invalidateCache();
         $this->invalidatePortalFacets();
+        $this->trackOaiPmhDeletion($resource);
     }
 
     /**
@@ -193,6 +198,36 @@ class ResourceObserver
         $this->cacheService->invalidateAllResourceCaches();
         $this->keywordService->invalidateCache();
         $this->invalidatePortalFacets();
+    }
+
+    /**
+     * Track a resource deletion in OAI-PMH deleted records.
+     *
+     * Only tracks resources that had a DOI (harvestable resources).
+     * The resource's relationships may already be deleted by cascade,
+     * so we load the resource type eagerly before deletion if possible.
+     */
+    private function trackOaiPmhDeletion(Resource $resource): void
+    {
+        if ($resource->doi === null || $resource->doi === '') {
+            return;
+        }
+
+        $oaiIdentifier = config('oaipmh.identifier_prefix') . ':' . $resource->doi;
+
+        // Don't create duplicate entries
+        if (OaiPmhDeletedRecord::where('oai_identifier', $oaiIdentifier)->exists()) {
+            return;
+        }
+
+        $sets = $this->oaiPmhSetService->getSetsForResource($resource);
+
+        OaiPmhDeletedRecord::create([
+            'oai_identifier' => $oaiIdentifier,
+            'doi' => $resource->doi,
+            'datestamp' => now(),
+            'sets' => $sets,
+        ]);
     }
 
     /**

--- a/app/Observers/ResourceObserver.php
+++ b/app/Observers/ResourceObserver.php
@@ -214,20 +214,16 @@ class ResourceObserver
         }
 
         $oaiIdentifier = config('oaipmh.identifier_prefix') . ':' . $resource->doi;
-
-        // Don't create duplicate entries
-        if (OaiPmhDeletedRecord::where('oai_identifier', $oaiIdentifier)->exists()) {
-            return;
-        }
-
         $sets = $this->oaiPmhSetService->getSetsForResource($resource);
 
-        OaiPmhDeletedRecord::create([
-            'oai_identifier' => $oaiIdentifier,
-            'doi' => $resource->doi,
-            'datestamp' => now(),
-            'sets' => $sets,
-        ]);
+        OaiPmhDeletedRecord::firstOrCreate(
+            ['oai_identifier' => $oaiIdentifier],
+            [
+                'doi' => $resource->doi,
+                'datestamp' => now(),
+                'sets' => $sets,
+            ],
+        );
     }
 
     /**

--- a/app/Observers/ResourceObserver.php
+++ b/app/Observers/ResourceObserver.php
@@ -173,6 +173,19 @@ class ResourceObserver
     }
 
     /**
+     * Handle the Resource "deleting" event.
+     *
+     * Eagerly loads relationships needed for OAI-PMH deletion tracking
+     * before database cascades remove related records.
+     */
+    public function deleting(Resource $resource): void
+    {
+        if ($resource->doi !== null && $resource->doi !== '') {
+            $resource->loadMissing('resourceType');
+        }
+    }
+
+    /**
      * Handle the Resource "deleted" event.
      *
      * Invalidates all resource caches since the resource
@@ -204,8 +217,8 @@ class ResourceObserver
      * Track a resource deletion in OAI-PMH deleted records.
      *
      * Only tracks resources that had a DOI (harvestable resources).
-     * The resource's relationships may already be deleted by cascade,
-     * so we load the resource type eagerly before deletion if possible.
+     * The resource type relationship is eagerly loaded in the `deleting`
+     * observer to ensure it is available after cascade deletes.
      */
     private function trackOaiPmhDeletion(Resource $resource): void
     {

--- a/app/Observers/ResourceObserver.php
+++ b/app/Observers/ResourceObserver.php
@@ -181,7 +181,7 @@ class ResourceObserver
     public function deleting(Resource $resource): void
     {
         if ($resource->doi !== null && $resource->doi !== '') {
-            $resource->loadMissing('resourceType');
+            $resource->loadMissing(['resourceType', 'landingPage']);
         }
     }
 
@@ -223,6 +223,12 @@ class ResourceObserver
     private function trackOaiPmhDeletion(Resource $resource): void
     {
         if ($resource->doi === null || $resource->doi === '') {
+            return;
+        }
+
+        // Only track deletion for resources that were previously published
+        // to avoid leaking draft DOIs via OAI-PMH deleted headers
+        if ($resource->landingPage === null || ! $resource->landingPage->is_published) {
             return;
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -82,6 +82,12 @@ class AppServiceProvider extends ServiceProvider
 
             return Limit::perMinute(60)->by((string) $identifier);
         });
+
+        // Rate limiter for OAI-PMH harvesting endpoint
+        // Allows 120 requests per minute per IP (harvester-friendly but prevents abuse)
+        RateLimiter::for('oai-pmh', function (Request $request) {
+            return Limit::perMinute(120)->by((string) $request->ip());
+        });
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,8 +9,10 @@ use App\Jobs\DiscoverRelationsJob;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Jobs\UpdatePidJob;
 use App\Jobs\UpdateThesaurusJob;
+use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\User;
+use App\Observers\LandingPageObserver;
 use App\Observers\ResourceObserver;
 use App\Services\DataCiteRegistrationService;
 use App\Services\DataCiteServiceInterface;
@@ -44,7 +46,7 @@ class AppServiceProvider extends ServiceProvider
     {
         // Register model observers
         Resource::observe(ResourceObserver::class);
-        \App\Models\LandingPage::observe(\App\Observers\LandingPageObserver::class);
+        LandingPage::observe(LandingPageObserver::class);
 
         // Configure rate limiters
         $this->configureRateLimiting();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -44,6 +44,7 @@ class AppServiceProvider extends ServiceProvider
     {
         // Register model observers
         Resource::observe(ResourceObserver::class);
+        \App\Models\LandingPage::observe(\App\Observers\LandingPageObserver::class);
 
         // Configure rate limiters
         $this->configureRateLimiting();

--- a/app/Services/OaiPmh/DublinCoreMapper.php
+++ b/app/Services/OaiPmh/DublinCoreMapper.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\OaiPmh;
+
+use App\Models\Resource;
+
+/**
+ * Maps a Resource model to Dublin Core (DC) elements for OAI-PMH oai_dc format.
+ *
+ * @see http://www.openarchives.org/OAI/2.0/oai_dc.xsd
+ * @see http://purl.org/dc/elements/1.1/
+ */
+class DublinCoreMapper
+{
+    /**
+     * Map a Resource to an associative array of DC elements.
+     *
+     * @return array<string, list<string>>
+     */
+    public function map(Resource $resource): array
+    {
+        /** @var array<string, list<string>> $dc */
+        $dc = [];
+
+        // dc:title
+        $titles = $resource->titles->pluck('value')->filter()->values()->all();
+        if ($titles !== []) {
+            $dc['title'] = $titles;
+        }
+
+        // dc:creator
+        $creators = $resource->creators
+            ->map(fn ($creator) => $this->formatCreatorName($creator))
+            ->filter()
+            ->values()
+            ->all();
+        if ($creators !== []) {
+            $dc['creator'] = $creators;
+        }
+
+        // dc:subject
+        $subjects = $resource->subjects->pluck('value')->filter()->values()->all();
+        if ($subjects !== []) {
+            $dc['subject'] = $subjects;
+        }
+
+        // dc:description (prefer Abstract type)
+        $descriptions = $resource->descriptions
+            ->sortByDesc(fn ($d) => $d->descriptionType->slug === 'Abstract' ? 1 : 0)
+            ->pluck('description')
+            ->filter()
+            ->values()
+            ->all();
+        if ($descriptions !== []) {
+            $dc['description'] = $descriptions;
+        }
+
+        // dc:publisher
+        $publisherName = $resource->publisher?->name;
+        if ($publisherName !== null && $publisherName !== '') {
+            $dc['publisher'] = [$publisherName];
+        }
+
+        // dc:contributor
+        $contributors = $resource->contributors
+            ->map(fn ($contributor) => $this->formatCreatorName($contributor))
+            ->filter()
+            ->values()
+            ->all();
+        if ($contributors !== []) {
+            $dc['contributor'] = $contributors;
+        }
+
+        // dc:date (publication year in W3CDTF)
+        if ($resource->publication_year !== null) {
+            $dc['date'] = [(string) $resource->publication_year];
+        }
+
+        // dc:type
+        $typeName = $resource->resourceType?->name;
+        if ($typeName !== null && $typeName !== '') {
+            $dc['type'] = [$typeName];
+        }
+
+        // dc:format
+        $formats = $resource->formats->pluck('value')->filter()->values()->all();
+        if ($formats !== []) {
+            $dc['format'] = $formats;
+        }
+
+        // dc:identifier (DOI as URL)
+        if ($resource->doi !== null && $resource->doi !== '') {
+            $dc['identifier'] = ["https://doi.org/{$resource->doi}"];
+        }
+
+        // dc:language
+        $langCode = $resource->language?->code;
+        if ($langCode !== null && $langCode !== '') {
+            $dc['language'] = [$langCode];
+        }
+
+        // dc:relation (related identifiers as URLs where possible)
+        $relations = $resource->relatedIdentifiers
+            ->map(fn ($ri) => $ri->identifier)
+            ->filter()
+            ->values()
+            ->all();
+        if ($relations !== []) {
+            $dc['relation'] = $relations;
+        }
+
+        // dc:coverage (geo locations as text)
+        $coverages = $resource->geoLocations
+            ->map(fn ($geo) => $this->formatGeoLocation($geo))
+            ->filter()
+            ->values()
+            ->all();
+        if ($coverages !== []) {
+            $dc['coverage'] = $coverages;
+        }
+
+        // dc:rights
+        $rights = $resource->rights
+            ->map(fn ($r) => $r->uri !== null && $r->uri !== '' ? "{$r->name} ({$r->uri})" : $r->name)
+            ->filter()
+            ->values()
+            ->all();
+        if ($rights !== []) {
+            $dc['rights'] = $rights;
+        }
+
+        /** @var array<string, list<string>> $dc */
+        return $dc;
+    }
+
+    /**
+     * Format a creator/contributor name from the polymorphic relation.
+     */
+    private function formatCreatorName(mixed $author): ?string
+    {
+        $entity = $author->creatorable ?? $author->contributorable ?? null;
+
+        if ($entity === null) {
+            return null;
+        }
+
+        // Person: "LastName, FirstName"
+        if ($entity instanceof \App\Models\Person) {
+            $parts = array_filter([$entity->family_name, $entity->given_name]);
+
+            return $parts !== [] ? implode(', ', $parts) : null;
+        }
+
+        // Institution: name
+        if ($entity instanceof \App\Models\Institution) {
+            return $entity->name !== '' ? $entity->name : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Format a GeoLocation as a human-readable coverage string.
+     */
+    private function formatGeoLocation(mixed $geo): ?string
+    {
+        $parts = [];
+
+        if ($geo->place !== null && $geo->place !== '') {
+            $parts[] = $geo->place;
+        }
+
+        if ($geo->point_latitude !== null && $geo->point_longitude !== null) {
+            $parts[] = "Point({$geo->point_latitude}, {$geo->point_longitude})";
+        }
+
+        if ($geo->box_south !== null && $geo->box_west !== null
+            && $geo->box_north !== null && $geo->box_east !== null) {
+            $parts[] = "Box({$geo->box_south}, {$geo->box_west}, {$geo->box_north}, {$geo->box_east})";
+        }
+
+        return $parts !== [] ? implode('; ', $parts) : null;
+    }
+}

--- a/app/Services/OaiPmh/DublinCoreMapper.php
+++ b/app/Services/OaiPmh/DublinCoreMapper.php
@@ -49,7 +49,7 @@ class DublinCoreMapper
         // dc:description (prefer Abstract type)
         $descriptions = $resource->descriptions
             ->sortByDesc(fn ($d) => $d->descriptionType->slug === 'Abstract' ? 1 : 0)
-            ->pluck('description')
+            ->pluck('value')
             ->filter()
             ->values()
             ->all();
@@ -176,9 +176,9 @@ class DublinCoreMapper
             $parts[] = "Point({$geo->point_latitude}, {$geo->point_longitude})";
         }
 
-        if ($geo->box_south !== null && $geo->box_west !== null
-            && $geo->box_north !== null && $geo->box_east !== null) {
-            $parts[] = "Box({$geo->box_south}, {$geo->box_west}, {$geo->box_north}, {$geo->box_east})";
+        if ($geo->south_bound_latitude !== null && $geo->west_bound_longitude !== null
+            && $geo->north_bound_latitude !== null && $geo->east_bound_longitude !== null) {
+            $parts[] = "Box({$geo->south_bound_latitude}, {$geo->west_bound_longitude}, {$geo->north_bound_latitude}, {$geo->east_bound_longitude})";
         }
 
         return $parts !== [] ? implode('; ', $parts) : null;

--- a/app/Services/OaiPmh/OaiPmhResumptionTokenService.php
+++ b/app/Services/OaiPmh/OaiPmhResumptionTokenService.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\OaiPmh;
+
+use App\Models\OaiPmhResumptionToken;
+use Illuminate\Support\Str;
+
+/**
+ * Manages OAI-PMH resumption tokens for cursor-based pagination.
+ *
+ * Tokens are stored in the database and expire after a configurable TTL.
+ */
+class OaiPmhResumptionTokenService
+{
+    /**
+     * Create a new resumption token.
+     */
+    public function create(
+        string $verb,
+        ?string $metadataPrefix,
+        ?string $setSpec,
+        ?\DateTimeInterface $from,
+        ?\DateTimeInterface $until,
+        int $cursor,
+        int $completeListSize,
+    ): OaiPmhResumptionToken {
+        $ttl = (int) config('oaipmh.resumption_token_ttl', 86400);
+
+        return OaiPmhResumptionToken::create([
+            'token' => Str::random(64),
+            'verb' => $verb,
+            'metadata_prefix' => $metadataPrefix,
+            'set_spec' => $setSpec,
+            'from_date' => $from,
+            'until_date' => $until,
+            'cursor' => $cursor,
+            'complete_list_size' => $completeListSize,
+            'expires_at' => now()->addSeconds($ttl),
+        ]);
+    }
+
+    /**
+     * Resolve a resumption token string to its stored data.
+     *
+     * Returns null if the token is invalid or expired.
+     */
+    public function resolve(string $token): ?OaiPmhResumptionToken
+    {
+        $record = OaiPmhResumptionToken::where('token', $token)->first();
+
+        if ($record === null) {
+            return null;
+        }
+
+        if ($record->expires_at->isPast()) {
+            $record->delete();
+
+            return null;
+        }
+
+        return $record;
+    }
+
+    /**
+     * Delete a consumed resumption token.
+     */
+    public function consume(OaiPmhResumptionToken $token): void
+    {
+        $token->delete();
+    }
+
+    /**
+     * Purge all expired resumption tokens.
+     */
+    public function purgeExpired(): int
+    {
+        return OaiPmhResumptionToken::where('expires_at', '<', now())->delete();
+    }
+}

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -251,7 +251,7 @@ class OaiPmhService
         }
 
         // Find the published resource
-        $resource = $this->findPublishedResource($doi);
+        $resource = $this->findPublishedResource($doi, $metadataPrefix);
         if ($resource === null) {
             return $this->errorResponse(
                 'idDoesNotExist',
@@ -324,9 +324,11 @@ class OaiPmhService
             // Parse and validate date parameters
             $from = null;
             $until = null;
+            $fromGranularity = null;
+            $untilGranularity = null;
 
             if ($fromStr !== null) {
-                $from = $this->parseOaiDate($fromStr);
+                [$from, $fromGranularity] = $this->parseOaiDate($fromStr);
                 if ($from === null) {
                     return $this->errorResponse('badArgument', 'Invalid from date format', $verb, $requestAttrs);
                 }
@@ -334,11 +336,21 @@ class OaiPmhService
             }
 
             if ($untilStr !== null) {
-                $until = $this->parseOaiDate($untilStr);
+                [$until, $untilGranularity] = $this->parseOaiDate($untilStr, isUntil: true);
                 if ($until === null) {
                     return $this->errorResponse('badArgument', 'Invalid until date format', $verb, $requestAttrs);
                 }
                 $requestAttrs['until'] = $untilStr;
+            }
+
+            // OAI-PMH requires from and until to have the same granularity
+            if ($fromGranularity !== null && $untilGranularity !== null && $fromGranularity !== $untilGranularity) {
+                return $this->errorResponse(
+                    'badArgument',
+                    'The from and until parameters must have the same granularity (both YYYY-MM-DD or both YYYY-MM-DDThh:mm:ssZ)',
+                    $verb,
+                    $requestAttrs,
+                );
             }
 
             if ($from !== null && $until !== null && $from->greaterThan($until)) {
@@ -382,9 +394,17 @@ class OaiPmhService
         $builder = $this->xmlBuilder->createEnvelope($verb, $requestAttrs);
         $container = $headersOnly ? $builder->beginListIdentifiers() : $builder->beginListRecords();
 
-        // First, include deleted records (only for the first page)
-        if ($cursor === 0) {
-            $deletedRecords = $deletedQuery->orderBy('datestamp')->get();
+        $emitted = 0;
+
+        // Deleted records occupy the first $deletedCount positions in the virtual list.
+        // If the cursor falls within that range, emit deleted records for this page.
+        if ($cursor < $deletedCount) {
+            $deletedRecords = $deletedQuery
+                ->orderBy('datestamp')
+                ->skip($cursor)
+                ->take($pageSize)
+                ->get();
+
             foreach ($deletedRecords as $deleted) {
                 if ($headersOnly) {
                     $builder->addHeader(
@@ -402,42 +422,43 @@ class OaiPmhService
                         array_values($deleted->sets ?? []),
                     );
                 }
+                $emitted++;
             }
         }
 
-        // Adjust cursor to account for deleted records
-        $resourceCursor = $cursor > 0 ? $cursor - $deletedCount : 0;
-        $resourceCursor = max(0, $resourceCursor);
+        // Fill remaining page space with live records
+        $remainingSlots = $pageSize - $emitted;
+        if ($remainingSlots > 0) {
+            $resourceOffset = max(0, $cursor - $deletedCount);
 
-        $resources = $query
-            ->skip($resourceCursor)
-            ->take($pageSize)
-            ->get();
+            $resources = $query
+                ->skip($resourceOffset)
+                ->take($remainingSlots)
+                ->get();
 
-        if (! $headersOnly) {
-            $resources->loadMissing($this->getRelationsForMetadata($metadataPrefix));
-        } else {
-            $resources->loadMissing(['resourceType']);
-        }
-
-        foreach ($resources as $resource) {
-            $oaiId = $this->buildOaiIdentifier($resource->doi);
-            $datestamp = ($resource->updated_at ?? now())->utc()->format('Y-m-d\TH:i:s\Z');
-            $sets = $this->setService->getSetsForResource($resource);
-
-            if ($headersOnly) {
-                $builder->addHeader($container, $oaiId, $datestamp, $sets);
+            if (! $headersOnly) {
+                $resources->loadMissing($this->getRelationsForMetadata($metadataPrefix));
             } else {
-                $metadataXml = $this->buildMetadataXml($resource, $metadataPrefix);
-                $builder->addRecord($container, $oaiId, $datestamp, $sets, $metadataXml);
+                $resources->loadMissing(['resourceType']);
+            }
+
+            foreach ($resources as $resource) {
+                $oaiId = $this->buildOaiIdentifier($resource->doi);
+                $datestamp = ($resource->updated_at ?? now())->utc()->format('Y-m-d\TH:i:s\Z');
+                $sets = $this->setService->getSetsForResource($resource);
+
+                if ($headersOnly) {
+                    $builder->addHeader($container, $oaiId, $datestamp, $sets);
+                } else {
+                    $metadataXml = $this->buildMetadataXml($resource, $metadataPrefix);
+                    $builder->addRecord($container, $oaiId, $datestamp, $sets, $metadataXml);
+                }
+                $emitted++;
             }
         }
 
         // Add resumption token if more results exist
-        $nextCursor = $cursor + $deletedCount + $resources->count();
-        if ($cursor === 0) {
-            $nextCursor = $deletedCount + $resources->count();
-        }
+        $nextCursor = $cursor + $emitted;
 
         if ($nextCursor < $completeListSize) {
             $newToken = $this->tokenService->create(
@@ -467,10 +488,13 @@ class OaiPmhService
 
     /**
      * Validate arguments for a given verb.
+     *
+     * Merges query string and POST body parameters to ensure consistent
+     * validation regardless of HTTP method (OAI-PMH supports both GET and POST).
      */
     private function validateArguments(Request $request, string $verb): ?string
     {
-        $allParams = array_keys($request->query());
+        $allParams = array_keys($request->all());
         $legalArgs = self::VERB_ARGUMENTS[$verb] ?? [];
         $requiredArgs = self::REQUIRED_ARGUMENTS[$verb] ?? [];
 
@@ -531,14 +555,16 @@ class OaiPmhService
 
     /**
      * Find a published resource by DOI.
+     *
+     * Eager-loads only the relations needed for the requested metadata format.
      */
-    private function findPublishedResource(string $doi): ?Resource
+    private function findPublishedResource(string $doi, string $metadataPrefix = 'oai_datacite'): ?Resource
     {
         $resource = $this->buildHarvestableQuery()
             ->where('doi', $doi)
             ->first();
 
-        $resource?->loadMissing($this->getRelationsForMetadata('oai_datacite'));
+        $resource?->loadMissing($this->getRelationsForMetadata($metadataPrefix));
 
         return $resource;
     }
@@ -672,19 +698,27 @@ class OaiPmhService
 
     /**
      * Parse an OAI-PMH date string (YYYY-MM-DD or YYYY-MM-DDThh:mm:ssZ).
+     *
+     * Returns [Carbon, granularity] or [null, null] if the format is invalid.
+     * When $isUntil is true and the granularity is date-only, the time is set
+     * to end-of-day (23:59:59) to make the range inclusive per OAI-PMH spec.
+     *
+     * @return array{0: Carbon|null, 1: string|null}
      */
-    private function parseOaiDate(string $dateStr): ?Carbon
+    private function parseOaiDate(string $dateStr, bool $isUntil = false): array
     {
         // Full datetime: YYYY-MM-DDThh:mm:ssZ
         if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $dateStr)) {
-            return Carbon::parse($dateStr)->utc();
+            return [Carbon::parse($dateStr)->utc(), 'datetime'];
         }
 
         // Date only: YYYY-MM-DD
         if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $dateStr)) {
-            return Carbon::parse($dateStr)->startOfDay()->utc();
+            $date = Carbon::parse($dateStr)->utc();
+
+            return [$isUntil ? $date->endOfDay() : $date->startOfDay(), 'date'];
         }
 
-        return null;
+        return [null, null];
     }
 }

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -308,12 +308,12 @@ class OaiPmhService
         if (is_string($resumptionToken)) {
             $token = $this->tokenService->resolve($resumptionToken);
             if ($token === null) {
-                return $this->errorResponse('badResumptionToken', 'Invalid or expired resumption token', $verb);
+                return $this->errorResponse('badResumptionToken', 'Invalid or expired resumption token', $verb, ['resumptionToken' => $resumptionToken]);
             }
 
             // Verify the token's verb matches the current request verb
             if ($token->verb !== $verb) {
-                return $this->errorResponse('badResumptionToken', 'Resumption token was issued for a different verb', $verb);
+                return $this->errorResponse('badResumptionToken', 'Resumption token was issued for a different verb', $verb, ['resumptionToken' => $resumptionToken]);
             }
 
             $metadataPrefix = $token->metadata_prefix ?? '';

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -141,6 +141,10 @@ class OaiPmhService
         $identifier = $request->input('identifier');
 
         if ($identifier !== null) {
+            if (! is_string($identifier)) {
+                return $this->errorResponse('badArgument', 'The identifier argument must be a single value', 'ListMetadataFormats');
+            }
+
             // Validate the identifier exists
             $doi = $this->extractDoiFromIdentifier($identifier);
             if ($doi === null || ! $this->resourceExists($doi)) {
@@ -209,8 +213,15 @@ class OaiPmhService
      */
     private function getRecord(Request $request): string
     {
-        $identifier = (string) $request->input('identifier', '');
-        $metadataPrefix = (string) $request->input('metadataPrefix', '');
+        $rawIdentifier = $request->input('identifier', '');
+        $rawMetadataPrefix = $request->input('metadataPrefix', '');
+
+        if (! is_string($rawIdentifier) || ! is_string($rawMetadataPrefix)) {
+            return $this->errorResponse('badArgument', 'Arguments must be single values', 'GetRecord');
+        }
+
+        $identifier = $rawIdentifier;
+        $metadataPrefix = $rawMetadataPrefix;
 
         $requestAttrs = ['identifier' => $identifier, 'metadataPrefix' => $metadataPrefix];
 
@@ -285,8 +296,16 @@ class OaiPmhService
         $resumptionToken = $request->input('resumptionToken');
         $pageSize = (int) config('oaipmh.page_size', 100);
 
+        // Reject array parameters – OAI-PMH arguments must be single values
+        foreach (['resumptionToken', 'metadataPrefix', 'set', 'from', 'until'] as $param) {
+            $value = $request->input($param);
+            if ($value !== null && ! is_string($value)) {
+                return $this->errorResponse('badArgument', "The {$param} argument must be a single value", $verb);
+            }
+        }
+
         // Resumption token mode: restore query state from token
-        if ($resumptionToken !== null) {
+        if (is_string($resumptionToken)) {
             $token = $this->tokenService->resolve($resumptionToken);
             if ($token === null) {
                 return $this->errorResponse('badResumptionToken', 'Invalid or expired resumption token', $verb);

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -108,12 +108,21 @@ class OaiPmhService
      */
     private function identify(): string
     {
-        $earliest = Resource::query()
+        $earliestPublished = Resource::query()
             ->whereNotNull('doi')
             ->join('landing_pages', 'landing_pages.resource_id', '=', 'resources.id')
             ->where('landing_pages.is_published', true)
             ->selectRaw('MIN(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) as earliest')
             ->value('earliest');
+
+        $earliestDeleted = OaiPmhDeletedRecord::query()->min('datestamp');
+
+        $earliest = match (true) {
+            $earliestPublished !== null && $earliestDeleted !== null => min($earliestPublished, $earliestDeleted),
+            $earliestPublished !== null => $earliestPublished,
+            $earliestDeleted !== null => $earliestDeleted,
+            default => null,
+        };
 
         $earliestDatestamp = $earliest !== null
             ? Carbon::parse($earliest)->utc()->format('Y-m-d\TH:i:s\Z')

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -7,7 +7,6 @@ namespace App\Services\OaiPmh;
 use App\Models\OaiPmhDeletedRecord;
 use App\Models\Resource;
 use App\Services\DataCiteXmlExporter;
-use DOMElement;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
@@ -109,10 +108,10 @@ class OaiPmhService
      */
     private function identify(): string
     {
-        $earliest = Resource::query()
-            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
-            ->whereNotNull('doi')
-            ->min('updated_at');
+        $earliest = $this->buildHarvestableQuery()
+            ->join('landing_pages', 'landing_pages.resource_id', '=', 'resources.id')
+            ->selectRaw('MIN(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) as earliest')
+            ->value('earliest');
 
         $earliestDatestamp = $earliest !== null
             ? Carbon::parse($earliest)->utc()->format('Y-m-d\TH:i:s\Z')
@@ -270,7 +269,7 @@ class OaiPmhService
         $builder->addRecord(
             $container,
             $this->buildOaiIdentifier($resource->doi),
-            ($resource->updated_at ?? now())->utc()->format('Y-m-d\TH:i:s\Z'),
+            $this->effectiveDatestamp($resource),
             $sets,
             $metadataXml,
         );
@@ -369,10 +368,12 @@ class OaiPmhService
 
         // Build query for published resources
         $query = $this->buildHarvestableQuery()
+            ->select('resources.*')
+            ->join('landing_pages', 'landing_pages.resource_id', '=', 'resources.id')
             ->when($setSpec !== null, fn (Builder $q) => $this->setService->applySetFilter($q, $setSpec))
-            ->when($from !== null, fn (Builder $q) => $q->where('resources.updated_at', '>=', $from))
-            ->when($until !== null, fn (Builder $q) => $q->where('resources.updated_at', '<=', $until))
-            ->orderBy('resources.updated_at')
+            ->when($from !== null, fn (Builder $q) => $q->whereRaw('(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) >= ?', [$from]))
+            ->when($until !== null, fn (Builder $q) => $q->whereRaw('(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) <= ?', [$until]))
+            ->orderByRaw('CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END')
             ->orderBy('resources.id');
 
         $totalCount = $query->count();
@@ -439,14 +440,14 @@ class OaiPmhService
                 ->get();
 
             if (! $headersOnly) {
-                $resources->loadMissing($this->getRelationsForMetadata($metadataPrefix));
+                $resources->loadMissing(['landingPage', ...$this->getRelationsForMetadata($metadataPrefix)]);
             } else {
-                $resources->loadMissing(['resourceType']);
+                $resources->loadMissing(['landingPage', 'resourceType']);
             }
 
             foreach ($resources as $resource) {
                 $oaiId = $this->buildOaiIdentifier($resource->doi);
-                $datestamp = ($resource->updated_at ?? now())->utc()->format('Y-m-d\TH:i:s\Z');
+                $datestamp = $this->effectiveDatestamp($resource);
                 $sets = $this->setService->getSetsForResource($resource);
 
                 if ($headersOnly) {
@@ -566,7 +567,7 @@ class OaiPmhService
             ->where('doi', $doi)
             ->first();
 
-        $resource?->loadMissing($this->getRelationsForMetadata($metadataPrefix));
+        $resource?->loadMissing(['landingPage', ...$this->getRelationsForMetadata($metadataPrefix)]);
 
         return $resource;
     }
@@ -587,6 +588,24 @@ class OaiPmhService
     private function buildOaiIdentifier(?string $doi): string
     {
         return config('oaipmh.identifier_prefix') . ':' . ($doi ?? 'unknown');
+    }
+
+    /**
+     * Compute the effective OAI-PMH datestamp for a resource.
+     *
+     * Uses the greater of resources.updated_at and landing_pages.published_at
+     * so that the datestamp reflects whichever event happened more recently.
+     */
+    private function effectiveDatestamp(Resource $resource): string
+    {
+        $updated = $resource->updated_at ?? now();
+        $published = $resource->landingPage?->published_at;
+
+        $effective = ($published !== null && $published->greaterThan($updated))
+            ? $published
+            : $updated;
+
+        return $effective->utc()->format('Y-m-d\TH:i:s\Z');
     }
 
     /**

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -1,0 +1,690 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\OaiPmh;
+
+use App\Models\OaiPmhDeletedRecord;
+use App\Models\Resource;
+use App\Services\DataCiteXmlExporter;
+use DOMElement;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+/**
+ * Orchestrates all 6 OAI-PMH 2.0 verbs.
+ *
+ * @see http://www.openarchives.org/OAI/openarchivesprotocol.html
+ */
+class OaiPmhService
+{
+    private const VALID_VERBS = [
+        'Identify',
+        'ListMetadataFormats',
+        'ListSets',
+        'ListIdentifiers',
+        'ListRecords',
+        'GetRecord',
+    ];
+
+    /**
+     * Legal arguments per verb (excluding the 'verb' parameter itself).
+     *
+     * @var array<string, list<string>>
+     */
+    private const VERB_ARGUMENTS = [
+        'Identify' => [],
+        'ListMetadataFormats' => ['identifier'],
+        'ListSets' => ['resumptionToken'],
+        'ListIdentifiers' => ['metadataPrefix', 'from', 'until', 'set', 'resumptionToken'],
+        'ListRecords' => ['metadataPrefix', 'from', 'until', 'set', 'resumptionToken'],
+        'GetRecord' => ['identifier', 'metadataPrefix'],
+    ];
+
+    /**
+     * Required arguments per verb.
+     *
+     * @var array<string, list<string>>
+     */
+    private const REQUIRED_ARGUMENTS = [
+        'Identify' => [],
+        'ListMetadataFormats' => [],
+        'ListSets' => [],
+        'ListIdentifiers' => ['metadataPrefix'],
+        'ListRecords' => ['metadataPrefix'],
+        'GetRecord' => ['identifier', 'metadataPrefix'],
+    ];
+
+    public function __construct(
+        private readonly OaiPmhXmlResponseBuilder $xmlBuilder,
+        private readonly DublinCoreMapper $dcMapper,
+        private readonly OaiPmhSetService $setService,
+        private readonly OaiPmhResumptionTokenService $tokenService,
+        private readonly DataCiteXmlExporter $dataCiteExporter,
+    ) {}
+
+    /**
+     * Handle an OAI-PMH request by dispatching to the correct verb handler.
+     */
+    public function handleRequest(Request $request): string
+    {
+        $verb = $request->input('verb', '');
+
+        if ($verb === '' || ! in_array($verb, self::VALID_VERBS, true)) {
+            return $this->errorResponse('badVerb', 'Illegal OAI verb');
+        }
+
+        // Check for illegal/duplicate arguments
+        $argumentError = $this->validateArguments($request, $verb);
+        if ($argumentError !== null) {
+            return $argumentError;
+        }
+
+        return match ($verb) {
+            'Identify' => $this->identify(),
+            'ListMetadataFormats' => $this->listMetadataFormats($request),
+            'ListSets' => $this->listSets($request),
+            'ListIdentifiers' => $this->listIdentifiers($request),
+            'ListRecords' => $this->listRecords($request),
+            'GetRecord' => $this->getRecord($request),
+        };
+    }
+
+    /**
+     * Build an OAI-PMH error response.
+     *
+     * @param  array<string, string>  $requestAttributes
+     */
+    public function errorResponse(string $code, string $message, string $verb = '', array $requestAttributes = []): string
+    {
+        return $this->xmlBuilder
+            ->createEnvelope($verb, $requestAttributes)
+            ->addError($code, $message)
+            ->toXml();
+    }
+
+    /**
+     * Identify verb – Repository information.
+     */
+    private function identify(): string
+    {
+        $earliest = Resource::query()
+            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
+            ->whereNotNull('doi')
+            ->min('updated_at');
+
+        $earliestDatestamp = $earliest !== null
+            ? Carbon::parse($earliest)->utc()->format('Y-m-d\TH:i:s\Z')
+            : (string) config('oaipmh.earliest_datestamp');
+
+        // Find a sample identifier from the first published resource
+        $sampleResource = Resource::query()
+            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
+            ->whereNotNull('doi')
+            ->first();
+
+        $sampleId = $sampleResource !== null
+            ? $this->buildOaiIdentifier($sampleResource->doi)
+            : config('oaipmh.identifier_prefix') . ':10.5880/example';
+
+        return $this->xmlBuilder
+            ->createEnvelope('Identify')
+            ->addIdentifyContent($earliestDatestamp, $sampleId)
+            ->toXml();
+    }
+
+    /**
+     * ListMetadataFormats verb.
+     */
+    private function listMetadataFormats(Request $request): string
+    {
+        $identifier = $request->input('identifier');
+
+        if ($identifier !== null) {
+            // Validate the identifier exists
+            $doi = $this->extractDoiFromIdentifier($identifier);
+            if ($doi === null || ! $this->resourceExists($doi)) {
+                // Check deleted records too
+                if ($doi === null || ! OaiPmhDeletedRecord::where('doi', $doi)->exists()) {
+                    return $this->errorResponse(
+                        'idDoesNotExist',
+                        'The identifier does not exist in this repository',
+                        'ListMetadataFormats',
+                        ['identifier' => $identifier],
+                    );
+                }
+            }
+        }
+
+        /** @var array<string, array{schema: string, namespace: string}> $formats */
+        $formats = config('oaipmh.metadata_formats', []);
+
+        return $this->xmlBuilder
+            ->createEnvelope('ListMetadataFormats', $identifier !== null ? ['identifier' => $identifier] : [])
+            ->addListMetadataFormatsContent($formats)
+            ->toXml();
+    }
+
+    /**
+     * ListSets verb.
+     */
+    private function listSets(Request $request): string
+    {
+        $resumptionToken = $request->input('resumptionToken');
+
+        if ($resumptionToken !== null) {
+            return $this->errorResponse(
+                'badResumptionToken',
+                'Resumption tokens are not supported for ListSets',
+                'ListSets',
+            );
+        }
+
+        $sets = $this->setService->listSets();
+
+        return $this->xmlBuilder
+            ->createEnvelope('ListSets')
+            ->addListSetsContent($sets)
+            ->toXml();
+    }
+
+    /**
+     * ListIdentifiers verb – Headers only.
+     */
+    private function listIdentifiers(Request $request): string
+    {
+        return $this->listItems($request, 'ListIdentifiers', headersOnly: true);
+    }
+
+    /**
+     * ListRecords verb – Full metadata records.
+     */
+    private function listRecords(Request $request): string
+    {
+        return $this->listItems($request, 'ListRecords', headersOnly: false);
+    }
+
+    /**
+     * GetRecord verb – Single record.
+     */
+    private function getRecord(Request $request): string
+    {
+        $identifier = (string) $request->input('identifier', '');
+        $metadataPrefix = (string) $request->input('metadataPrefix', '');
+
+        $requestAttrs = ['identifier' => $identifier, 'metadataPrefix' => $metadataPrefix];
+
+        if (! $this->isValidMetadataPrefix($metadataPrefix)) {
+            return $this->errorResponse(
+                'cannotDisseminateFormat',
+                "The metadata format '{$metadataPrefix}' is not supported by this repository",
+                'GetRecord',
+                $requestAttrs,
+            );
+        }
+
+        $doi = $this->extractDoiFromIdentifier($identifier);
+
+        if ($doi === null) {
+            return $this->errorResponse(
+                'idDoesNotExist',
+                'The identifier does not exist in this repository',
+                'GetRecord',
+                $requestAttrs,
+            );
+        }
+
+        // Check for deleted record first
+        $deletedRecord = OaiPmhDeletedRecord::where('doi', $doi)->first();
+        if ($deletedRecord !== null) {
+            $builder = $this->xmlBuilder->createEnvelope('GetRecord', $requestAttrs);
+            $container = $builder->beginGetRecord();
+            $builder->addDeletedRecord(
+                $container,
+                $deletedRecord->oai_identifier,
+                $deletedRecord->datestamp->utc()->format('Y-m-d\TH:i:s\Z'),
+                array_values($deletedRecord->sets ?? []),
+            );
+
+            return $builder->toXml();
+        }
+
+        // Find the published resource
+        $resource = $this->findPublishedResource($doi);
+        if ($resource === null) {
+            return $this->errorResponse(
+                'idDoesNotExist',
+                'The identifier does not exist in this repository',
+                'GetRecord',
+                $requestAttrs,
+            );
+        }
+
+        $builder = $this->xmlBuilder->createEnvelope('GetRecord', $requestAttrs);
+        $container = $builder->beginGetRecord();
+
+        $metadataXml = $this->buildMetadataXml($resource, $metadataPrefix);
+        $sets = $this->setService->getSetsForResource($resource);
+
+        $builder->addRecord(
+            $container,
+            $this->buildOaiIdentifier($resource->doi),
+            ($resource->updated_at ?? now())->utc()->format('Y-m-d\TH:i:s\Z'),
+            $sets,
+            $metadataXml,
+        );
+
+        return $builder->toXml();
+    }
+
+    /**
+     * Shared logic for ListIdentifiers and ListRecords.
+     */
+    private function listItems(Request $request, string $verb, bool $headersOnly): string
+    {
+        $resumptionToken = $request->input('resumptionToken');
+        $pageSize = (int) config('oaipmh.page_size', 100);
+
+        // Resumption token mode: restore query state from token
+        if ($resumptionToken !== null) {
+            $token = $this->tokenService->resolve($resumptionToken);
+            if ($token === null) {
+                return $this->errorResponse('badResumptionToken', 'Invalid or expired resumption token', $verb);
+            }
+
+            $metadataPrefix = $token->metadata_prefix ?? '';
+            $setSpec = $token->set_spec;
+            $from = $token->from_date;
+            $until = $token->until_date;
+            $cursor = $token->cursor;
+
+            // Consume the token (one-time use)
+            $this->tokenService->consume($token);
+
+            $requestAttrs = ['metadataPrefix' => $metadataPrefix];
+        } else {
+            $metadataPrefix = (string) $request->input('metadataPrefix', '');
+            $setSpec = $request->input('set');
+            $fromStr = $request->input('from');
+            $untilStr = $request->input('until');
+            $cursor = 0;
+
+            $requestAttrs = ['metadataPrefix' => $metadataPrefix];
+
+            if (! $this->isValidMetadataPrefix($metadataPrefix)) {
+                return $this->errorResponse(
+                    'cannotDisseminateFormat',
+                    "The metadata format '{$metadataPrefix}' is not supported by this repository",
+                    $verb,
+                    $requestAttrs,
+                );
+            }
+
+            // Parse and validate date parameters
+            $from = null;
+            $until = null;
+
+            if ($fromStr !== null) {
+                $from = $this->parseOaiDate($fromStr);
+                if ($from === null) {
+                    return $this->errorResponse('badArgument', 'Invalid from date format', $verb, $requestAttrs);
+                }
+                $requestAttrs['from'] = $fromStr;
+            }
+
+            if ($untilStr !== null) {
+                $until = $this->parseOaiDate($untilStr);
+                if ($until === null) {
+                    return $this->errorResponse('badArgument', 'Invalid until date format', $verb, $requestAttrs);
+                }
+                $requestAttrs['until'] = $untilStr;
+            }
+
+            if ($from !== null && $until !== null && $from->greaterThan($until)) {
+                return $this->errorResponse('badArgument', 'The from date must be less than or equal to the until date', $verb, $requestAttrs);
+            }
+
+            if ($setSpec !== null) {
+                if (! $this->setService->isValidSetSpec($setSpec)) {
+                    return $this->errorResponse('badArgument', "Invalid set specification: {$setSpec}", $verb, $requestAttrs);
+                }
+                $requestAttrs['set'] = $setSpec;
+            }
+        }
+
+        // Build query for published resources
+        $query = $this->buildHarvestableQuery()
+            ->when($setSpec !== null, fn (Builder $q) => $this->setService->applySetFilter($q, $setSpec))
+            ->when($from !== null, fn (Builder $q) => $q->where('resources.updated_at', '>=', $from))
+            ->when($until !== null, fn (Builder $q) => $q->where('resources.updated_at', '<=', $until))
+            ->orderBy('resources.updated_at')
+            ->orderBy('resources.id');
+
+        $totalCount = $query->count();
+
+        // Also count deleted records matching the filters
+        $deletedQuery = OaiPmhDeletedRecord::query()
+            ->when($from !== null, fn ($q) => $q->where('datestamp', '>=', $from))
+            ->when($until !== null, fn ($q) => $q->where('datestamp', '<=', $until));
+
+        if ($setSpec !== null) {
+            $deletedQuery->whereJsonContains('sets', $setSpec);
+        }
+
+        $deletedCount = $deletedQuery->count();
+        $completeListSize = $totalCount + $deletedCount;
+
+        if ($completeListSize === 0) {
+            return $this->errorResponse('noRecordsMatch', 'No records match the given criteria', $verb, $requestAttrs);
+        }
+
+        $builder = $this->xmlBuilder->createEnvelope($verb, $requestAttrs);
+        $container = $headersOnly ? $builder->beginListIdentifiers() : $builder->beginListRecords();
+
+        // First, include deleted records (only for the first page)
+        if ($cursor === 0) {
+            $deletedRecords = $deletedQuery->orderBy('datestamp')->get();
+            foreach ($deletedRecords as $deleted) {
+                if ($headersOnly) {
+                    $builder->addHeader(
+                        $container,
+                        $deleted->oai_identifier,
+                        $deleted->datestamp->utc()->format('Y-m-d\TH:i:s\Z'),
+                        array_values($deleted->sets ?? []),
+                        deleted: true,
+                    );
+                } else {
+                    $builder->addDeletedRecord(
+                        $container,
+                        $deleted->oai_identifier,
+                        $deleted->datestamp->utc()->format('Y-m-d\TH:i:s\Z'),
+                        array_values($deleted->sets ?? []),
+                    );
+                }
+            }
+        }
+
+        // Adjust cursor to account for deleted records
+        $resourceCursor = $cursor > 0 ? $cursor - $deletedCount : 0;
+        $resourceCursor = max(0, $resourceCursor);
+
+        $resources = $query
+            ->skip($resourceCursor)
+            ->take($pageSize)
+            ->get();
+
+        if (! $headersOnly) {
+            $resources->loadMissing($this->getRelationsForMetadata($metadataPrefix));
+        } else {
+            $resources->loadMissing(['resourceType']);
+        }
+
+        foreach ($resources as $resource) {
+            $oaiId = $this->buildOaiIdentifier($resource->doi);
+            $datestamp = ($resource->updated_at ?? now())->utc()->format('Y-m-d\TH:i:s\Z');
+            $sets = $this->setService->getSetsForResource($resource);
+
+            if ($headersOnly) {
+                $builder->addHeader($container, $oaiId, $datestamp, $sets);
+            } else {
+                $metadataXml = $this->buildMetadataXml($resource, $metadataPrefix);
+                $builder->addRecord($container, $oaiId, $datestamp, $sets, $metadataXml);
+            }
+        }
+
+        // Add resumption token if more results exist
+        $nextCursor = $cursor + $deletedCount + $resources->count();
+        if ($cursor === 0) {
+            $nextCursor = $deletedCount + $resources->count();
+        }
+
+        if ($nextCursor < $completeListSize) {
+            $newToken = $this->tokenService->create(
+                $verb,
+                $metadataPrefix,
+                $setSpec,
+                $from,
+                $until,
+                $nextCursor,
+                $completeListSize,
+            );
+
+            $builder->addResumptionToken(
+                $container,
+                $newToken->token,
+                $completeListSize,
+                $cursor,
+                $newToken->expires_at->utc()->format('Y-m-d\TH:i:s\Z'),
+            );
+        } elseif ($resumptionToken !== null) {
+            // Last page with a resumption token: emit empty token to signal end
+            $builder->addResumptionToken($container, null, $completeListSize, $cursor);
+        }
+
+        return $builder->toXml();
+    }
+
+    /**
+     * Validate arguments for a given verb.
+     */
+    private function validateArguments(Request $request, string $verb): ?string
+    {
+        $allParams = array_keys($request->query());
+        $legalArgs = self::VERB_ARGUMENTS[$verb] ?? [];
+        $requiredArgs = self::REQUIRED_ARGUMENTS[$verb] ?? [];
+
+        // Check for illegal arguments
+        foreach ($allParams as $param) {
+            if ($param === 'verb') {
+                continue;
+            }
+            if (! in_array($param, $legalArgs, true)) {
+                return $this->errorResponse(
+                    'badArgument',
+                    "Illegal argument '{$param}' for verb '{$verb}'",
+                    $verb,
+                );
+            }
+        }
+
+        // If resumptionToken is present, it must be the exclusive argument
+        if ($request->has('resumptionToken') && in_array('resumptionToken', $legalArgs, true)) {
+            $otherArgs = array_filter($allParams, fn (string $p) => $p !== 'verb' && $p !== 'resumptionToken');
+            if ($otherArgs !== []) {
+                return $this->errorResponse(
+                    'badArgument',
+                    'resumptionToken is an exclusive argument and cannot be combined with other arguments',
+                    $verb,
+                );
+            }
+
+            // When resumptionToken is present, skip required argument checks
+            return null;
+        }
+
+        // Check for required arguments
+        foreach ($requiredArgs as $required) {
+            if (! $request->has($required) || $request->input($required) === '') {
+                return $this->errorResponse(
+                    'badArgument',
+                    "Missing required argument '{$required}' for verb '{$verb}'",
+                    $verb,
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build a base query for harvestable (published) resources.
+     *
+     * @return Builder<Resource>
+     */
+    private function buildHarvestableQuery(): Builder
+    {
+        return Resource::query()
+            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
+            ->whereNotNull('doi');
+    }
+
+    /**
+     * Find a published resource by DOI.
+     */
+    private function findPublishedResource(string $doi): ?Resource
+    {
+        $resource = $this->buildHarvestableQuery()
+            ->where('doi', $doi)
+            ->first();
+
+        $resource?->loadMissing($this->getRelationsForMetadata('oai_datacite'));
+
+        return $resource;
+    }
+
+    /**
+     * Check if a resource with the given DOI exists and is published.
+     */
+    private function resourceExists(string $doi): bool
+    {
+        return $this->buildHarvestableQuery()
+            ->where('doi', $doi)
+            ->exists();
+    }
+
+    /**
+     * Build the OAI identifier from a DOI.
+     */
+    private function buildOaiIdentifier(?string $doi): string
+    {
+        return config('oaipmh.identifier_prefix') . ':' . ($doi ?? 'unknown');
+    }
+
+    /**
+     * Extract DOI from an OAI identifier.
+     *
+     * Format: "oai:ernie.gfz.de:{doi}"
+     */
+    private function extractDoiFromIdentifier(string $identifier): ?string
+    {
+        $prefix = config('oaipmh.identifier_prefix') . ':';
+
+        if (! str_starts_with($identifier, $prefix)) {
+            return null;
+        }
+
+        $doi = substr($identifier, strlen($prefix));
+
+        return $doi !== '' ? $doi : null;
+    }
+
+    /**
+     * Build the metadata XML for a resource in the given format.
+     */
+    private function buildMetadataXml(Resource $resource, string $metadataPrefix): string
+    {
+        return match ($metadataPrefix) {
+            'oai_dc' => $this->buildDublinCoreXml($resource),
+            'oai_datacite' => $this->buildDataCiteXml($resource),
+            default => '',
+        };
+    }
+
+    /**
+     * Build Dublin Core XML for a resource.
+     */
+    private function buildDublinCoreXml(Resource $resource): string
+    {
+        $dcElements = $this->dcMapper->map($resource);
+
+        return $this->xmlBuilder->buildDublinCoreXml($dcElements);
+    }
+
+    /**
+     * Build DataCite XML for a resource (reuses the existing DataCiteXmlExporter).
+     */
+    private function buildDataCiteXml(Resource $resource): string
+    {
+        return $this->dataCiteExporter->export($resource);
+    }
+
+    /**
+     * Get the relations that should be loaded for metadata rendering.
+     *
+     * @return list<string>
+     */
+    private function getRelationsForMetadata(string $metadataPrefix): array
+    {
+        return match ($metadataPrefix) {
+            'oai_dc' => [
+                'resourceType',
+                'language',
+                'publisher',
+                'titles',
+                'creators.creatorable',
+                'contributors.contributorable',
+                'descriptions.descriptionType',
+                'subjects',
+                'rights',
+                'formats',
+                'relatedIdentifiers',
+                'geoLocations',
+            ],
+            'oai_datacite' => [
+                'resourceType',
+                'language',
+                'publisher',
+                'titles.titleType',
+                'creators.creatorable',
+                'creators.affiliations',
+                'contributors.contributorable',
+                'contributors.contributorTypes',
+                'contributors.affiliations',
+                'descriptions.descriptionType',
+                'dates.dateType',
+                'subjects',
+                'geoLocations',
+                'rights',
+                'relatedIdentifiers.identifierType',
+                'relatedIdentifiers.relationType',
+                'fundingReferences.funderIdentifierType',
+                'alternateIdentifiers',
+                'sizes',
+                'formats',
+                'igsnMetadata',
+                'instruments',
+            ],
+            default => ['resourceType'],
+        };
+    }
+
+    /**
+     * Check if a metadata prefix is supported.
+     */
+    private function isValidMetadataPrefix(string $prefix): bool
+    {
+        /** @var array<string, mixed> $formats */
+        $formats = config('oaipmh.metadata_formats', []);
+
+        return array_key_exists($prefix, $formats);
+    }
+
+    /**
+     * Parse an OAI-PMH date string (YYYY-MM-DD or YYYY-MM-DDThh:mm:ssZ).
+     */
+    private function parseOaiDate(string $dateStr): ?Carbon
+    {
+        // Full datetime: YYYY-MM-DDThh:mm:ssZ
+        if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $dateStr)) {
+            return Carbon::parse($dateStr)->utc();
+        }
+
+        // Date only: YYYY-MM-DD
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $dateStr)) {
+            return Carbon::parse($dateStr)->startOfDay()->utc();
+        }
+
+        return null;
+    }
+}

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -423,7 +423,14 @@ class OaiPmhService
         }
 
         $deletedCount = $deletedQuery->count();
-        $completeListSize = $totalCount + $deletedCount;
+
+        // In resumption token mode, use the stored complete_list_size for stable
+        // pagination across pages. For initial requests, calculate from current state.
+        if (is_string($resumptionToken)) {
+            $completeListSize = $token->complete_list_size;
+        } else {
+            $completeListSize = $totalCount + $deletedCount;
+        }
 
         if ($completeListSize === 0) {
             return $this->errorResponse('noRecordsMatch', 'No records match the given criteria', $verb, $requestAttrs);

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -293,16 +293,18 @@ class OaiPmhService
                 return $this->errorResponse('badResumptionToken', 'Invalid or expired resumption token', $verb);
             }
 
+            // Verify the token's verb matches the current request verb
+            if ($token->verb !== $verb) {
+                return $this->errorResponse('badResumptionToken', 'Resumption token was issued for a different verb', $verb);
+            }
+
             $metadataPrefix = $token->metadata_prefix ?? '';
             $setSpec = $token->set_spec;
             $from = $token->from_date;
             $until = $token->until_date;
             $cursor = $token->cursor;
 
-            // Consume the token (one-time use)
-            $this->tokenService->consume($token);
-
-            $requestAttrs = ['metadataPrefix' => $metadataPrefix];
+            $requestAttrs = ['resumptionToken' => $resumptionToken];
         } else {
             $metadataPrefix = (string) $request->input('metadataPrefix', '');
             $setSpec = $request->input('set');

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -108,8 +108,10 @@ class OaiPmhService
      */
     private function identify(): string
     {
-        $earliest = $this->buildHarvestableQuery()
+        $earliest = Resource::query()
+            ->whereNotNull('doi')
             ->join('landing_pages', 'landing_pages.resource_id', '=', 'resources.id')
+            ->where('landing_pages.is_published', true)
             ->selectRaw('MIN(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) as earliest')
             ->value('earliest');
 
@@ -177,10 +179,13 @@ class OaiPmhService
         $resumptionToken = $request->input('resumptionToken');
 
         if ($resumptionToken !== null) {
+            $requestAttrs = is_string($resumptionToken) ? ['resumptionToken' => $resumptionToken] : [];
+
             return $this->errorResponse(
                 'badResumptionToken',
                 'Resumption tokens are not supported for ListSets',
                 'ListSets',
+                $requestAttrs,
             );
         }
 
@@ -385,10 +390,12 @@ class OaiPmhService
             }
         }
 
-        // Build query for published resources
-        $query = $this->buildHarvestableQuery()
+        // Build query for published resources (join replaces whereHas to avoid redundant EXISTS)
+        $query = Resource::query()
+            ->whereNotNull('doi')
             ->select('resources.*')
             ->join('landing_pages', 'landing_pages.resource_id', '=', 'resources.id')
+            ->where('landing_pages.is_published', true)
             ->when($setSpec !== null, fn (Builder $q) => $this->setService->applySetFilter($q, $setSpec))
             ->when($from !== null, fn (Builder $q) => $q->whereRaw('(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) >= ?', [$from]))
             ->when($until !== null, fn (Builder $q) => $q->whereRaw('(CASE WHEN landing_pages.published_at > resources.updated_at THEN landing_pages.published_at ELSE resources.updated_at END) <= ?', [$until]))

--- a/app/Services/OaiPmh/OaiPmhService.php
+++ b/app/Services/OaiPmh/OaiPmhService.php
@@ -423,6 +423,7 @@ class OaiPmhService
         if ($cursor < $deletedCount) {
             $deletedRecords = $deletedQuery
                 ->orderBy('datestamp')
+                ->orderBy('id')
                 ->skip($cursor)
                 ->take($pageSize)
                 ->get();

--- a/app/Services/OaiPmh/OaiPmhSetService.php
+++ b/app/Services/OaiPmh/OaiPmhSetService.php
@@ -114,10 +114,13 @@ class OaiPmhSetService
 
     /**
      * Validate whether a set spec is syntactically valid.
+     *
+     * - resourcetype:{non-empty alphanumeric/space value}
+     * - year:{4-digit year}
      */
     public function isValidSetSpec(string $setSpec): bool
     {
-        return str_starts_with($setSpec, 'resourcetype:')
-            || str_starts_with($setSpec, 'year:');
+        return (bool) preg_match('/^resourcetype:[A-Za-z0-9 ]+$/', $setSpec)
+            || (bool) preg_match('/^year:\d{4}$/', $setSpec);
     }
 }

--- a/app/Services/OaiPmh/OaiPmhSetService.php
+++ b/app/Services/OaiPmh/OaiPmhSetService.php
@@ -6,6 +6,7 @@ namespace App\Services\OaiPmh;
 
 use App\Models\Resource;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -26,18 +27,18 @@ class OaiPmhSetService
     {
         $sets = [];
 
-        // Resource type sets from published resources
-        $types = Resource::query()
-            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
-            ->whereNotNull('doi')
-            ->whereHas('resourceType')
-            ->with('resourceType')
-            ->get()
-            ->pluck('resourceType.name')
-            ->unique()
-            ->filter()
-            ->sort()
-            ->values();
+        // Resource type sets via SQL join + distinct (avoids loading all models)
+        $types = DB::table('resources')
+            ->join('resource_types', 'resources.resource_type_id', '=', 'resource_types.id')
+            ->whereExists(fn ($q) => $q->select(DB::raw(1))
+                ->from('landing_pages')
+                ->whereColumn('landing_pages.resource_id', 'resources.id')
+                ->where('landing_pages.is_published', true))
+            ->whereNotNull('resources.doi')
+            ->select('resource_types.name')
+            ->distinct()
+            ->orderBy('resource_types.name')
+            ->pluck('name');
 
         foreach ($types as $typeName) {
             $sets[] = [
@@ -46,13 +47,17 @@ class OaiPmhSetService
             ];
         }
 
-        // Publication year sets from published resources
-        $years = Resource::query()
-            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
-            ->whereNotNull('doi')
-            ->whereNotNull('publication_year')
+        // Publication year sets via SQL distinct
+        $years = DB::table('resources')
+            ->whereExists(fn ($q) => $q->select(DB::raw(1))
+                ->from('landing_pages')
+                ->whereColumn('landing_pages.resource_id', 'resources.id')
+                ->where('landing_pages.is_published', true))
+            ->whereNotNull('resources.doi')
+            ->whereNotNull('resources.publication_year')
+            ->select('resources.publication_year')
             ->distinct()
-            ->orderBy('publication_year')
+            ->orderBy('resources.publication_year')
             ->pluck('publication_year');
 
         foreach ($years as $year) {

--- a/app/Services/OaiPmh/OaiPmhSetService.php
+++ b/app/Services/OaiPmh/OaiPmhSetService.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\OaiPmh;
+
+use App\Models\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+/**
+ * Manages OAI-PMH set enumeration and query filtering.
+ *
+ * Sets are organized hierarchically:
+ * - resourcetype:{TypeName} – By DataCite resource type
+ * - year:{YYYY} – By publication year
+ */
+class OaiPmhSetService
+{
+    /**
+     * Get all available OAI-PMH sets.
+     *
+     * @return list<array{spec: string, name: string}>
+     */
+    public function listSets(): array
+    {
+        $sets = [];
+
+        // Resource type sets from published resources
+        $types = Resource::query()
+            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
+            ->whereNotNull('doi')
+            ->whereHas('resourceType')
+            ->with('resourceType')
+            ->get()
+            ->pluck('resourceType.name')
+            ->unique()
+            ->filter()
+            ->sort()
+            ->values();
+
+        foreach ($types as $typeName) {
+            $sets[] = [
+                'spec' => 'resourcetype:' . $typeName,
+                'name' => $typeName,
+            ];
+        }
+
+        // Publication year sets from published resources
+        $years = Resource::query()
+            ->whereHas('landingPage', fn (Builder $q) => $q->where('is_published', true))
+            ->whereNotNull('doi')
+            ->whereNotNull('publication_year')
+            ->distinct()
+            ->orderBy('publication_year')
+            ->pluck('publication_year');
+
+        foreach ($years as $year) {
+            $sets[] = [
+                'spec' => 'year:' . $year,
+                'name' => 'Publication Year ' . $year,
+            ];
+        }
+
+        return $sets;
+    }
+
+    /**
+     * Apply a set filter to a resource query.
+     *
+     * @param  Builder<Resource>  $query
+     * @return Builder<Resource>
+     */
+    public function applySetFilter(Builder $query, string $setSpec): Builder
+    {
+        return match (true) {
+            str_starts_with($setSpec, 'resourcetype:') => $query->whereHas(
+                'resourceType',
+                fn (Builder $q) => $q->where('name', Str::after($setSpec, 'resourcetype:')),
+            ),
+            str_starts_with($setSpec, 'year:') => $query->where(
+                'publication_year',
+                (int) Str::after($setSpec, 'year:'),
+            ),
+            default => $query->whereRaw('1 = 0'), // Unknown set → no results
+        };
+    }
+
+    /**
+     * Determine the set specs for a given resource.
+     *
+     * @return list<string>
+     */
+    public function getSetsForResource(Resource $resource): array
+    {
+        $sets = [];
+
+        $typeName = $resource->resourceType?->name;
+        if ($typeName !== null && $typeName !== '') {
+            $sets[] = 'resourcetype:' . $typeName;
+        }
+
+        if ($resource->publication_year !== null) {
+            $sets[] = 'year:' . $resource->publication_year;
+        }
+
+        return $sets;
+    }
+
+    /**
+     * Validate whether a set spec is syntactically valid.
+     */
+    public function isValidSetSpec(string $setSpec): bool
+    {
+        return str_starts_with($setSpec, 'resourcetype:')
+            || str_starts_with($setSpec, 'year:');
+    }
+}

--- a/app/Services/OaiPmh/OaiPmhSetService.php
+++ b/app/Services/OaiPmh/OaiPmhSetService.php
@@ -35,15 +35,15 @@ class OaiPmhSetService
                 ->whereColumn('landing_pages.resource_id', 'resources.id')
                 ->where('landing_pages.is_published', true))
             ->whereNotNull('resources.doi')
-            ->select('resource_types.name')
+            ->select('resource_types.slug', 'resource_types.name')
             ->distinct()
             ->orderBy('resource_types.name')
-            ->pluck('name');
+            ->get();
 
-        foreach ($types as $typeName) {
+        foreach ($types as $type) {
             $sets[] = [
-                'spec' => 'resourcetype:' . $typeName,
-                'name' => $typeName,
+                'spec' => 'resourcetype:' . $type->slug,
+                'name' => $type->name,
             ];
         }
 
@@ -81,7 +81,7 @@ class OaiPmhSetService
         return match (true) {
             str_starts_with($setSpec, 'resourcetype:') => $query->whereHas(
                 'resourceType',
-                fn (Builder $q) => $q->where('name', Str::after($setSpec, 'resourcetype:')),
+                fn (Builder $q) => $q->where('slug', Str::after($setSpec, 'resourcetype:')),
             ),
             str_starts_with($setSpec, 'year:') => $query->where(
                 'publication_year',
@@ -100,9 +100,9 @@ class OaiPmhSetService
     {
         $sets = [];
 
-        $typeName = $resource->resourceType?->name;
-        if ($typeName !== null && $typeName !== '') {
-            $sets[] = 'resourcetype:' . $typeName;
+        $typeSlug = $resource->resourceType?->slug;
+        if ($typeSlug !== null && $typeSlug !== '') {
+            $sets[] = 'resourcetype:' . $typeSlug;
         }
 
         if ($resource->publication_year !== null) {
@@ -115,12 +115,13 @@ class OaiPmhSetService
     /**
      * Validate whether a set spec is syntactically valid.
      *
-     * - resourcetype:{non-empty alphanumeric/space value}
+     * OAI-PMH setSpec grammar requires URL-safe characters without spaces.
+     * - resourcetype:{slug with alphanumeric, hyphens, underscores}
      * - year:{4-digit year}
      */
     public function isValidSetSpec(string $setSpec): bool
     {
-        return (bool) preg_match('/^resourcetype:[A-Za-z0-9 ]+$/', $setSpec)
+        return (bool) preg_match('/^resourcetype:[A-Za-z0-9_-]+$/', $setSpec)
             || (bool) preg_match('/^year:\d{4}$/', $setSpec);
     }
 }

--- a/app/Services/OaiPmh/OaiPmhSetService.php
+++ b/app/Services/OaiPmh/OaiPmhSetService.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Str;
  * Manages OAI-PMH set enumeration and query filtering.
  *
  * Sets are organized hierarchically:
- * - resourcetype:{TypeName} – By DataCite resource type
+ * - resourcetype:{slug} – By resource type slug (lowercase, e.g. dataset, physical-object)
  * - year:{YYYY} – By publication year
  */
 class OaiPmhSetService
@@ -121,7 +121,7 @@ class OaiPmhSetService
      */
     public function isValidSetSpec(string $setSpec): bool
     {
-        return (bool) preg_match('/^resourcetype:[A-Za-z0-9_-]+$/', $setSpec)
+        return (bool) preg_match('/^resourcetype:[a-z0-9_-]+$/', $setSpec)
             || (bool) preg_match('/^year:\d{4}$/', $setSpec);
     }
 }

--- a/app/Services/OaiPmh/OaiPmhXmlResponseBuilder.php
+++ b/app/Services/OaiPmh/OaiPmhXmlResponseBuilder.php
@@ -82,7 +82,7 @@ class OaiPmhXmlResponseBuilder
      */
     public function addIdentifyContent(string $earliestDatestamp, string $sampleIdentifier): self
     {
-        $identify = $this->dom->createElement('Identify');
+        $identify = $this->dom->createElementNS(self::OAI_NAMESPACE, 'Identify');
         $this->root->appendChild($identify);
 
         $this->appendTextElement($identify, 'repositoryName', (string) config('oaipmh.repository_name'));
@@ -94,7 +94,7 @@ class OaiPmhXmlResponseBuilder
         $this->appendTextElement($identify, 'granularity', (string) config('oaipmh.granularity'));
 
         // oai-identifier description
-        $description = $this->dom->createElement('description');
+        $description = $this->dom->createElementNS(self::OAI_NAMESPACE, 'description');
         $identify->appendChild($description);
 
         $oaiId = $this->dom->createElementNS(self::OAI_IDENTIFIER_NAMESPACE, 'oai-identifier');
@@ -110,10 +110,10 @@ class OaiPmhXmlResponseBuilder
         );
         $description->appendChild($oaiId);
 
-        $this->appendTextElement($oaiId, 'scheme', 'oai');
-        $this->appendTextElement($oaiId, 'repositoryIdentifier', 'ernie.gfz.de');
-        $this->appendTextElement($oaiId, 'delimiter', ':');
-        $this->appendTextElement($oaiId, 'sampleIdentifier', $sampleIdentifier);
+        $this->appendTextElement($oaiId, 'scheme', 'oai', self::OAI_IDENTIFIER_NAMESPACE);
+        $this->appendTextElement($oaiId, 'repositoryIdentifier', 'ernie.gfz.de', self::OAI_IDENTIFIER_NAMESPACE);
+        $this->appendTextElement($oaiId, 'delimiter', ':', self::OAI_IDENTIFIER_NAMESPACE);
+        $this->appendTextElement($oaiId, 'sampleIdentifier', $sampleIdentifier, self::OAI_IDENTIFIER_NAMESPACE);
 
         return $this;
     }
@@ -125,11 +125,11 @@ class OaiPmhXmlResponseBuilder
      */
     public function addListMetadataFormatsContent(array $formats): self
     {
-        $listFormats = $this->dom->createElement('ListMetadataFormats');
+        $listFormats = $this->dom->createElementNS(self::OAI_NAMESPACE, 'ListMetadataFormats');
         $this->root->appendChild($listFormats);
 
         foreach ($formats as $prefix => $format) {
-            $mf = $this->dom->createElement('metadataFormat');
+            $mf = $this->dom->createElementNS(self::OAI_NAMESPACE, 'metadataFormat');
             $listFormats->appendChild($mf);
 
             $this->appendTextElement($mf, 'metadataPrefix', $prefix);
@@ -147,11 +147,11 @@ class OaiPmhXmlResponseBuilder
      */
     public function addListSetsContent(array $sets): self
     {
-        $listSets = $this->dom->createElement('ListSets');
+        $listSets = $this->dom->createElementNS(self::OAI_NAMESPACE, 'ListSets');
         $this->root->appendChild($listSets);
 
         foreach ($sets as $set) {
-            $setEl = $this->dom->createElement('set');
+            $setEl = $this->dom->createElementNS(self::OAI_NAMESPACE, 'set');
             $listSets->appendChild($setEl);
 
             $this->appendTextElement($setEl, 'setSpec', $set['spec']);
@@ -166,7 +166,7 @@ class OaiPmhXmlResponseBuilder
      */
     public function beginListIdentifiers(): DOMElement
     {
-        $el = $this->dom->createElement('ListIdentifiers');
+        $el = $this->dom->createElementNS(self::OAI_NAMESPACE, 'ListIdentifiers');
         $this->root->appendChild($el);
 
         return $el;
@@ -177,7 +177,7 @@ class OaiPmhXmlResponseBuilder
      */
     public function beginListRecords(): DOMElement
     {
-        $el = $this->dom->createElement('ListRecords');
+        $el = $this->dom->createElementNS(self::OAI_NAMESPACE, 'ListRecords');
         $this->root->appendChild($el);
 
         return $el;
@@ -188,7 +188,7 @@ class OaiPmhXmlResponseBuilder
      */
     public function beginGetRecord(): DOMElement
     {
-        $el = $this->dom->createElement('GetRecord');
+        $el = $this->dom->createElementNS(self::OAI_NAMESPACE, 'GetRecord');
         $this->root->appendChild($el);
 
         return $el;
@@ -206,7 +206,7 @@ class OaiPmhXmlResponseBuilder
         array $setSpecs = [],
         bool $deleted = false,
     ): DOMElement {
-        $header = $this->dom->createElement('header');
+        $header = $this->dom->createElementNS(self::OAI_NAMESPACE, 'header');
         if ($deleted) {
             $header->setAttribute('status', 'deleted');
         }
@@ -234,12 +234,12 @@ class OaiPmhXmlResponseBuilder
         array $setSpecs,
         string $metadataXml,
     ): void {
-        $record = $this->dom->createElement('record');
+        $record = $this->dom->createElementNS(self::OAI_NAMESPACE, 'record');
         $parent->appendChild($record);
 
         $this->addHeader($record, $identifier, $datestamp, $setSpecs);
 
-        $metadata = $this->dom->createElement('metadata');
+        $metadata = $this->dom->createElementNS(self::OAI_NAMESPACE, 'metadata');
         $record->appendChild($metadata);
 
         // Import metadata XML fragment
@@ -263,7 +263,7 @@ class OaiPmhXmlResponseBuilder
         string $datestamp,
         array $setSpecs = [],
     ): void {
-        $record = $this->dom->createElement('record');
+        $record = $this->dom->createElementNS(self::OAI_NAMESPACE, 'record');
         $parent->appendChild($record);
 
         $this->addHeader($record, $identifier, $datestamp, $setSpecs, deleted: true);
@@ -279,7 +279,7 @@ class OaiPmhXmlResponseBuilder
         int $cursor,
         ?string $expirationDate = null,
     ): void {
-        $el = $this->dom->createElement('resumptionToken');
+        $el = $this->dom->createElementNS(self::OAI_NAMESPACE, 'resumptionToken');
         if ($token !== null) {
             $el->textContent = $token;
         }
@@ -296,7 +296,7 @@ class OaiPmhXmlResponseBuilder
      */
     public function addError(string $code, string $message): self
     {
-        $error = $this->dom->createElement('error');
+        $error = $this->dom->createElementNS(self::OAI_NAMESPACE, 'error');
         $error->setAttribute('code', $code);
         $error->textContent = $message;
         $this->root->appendChild($error);
@@ -352,11 +352,14 @@ class OaiPmhXmlResponseBuilder
     }
 
     /**
-     * Append a text element to a parent.
+     * Append a namespaced text element to a parent.
+     *
+     * Defaults to the OAI-PMH namespace so child elements inherit the root
+     * namespace declaration instead of producing an empty xmlns="".
      */
-    private function appendTextElement(DOMElement $parent, string $name, string $value): DOMElement
+    private function appendTextElement(DOMElement $parent, string $name, string $value, string $namespace = self::OAI_NAMESPACE): DOMElement
     {
-        $el = $this->dom->createElement($name);
+        $el = $this->dom->createElementNS($namespace, $name);
         $el->textContent = $value;
         $parent->appendChild($el);
 

--- a/app/Services/OaiPmh/OaiPmhXmlResponseBuilder.php
+++ b/app/Services/OaiPmh/OaiPmhXmlResponseBuilder.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\OaiPmh;
+
+use DOMDocument;
+use DOMElement;
+
+/**
+ * Builds well-formed OAI-PMH 2.0 XML responses.
+ *
+ * @see http://www.openarchives.org/OAI/openarchivesprotocol.html
+ */
+class OaiPmhXmlResponseBuilder
+{
+    private const OAI_NAMESPACE = 'http://www.openarchives.org/OAI/2.0/';
+
+    private const XSI_NAMESPACE = 'http://www.w3.org/2001/XMLSchema-instance';
+
+    private const SCHEMA_LOCATION = 'http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd';
+
+    private const OAI_IDENTIFIER_NAMESPACE = 'http://www.openarchives.org/OAI/2.0/oai-identifier';
+
+    private const OAI_IDENTIFIER_SCHEMA = 'http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd';
+
+    private const DC_NAMESPACE = 'http://purl.org/dc/elements/1.1/';
+
+    private const OAI_DC_NAMESPACE = 'http://www.openarchives.org/OAI/2.0/oai_dc/';
+
+    private const OAI_DC_SCHEMA = 'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd';
+
+    private DOMDocument $dom;
+
+    private DOMElement $root;
+
+    /**
+     * Create a new XML response envelope with the standard OAI-PMH wrapper.
+     *
+     * @param  string  $verb  The OAI-PMH verb being responded to
+     * @param  array<string, string>  $requestAttributes  Attributes for the <request> element
+     */
+    public function createEnvelope(string $verb, array $requestAttributes = []): self
+    {
+        $this->dom = new DOMDocument('1.0', 'UTF-8');
+        $this->dom->formatOutput = true;
+
+        $this->root = $this->dom->createElementNS(self::OAI_NAMESPACE, 'OAI-PMH');
+        $this->root->setAttributeNS(
+            'http://www.w3.org/2000/xmlns/',
+            'xmlns:xsi',
+            self::XSI_NAMESPACE,
+        );
+        $this->root->setAttributeNS(
+            self::XSI_NAMESPACE,
+            'xsi:schemaLocation',
+            self::SCHEMA_LOCATION,
+        );
+        $this->dom->appendChild($this->root);
+
+        // <responseDate>
+        $this->appendTextElement($this->root, 'responseDate', gmdate('Y-m-d\TH:i:s\Z'));
+
+        // <request>
+        $requestEl = $this->appendTextElement(
+            $this->root,
+            'request',
+            (string) config('oaipmh.base_url'),
+        );
+        if ($verb !== '') {
+            $requestEl->setAttribute('verb', $verb);
+        }
+        foreach ($requestAttributes as $name => $value) {
+            $requestEl->setAttribute($name, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Build and return the Identify response content.
+     */
+    public function addIdentifyContent(string $earliestDatestamp, string $sampleIdentifier): self
+    {
+        $identify = $this->dom->createElement('Identify');
+        $this->root->appendChild($identify);
+
+        $this->appendTextElement($identify, 'repositoryName', (string) config('oaipmh.repository_name'));
+        $this->appendTextElement($identify, 'baseURL', (string) config('oaipmh.base_url'));
+        $this->appendTextElement($identify, 'protocolVersion', (string) config('oaipmh.protocol_version'));
+        $this->appendTextElement($identify, 'adminEmail', (string) config('oaipmh.admin_email'));
+        $this->appendTextElement($identify, 'earliestDatestamp', $earliestDatestamp);
+        $this->appendTextElement($identify, 'deletedRecord', (string) config('oaipmh.deleted_record'));
+        $this->appendTextElement($identify, 'granularity', (string) config('oaipmh.granularity'));
+
+        // oai-identifier description
+        $description = $this->dom->createElement('description');
+        $identify->appendChild($description);
+
+        $oaiId = $this->dom->createElementNS(self::OAI_IDENTIFIER_NAMESPACE, 'oai-identifier');
+        $oaiId->setAttributeNS(
+            'http://www.w3.org/2000/xmlns/',
+            'xmlns:xsi',
+            self::XSI_NAMESPACE,
+        );
+        $oaiId->setAttributeNS(
+            self::XSI_NAMESPACE,
+            'xsi:schemaLocation',
+            self::OAI_IDENTIFIER_SCHEMA,
+        );
+        $description->appendChild($oaiId);
+
+        $this->appendTextElement($oaiId, 'scheme', 'oai');
+        $this->appendTextElement($oaiId, 'repositoryIdentifier', 'ernie.gfz.de');
+        $this->appendTextElement($oaiId, 'delimiter', ':');
+        $this->appendTextElement($oaiId, 'sampleIdentifier', $sampleIdentifier);
+
+        return $this;
+    }
+
+    /**
+     * Add ListMetadataFormats content.
+     *
+     * @param  array<string, array{schema: string, namespace: string}>  $formats
+     */
+    public function addListMetadataFormatsContent(array $formats): self
+    {
+        $listFormats = $this->dom->createElement('ListMetadataFormats');
+        $this->root->appendChild($listFormats);
+
+        foreach ($formats as $prefix => $format) {
+            $mf = $this->dom->createElement('metadataFormat');
+            $listFormats->appendChild($mf);
+
+            $this->appendTextElement($mf, 'metadataPrefix', $prefix);
+            $this->appendTextElement($mf, 'schema', $format['schema']);
+            $this->appendTextElement($mf, 'metadataNamespace', $format['namespace']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add ListSets content.
+     *
+     * @param  array<int, array{spec: string, name: string}>  $sets
+     */
+    public function addListSetsContent(array $sets): self
+    {
+        $listSets = $this->dom->createElement('ListSets');
+        $this->root->appendChild($listSets);
+
+        foreach ($sets as $set) {
+            $setEl = $this->dom->createElement('set');
+            $listSets->appendChild($setEl);
+
+            $this->appendTextElement($setEl, 'setSpec', $set['spec']);
+            $this->appendTextElement($setEl, 'setName', $set['name']);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Begin a ListIdentifiers container.
+     */
+    public function beginListIdentifiers(): DOMElement
+    {
+        $el = $this->dom->createElement('ListIdentifiers');
+        $this->root->appendChild($el);
+
+        return $el;
+    }
+
+    /**
+     * Begin a ListRecords container.
+     */
+    public function beginListRecords(): DOMElement
+    {
+        $el = $this->dom->createElement('ListRecords');
+        $this->root->appendChild($el);
+
+        return $el;
+    }
+
+    /**
+     * Begin a GetRecord container.
+     */
+    public function beginGetRecord(): DOMElement
+    {
+        $el = $this->dom->createElement('GetRecord');
+        $this->root->appendChild($el);
+
+        return $el;
+    }
+
+    /**
+     * Add a record header element.
+     *
+     * @param  list<string>  $setSpecs
+     */
+    public function addHeader(
+        DOMElement $parent,
+        string $identifier,
+        string $datestamp,
+        array $setSpecs = [],
+        bool $deleted = false,
+    ): DOMElement {
+        $header = $this->dom->createElement('header');
+        if ($deleted) {
+            $header->setAttribute('status', 'deleted');
+        }
+        $parent->appendChild($header);
+
+        $this->appendTextElement($header, 'identifier', $identifier);
+        $this->appendTextElement($header, 'datestamp', $datestamp);
+
+        foreach ($setSpecs as $spec) {
+            $this->appendTextElement($header, 'setSpec', $spec);
+        }
+
+        return $header;
+    }
+
+    /**
+     * Add a full record element (header + metadata).
+     *
+     * @param  list<string>  $setSpecs
+     */
+    public function addRecord(
+        DOMElement $parent,
+        string $identifier,
+        string $datestamp,
+        array $setSpecs,
+        string $metadataXml,
+    ): void {
+        $record = $this->dom->createElement('record');
+        $parent->appendChild($record);
+
+        $this->addHeader($record, $identifier, $datestamp, $setSpecs);
+
+        $metadata = $this->dom->createElement('metadata');
+        $record->appendChild($metadata);
+
+        // Import metadata XML fragment
+        $metadataDoc = new DOMDocument('1.0', 'UTF-8');
+        $metadataDoc->loadXML($metadataXml);
+
+        if ($metadataDoc->documentElement !== null) {
+            $imported = $this->dom->importNode($metadataDoc->documentElement, true);
+            $metadata->appendChild($imported);
+        }
+    }
+
+    /**
+     * Add a deleted record (header only, no metadata).
+     *
+     * @param  list<string>  $setSpecs
+     */
+    public function addDeletedRecord(
+        DOMElement $parent,
+        string $identifier,
+        string $datestamp,
+        array $setSpecs = [],
+    ): void {
+        $record = $this->dom->createElement('record');
+        $parent->appendChild($record);
+
+        $this->addHeader($record, $identifier, $datestamp, $setSpecs, deleted: true);
+    }
+
+    /**
+     * Add a resumption token element.
+     */
+    public function addResumptionToken(
+        DOMElement $parent,
+        ?string $token,
+        int $completeListSize,
+        int $cursor,
+        ?string $expirationDate = null,
+    ): void {
+        $el = $this->dom->createElement('resumptionToken');
+        if ($token !== null) {
+            $el->textContent = $token;
+        }
+        $el->setAttribute('completeListSize', (string) $completeListSize);
+        $el->setAttribute('cursor', (string) $cursor);
+        if ($expirationDate !== null) {
+            $el->setAttribute('expirationDate', $expirationDate);
+        }
+        $parent->appendChild($el);
+    }
+
+    /**
+     * Add an OAI-PMH error element.
+     */
+    public function addError(string $code, string $message): self
+    {
+        $error = $this->dom->createElement('error');
+        $error->setAttribute('code', $code);
+        $error->textContent = $message;
+        $this->root->appendChild($error);
+
+        return $this;
+    }
+
+    /**
+     * Build Dublin Core metadata XML for a resource.
+     *
+     * @param  array<string, list<string>>  $dcElements  DC elements mapped as element_name => values
+     */
+    public function buildDublinCoreXml(array $dcElements): string
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->formatOutput = true;
+
+        $dcRoot = $doc->createElementNS(self::OAI_DC_NAMESPACE, 'oai_dc:dc');
+        $dcRoot->setAttributeNS(
+            'http://www.w3.org/2000/xmlns/',
+            'xmlns:dc',
+            self::DC_NAMESPACE,
+        );
+        $dcRoot->setAttributeNS(
+            'http://www.w3.org/2000/xmlns/',
+            'xmlns:xsi',
+            self::XSI_NAMESPACE,
+        );
+        $dcRoot->setAttributeNS(
+            self::XSI_NAMESPACE,
+            'xsi:schemaLocation',
+            self::OAI_DC_SCHEMA,
+        );
+        $doc->appendChild($dcRoot);
+
+        foreach ($dcElements as $element => $values) {
+            foreach ($values as $value) {
+                $el = $doc->createElementNS(self::DC_NAMESPACE, "dc:{$element}");
+                $el->textContent = $value;
+                $dcRoot->appendChild($el);
+            }
+        }
+
+        return $doc->saveXML($doc->documentElement) ?: '';
+    }
+
+    /**
+     * Render the final XML string.
+     */
+    public function toXml(): string
+    {
+        return $this->dom->saveXML() ?: '';
+    }
+
+    /**
+     * Append a text element to a parent.
+     */
+    private function appendTextElement(DOMElement $parent, string $name, string $value): DOMElement
+    {
+        $el = $this->dom->createElement($name);
+        $el->textContent = $value;
+        $parent->appendChild($el);
+
+        return $el;
+    }
+}

--- a/app/Services/OaiPmh/OaiPmhXmlResponseBuilder.php
+++ b/app/Services/OaiPmh/OaiPmhXmlResponseBuilder.php
@@ -111,7 +111,8 @@ class OaiPmhXmlResponseBuilder
         $description->appendChild($oaiId);
 
         $this->appendTextElement($oaiId, 'scheme', 'oai', self::OAI_IDENTIFIER_NAMESPACE);
-        $this->appendTextElement($oaiId, 'repositoryIdentifier', 'ernie.gfz.de', self::OAI_IDENTIFIER_NAMESPACE);
+        $repositoryIdentifier = str_replace('oai:', '', (string) config('oaipmh.identifier_prefix'));
+        $this->appendTextElement($oaiId, 'repositoryIdentifier', $repositoryIdentifier, self::OAI_IDENTIFIER_NAMESPACE);
         $this->appendTextElement($oaiId, 'delimiter', ':', self::OAI_IDENTIFIER_NAMESPACE);
         $this->appendTextElement($oaiId, 'sampleIdentifier', $sampleIdentifier, self::OAI_IDENTIFIER_NAMESPACE);
 
@@ -225,6 +226,9 @@ class OaiPmhXmlResponseBuilder
     /**
      * Add a full record element (header + metadata).
      *
+     * Uses libxml internal error handling to gracefully handle malformed
+     * metadata XML. If parsing fails, the record is emitted without metadata.
+     *
      * @param  list<string>  $setSpecs
      */
     public function addRecord(
@@ -242,11 +246,14 @@ class OaiPmhXmlResponseBuilder
         $metadata = $this->dom->createElementNS(self::OAI_NAMESPACE, 'metadata');
         $record->appendChild($metadata);
 
-        // Import metadata XML fragment
+        // Import metadata XML fragment with error handling
+        $previousUseErrors = libxml_use_internal_errors(true);
         $metadataDoc = new DOMDocument('1.0', 'UTF-8');
-        $metadataDoc->loadXML($metadataXml);
+        $parseSuccess = $metadataDoc->loadXML($metadataXml);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousUseErrors);
 
-        if ($metadataDoc->documentElement !== null) {
+        if ($parseSuccess && $metadataDoc->documentElement !== null) {
             $imported = $this->dom->importNode($metadataDoc->documentElement, true);
             $metadata->appendChild($imported);
         }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -35,7 +35,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         // CSRF token validation - using standard Laravel middleware
         $middleware->preventRequestForgery(except: [
-            // Add any routes that should be excluded from CSRF verification
+            'oai-pmh', // OAI-PMH harvesting endpoint (harvesters send POST without CSRF tokens)
         ]);
 
         $middleware->web(append: [

--- a/composer.lock
+++ b/composer.lock
@@ -9391,21 +9391,21 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.4.5",
+            "version": "v4.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "9797a71dbc776f46d6fcacb708b002755da6f37a"
+                "reference": "d9d46c73f8d1f4edb449d889632e3d8c3cd2172d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/9797a71dbc776f46d6fcacb708b002755da6f37a",
-                "reference": "9797a71dbc776f46d6fcacb708b002755da6f37a",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/d9d46c73f8d1f4edb449d889632e3d8c3cd2172d",
+                "reference": "d9d46c73f8d1f4edb449d889632e3d8c3cd2172d",
                 "shasum": ""
             },
             "require": {
                 "brianium/paratest": "^7.20.0",
-                "nunomaduro/collision": "^8.9.2",
+                "nunomaduro/collision": "^8.9.3",
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^4.0.0",
                 "pestphp/pest-plugin-arch": "^4.0.0",
@@ -9424,7 +9424,7 @@
             "require-dev": {
                 "pestphp/pest-dev-tools": "^4.1.0",
                 "pestphp/pest-plugin-browser": "^4.3.0",
-                "pestphp/pest-plugin-type-coverage": "^4.0.3",
+                "pestphp/pest-plugin-type-coverage": "^4.0.4",
                 "psy/psysh": "^0.12.22"
             },
             "bin": [
@@ -9491,7 +9491,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.4.5"
+                "source": "https://github.com/pestphp/pest/tree/v4.4.6"
             },
             "funding": [
                 {
@@ -9503,7 +9503,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-03T13:43:28+00:00"
+            "time": "2026-04-09T20:36:49+00:00"
         },
         {
             "name": "pestphp/pest-plugin",

--- a/config/oaipmh.php
+++ b/config/oaipmh.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | OAI-PMH Repository Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the OAI-PMH 2.0 harvesting endpoint.
+    | See: http://www.openarchives.org/OAI/openarchivesprotocol.html
+    |
+    */
+
+    'repository_name' => 'ERNIE – GFZ Data Publication Repository',
+
+    'base_url' => env('APP_URL', 'https://ernie.gfz.de') . '/oai-pmh',
+
+    'admin_email' => 'datapub@gfz.de',
+
+    'identifier_prefix' => 'oai:ernie.gfz.de',
+
+    'deleted_record' => 'persistent',
+
+    'granularity' => 'YYYY-MM-DDThh:mm:ssZ',
+
+    'protocol_version' => '2.0',
+
+    'earliest_datestamp' => '2000-01-01T00:00:00Z',
+
+    'page_size' => 100,
+
+    'resumption_token_ttl' => 86400, // 24 hours in seconds
+
+    'metadata_formats' => [
+        'oai_dc' => [
+            'schema' => 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+            'namespace' => 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+        ],
+        'oai_datacite' => [
+            'schema' => 'https://schema.datacite.org/meta/kernel-4.7/metadata.xsd',
+            'namespace' => 'http://datacite.org/schema/kernel-4',
+        ],
+    ],
+];

--- a/config/oaipmh.php
+++ b/config/oaipmh.php
@@ -19,7 +19,7 @@ return [
 
     'admin_email' => 'datapub@gfz.de',
 
-    'identifier_prefix' => 'oai:' . parse_url((string) env('APP_URL', 'https://ernie.gfz.de'), PHP_URL_HOST),
+    'identifier_prefix' => env('OAI_IDENTIFIER_PREFIX', 'oai:' . (parse_url((string) env('APP_URL', 'https://ernie.gfz.de'), PHP_URL_HOST) ?: 'ernie.gfz.de')),
 
     'deleted_record' => 'persistent',
 

--- a/config/oaipmh.php
+++ b/config/oaipmh.php
@@ -19,7 +19,7 @@ return [
 
     'admin_email' => 'datapub@gfz.de',
 
-    'identifier_prefix' => 'oai:ernie.gfz.de',
+    'identifier_prefix' => 'oai:' . parse_url((string) env('APP_URL', 'https://ernie.gfz.de'), PHP_URL_HOST),
 
     'deleted_record' => 'persistent',
 

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -815,8 +815,8 @@ entity oai_pmh_resumption_tokens {
     set_spec : VARCHAR
     from_date : TIMESTAMP
     until_date : TIMESTAMP
-    * cursor : INT
-    * complete_list_size : INT
+    * cursor : BIGINT UNSIGNED
+    * complete_list_size : BIGINT UNSIGNED
     * expires_at : TIMESTAMP
     created_at : TIMESTAMP
     updated_at : TIMESTAMP

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -792,6 +792,37 @@ entity "dismissed_rors" as dismissed_rors {
 }
 
 ' ==========================================================================
+' OAI-PMH TABLES (Harvesting Protocol)
+' ==========================================================================
+
+entity oai_pmh_deleted_records {
+    * id : BIGINT <<PK>>
+    --
+    * oai_identifier : VARCHAR <<UNIQUE>>
+    * doi : VARCHAR
+    * datestamp : TIMESTAMP
+    sets : JSON
+    created_at : TIMESTAMP
+    updated_at : TIMESTAMP
+}
+
+entity oai_pmh_resumption_tokens {
+    * id : BIGINT <<PK>>
+    --
+    * token : VARCHAR(64) <<UNIQUE>>
+    * verb : VARCHAR
+    metadata_prefix : VARCHAR
+    set_spec : VARCHAR
+    from_date : TIMESTAMP
+    until_date : TIMESTAMP
+    * cursor : INT
+    * complete_list_size : INT
+    * expires_at : TIMESTAMP
+    created_at : TIMESTAMP
+    updated_at : TIMESTAMP
+}
+
+' ==========================================================================
 ' RELATIONSHIPS
 ' ==========================================================================
 

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -721,6 +721,35 @@ erDiagram
     }
 
     %% =========================================================================
+    %% OAI-PMH TABLES (Harvesting Protocol)
+    %% =========================================================================
+
+    oai_pmh_deleted_records {
+        bigint id PK
+        varchar oai_identifier UK
+        varchar doi
+        timestamp datestamp
+        json sets "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    oai_pmh_resumption_tokens {
+        bigint id PK
+        varchar token UK "64 chars"
+        varchar verb
+        varchar metadata_prefix "nullable"
+        varchar set_spec "nullable"
+        timestamp from_date "nullable"
+        timestamp until_date "nullable"
+        int cursor "unsigned, default 0"
+        int complete_list_size "unsigned, default 0"
+        timestamp expires_at
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    %% =========================================================================
     %% RELATIONSHIPS
     %% =========================================================================
 

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -742,8 +742,8 @@ erDiagram
         varchar set_spec "nullable"
         timestamp from_date "nullable"
         timestamp until_date "nullable"
-        int cursor "unsigned, default 0"
-        int complete_list_size "unsigned, default 0"
+        bigint_unsigned cursor
+        bigint_unsigned complete_list_size
         timestamp expires_at
         timestamp created_at
         timestamp updated_at

--- a/database/factories/ResourceFactory.php
+++ b/database/factories/ResourceFactory.php
@@ -26,8 +26,8 @@ class ResourceFactory extends Factory
     {
         // Get or create default resource type
         $resourceType = ResourceType::firstOrCreate(
-            ['slug' => 'Dataset'],
-            ['name' => 'Dataset', 'slug' => 'Dataset', 'is_active' => true]
+            ['slug' => 'dataset'],
+            ['name' => 'Dataset', 'slug' => 'dataset', 'is_active' => true]
         );
 
         // Get or create default language

--- a/database/migrations/2026_04_09_000001_create_oai_pmh_tables.php
+++ b/database/migrations/2026_04_09_000001_create_oai_pmh_tables.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create tables for OAI-PMH 2.0 harvesting endpoint.
+ *
+ * - oai_pmh_deleted_records: Permanent tracking of deleted/depublished records
+ * - oai_pmh_resumption_tokens: Cursor-based pagination tokens
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Tracks permanently deleted/depublished records for OAI-PMH
+        // persistent deleted record support.
+        Schema::create('oai_pmh_deleted_records', function (Blueprint $table): void {
+            $table->id();
+            $table->string('oai_identifier')->unique();
+            $table->string('doi');
+            $table->timestamp('datestamp');
+            $table->json('sets')->nullable();
+            $table->timestamps();
+
+            $table->index('datestamp');
+            $table->index('doi');
+        });
+
+        // Stores cursor-based resumption tokens for paginated OAI-PMH responses.
+        Schema::create('oai_pmh_resumption_tokens', function (Blueprint $table): void {
+            $table->id();
+            $table->string('token', 64)->unique();
+            $table->string('verb');
+            $table->string('metadata_prefix')->nullable();
+            $table->string('set_spec')->nullable();
+            $table->timestamp('from_date')->nullable();
+            $table->timestamp('until_date')->nullable();
+            $table->unsignedBigInteger('cursor');
+            $table->unsignedBigInteger('complete_list_size');
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oai_pmh_resumption_tokens');
+        Schema::dropIfExists('oai_pmh_deleted_records');
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5865,9 +5865,9 @@
       }
     },
     "node_modules/@vis.gl/react-google-maps": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.2.tgz",
-      "integrity": "sha512-s9OPwGyMBobip6W1dgEtzwKs3jIg0DP9zvGJRbjDEGB4PgrWl1d5VDQXoCFFEdt1/47SR9RVvSqv/LKfh5cnvw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
+      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
       "license": "MIT",
       "dependencies": {
         "@googlemaps/js-api-loader": "^2.0.2",
@@ -6726,9 +6726,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6862,14 +6862,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,9 +103,9 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.8.tgz",
-      "integrity": "sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.9.tgz",
+      "integrity": "sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.8.tgz",
-      "integrity": "sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-04-09",
         "features": [
             {
+                "title": "OAI-PMH 2.0 Harvesting Endpoint",
+                "description": "A fully OAI-PMH 2.0 compliant harvesting endpoint is now available at /oai-pmh for third-party metadata harvesters. It supports all 6 standard verbs (Identify, ListMetadataFormats, ListSets, ListIdentifiers, ListRecords, GetRecord) with Dublin Core (oai_dc) and DataCite Kernel 4.7 (oai_datacite) metadata formats. Features include cursor-based pagination with resumption tokens, selective harvesting by date range and sets (resource type, publication year), and persistent deleted record tracking. A comprehensive harvester documentation page is available at /oai-pmh/docs."
+            },
+            {
                 "title": "IGSN Import from DataCite",
                 "description": "Admins and Group Leaders can now bulk-import all ~38,500 IGSNs registered under the GFZ IGSN prefix (10.60510) directly from the DataCite API. The import automatically enriches each IGSN with legacy metadata (sample type, material, coordinates, collector, classifications, geological ages) from Solr and the legacy IGSN database (~94% enrichment rate). Parent-child relationships between samples are resolved after import. Progress is tracked in real-time with counters for imported, enriched, skipped, and failed records."
             },

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -20,6 +20,8 @@ interface Props {
     metadataFormats: Record<string, MetadataFormat>;
     resourceTypeSlugs: string[];
     identifierPrefix: string;
+    pageSize: number;
+    tokenTtlHours: number;
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -57,7 +59,7 @@ function ExampleUrl({ url }: { url: string }) {
     );
 }
 
-export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resourceTypeSlugs, identifierPrefix }: Props) {
+export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resourceTypeSlugs, identifierPrefix, pageSize, tokenTtlHours }: Props) {
     const exampleSetSpec = resourceTypeSlugs.includes('dataset')
         ? 'resourcetype:dataset'
         : resourceTypeSlugs.length > 0
@@ -285,13 +287,13 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                     </CardHeader>
                     <CardContent className="space-y-3 text-sm">
                         <p>
-                            When a <code>ListRecords</code> or <code>ListIdentifiers</code> response contains more than <strong>100 records</strong>,
+                            When a <code>ListRecords</code> or <code>ListIdentifiers</code> response contains more than <strong>{pageSize} records</strong>,
                             the response includes a <code>&lt;resumptionToken&gt;</code> element.
                         </p>
                         <p>To retrieve the next page, send a new request with the token as the exclusive parameter:</p>
                         <ExampleUrl url={`${baseUrl}?verb=ListRecords&resumptionToken=<token_value>`} />
                         <p className="text-muted-foreground">
-                            Tokens expire after <strong>24 hours</strong>. An empty <code>&lt;resumptionToken&gt;</code> element
+                            Tokens expire after <strong>{tokenTtlHours} hours</strong>. An empty <code>&lt;resumptionToken&gt;</code> element
                             (with no text content) signals the end of the result set.
                         </p>
                     </CardContent>
@@ -358,7 +360,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                             <li>Use incremental harvesting with <code>from</code> dates to avoid re-harvesting unchanged records.</li>
                             <li>Prefer <code>oai_datacite</code> format for richer metadata (DataCite Kernel 4.7).</li>
                             <li>Implement retry logic for transient errors (HTTP 503 with Retry-After header).</li>
-                            <li>Respect the <code>resumptionToken</code> expiration; do not cache tokens beyond 24 hours.</li>
+                            <li>Respect the <code>resumptionToken</code> expiration; do not cache tokens beyond {tokenTtlHours} hours.</li>
                             <li>Process deleted records to remove or flag previously harvested entries.</li>
                         </ul>
                     </CardContent>

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -18,6 +18,7 @@ interface Props {
     baseUrl: string;
     adminEmail: string;
     metadataFormats: Record<string, MetadataFormat>;
+    resourceTypeSlugs: string[];
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -55,7 +56,7 @@ function ExampleUrl({ url }: { url: string }) {
     );
 }
 
-export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats }: Props) {
+export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resourceTypeSlugs }: Props) {
     return (
         <PublicLayout>
             <Head title="OAI-PMH Documentation" />
@@ -188,8 +189,8 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats }: Pro
                                 Filter by DataCite resource type using the <code>set</code> parameter.
                             </p>
                             <div className="flex flex-wrap gap-2">
-                                {['Dataset', 'Text', 'Image', 'PhysicalObject', 'Software', 'Collection'].map((type) => (
-                                    <Badge key={type} variant="outline">resourcetype:{type}</Badge>
+                                {resourceTypeSlugs.map((slug) => (
+                                    <Badge key={slug} variant="outline">resourcetype:{slug}</Badge>
                                 ))}
                             </div>
                         </div>

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -23,15 +23,25 @@ interface Props {
 function CopyButton({ text }: { text: string }) {
     const [copied, setCopied] = useState(false);
 
-    const handleCopy = () => {
-        navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(text);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            // Clipboard API not available or denied — silently ignore
+        }
     };
 
     return (
-        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={handleCopy} title="Copy to clipboard">
-            {copied ? <span className="text-xs text-green-600">✓</span> : <Copy className="h-3.5 w-3.5" />}
+        <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={handleCopy}
+            aria-label={copied ? 'Copied to clipboard' : 'Copy to clipboard'}
+        >
+            {copied ? <span className="text-xs text-green-600" aria-hidden="true">✓</span> : <Copy className="h-3.5 w-3.5" />}
         </Button>
     );
 }

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -1,0 +1,368 @@
+import { Head } from '@inertiajs/react';
+import { Copy } from 'lucide-react';
+import { useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import PublicLayout from '@/layouts/public-layout';
+
+interface MetadataFormat {
+    schema: string;
+    namespace: string;
+}
+
+interface Props {
+    baseUrl: string;
+    adminEmail: string;
+    metadataFormats: Record<string, MetadataFormat>;
+}
+
+function CopyButton({ text }: { text: string }) {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={handleCopy} title="Copy to clipboard">
+            {copied ? <span className="text-xs text-green-600">✓</span> : <Copy className="h-3.5 w-3.5" />}
+        </Button>
+    );
+}
+
+function ExampleUrl({ url }: { url: string }) {
+    return (
+        <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
+            <code className="flex-1 break-all text-sm">{url}</code>
+            <CopyButton text={url} />
+        </div>
+    );
+}
+
+export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats }: Props) {
+    return (
+        <PublicLayout>
+            <Head title="OAI-PMH Documentation" />
+
+            <div className="space-y-8">
+                {/* Header */}
+                <div>
+                    <h1 className="mb-2 text-3xl font-bold tracking-tight">OAI-PMH Harvesting Endpoint</h1>
+                    <p className="text-lg text-muted-foreground">
+                        This repository provides a fully compliant{' '}
+                        <a
+                            href="http://www.openarchives.org/OAI/openarchivesprotocol.html"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-primary underline"
+                        >
+                            OAI-PMH 2.0
+                        </a>{' '}
+                        endpoint for harvesting metadata of published research datasets and physical samples (IGSN).
+                    </p>
+                </div>
+
+                {/* Base URL */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Base URL</CardTitle>
+                        <CardDescription>Use this URL as the base for all OAI-PMH requests</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <ExampleUrl url={baseUrl} />
+                        <p className="mt-2 text-sm text-muted-foreground">
+                            Contact: <a href={`mailto:${adminEmail}`} className="text-primary underline">{adminEmail}</a>
+                        </p>
+                    </CardContent>
+                </Card>
+
+                {/* Supported Verbs */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Supported Verbs</CardTitle>
+                        <CardDescription>The endpoint supports all 6 standard OAI-PMH verbs</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Verb</TableHead>
+                                    <TableHead>Description</TableHead>
+                                    <TableHead>Required Parameters</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell><Badge variant="secondary">Identify</Badge></TableCell>
+                                    <TableCell>Information about the repository</TableCell>
+                                    <TableCell className="text-muted-foreground">None</TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell><Badge variant="secondary">ListMetadataFormats</Badge></TableCell>
+                                    <TableCell>Supported metadata formats (optionally per record)</TableCell>
+                                    <TableCell className="text-muted-foreground">None (optional: <code>identifier</code>)</TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell><Badge variant="secondary">ListSets</Badge></TableCell>
+                                    <TableCell>Available set structure for selective harvesting</TableCell>
+                                    <TableCell className="text-muted-foreground">None</TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell><Badge variant="secondary">ListIdentifiers</Badge></TableCell>
+                                    <TableCell>Record headers only (identifier, datestamp, sets)</TableCell>
+                                    <TableCell><code>metadataPrefix</code></TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell><Badge variant="secondary">ListRecords</Badge></TableCell>
+                                    <TableCell>Full metadata records with headers</TableCell>
+                                    <TableCell><code>metadataPrefix</code></TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell><Badge variant="secondary">GetRecord</Badge></TableCell>
+                                    <TableCell>A single record by its unique identifier</TableCell>
+                                    <TableCell><code>identifier</code>, <code>metadataPrefix</code></TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+
+                {/* Metadata Formats */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Metadata Formats</CardTitle>
+                        <CardDescription>Two metadata formats are available for harvesting</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Prefix</TableHead>
+                                    <TableHead>Description</TableHead>
+                                    <TableHead>Schema</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {Object.entries(metadataFormats).map(([prefix, format]) => (
+                                    <TableRow key={prefix}>
+                                        <TableCell><code>{prefix}</code></TableCell>
+                                        <TableCell>{prefix === 'oai_dc' ? 'Dublin Core (mandatory)' : 'DataCite Kernel 4.7'}</TableCell>
+                                        <TableCell>
+                                            <a href={format.schema} target="_blank" rel="noreferrer" className="text-primary underline break-all text-sm">
+                                                {format.schema}
+                                            </a>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+
+                {/* Sets */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Sets (Selective Harvesting)</CardTitle>
+                        <CardDescription>Records are organized into sets for selective harvesting</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <div>
+                            <h4 className="mb-2 font-medium">Resource Type Sets</h4>
+                            <p className="mb-2 text-sm text-muted-foreground">
+                                Filter by DataCite resource type using the <code>set</code> parameter.
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                                {['Dataset', 'Text', 'Image', 'PhysicalObject', 'Software', 'Collection'].map((type) => (
+                                    <Badge key={type} variant="outline">resourcetype:{type}</Badge>
+                                ))}
+                            </div>
+                        </div>
+                        <div>
+                            <h4 className="mb-2 font-medium">Publication Year Sets</h4>
+                            <p className="mb-2 text-sm text-muted-foreground">
+                                Filter by publication year.
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                                <Badge variant="outline">year:2023</Badge>
+                                <Badge variant="outline">year:2024</Badge>
+                                <Badge variant="outline">year:2025</Badge>
+                                <span className="text-sm text-muted-foreground">...</span>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                {/* Example Requests */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Example Requests</CardTitle>
+                        <CardDescription>Copyable example URLs for each verb</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <Tabs defaultValue="identify" className="w-full">
+                            <TabsList className="mb-4 flex flex-wrap h-auto gap-1">
+                                <TabsTrigger value="identify">Identify</TabsTrigger>
+                                <TabsTrigger value="formats">ListMetadataFormats</TabsTrigger>
+                                <TabsTrigger value="sets">ListSets</TabsTrigger>
+                                <TabsTrigger value="identifiers">ListIdentifiers</TabsTrigger>
+                                <TabsTrigger value="records">ListRecords</TabsTrigger>
+                                <TabsTrigger value="getrecord">GetRecord</TabsTrigger>
+                            </TabsList>
+
+                            <TabsContent value="identify" className="space-y-2">
+                                <p className="text-sm">Retrieve information about this repository:</p>
+                                <ExampleUrl url={`${baseUrl}?verb=Identify`} />
+                            </TabsContent>
+
+                            <TabsContent value="formats" className="space-y-2">
+                                <p className="text-sm">List all supported metadata formats:</p>
+                                <ExampleUrl url={`${baseUrl}?verb=ListMetadataFormats`} />
+                            </TabsContent>
+
+                            <TabsContent value="sets" className="space-y-2">
+                                <p className="text-sm">List all available sets:</p>
+                                <ExampleUrl url={`${baseUrl}?verb=ListSets`} />
+                            </TabsContent>
+
+                            <TabsContent value="identifiers" className="space-y-4">
+                                <div className="space-y-2">
+                                    <p className="text-sm">List all record headers in Dublin Core format:</p>
+                                    <ExampleUrl url={`${baseUrl}?verb=ListIdentifiers&metadataPrefix=oai_dc`} />
+                                </div>
+                                <div className="space-y-2">
+                                    <p className="text-sm">Filter by set and date range:</p>
+                                    <ExampleUrl url={`${baseUrl}?verb=ListIdentifiers&metadataPrefix=oai_dc&set=resourcetype:Dataset&from=2024-01-01&until=2024-12-31`} />
+                                </div>
+                            </TabsContent>
+
+                            <TabsContent value="records" className="space-y-4">
+                                <div className="space-y-2">
+                                    <p className="text-sm">Harvest all records in Dublin Core format:</p>
+                                    <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_dc`} />
+                                </div>
+                                <div className="space-y-2">
+                                    <p className="text-sm">Harvest DataCite XML for datasets only:</p>
+                                    <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_datacite&set=resourcetype:Dataset`} />
+                                </div>
+                            </TabsContent>
+
+                            <TabsContent value="getrecord" className="space-y-2">
+                                <p className="text-sm">Retrieve a single record by its OAI identifier:</p>
+                                <ExampleUrl url={`${baseUrl}?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001&metadataPrefix=oai_dc`} />
+                            </TabsContent>
+                        </Tabs>
+                    </CardContent>
+                </Card>
+
+                {/* Resumption Tokens */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Resumption Tokens (Pagination)</CardTitle>
+                        <CardDescription>How large result sets are paginated</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm">
+                        <p>
+                            When a <code>ListRecords</code> or <code>ListIdentifiers</code> response contains more than <strong>100 records</strong>,
+                            the response includes a <code>&lt;resumptionToken&gt;</code> element.
+                        </p>
+                        <p>To retrieve the next page, send a new request with the token as the exclusive parameter:</p>
+                        <ExampleUrl url={`${baseUrl}?verb=ListRecords&resumptionToken=<token_value>`} />
+                        <p className="text-muted-foreground">
+                            Tokens expire after <strong>24 hours</strong>. An empty <code>&lt;resumptionToken&gt;</code> element
+                            (with no text content) signals the end of the result set.
+                        </p>
+                    </CardContent>
+                </Card>
+
+                {/* Selective Harvesting */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Selective Harvesting</CardTitle>
+                        <CardDescription>Filtering records by date and set</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4 text-sm">
+                        <div>
+                            <h4 className="mb-1 font-medium">Date-based Harvesting</h4>
+                            <p className="text-muted-foreground">
+                                Use <code>from</code> and <code>until</code> parameters to harvest records modified within a date range.
+                                Both parameters accept dates in <code>YYYY-MM-DD</code> or <code>YYYY-MM-DDThh:mm:ssZ</code> format.
+                            </p>
+                        </div>
+                        <div>
+                            <h4 className="mb-1 font-medium">Set-based Harvesting</h4>
+                            <p className="text-muted-foreground">
+                                Use the <code>set</code> parameter to harvest only records belonging to a specific set.
+                                For example, <code>set=resourcetype:Dataset</code> harvests only dataset records.
+                            </p>
+                        </div>
+                        <div>
+                            <h4 className="mb-1 font-medium">Combining Filters</h4>
+                            <p className="text-muted-foreground">
+                                Date and set filters can be combined for targeted harvesting:
+                            </p>
+                            <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_datacite&set=resourcetype:Dataset&from=2024-01-01`} />
+                        </div>
+                    </CardContent>
+                </Card>
+
+                {/* Deleted Records */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Deleted Records</CardTitle>
+                        <CardDescription>How this repository handles deleted or depublished records</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm">
+                        <p>
+                            This repository uses <strong>persistent</strong> deleted record tracking.
+                            When a record is deleted or depublished, it remains permanently in the OAI-PMH responses
+                            with a <code>status=&quot;deleted&quot;</code> attribute in the header.
+                        </p>
+                        <p>
+                            Deleted records appear in <code>ListRecords</code> and <code>ListIdentifiers</code> responses
+                            and can be individually retrieved via <code>GetRecord</code>. They do not include metadata,
+                            only the header with identifier, datestamp, and set memberships.
+                        </p>
+                    </CardContent>
+                </Card>
+
+                {/* Best Practices */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Best Practices for Harvesters</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm">
+                        <ul className="list-inside list-disc space-y-2 text-muted-foreground">
+                            <li>Use incremental harvesting with <code>from</code> dates to avoid re-harvesting unchanged records.</li>
+                            <li>Prefer <code>oai_datacite</code> format for richer metadata (DataCite Kernel 4.7).</li>
+                            <li>Implement retry logic for transient errors (HTTP 503 with Retry-After header).</li>
+                            <li>Respect the <code>resumptionToken</code> expiration; do not cache tokens beyond 24 hours.</li>
+                            <li>Process deleted records to remove or flag previously harvested entries.</li>
+                        </ul>
+                    </CardContent>
+                </Card>
+
+                {/* OAI Identifier Format */}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>OAI Identifier Format</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2 text-sm">
+                        <p>Record identifiers follow the format:</p>
+                        <div className="rounded-md bg-muted/50 px-3 py-2">
+                            <code>oai:ernie.gfz.de:&#123;DOI&#125;</code>
+                        </div>
+                        <p className="text-muted-foreground">
+                            Example: <code>oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001</code>
+                        </p>
+                    </CardContent>
+                </Card>
+            </div>
+        </PublicLayout>
+    );
+}

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -19,6 +19,7 @@ interface Props {
     adminEmail: string;
     metadataFormats: Record<string, MetadataFormat>;
     resourceTypeSlugs: string[];
+    identifierPrefix: string;
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -56,7 +57,7 @@ function ExampleUrl({ url }: { url: string }) {
     );
 }
 
-export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resourceTypeSlugs }: Props) {
+export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resourceTypeSlugs, identifierPrefix }: Props) {
     const exampleSetSpec = resourceTypeSlugs.includes('dataset')
         ? 'resourcetype:dataset'
         : resourceTypeSlugs.length > 0
@@ -270,7 +271,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
 
                             <TabsContent value="getrecord" className="space-y-2">
                                 <p className="text-sm">Retrieve a single record by its OAI identifier:</p>
-                                <ExampleUrl url={`${baseUrl}?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001&metadataPrefix=oai_dc`} />
+                                <ExampleUrl url={`${baseUrl}?verb=GetRecord&identifier=${identifierPrefix}:10.5880/GFZ.1.2.2024.001&metadataPrefix=oai_dc`} />
                             </TabsContent>
                         </Tabs>
                     </CardContent>
@@ -371,10 +372,10 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                     <CardContent className="space-y-2 text-sm">
                         <p>Record identifiers follow the format:</p>
                         <div className="rounded-md bg-muted/50 px-3 py-2">
-                            <code>oai:ernie.gfz.de:&#123;DOI&#125;</code>
+                            <code>{identifierPrefix}:&#123;DOI&#125;</code>
                         </div>
                         <p className="text-muted-foreground">
-                            Example: <code>oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001</code>
+                            Example: <code>{identifierPrefix}:10.5880/GFZ.1.2.2024.001</code>
                         </p>
                     </CardContent>
                 </Card>

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -359,7 +359,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                         <ul className="list-inside list-disc space-y-2 text-muted-foreground">
                             <li>Use incremental harvesting with <code>from</code> dates to avoid re-harvesting unchanged records.</li>
                             <li>Prefer <code>oai_datacite</code> format for richer metadata (DataCite Kernel 4.7).</li>
-                            <li>Implement retry logic for transient errors (HTTP 503 with Retry-After header).</li>
+                            <li>Implement retry logic for rate limiting (HTTP 429); back off and retry after the indicated delay.</li>
                             <li>Respect the <code>resumptionToken</code> expiration; do not cache tokens beyond {tokenTtlHours} hours.</li>
                             <li>Process deleted records to remove or flag previously harvested entries.</li>
                         </ul>

--- a/resources/js/pages/oai-pmh/docs.tsx
+++ b/resources/js/pages/oai-pmh/docs.tsx
@@ -57,6 +57,11 @@ function ExampleUrl({ url }: { url: string }) {
 }
 
 export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resourceTypeSlugs }: Props) {
+    const exampleSetSpec = resourceTypeSlugs.includes('dataset')
+        ? 'resourcetype:dataset'
+        : resourceTypeSlugs.length > 0
+          ? `resourcetype:${resourceTypeSlugs[0]}`
+          : 'resourcetype:dataset';
     return (
         <PublicLayout>
             <Head title="OAI-PMH Documentation" />
@@ -248,7 +253,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                                 </div>
                                 <div className="space-y-2">
                                     <p className="text-sm">Filter by set and date range:</p>
-                                    <ExampleUrl url={`${baseUrl}?verb=ListIdentifiers&metadataPrefix=oai_dc&set=resourcetype:Dataset&from=2024-01-01&until=2024-12-31`} />
+                                    <ExampleUrl url={`${baseUrl}?verb=ListIdentifiers&metadataPrefix=oai_dc&set=${exampleSetSpec}&from=2024-01-01&until=2024-12-31`} />
                                 </div>
                             </TabsContent>
 
@@ -259,7 +264,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                                 </div>
                                 <div className="space-y-2">
                                     <p className="text-sm">Harvest DataCite XML for datasets only:</p>
-                                    <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_datacite&set=resourcetype:Dataset`} />
+                                    <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_datacite&set=${exampleSetSpec}`} />
                                 </div>
                             </TabsContent>
 
@@ -309,7 +314,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                             <h4 className="mb-1 font-medium">Set-based Harvesting</h4>
                             <p className="text-muted-foreground">
                                 Use the <code>set</code> parameter to harvest only records belonging to a specific set.
-                                For example, <code>set=resourcetype:Dataset</code> harvests only dataset records.
+                                For example, <code>set={exampleSetSpec}</code> harvests only dataset records.
                             </p>
                         </div>
                         <div>
@@ -317,7 +322,7 @@ export default function OaiPmhDocs({ baseUrl, adminEmail, metadataFormats, resou
                             <p className="text-muted-foreground">
                                 Date and set filters can be combined for targeted harvesting:
                             </p>
-                            <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_datacite&set=resourcetype:Dataset&from=2024-01-01`} />
+                            <ExampleUrl url={`${baseUrl}?verb=ListRecords&metadataPrefix=oai_datacite&set=${exampleSetSpec}&from=2024-01-01`} />
                         </div>
                     </CardContent>
                 </Card>

--- a/routes/console.php
+++ b/routes/console.php
@@ -54,3 +54,9 @@ Schedule::call(function () {
 })->weeklyOn(0, '02:00')
     ->name('discover-relations')
     ->withoutOverlapping();
+
+// Purge expired OAI-PMH resumption tokens daily at 03:00 UTC
+Schedule::command('oaipmh:purge-tokens')
+    ->dailyAt('03:00')
+    ->name('purge-oaipmh-tokens')
+    ->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,7 +80,7 @@ Route::get('/portal', [PortalController::class, 'index'])->name('portal');
 // OAI-PMH Harvesting Endpoint
 // ===========================================================
 Route::get('/oai-pmh/docs', [OaiPmhDocsController::class, 'index'])->name('oaipmh.docs');
-Route::match(['get', 'post'], '/oai-pmh', OaiPmhController::class)->name('oaipmh');
+Route::match(['get', 'post'], '/oai-pmh', OaiPmhController::class)->middleware('throttle:oai-pmh')->name('oaipmh');
 
 // Public Landing Pages (accessible without authentication)
 // ===========================================================

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,6 +75,11 @@ Route::get('/changelog', function () {
 // ===========================================================
 Route::get('/portal', [PortalController::class, 'index'])->name('portal');
 
+// OAI-PMH Harvesting Endpoint
+// ===========================================================
+Route::get('/oai-pmh/docs', [\App\Http\Controllers\OaiPmh\OaiPmhDocsController::class, 'index'])->name('oaipmh.docs');
+Route::match(['get', 'post'], '/oai-pmh', \App\Http\Controllers\OaiPmh\OaiPmhController::class)->name('oaipmh');
+
 // Public Landing Pages (accessible without authentication)
 // ===========================================================
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\IgsnMapController;
 use App\Http\Controllers\LandingPageController;
 use App\Http\Controllers\LandingPagePreviewController;
 use App\Http\Controllers\LandingPagePublicController;
+use App\Http\Controllers\OaiPmh\OaiPmhController;
+use App\Http\Controllers\OaiPmh\OaiPmhDocsController;
 use App\Http\Controllers\OldDatasetController;
 use App\Http\Controllers\OldDataStatisticsController;
 use App\Http\Controllers\PortalController;
@@ -77,8 +79,8 @@ Route::get('/portal', [PortalController::class, 'index'])->name('portal');
 
 // OAI-PMH Harvesting Endpoint
 // ===========================================================
-Route::get('/oai-pmh/docs', [\App\Http\Controllers\OaiPmh\OaiPmhDocsController::class, 'index'])->name('oaipmh.docs');
-Route::match(['get', 'post'], '/oai-pmh', \App\Http\Controllers\OaiPmh\OaiPmhController::class)->name('oaipmh');
+Route::get('/oai-pmh/docs', [OaiPmhDocsController::class, 'index'])->name('oaipmh.docs');
+Route::match(['get', 'post'], '/oai-pmh', OaiPmhController::class)->name('oaipmh');
 
 // Public Landing Pages (accessible without authentication)
 // ===========================================================

--- a/tests/pest/Arch/ArchTest.php
+++ b/tests/pest/Arch/ArchTest.php
@@ -65,7 +65,7 @@ describe('Services', function () {
             'App\Services\OldDatasetEditorLoader',
             'App\Services\JsonSchemaValidator',
             'App\Services\DataCiteSyncResult',
-        ]);
+            'App\Services\OaiPmh\OaiPmhXmlResponseBuilder',            'App\\Services\\OaiPmh\\DublinCoreMapper',        ]);
 
     arch('services are not extending controllers')
         ->expect('App\Services')

--- a/tests/pest/Arch/ArchTest.php
+++ b/tests/pest/Arch/ArchTest.php
@@ -65,7 +65,9 @@ describe('Services', function () {
             'App\Services\OldDatasetEditorLoader',
             'App\Services\JsonSchemaValidator',
             'App\Services\DataCiteSyncResult',
-            'App\Services\OaiPmh\OaiPmhXmlResponseBuilder',            'App\\Services\\OaiPmh\\DublinCoreMapper',        ]);
+            'App\Services\OaiPmh\OaiPmhXmlResponseBuilder',
+            'App\Services\OaiPmh\DublinCoreMapper',
+        ]);
 
     arch('services are not extending controllers')
         ->expect('App\Services')

--- a/tests/pest/Feature/OaiPmh/LandingPageObserverOaiPmhTest.php
+++ b/tests/pest/Feature/OaiPmh/LandingPageObserverOaiPmhTest.php
@@ -37,7 +37,7 @@ describe('LandingPageObserver OAI-PMH tracking', function () {
             'oai_identifier' => "{$prefix}:10.5880/obs.2024.002",
             'doi' => '10.5880/obs.2024.002',
             'datestamp' => now(),
-            'sets' => ['resourcetype:Dataset'],
+            'sets' => ['resourcetype:dataset'],
         ]);
 
         $landingPage->update(['is_published' => true]);

--- a/tests/pest/Feature/OaiPmh/LandingPageObserverOaiPmhTest.php
+++ b/tests/pest/Feature/OaiPmh/LandingPageObserverOaiPmhTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\OaiPmhDeletedRecord;
+use App\Models\Resource;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('LandingPageObserver OAI-PMH tracking', function () {
+    it('creates a deleted record when landing page is depublished', function () {
+        $resource = Resource::factory()->create(['doi' => '10.5880/obs.2024.001']);
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+        ]);
+
+        $landingPage->update(['is_published' => false]);
+
+        $deleted = OaiPmhDeletedRecord::where('doi', '10.5880/obs.2024.001')->first();
+
+        expect($deleted)->not->toBeNull()
+            ->and($deleted->oai_identifier)->toBe('oai:ernie.gfz.de:10.5880/obs.2024.001');
+    });
+
+    it('removes deleted record when landing page is republished', function () {
+        $resource = Resource::factory()->create(['doi' => '10.5880/obs.2024.002']);
+        $landingPage = LandingPage::factory()->draft()->create([
+            'resource_id' => $resource->id,
+        ]);
+
+        // Create a deleted record as if previously depublished
+        OaiPmhDeletedRecord::create([
+            'oai_identifier' => 'oai:ernie.gfz.de:10.5880/obs.2024.002',
+            'doi' => '10.5880/obs.2024.002',
+            'datestamp' => now(),
+            'sets' => ['resourcetype:Dataset'],
+        ]);
+
+        $landingPage->update(['is_published' => true]);
+
+        expect(OaiPmhDeletedRecord::where('doi', '10.5880/obs.2024.002')->exists())->toBeFalse();
+    });
+
+    it('does not create deleted record when resource has no DOI', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+        ]);
+
+        $landingPage->update(['is_published' => false]);
+
+        expect(OaiPmhDeletedRecord::count())->toBe(0);
+    });
+
+    it('does not create duplicate deleted records', function () {
+        $resource = Resource::factory()->create(['doi' => '10.5880/obs.2024.003']);
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+        ]);
+
+        // Pre-create a deleted record
+        OaiPmhDeletedRecord::create([
+            'oai_identifier' => 'oai:ernie.gfz.de:10.5880/obs.2024.003',
+            'doi' => '10.5880/obs.2024.003',
+            'datestamp' => now(),
+            'sets' => [],
+        ]);
+
+        $landingPage->update(['is_published' => false]);
+
+        expect(OaiPmhDeletedRecord::where('doi', '10.5880/obs.2024.003')->count())->toBe(1);
+    });
+});

--- a/tests/pest/Feature/OaiPmh/LandingPageObserverOaiPmhTest.php
+++ b/tests/pest/Feature/OaiPmh/LandingPageObserverOaiPmhTest.php
@@ -11,6 +11,7 @@ uses(RefreshDatabase::class);
 
 describe('LandingPageObserver OAI-PMH tracking', function () {
     it('creates a deleted record when landing page is depublished', function () {
+        $prefix = config('oaipmh.identifier_prefix');
         $resource = Resource::factory()->create(['doi' => '10.5880/obs.2024.001']);
         $landingPage = LandingPage::factory()->published()->create([
             'resource_id' => $resource->id,
@@ -21,10 +22,11 @@ describe('LandingPageObserver OAI-PMH tracking', function () {
         $deleted = OaiPmhDeletedRecord::where('doi', '10.5880/obs.2024.001')->first();
 
         expect($deleted)->not->toBeNull()
-            ->and($deleted->oai_identifier)->toBe('oai:ernie.gfz.de:10.5880/obs.2024.001');
+            ->and($deleted->oai_identifier)->toBe("{$prefix}:10.5880/obs.2024.001");
     });
 
     it('removes deleted record when landing page is republished', function () {
+        $prefix = config('oaipmh.identifier_prefix');
         $resource = Resource::factory()->create(['doi' => '10.5880/obs.2024.002']);
         $landingPage = LandingPage::factory()->draft()->create([
             'resource_id' => $resource->id,
@@ -32,7 +34,7 @@ describe('LandingPageObserver OAI-PMH tracking', function () {
 
         // Create a deleted record as if previously depublished
         OaiPmhDeletedRecord::create([
-            'oai_identifier' => 'oai:ernie.gfz.de:10.5880/obs.2024.002',
+            'oai_identifier' => "{$prefix}:10.5880/obs.2024.002",
             'doi' => '10.5880/obs.2024.002',
             'datestamp' => now(),
             'sets' => ['resourcetype:Dataset'],
@@ -55,6 +57,7 @@ describe('LandingPageObserver OAI-PMH tracking', function () {
     });
 
     it('does not create duplicate deleted records', function () {
+        $prefix = config('oaipmh.identifier_prefix');
         $resource = Resource::factory()->create(['doi' => '10.5880/obs.2024.003']);
         $landingPage = LandingPage::factory()->published()->create([
             'resource_id' => $resource->id,
@@ -62,7 +65,7 @@ describe('LandingPageObserver OAI-PMH tracking', function () {
 
         // Pre-create a deleted record
         OaiPmhDeletedRecord::create([
-            'oai_identifier' => 'oai:ernie.gfz.de:10.5880/obs.2024.003',
+            'oai_identifier' => "{$prefix}:10.5880/obs.2024.003",
             'doi' => '10.5880/obs.2024.003',
             'datestamp' => now(),
             'sets' => [],

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -116,7 +116,7 @@ test('ListMetadataFormats with unknown identifier returns idDoesNotExist', funct
 // ===================================================================
 
 test('ListSets returns resource type and year sets', function () {
-    createOaiPmhResource(['publication_year' => 2024]);
+    $resource = createOaiPmhResource(['publication_year' => 2024]);
 
     $response = $this->get('/oai-pmh?verb=ListSets');
 
@@ -128,7 +128,7 @@ test('ListSets returns resource type and year sets', function () {
         $specs[] = (string) $set->setSpec;
     }
 
-    expect($specs)->toContain('resourcetype:Dataset')
+    expect($specs)->toContain('resourcetype:' . $resource->resourceType->slug)
         ->and($specs)->toContain('year:2024');
 });
 

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -242,7 +242,7 @@ test('ListRecords includes deleted records on the first page', function () {
         'oai_identifier' => oaiId('10.5880/deleted.2024.001'),
         'doi' => '10.5880/deleted.2024.001',
         'datestamp' => now(),
-        'sets' => ['resourcetype:Dataset'],
+        'sets' => ['resourcetype:dataset'],
     ]);
 
     $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc');
@@ -299,7 +299,7 @@ test('GetRecord for deleted record returns status deleted', function () {
         'oai_identifier' => oaiId('10.5880/deleted.001'),
         'doi' => '10.5880/deleted.001',
         'datestamp' => now(),
-        'sets' => ['resourcetype:Dataset'],
+        'sets' => ['resourcetype:dataset'],
     ]);
 
     $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.5880/deleted.001') . '&metadataPrefix=oai_dc');

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Models\Description;
+use App\Models\DescriptionType;
 use App\Models\LandingPage;
 use App\Models\OaiPmhDeletedRecord;
+use App\Models\OaiPmhResumptionToken;
 use App\Models\Resource;
 use App\Models\Title;
 use App\Models\TitleType;
@@ -408,4 +411,185 @@ test('OAI-PMH docs page is accessible', function () {
     $response = $this->get('/oai-pmh/docs');
 
     $response->assertStatus(200);
+});
+
+// ===================================================================
+// CSRF Exclusion (POST without CSRF token)
+// ===================================================================
+
+test('POST requests work without CSRF token', function () {
+    // Simulate an external harvester (no session/CSRF)
+    $response = $this->post('/oai-pmh', ['verb' => 'Identify']);
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->Identify->repositoryName)->not->toBeEmpty();
+});
+
+// ===================================================================
+// Resumption Token Verb Mismatch
+// ===================================================================
+
+test('resumption token issued for different verb returns badResumptionToken', function () {
+    $token = OaiPmhResumptionToken::create([
+        'token' => 'verb-mismatch-token',
+        'verb' => 'ListIdentifiers',
+        'metadata_prefix' => 'oai_dc',
+        'cursor' => 100,
+        'complete_list_size' => 200,
+        'expires_at' => now()->addDay(),
+    ]);
+
+    // Try using the ListIdentifiers token with ListRecords
+    $response = $this->get('/oai-pmh?verb=ListRecords&resumptionToken=verb-mismatch-token');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badResumptionToken');
+});
+
+// ===================================================================
+// Idempotent Resumption Token Reuse
+// ===================================================================
+
+test('resumption token can be reused for retry on transient failure', function () {
+    // Create enough resources to trigger pagination
+    for ($i = 1; $i <= 3; $i++) {
+        createOaiPmhResource(['doi' => "10.5880/page.2024.{$i}"]);
+    }
+
+    // Create a resumption token pointing to cursor=1
+    $token = OaiPmhResumptionToken::create([
+        'token' => 'retry-token',
+        'verb' => 'ListRecords',
+        'metadata_prefix' => 'oai_dc',
+        'cursor' => 1,
+        'complete_list_size' => 3,
+        'expires_at' => now()->addDay(),
+    ]);
+
+    // First request
+    $response1 = $this->get('/oai-pmh?verb=ListRecords&resumptionToken=retry-token');
+    $response1->assertStatus(200);
+
+    // Token should still exist (idempotent reuse)
+    expect(OaiPmhResumptionToken::where('token', 'retry-token')->exists())->toBeTrue();
+
+    // Second request (retry) should also succeed
+    $response2 = $this->get('/oai-pmh?verb=ListRecords&resumptionToken=retry-token');
+    $response2->assertStatus(200);
+});
+
+// ===================================================================
+// Request Element Echoes resumptionToken
+// ===================================================================
+
+test('request element echoes resumptionToken attribute when using token', function () {
+    createOaiPmhResource(['doi' => '10.5880/echo.2024.001']);
+
+    $token = OaiPmhResumptionToken::create([
+        'token' => 'echo-test-token',
+        'verb' => 'ListRecords',
+        'metadata_prefix' => 'oai_dc',
+        'cursor' => 0,
+        'complete_list_size' => 1,
+        'expires_at' => now()->addDay(),
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=ListRecords&resumptionToken=echo-test-token');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->request['resumptionToken'])->toBe('echo-test-token');
+});
+
+// ===================================================================
+// Stricter Set Spec Validation
+// ===================================================================
+
+test('empty set value after prefix returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=year:');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('non-numeric year set value returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=year:abcd');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('five-digit year set value returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=year:20241');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('empty resourcetype value returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=resourcetype:');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+// ===================================================================
+// Granularity Mismatch
+// ===================================================================
+
+test('mixed date granularity between from and until returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&from=2024-01-01&until=2024-12-31T23:59:59Z');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument')
+        ->and((string) $xml->error)->toContain('granularity');
+});
+
+// ===================================================================
+// Dublin Core Description Mapping
+// ===================================================================
+
+test('ListRecords oai_dc includes dc:description from resource', function () {
+    $resource = createOaiPmhResource(['doi' => '10.5880/desc.2024.001']);
+
+    $descType = DescriptionType::firstOrCreate(
+        ['slug' => 'Abstract'],
+        ['name' => 'Abstract', 'slug' => 'Abstract', 'is_active' => true],
+    );
+
+    Description::create([
+        'resource_id' => $resource->id,
+        'value' => 'This is a test abstract for DC mapping',
+        'description_type_id' => $descType->id,
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc');
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('dc:description')
+        ->and($content)->toContain('This is a test abstract for DC mapping');
+});
+
+// ===================================================================
+// Identify repositoryIdentifier from config
+// ===================================================================
+
+test('Identify response derives repositoryIdentifier from config', function () {
+    $response = $this->get('/oai-pmh?verb=Identify');
+
+    $content = $response->getContent();
+
+    // repositoryIdentifier should match the part after "oai:" in identifier_prefix
+    $expectedId = str_replace('oai:', '', (string) config('oaipmh.identifier_prefix'));
+
+    expect($content)->toContain("<repositoryIdentifier>{$expectedId}</repositoryIdentifier>");
 });

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -42,6 +42,14 @@ function createOaiPmhResource(array $attributes = []): Resource
     return $resource->refresh();
 }
 
+/**
+ * Build OAI identifier from a DOI using the configured prefix.
+ */
+function oaiId(string $doi): string
+{
+    return config('oaipmh.identifier_prefix') . ':' . $doi;
+}
+
 // ===================================================================
 // Verb: Identify
 // ===================================================================
@@ -92,7 +100,7 @@ test('ListMetadataFormats returns oai_dc and oai_datacite', function () {
 
 test('ListMetadataFormats with valid identifier returns formats', function () {
     $resource = createOaiPmhResource(['doi' => '10.5880/test.2024.001']);
-    $identifier = 'oai:ernie.gfz.de:10.5880/test.2024.001';
+    $identifier = oaiId('10.5880/test.2024.001');
 
     $response = $this->get("/oai-pmh?verb=ListMetadataFormats&identifier={$identifier}");
 
@@ -103,7 +111,7 @@ test('ListMetadataFormats with valid identifier returns formats', function () {
 });
 
 test('ListMetadataFormats with unknown identifier returns idDoesNotExist', function () {
-    $response = $this->get('/oai-pmh?verb=ListMetadataFormats&identifier=oai:ernie.gfz.de:10.9999/nonexistent');
+    $response = $this->get('/oai-pmh?verb=ListMetadataFormats&identifier=' . oaiId('10.9999/nonexistent'));
 
     $response->assertStatus(200);
     $xml = simplexml_load_string($response->getContent());
@@ -152,7 +160,7 @@ test('ListRecords with oai_dc returns Dublin Core metadata', function () {
     $response->assertStatus(200);
     $content = $response->getContent();
 
-    expect($content)->toContain('oai:ernie.gfz.de:10.5880/test.2024.001')
+    expect($content)->toContain(oaiId('10.5880/test.2024.001'))
         ->and($content)->toContain('Test Dataset Title')
         ->and($content)->toContain('dc:title');
 });
@@ -165,7 +173,7 @@ test('ListRecords with oai_datacite returns DataCite metadata', function () {
     $response->assertStatus(200);
     $content = $response->getContent();
 
-    expect($content)->toContain('oai:ernie.gfz.de:10.5880/test.2024.002');
+    expect($content)->toContain(oaiId('10.5880/test.2024.002'));
 });
 
 test('ListRecords without metadataPrefix returns badArgument', function () {
@@ -231,7 +239,7 @@ test('ListRecords includes deleted records on the first page', function () {
     createOaiPmhResource(['doi' => '10.5880/live.2024.001']);
 
     OaiPmhDeletedRecord::create([
-        'oai_identifier' => 'oai:ernie.gfz.de:10.5880/deleted.2024.001',
+        'oai_identifier' => oaiId('10.5880/deleted.2024.001'),
         'doi' => '10.5880/deleted.2024.001',
         'datestamp' => now(),
         'sets' => ['resourcetype:Dataset'],
@@ -258,7 +266,7 @@ test('ListIdentifiers returns headers without metadata', function () {
     $response->assertStatus(200);
     $content = $response->getContent();
 
-    expect($content)->toContain('oai:ernie.gfz.de:10.5880/hdr.2024.001')
+    expect($content)->toContain(oaiId('10.5880/hdr.2024.001'))
         ->and($content)->not->toContain('dc:title');
 });
 
@@ -269,17 +277,17 @@ test('ListIdentifiers returns headers without metadata', function () {
 test('GetRecord returns a single record', function () {
     createOaiPmhResource(['doi' => '10.5880/single.2024.001']);
 
-    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/single.2024.001&metadataPrefix=oai_dc');
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.5880/single.2024.001') . '&metadataPrefix=oai_dc');
 
     $response->assertStatus(200);
     $content = $response->getContent();
 
-    expect($content)->toContain('oai:ernie.gfz.de:10.5880/single.2024.001')
+    expect($content)->toContain(oaiId('10.5880/single.2024.001'))
         ->and($content)->toContain('dc:title');
 });
 
 test('GetRecord with nonexistent identifier returns idDoesNotExist', function () {
-    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.9999/nonexistent&metadataPrefix=oai_dc');
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.9999/nonexistent') . '&metadataPrefix=oai_dc');
 
     $xml = simplexml_load_string($response->getContent());
 
@@ -288,13 +296,13 @@ test('GetRecord with nonexistent identifier returns idDoesNotExist', function ()
 
 test('GetRecord for deleted record returns status deleted', function () {
     OaiPmhDeletedRecord::create([
-        'oai_identifier' => 'oai:ernie.gfz.de:10.5880/deleted.001',
+        'oai_identifier' => oaiId('10.5880/deleted.001'),
         'doi' => '10.5880/deleted.001',
         'datestamp' => now(),
         'sets' => ['resourcetype:Dataset'],
     ]);
 
-    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/deleted.001&metadataPrefix=oai_dc');
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.5880/deleted.001') . '&metadataPrefix=oai_dc');
 
     $content = $response->getContent();
 
@@ -310,7 +318,7 @@ test('GetRecord without identifier returns badArgument', function () {
 });
 
 test('GetRecord without metadataPrefix returns badArgument', function () {
-    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/test');
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.5880/test') . '');
 
     $xml = simplexml_load_string($response->getContent());
 
@@ -627,7 +635,7 @@ test('datestamp reflects published_at when it is newer than updated_at', functio
         'published_at' => $publishedAt,
     ]);
 
-    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/datestamp.2024.001&metadataPrefix=oai_dc');
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.5880/datestamp.2024.001') . '&metadataPrefix=oai_dc');
 
     $content = $response->getContent();
 
@@ -647,7 +655,7 @@ test('datestamp reflects updated_at when it is newer than published_at', functio
         'published_at' => Carbon::parse('2024-01-01 00:00:00'),
     ]);
 
-    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/datestamp.2024.002&metadataPrefix=oai_dc');
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=' . oaiId('10.5880/datestamp.2024.002') . '&metadataPrefix=oai_dc');
 
     $content = $response->getContent();
 

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -11,6 +11,7 @@ use App\Models\Resource;
 use App\Models\Title;
 use App\Models\TitleType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 
 uses(RefreshDatabase::class);
 
@@ -592,4 +593,63 @@ test('Identify response derives repositoryIdentifier from config', function () {
     $expectedId = str_replace('oai:', '', (string) config('oaipmh.identifier_prefix'));
 
     expect($content)->toContain("<repositoryIdentifier>{$expectedId}</repositoryIdentifier>");
+});
+
+// ===================================================================
+// Set Spec with Spaces (OAI-PMH grammar violation)
+// ===================================================================
+
+test('resourcetype set spec with spaces returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=resourcetype:Physical Object');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+// ===================================================================
+// Effective Datestamp (GREATEST of updated_at, published_at)
+// ===================================================================
+
+test('datestamp reflects published_at when it is newer than updated_at', function () {
+    $resource = Resource::factory()->create(['doi' => '10.5880/datestamp.2024.001']);
+
+    // Set updated_at to an older date without triggering model events
+    Resource::withoutTimestamps(fn () => Resource::where('id', $resource->id)->update([
+        'updated_at' => '2024-01-01 00:00:00',
+    ]));
+
+    // Set published_at to a newer date
+    $publishedAt = Carbon::parse('2024-06-15 12:00:00');
+    LandingPage::factory()->create([
+        'resource_id' => $resource->id,
+        'is_published' => true,
+        'published_at' => $publishedAt,
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/datestamp.2024.001&metadataPrefix=oai_dc');
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('2024-06-15T12:00:00Z');
+});
+
+test('datestamp reflects updated_at when it is newer than published_at', function () {
+    $updatedAt = Carbon::parse('2024-09-01 10:00:00');
+    $resource = Resource::factory()->create([
+        'doi' => '10.5880/datestamp.2024.002',
+        'updated_at' => $updatedAt,
+    ]);
+
+    LandingPage::factory()->create([
+        'resource_id' => $resource->id,
+        'is_published' => true,
+        'published_at' => Carbon::parse('2024-01-01 00:00:00'),
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/datestamp.2024.002&metadataPrefix=oai_dc');
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('2024-09-01T10:00:00Z');
 });

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -1,0 +1,411 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\OaiPmhDeletedRecord;
+use App\Models\Resource;
+use App\Models\Title;
+use App\Models\TitleType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Create a published resource with landing page for OAI-PMH testing.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function createPublishedResource(array $attributes = []): Resource
+{
+    $resource = Resource::factory()->create($attributes);
+
+    LandingPage::factory()->published()->create([
+        'resource_id' => $resource->id,
+    ]);
+
+    $titleType = TitleType::firstOrCreate(
+        ['slug' => 'MainTitle'],
+        ['name' => 'Main Title', 'slug' => 'MainTitle', 'is_active' => true],
+    );
+
+    Title::create([
+        'resource_id' => $resource->id,
+        'value' => 'Test Dataset Title',
+        'title_type_id' => $titleType->id,
+    ]);
+
+    return $resource->refresh();
+}
+
+// ===================================================================
+// Verb: Identify
+// ===================================================================
+
+test('Identify returns valid OAI-PMH response', function () {
+    $response = $this->get('/oai-pmh?verb=Identify');
+
+    $response->assertStatus(200)
+        ->assertHeader('Content-Type', 'text/xml; charset=utf-8');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect($xml->getName())->toBe('OAI-PMH')
+        ->and((string) $xml->Identify->repositoryName)->toBe('ERNIE – GFZ Data Publication Repository')
+        ->and((string) $xml->Identify->protocolVersion)->toBe('2.0')
+        ->and((string) $xml->Identify->adminEmail)->toBe('datapub@gfz.de')
+        ->and((string) $xml->Identify->deletedRecord)->toBe('persistent')
+        ->and((string) $xml->Identify->granularity)->toBe('YYYY-MM-DDThh:mm:ssZ');
+});
+
+test('Identify includes sample identifier when published resources exist', function () {
+    $resource = createPublishedResource(['doi' => '10.5880/GFZ.1.2.2024.001']);
+
+    $response = $this->get('/oai-pmh?verb=Identify');
+    $content = $response->getContent();
+
+    expect($content)->toContain('10.5880/GFZ.1.2.2024.001');
+});
+
+// ===================================================================
+// Verb: ListMetadataFormats
+// ===================================================================
+
+test('ListMetadataFormats returns oai_dc and oai_datacite', function () {
+    $response = $this->get('/oai-pmh?verb=ListMetadataFormats');
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    $prefixes = [];
+    foreach ($xml->ListMetadataFormats->metadataFormat as $format) {
+        $prefixes[] = (string) $format->metadataPrefix;
+    }
+
+    expect($prefixes)->toContain('oai_dc')
+        ->and($prefixes)->toContain('oai_datacite');
+});
+
+test('ListMetadataFormats with valid identifier returns formats', function () {
+    $resource = createPublishedResource(['doi' => '10.5880/test.2024.001']);
+    $identifier = 'oai:ernie.gfz.de:10.5880/test.2024.001';
+
+    $response = $this->get("/oai-pmh?verb=ListMetadataFormats&identifier={$identifier}");
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    expect(count($xml->ListMetadataFormats->metadataFormat))->toBe(2);
+});
+
+test('ListMetadataFormats with unknown identifier returns idDoesNotExist', function () {
+    $response = $this->get('/oai-pmh?verb=ListMetadataFormats&identifier=oai:ernie.gfz.de:10.9999/nonexistent');
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('idDoesNotExist');
+});
+
+// ===================================================================
+// Verb: ListSets
+// ===================================================================
+
+test('ListSets returns resource type and year sets', function () {
+    createPublishedResource(['publication_year' => 2024]);
+
+    $response = $this->get('/oai-pmh?verb=ListSets');
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    $specs = [];
+    foreach ($xml->ListSets->set as $set) {
+        $specs[] = (string) $set->setSpec;
+    }
+
+    expect($specs)->toContain('resourcetype:Dataset')
+        ->and($specs)->toContain('year:2024');
+});
+
+test('ListSets with resumptionToken returns badResumptionToken', function () {
+    $response = $this->get('/oai-pmh?verb=ListSets&resumptionToken=sometoken');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badResumptionToken');
+});
+
+// ===================================================================
+// Verb: ListRecords
+// ===================================================================
+
+test('ListRecords with oai_dc returns Dublin Core metadata', function () {
+    createPublishedResource(['doi' => '10.5880/test.2024.001', 'publication_year' => 2024]);
+
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc');
+
+    $response->assertStatus(200);
+    $content = $response->getContent();
+
+    expect($content)->toContain('oai:ernie.gfz.de:10.5880/test.2024.001')
+        ->and($content)->toContain('Test Dataset Title')
+        ->and($content)->toContain('dc:title');
+});
+
+test('ListRecords with oai_datacite returns DataCite metadata', function () {
+    createPublishedResource(['doi' => '10.5880/test.2024.002']);
+
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_datacite');
+
+    $response->assertStatus(200);
+    $content = $response->getContent();
+
+    expect($content)->toContain('oai:ernie.gfz.de:10.5880/test.2024.002');
+});
+
+test('ListRecords without metadataPrefix returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('ListRecords with invalid metadataPrefix returns cannotDisseminateFormat', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=invalid_format');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('cannotDisseminateFormat');
+});
+
+test('ListRecords with set filter returns only matching records', function () {
+    createPublishedResource(['doi' => '10.5880/a.2024.001', 'publication_year' => 2024]);
+    createPublishedResource(['doi' => '10.5880/a.2023.001', 'publication_year' => 2023]);
+
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=year:2024');
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('10.5880/a.2024.001')
+        ->and($content)->not->toContain('10.5880/a.2023.001');
+});
+
+test('ListRecords with date range filtering works', function () {
+    $resource = createPublishedResource(['doi' => '10.5880/date.2024.001']);
+
+    // Use current time range to ensure the record is within range
+    $from = now()->subDay()->format('Y-m-d');
+    $until = now()->addDay()->format('Y-m-d');
+
+    $response = $this->get("/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&from={$from}&until={$until}");
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('10.5880/date.2024.001');
+});
+
+test('ListRecords with from > until returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&from=2025-01-01&until=2024-01-01');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('ListRecords with no matching records returns noRecordsMatch', function () {
+    // No published resources exist
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('noRecordsMatch');
+});
+
+test('ListRecords includes deleted records on the first page', function () {
+    createPublishedResource(['doi' => '10.5880/live.2024.001']);
+
+    OaiPmhDeletedRecord::create([
+        'oai_identifier' => 'oai:ernie.gfz.de:10.5880/deleted.2024.001',
+        'doi' => '10.5880/deleted.2024.001',
+        'datestamp' => now(),
+        'sets' => ['resourcetype:Dataset'],
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc');
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('status="deleted"')
+        ->and($content)->toContain('10.5880/deleted.2024.001')
+        ->and($content)->toContain('10.5880/live.2024.001');
+});
+
+// ===================================================================
+// Verb: ListIdentifiers
+// ===================================================================
+
+test('ListIdentifiers returns headers without metadata', function () {
+    createPublishedResource(['doi' => '10.5880/hdr.2024.001']);
+
+    $response = $this->get('/oai-pmh?verb=ListIdentifiers&metadataPrefix=oai_dc');
+
+    $response->assertStatus(200);
+    $content = $response->getContent();
+
+    expect($content)->toContain('oai:ernie.gfz.de:10.5880/hdr.2024.001')
+        ->and($content)->not->toContain('dc:title');
+});
+
+// ===================================================================
+// Verb: GetRecord
+// ===================================================================
+
+test('GetRecord returns a single record', function () {
+    createPublishedResource(['doi' => '10.5880/single.2024.001']);
+
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/single.2024.001&metadataPrefix=oai_dc');
+
+    $response->assertStatus(200);
+    $content = $response->getContent();
+
+    expect($content)->toContain('oai:ernie.gfz.de:10.5880/single.2024.001')
+        ->and($content)->toContain('dc:title');
+});
+
+test('GetRecord with nonexistent identifier returns idDoesNotExist', function () {
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.9999/nonexistent&metadataPrefix=oai_dc');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('idDoesNotExist');
+});
+
+test('GetRecord for deleted record returns status deleted', function () {
+    OaiPmhDeletedRecord::create([
+        'oai_identifier' => 'oai:ernie.gfz.de:10.5880/deleted.001',
+        'doi' => '10.5880/deleted.001',
+        'datestamp' => now(),
+        'sets' => ['resourcetype:Dataset'],
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/deleted.001&metadataPrefix=oai_dc');
+
+    $content = $response->getContent();
+
+    expect($content)->toContain('status="deleted"');
+});
+
+test('GetRecord without identifier returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=GetRecord&metadataPrefix=oai_dc');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('GetRecord without metadataPrefix returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/test');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+// ===================================================================
+// Error Handling
+// ===================================================================
+
+test('request without verb returns badVerb error', function () {
+    $response = $this->get('/oai-pmh');
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badVerb');
+});
+
+test('request with invalid verb returns badVerb error', function () {
+    $response = $this->get('/oai-pmh?verb=InvalidVerb');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badVerb');
+});
+
+test('request with illegal argument returns badArgument error', function () {
+    $response = $this->get('/oai-pmh?verb=Identify&illegalParam=value');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('resumptionToken cannot be combined with other arguments', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&resumptionToken=abc&metadataPrefix=oai_dc');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('invalid resumptionToken returns badResumptionToken', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&resumptionToken=nonexistent_token');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badResumptionToken');
+});
+
+test('invalid set specification returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=invalid:set');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+test('invalid date format returns badArgument', function () {
+    $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&from=not-a-date');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->error['code'])->toBe('badArgument');
+});
+
+// ===================================================================
+// POST Support
+// ===================================================================
+
+test('OAI-PMH endpoint supports POST requests', function () {
+    $response = $this->post('/oai-pmh', ['verb' => 'Identify']);
+
+    $response->assertStatus(200);
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->Identify->repositoryName)->toBe('ERNIE – GFZ Data Publication Repository');
+});
+
+// ===================================================================
+// XML Response Structure
+// ===================================================================
+
+test('all responses include OAI-PMH envelope with responseDate and request element', function () {
+    $response = $this->get('/oai-pmh?verb=Identify');
+
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->responseDate)->not->toBeEmpty()
+        ->and((string) $xml->request)->not->toBeEmpty();
+});
+
+// ===================================================================
+// Docs Page
+// ===================================================================
+
+test('OAI-PMH docs page is accessible', function () {
+    $response = $this->get('/oai-pmh/docs');
+
+    $response->assertStatus(200);
+});

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -145,7 +145,8 @@ test('ListSets with resumptionToken returns badResumptionToken', function () {
 
     $xml = simplexml_load_string($response->getContent());
 
-    expect((string) $xml->error['code'])->toBe('badResumptionToken');
+    expect((string) $xml->error['code'])->toBe('badResumptionToken')
+        ->and((string) $xml->request['resumptionToken'])->toBe('sometoken');
 });
 
 // ===================================================================

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -606,6 +606,24 @@ test('Identify response derives repositoryIdentifier from config', function () {
     expect($content)->toContain("<repositoryIdentifier>{$expectedId}</repositoryIdentifier>");
 });
 
+test('Identify earliestDatestamp considers deleted records', function () {
+    // Create a published resource with a recent datestamp
+    createOaiPmhResource(['doi' => '10.5880/recent.2024.001']);
+
+    // Create a deleted record with an earlier datestamp
+    OaiPmhDeletedRecord::create([
+        'oai_identifier' => oaiId('10.5880/old.2020.001'),
+        'doi' => '10.5880/old.2020.001',
+        'datestamp' => '2020-01-15 08:00:00',
+        'sets' => ['resourcetype:dataset'],
+    ]);
+
+    $response = $this->get('/oai-pmh?verb=Identify');
+    $xml = simplexml_load_string($response->getContent());
+
+    expect((string) $xml->Identify->earliestDatestamp)->toBe('2020-01-15T08:00:00Z');
+});
+
 // ===================================================================
 // Set Spec with Spaces (OAI-PMH grammar violation)
 // ===================================================================

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -367,7 +367,8 @@ test('invalid resumptionToken returns badResumptionToken', function () {
 
     $xml = simplexml_load_string($response->getContent());
 
-    expect((string) $xml->error['code'])->toBe('badResumptionToken');
+    expect((string) $xml->error['code'])->toBe('badResumptionToken')
+        ->and((string) $xml->request['resumptionToken'])->toBe('nonexistent_token');
 });
 
 test('invalid set specification returns badArgument', function () {
@@ -455,7 +456,8 @@ test('resumption token issued for different verb returns badResumptionToken', fu
 
     $xml = simplexml_load_string($response->getContent());
 
-    expect((string) $xml->error['code'])->toBe('badResumptionToken');
+    expect((string) $xml->error['code'])->toBe('badResumptionToken')
+        ->and((string) $xml->request['resumptionToken'])->toBe('verb-mismatch-token');
 });
 
 // ===================================================================

--- a/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
+++ b/tests/pest/Feature/OaiPmh/OaiPmhEndpointTest.php
@@ -16,7 +16,7 @@ uses(RefreshDatabase::class);
  *
  * @param  array<string, mixed>  $attributes
  */
-function createPublishedResource(array $attributes = []): Resource
+function createOaiPmhResource(array $attributes = []): Resource
 {
     $resource = Resource::factory()->create($attributes);
 
@@ -59,7 +59,7 @@ test('Identify returns valid OAI-PMH response', function () {
 });
 
 test('Identify includes sample identifier when published resources exist', function () {
-    $resource = createPublishedResource(['doi' => '10.5880/GFZ.1.2.2024.001']);
+    $resource = createOaiPmhResource(['doi' => '10.5880/GFZ.1.2.2024.001']);
 
     $response = $this->get('/oai-pmh?verb=Identify');
     $content = $response->getContent();
@@ -87,7 +87,7 @@ test('ListMetadataFormats returns oai_dc and oai_datacite', function () {
 });
 
 test('ListMetadataFormats with valid identifier returns formats', function () {
-    $resource = createPublishedResource(['doi' => '10.5880/test.2024.001']);
+    $resource = createOaiPmhResource(['doi' => '10.5880/test.2024.001']);
     $identifier = 'oai:ernie.gfz.de:10.5880/test.2024.001';
 
     $response = $this->get("/oai-pmh?verb=ListMetadataFormats&identifier={$identifier}");
@@ -112,7 +112,7 @@ test('ListMetadataFormats with unknown identifier returns idDoesNotExist', funct
 // ===================================================================
 
 test('ListSets returns resource type and year sets', function () {
-    createPublishedResource(['publication_year' => 2024]);
+    createOaiPmhResource(['publication_year' => 2024]);
 
     $response = $this->get('/oai-pmh?verb=ListSets');
 
@@ -141,7 +141,7 @@ test('ListSets with resumptionToken returns badResumptionToken', function () {
 // ===================================================================
 
 test('ListRecords with oai_dc returns Dublin Core metadata', function () {
-    createPublishedResource(['doi' => '10.5880/test.2024.001', 'publication_year' => 2024]);
+    createOaiPmhResource(['doi' => '10.5880/test.2024.001', 'publication_year' => 2024]);
 
     $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc');
 
@@ -154,7 +154,7 @@ test('ListRecords with oai_dc returns Dublin Core metadata', function () {
 });
 
 test('ListRecords with oai_datacite returns DataCite metadata', function () {
-    createPublishedResource(['doi' => '10.5880/test.2024.002']);
+    createOaiPmhResource(['doi' => '10.5880/test.2024.002']);
 
     $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_datacite');
 
@@ -181,8 +181,8 @@ test('ListRecords with invalid metadataPrefix returns cannotDisseminateFormat', 
 });
 
 test('ListRecords with set filter returns only matching records', function () {
-    createPublishedResource(['doi' => '10.5880/a.2024.001', 'publication_year' => 2024]);
-    createPublishedResource(['doi' => '10.5880/a.2023.001', 'publication_year' => 2023]);
+    createOaiPmhResource(['doi' => '10.5880/a.2024.001', 'publication_year' => 2024]);
+    createOaiPmhResource(['doi' => '10.5880/a.2023.001', 'publication_year' => 2023]);
 
     $response = $this->get('/oai-pmh?verb=ListRecords&metadataPrefix=oai_dc&set=year:2024');
 
@@ -193,7 +193,7 @@ test('ListRecords with set filter returns only matching records', function () {
 });
 
 test('ListRecords with date range filtering works', function () {
-    $resource = createPublishedResource(['doi' => '10.5880/date.2024.001']);
+    $resource = createOaiPmhResource(['doi' => '10.5880/date.2024.001']);
 
     // Use current time range to ensure the record is within range
     $from = now()->subDay()->format('Y-m-d');
@@ -224,7 +224,7 @@ test('ListRecords with no matching records returns noRecordsMatch', function () 
 });
 
 test('ListRecords includes deleted records on the first page', function () {
-    createPublishedResource(['doi' => '10.5880/live.2024.001']);
+    createOaiPmhResource(['doi' => '10.5880/live.2024.001']);
 
     OaiPmhDeletedRecord::create([
         'oai_identifier' => 'oai:ernie.gfz.de:10.5880/deleted.2024.001',
@@ -247,7 +247,7 @@ test('ListRecords includes deleted records on the first page', function () {
 // ===================================================================
 
 test('ListIdentifiers returns headers without metadata', function () {
-    createPublishedResource(['doi' => '10.5880/hdr.2024.001']);
+    createOaiPmhResource(['doi' => '10.5880/hdr.2024.001']);
 
     $response = $this->get('/oai-pmh?verb=ListIdentifiers&metadataPrefix=oai_dc');
 
@@ -263,7 +263,7 @@ test('ListIdentifiers returns headers without metadata', function () {
 // ===================================================================
 
 test('GetRecord returns a single record', function () {
-    createPublishedResource(['doi' => '10.5880/single.2024.001']);
+    createOaiPmhResource(['doi' => '10.5880/single.2024.001']);
 
     $response = $this->get('/oai-pmh?verb=GetRecord&identifier=oai:ernie.gfz.de:10.5880/single.2024.001&metadataPrefix=oai_dc');
 

--- a/tests/pest/Feature/OaiPmh/PurgeExpiredOaiPmhTokensTest.php
+++ b/tests/pest/Feature/OaiPmh/PurgeExpiredOaiPmhTokensTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\OaiPmhResumptionToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('oaipmh:purge-tokens command purges expired tokens', function () {
+    // Create expired tokens
+    OaiPmhResumptionToken::create([
+        'token' => 'expired-token-1',
+        'verb' => 'ListRecords',
+        'metadata_prefix' => 'oai_dc',
+        'cursor' => 0,
+        'complete_list_size' => 100,
+        'expires_at' => now()->subDay(),
+    ]);
+
+    OaiPmhResumptionToken::create([
+        'token' => 'expired-token-2',
+        'verb' => 'ListIdentifiers',
+        'metadata_prefix' => 'oai_dc',
+        'cursor' => 50,
+        'complete_list_size' => 200,
+        'expires_at' => now()->subHour(),
+    ]);
+
+    // Create a valid token that should NOT be purged
+    OaiPmhResumptionToken::create([
+        'token' => 'valid-token',
+        'verb' => 'ListRecords',
+        'metadata_prefix' => 'oai_dc',
+        'cursor' => 0,
+        'complete_list_size' => 50,
+        'expires_at' => now()->addDay(),
+    ]);
+
+    $this->artisan('oaipmh:purge-tokens')
+        ->expectsOutputToContain('Purged 2 expired')
+        ->assertExitCode(0);
+
+    expect(OaiPmhResumptionToken::count())->toBe(1)
+        ->and(OaiPmhResumptionToken::where('token', 'valid-token')->exists())->toBeTrue();
+});
+
+test('oaipmh:purge-tokens command handles no expired tokens', function () {
+    $this->artisan('oaipmh:purge-tokens')
+        ->expectsOutputToContain('Purged 0 expired')
+        ->assertExitCode(0);
+});

--- a/tests/pest/Feature/Observers/ResourceObserverTest.php
+++ b/tests/pest/Feature/Observers/ResourceObserverTest.php
@@ -6,6 +6,7 @@ use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Observers\ResourceObserver;
 use App\Services\KeywordSuggestionService;
+use App\Services\OaiPmh\OaiPmhSetService;
 use App\Services\ResourceCacheService;
 use Illuminate\Support\Facades\Cache;
 
@@ -14,7 +15,8 @@ covers(ResourceObserver::class);
 beforeEach(function () {
     $this->cacheService = Mockery::mock(ResourceCacheService::class); // @phpstan-ignore variable.undefined
     $this->keywordService = Mockery::mock(KeywordSuggestionService::class); // @phpstan-ignore variable.undefined
-    $this->observer = new ResourceObserver($this->cacheService, $this->keywordService);
+    $this->oaiPmhSetService = Mockery::mock(OaiPmhSetService::class); // @phpstan-ignore variable.undefined
+    $this->observer = new ResourceObserver($this->cacheService, $this->keywordService, $this->oaiPmhSetService);
 });
 
 // =========================================================================
@@ -98,6 +100,8 @@ describe('deleted', function () {
             ->once();
         $this->keywordService->shouldReceive('invalidateCache')
             ->once();
+        $this->oaiPmhSetService->shouldReceive('getSetsForResource')
+            ->andReturn([]);
 
         $this->observer->deleted($resource);
     });

--- a/tests/pest/Feature/Observers/ResourceObserverTest.php
+++ b/tests/pest/Feature/Observers/ResourceObserverTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\LandingPage;
+use App\Models\OaiPmhDeletedRecord;
 use App\Models\Resource;
 use App\Observers\ResourceObserver;
 use App\Services\KeywordSuggestionService;
@@ -104,6 +105,20 @@ describe('deleted', function () {
             ->andReturn([]);
 
         $this->observer->deleted($resource);
+    });
+
+    it('does not track OAI-PMH deletion for resources without DOI', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+
+        $this->cacheService->shouldReceive('invalidateAllResourceCaches')
+            ->once();
+        $this->keywordService->shouldReceive('invalidateCache')
+            ->once();
+        $this->oaiPmhSetService->shouldNotReceive('getSetsForResource');
+
+        $this->observer->deleted($resource);
+
+        expect(OaiPmhDeletedRecord::count())->toBe(0);
     });
 });
 

--- a/tests/pest/Unit/OaiPmh/DublinCoreMapperTest.php
+++ b/tests/pest/Unit/OaiPmh/DublinCoreMapperTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Format;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\Right;
+use App\Models\Subject;
+use App\Models\Title;
+use App\Models\TitleType;
+use App\Services\OaiPmh\DublinCoreMapper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->mapper = new DublinCoreMapper;
+    $this->resource = Resource::factory()->create([
+        'doi' => '10.5880/GFZ.1.2.2024.001',
+        'publication_year' => 2024,
+    ]);
+    $this->titleType = TitleType::firstOrCreate(
+        ['slug' => 'MainTitle'],
+        ['name' => 'Main Title', 'slug' => 'MainTitle', 'is_active' => true],
+    );
+});
+
+it('maps dc:title from resource titles', function () {
+    Title::create(['resource_id' => $this->resource->id, 'value' => 'My Test Dataset', 'title_type_id' => $this->titleType->id]);
+
+    $this->resource->load('titles');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['title'])->toBe(['My Test Dataset']);
+});
+
+it('maps dc:identifier as DOI URL', function () {
+    $this->resource->load('titles');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['identifier'])->toBe(['https://doi.org/10.5880/GFZ.1.2.2024.001']);
+});
+
+it('maps dc:date from publication year', function () {
+    $this->resource->load('titles');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['date'])->toBe(['2024']);
+});
+
+it('maps dc:publisher from resource publisher', function () {
+    $this->resource->load(['publisher', 'titles']);
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['publisher'])->toBe(['GFZ Data Services']);
+});
+
+it('maps dc:type from resource type', function () {
+    $this->resource->load(['resourceType', 'titles']);
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['type'])->toBe(['Dataset']);
+});
+
+it('maps dc:subject from resource subjects', function () {
+    Subject::create(['resource_id' => $this->resource->id, 'value' => 'Geophysics']);
+    Subject::create(['resource_id' => $this->resource->id, 'value' => 'Seismology']);
+
+    $this->resource->load('subjects');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['subject'])->toBe(['Geophysics', 'Seismology']);
+});
+
+it('maps dc:language from resource language', function () {
+    $this->resource->load(['language', 'titles']);
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['language'])->toBe(['en']);
+});
+
+it('maps dc:format from resource formats', function () {
+    Format::create(['resource_id' => $this->resource->id, 'value' => 'application/pdf']);
+
+    $this->resource->load('formats');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['format'])->toBe(['application/pdf']);
+});
+
+it('maps dc:rights with URI when available', function () {
+    $right = Right::firstOrCreate(
+        ['identifier' => 'CC-BY-4.0'],
+        ['name' => 'CC BY 4.0', 'uri' => 'https://creativecommons.org/licenses/by/4.0/', 'identifier' => 'CC-BY-4.0'],
+    );
+    $this->resource->rights()->attach($right->id);
+
+    $this->resource->load('rights');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['rights'][0])->toContain('CC BY 4.0')
+        ->and($dc['rights'][0])->toContain('https://creativecommons.org/licenses/by/4.0/');
+});
+
+it('returns empty array for resource with no metadata', function () {
+    $resource = Resource::factory()->create([
+        'doi' => null,
+        'publication_year' => null,
+        'publisher_id' => null,
+        'language_id' => null,
+        'resource_type_id' => null,
+    ]);
+
+    $resource->load([
+        'titles', 'creators', 'subjects', 'descriptions', 'publisher',
+        'contributors', 'resourceType', 'formats', 'relatedIdentifiers',
+        'geoLocations', 'rights', 'language',
+    ]);
+
+    $dc = $this->mapper->map($resource);
+
+    expect($dc)->toBe([]);
+});
+
+it('maps dc:creator from person creators', function () {
+    $person = Person::create([
+        'family_name' => 'Doe',
+        'given_name' => 'John',
+    ]);
+
+    ResourceCreator::create([
+        'resource_id' => $this->resource->id,
+        'creatorable_id' => $person->id,
+        'creatorable_type' => Person::class,
+        'position' => 0,
+    ]);
+
+    $this->resource->load('creators.creatorable');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['creator'])->toContain('Doe, John');
+});

--- a/tests/pest/Unit/OaiPmh/DublinCoreMapperTest.php
+++ b/tests/pest/Unit/OaiPmh/DublinCoreMapperTest.php
@@ -2,9 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Models\Description;
+use App\Models\DescriptionType;
 use App\Models\Format;
+use App\Models\GeoLocation;
+use App\Models\Institution;
 use App\Models\Person;
+use App\Models\RelatedIdentifier;
 use App\Models\Resource;
+use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\Right;
 use App\Models\Subject;
@@ -141,4 +147,128 @@ it('maps dc:creator from person creators', function () {
     $dc = $this->mapper->map($this->resource);
 
     expect($dc['creator'])->toContain('Doe, John');
+});
+
+it('maps dc:creator from institution creators', function () {
+    $institution = Institution::create([
+        'name' => 'GFZ Helmholtz Centre Potsdam',
+    ]);
+
+    ResourceCreator::create([
+        'resource_id' => $this->resource->id,
+        'creatorable_id' => $institution->id,
+        'creatorable_type' => Institution::class,
+        'position' => 0,
+    ]);
+
+    $this->resource->load('creators.creatorable');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['creator'])->toContain('GFZ Helmholtz Centre Potsdam');
+});
+
+it('maps dc:description from resource descriptions', function () {
+    $descType = DescriptionType::firstOrCreate(
+        ['slug' => 'Abstract'],
+        ['name' => 'Abstract', 'slug' => 'Abstract', 'is_active' => true],
+    );
+
+    Description::create([
+        'resource_id' => $this->resource->id,
+        'value' => 'A comprehensive dataset about seismic activity',
+        'description_type_id' => $descType->id,
+    ]);
+
+    $this->resource->load('descriptions.descriptionType');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['description'])->toBe(['A comprehensive dataset about seismic activity']);
+});
+
+it('maps dc:contributor from person contributors', function () {
+    $person = Person::create([
+        'family_name' => 'Smith',
+        'given_name' => 'Jane',
+    ]);
+
+    ResourceContributor::create([
+        'resource_id' => $this->resource->id,
+        'contributorable_id' => $person->id,
+        'contributorable_type' => Person::class,
+        'position' => 0,
+    ]);
+
+    $this->resource->load('contributors.contributorable');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['contributor'])->toContain('Smith, Jane');
+});
+
+it('maps dc:relation from related identifiers', function () {
+    $identifierType = \App\Models\IdentifierType::firstOrCreate(
+        ['slug' => 'DOI'],
+        ['name' => 'DOI', 'slug' => 'DOI', 'is_active' => true],
+    );
+
+    $relationType = \App\Models\RelationType::firstOrCreate(
+        ['slug' => 'References'],
+        ['name' => 'References', 'slug' => 'References', 'is_active' => true],
+    );
+
+    RelatedIdentifier::create([
+        'resource_id' => $this->resource->id,
+        'identifier' => 'https://doi.org/10.1234/related',
+        'identifier_type_id' => $identifierType->id,
+        'relation_type_id' => $relationType->id,
+        'position' => 0,
+    ]);
+
+    $this->resource->load('relatedIdentifiers');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['relation'])->toBe(['https://doi.org/10.1234/related']);
+});
+
+it('maps dc:coverage from geo locations with place', function () {
+    GeoLocation::create([
+        'resource_id' => $this->resource->id,
+        'place' => 'Potsdam, Germany',
+    ]);
+
+    $this->resource->load('geoLocations');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['coverage'])->toBe(['Potsdam, Germany']);
+});
+
+it('maps dc:coverage from geo locations with point coordinates', function () {
+    GeoLocation::create([
+        'resource_id' => $this->resource->id,
+        'point_latitude' => 52.3906,
+        'point_longitude' => 13.0645,
+    ]);
+
+    $this->resource->load('geoLocations');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['coverage'][0])->toContain('Point(')
+        ->and($dc['coverage'][0])->toContain('52.3906')
+        ->and($dc['coverage'][0])->toContain('13.0645');
+});
+
+it('maps dc:coverage from geo locations with bounding box', function () {
+    GeoLocation::create([
+        'resource_id' => $this->resource->id,
+        'south_bound_latitude' => 50.0,
+        'west_bound_longitude' => 10.0,
+        'north_bound_latitude' => 55.0,
+        'east_bound_longitude' => 15.0,
+    ]);
+
+    $this->resource->load('geoLocations');
+    $dc = $this->mapper->map($this->resource);
+
+    expect($dc['coverage'][0])->toContain('Box(')
+        ->and($dc['coverage'][0])->toContain('50')
+        ->and($dc['coverage'][0])->toContain('15');
 });

--- a/tests/pest/Unit/OaiPmh/OaiPmhResumptionTokenServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhResumptionTokenServiceTest.php
@@ -15,7 +15,7 @@ describe('create', function () {
         $token = $service->create(
             verb: 'ListRecords',
             metadataPrefix: 'oai_dc',
-            setSpec: 'resourcetype:Dataset',
+            setSpec: 'resourcetype:dataset',
             from: null,
             until: null,
             cursor: 100,
@@ -25,7 +25,7 @@ describe('create', function () {
         expect($token)->toBeInstanceOf(OaiPmhResumptionToken::class)
             ->and($token->verb)->toBe('ListRecords')
             ->and($token->metadata_prefix)->toBe('oai_dc')
-            ->and($token->set_spec)->toBe('resourcetype:Dataset')
+            ->and($token->set_spec)->toBe('resourcetype:dataset')
             ->and($token->cursor)->toBe(100)
             ->and($token->complete_list_size)->toBe(500)
             ->and($token->token)->toHaveLength(64)

--- a/tests/pest/Unit/OaiPmh/OaiPmhResumptionTokenServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhResumptionTokenServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\OaiPmhResumptionToken;
+use App\Services\OaiPmh\OaiPmhResumptionTokenService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('create', function () {
+    it('creates a token with correct attributes', function () {
+        $service = app(OaiPmhResumptionTokenService::class);
+
+        $token = $service->create(
+            verb: 'ListRecords',
+            metadataPrefix: 'oai_dc',
+            setSpec: 'resourcetype:Dataset',
+            from: null,
+            until: null,
+            cursor: 100,
+            completeListSize: 500,
+        );
+
+        expect($token)->toBeInstanceOf(OaiPmhResumptionToken::class)
+            ->and($token->verb)->toBe('ListRecords')
+            ->and($token->metadata_prefix)->toBe('oai_dc')
+            ->and($token->set_spec)->toBe('resourcetype:Dataset')
+            ->and($token->cursor)->toBe(100)
+            ->and($token->complete_list_size)->toBe(500)
+            ->and($token->token)->toHaveLength(64)
+            ->and($token->expires_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+    });
+});
+
+describe('resolve', function () {
+    it('resolves a valid token', function () {
+        $service = app(OaiPmhResumptionTokenService::class);
+
+        $created = $service->create('ListRecords', 'oai_dc', null, null, null, 0, 100);
+        $resolved = $service->resolve($created->token);
+
+        expect($resolved)->not->toBeNull()
+            ->and($resolved->id)->toBe($created->id);
+    });
+
+    it('returns null for nonexistent token', function () {
+        $service = app(OaiPmhResumptionTokenService::class);
+
+        expect($service->resolve('nonexistent_token'))->toBeNull();
+    });
+
+    it('returns null and deletes expired token', function () {
+        $service = app(OaiPmhResumptionTokenService::class);
+
+        $token = $service->create('ListRecords', 'oai_dc', null, null, null, 0, 100);
+        $token->update(['expires_at' => now()->subHour()]);
+
+        $resolved = $service->resolve($token->token);
+
+        expect($resolved)->toBeNull()
+            ->and(OaiPmhResumptionToken::find($token->id))->toBeNull();
+    });
+});
+
+describe('consume', function () {
+    it('deletes the token after consumption', function () {
+        $service = app(OaiPmhResumptionTokenService::class);
+
+        $token = $service->create('ListRecords', 'oai_dc', null, null, null, 0, 100);
+        $service->consume($token);
+
+        expect(OaiPmhResumptionToken::find($token->id))->toBeNull();
+    });
+});
+
+describe('purgeExpired', function () {
+    it('deletes all expired tokens', function () {
+        $service = app(OaiPmhResumptionTokenService::class);
+
+        // Create expired tokens
+        $service->create('ListRecords', 'oai_dc', null, null, null, 0, 100);
+        $service->create('ListRecords', 'oai_dc', null, null, null, 100, 200);
+        OaiPmhResumptionToken::query()->update(['expires_at' => now()->subDay()]);
+
+        // Create a valid token
+        $service->create('ListRecords', 'oai_dc', null, null, null, 0, 50);
+
+        $purged = $service->purgeExpired();
+
+        expect($purged)->toBe(2)
+            ->and(OaiPmhResumptionToken::count())->toBe(1);
+    });
+});

--- a/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
@@ -25,7 +25,7 @@ describe('listSets', function () {
 
         $specs = array_column($sets, 'spec');
 
-        expect($specs)->toContain('resourcetype:Dataset');
+        expect($specs)->toContain('resourcetype:' . $resource->resourceType->slug);
     });
 
     it('returns year sets from published resources', function () {
@@ -57,7 +57,7 @@ describe('getSetsForResource', function () {
         $service = app(OaiPmhSetService::class);
         $sets = $service->getSetsForResource($resource);
 
-        expect($sets)->toContain('resourcetype:Dataset')
+        expect($sets)->toContain('resourcetype:' . $resource->resourceType->slug)
             ->and($sets)->toContain('year:2024');
     });
 
@@ -138,7 +138,7 @@ describe('applySetFilter', function () {
 
         $service = app(OaiPmhSetService::class);
         $query = Resource::query();
-        $filtered = $service->applySetFilter($query, 'resourcetype:Dataset');
+        $filtered = $service->applySetFilter($query, 'resourcetype:' . $resource->resourceType->slug);
 
         expect($filtered->count())->toBe(1);
     });

--- a/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
@@ -91,6 +91,26 @@ describe('isValidSetSpec', function () {
         expect($service->isValidSetSpec('unknown:value'))->toBeFalse()
             ->and($service->isValidSetSpec('invalid'))->toBeFalse();
     });
+
+    it('rejects empty value after year prefix', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('year:'))->toBeFalse();
+    });
+
+    it('rejects non-numeric year values', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('year:abcd'))->toBeFalse()
+            ->and($service->isValidSetSpec('year:20'))->toBeFalse()
+            ->and($service->isValidSetSpec('year:20241'))->toBeFalse();
+    });
+
+    it('rejects empty value after resourcetype prefix', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('resourcetype:'))->toBeFalse();
+    });
 });
 
 describe('applySetFilter', function () {

--- a/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
@@ -76,7 +76,7 @@ describe('isValidSetSpec', function () {
     it('accepts resourcetype: prefix with alphanumeric slug', function () {
         $service = app(OaiPmhSetService::class);
 
-        expect($service->isValidSetSpec('resourcetype:Dataset'))->toBeTrue();
+        expect($service->isValidSetSpec('resourcetype:dataset'))->toBeTrue();
     });
 
     it('accepts resourcetype: prefix with hyphens', function () {
@@ -95,6 +95,13 @@ describe('isValidSetSpec', function () {
         $service = app(OaiPmhSetService::class);
 
         expect($service->isValidSetSpec('resourcetype:Physical Object'))->toBeFalse();
+    });
+
+    it('rejects resourcetype: prefix with uppercase letters', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('resourcetype:Dataset'))->toBeFalse()
+            ->and($service->isValidSetSpec('resourcetype:PhysicalObject'))->toBeFalse();
     });
 
     it('accepts year: prefix', function () {

--- a/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\Resource;
+use App\Services\OaiPmh\OaiPmhSetService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('listSets', function () {
+    it('returns empty array when no published resources exist', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->listSets())->toBe([]);
+    });
+
+    it('returns resource type sets from published resources', function () {
+        $resource = Resource::factory()->create();
+        LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+
+        $service = app(OaiPmhSetService::class);
+        $sets = $service->listSets();
+
+        $specs = array_column($sets, 'spec');
+
+        expect($specs)->toContain('resourcetype:Dataset');
+    });
+
+    it('returns year sets from published resources', function () {
+        $resource = Resource::factory()->create(['publication_year' => 2024]);
+        LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+
+        $service = app(OaiPmhSetService::class);
+        $sets = $service->listSets();
+
+        $specs = array_column($sets, 'spec');
+
+        expect($specs)->toContain('year:2024');
+    });
+
+    it('does not include sets from unpublished resources', function () {
+        $resource = Resource::factory()->create(['publication_year' => 2023]);
+        LandingPage::factory()->draft()->create(['resource_id' => $resource->id]);
+
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->listSets())->toBe([]);
+    });
+});
+
+describe('getSetsForResource', function () {
+    it('returns type and year sets for a resource', function () {
+        $resource = Resource::factory()->create(['publication_year' => 2024]);
+
+        $service = app(OaiPmhSetService::class);
+        $sets = $service->getSetsForResource($resource);
+
+        expect($sets)->toContain('resourcetype:Dataset')
+            ->and($sets)->toContain('year:2024');
+    });
+
+    it('excludes year set when publication_year is null', function () {
+        $resource = Resource::factory()->create(['publication_year' => null]);
+
+        $service = app(OaiPmhSetService::class);
+        $sets = $service->getSetsForResource($resource);
+
+        expect($sets)->not->toContain('year:');
+    });
+});
+
+describe('isValidSetSpec', function () {
+    it('accepts resourcetype: prefix', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('resourcetype:Dataset'))->toBeTrue();
+    });
+
+    it('accepts year: prefix', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('year:2024'))->toBeTrue();
+    });
+
+    it('rejects unknown prefixes', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('unknown:value'))->toBeFalse()
+            ->and($service->isValidSetSpec('invalid'))->toBeFalse();
+    });
+});
+
+describe('applySetFilter', function () {
+    it('filters by resource type', function () {
+        $resource = Resource::factory()->create();
+        LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+
+        $service = app(OaiPmhSetService::class);
+        $query = Resource::query();
+        $filtered = $service->applySetFilter($query, 'resourcetype:Dataset');
+
+        expect($filtered->count())->toBe(1);
+    });
+
+    it('filters by year', function () {
+        Resource::factory()->create(['publication_year' => 2024]);
+        Resource::factory()->create(['publication_year' => 2023]);
+
+        $service = app(OaiPmhSetService::class);
+        $query = Resource::query();
+        $filtered = $service->applySetFilter($query, 'year:2024');
+
+        expect($filtered->count())->toBe(1);
+    });
+
+    it('returns no results for unknown set specs', function () {
+        Resource::factory()->create();
+
+        $service = app(OaiPmhSetService::class);
+        $query = Resource::query();
+        $filtered = $service->applySetFilter($query, 'unknown:value');
+
+        expect($filtered->count())->toBe(0);
+    });
+});

--- a/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
@@ -67,7 +67,8 @@ describe('getSetsForResource', function () {
         $service = app(OaiPmhSetService::class);
         $sets = $service->getSetsForResource($resource);
 
-        expect($sets)->not->toContain('year:');
+        $yearSets = array_filter($sets, fn (string $s) => str_starts_with($s, 'year:'));
+        expect($yearSets)->toBeEmpty();
     });
 });
 

--- a/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhSetServiceTest.php
@@ -73,10 +73,28 @@ describe('getSetsForResource', function () {
 });
 
 describe('isValidSetSpec', function () {
-    it('accepts resourcetype: prefix', function () {
+    it('accepts resourcetype: prefix with alphanumeric slug', function () {
         $service = app(OaiPmhSetService::class);
 
         expect($service->isValidSetSpec('resourcetype:Dataset'))->toBeTrue();
+    });
+
+    it('accepts resourcetype: prefix with hyphens', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('resourcetype:physical-object'))->toBeTrue();
+    });
+
+    it('accepts resourcetype: prefix with underscores', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('resourcetype:data_paper'))->toBeTrue();
+    });
+
+    it('rejects resourcetype: prefix with spaces', function () {
+        $service = app(OaiPmhSetService::class);
+
+        expect($service->isValidSetSpec('resourcetype:Physical Object'))->toBeFalse();
     });
 
     it('accepts year: prefix', function () {

--- a/tests/pest/Unit/OaiPmh/OaiPmhXmlResponseBuilderTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhXmlResponseBuilderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\OaiPmh\OaiPmhXmlResponseBuilder;
+
+beforeEach(function () {
+    $this->builder = new OaiPmhXmlResponseBuilder;
+});
+
+it('handles malformed metadata XML gracefully in addRecord', function () {
+    $this->builder->createEnvelope('GetRecord', ['metadataPrefix' => 'oai_dc']);
+    $container = $this->builder->beginGetRecord();
+
+    // Pass invalid XML — should not throw or produce warnings
+    $this->builder->addRecord(
+        $container,
+        'oai:ernie.gfz.de:10.5880/test',
+        '2024-01-01T00:00:00Z',
+        ['resourcetype:Dataset'],
+        'this is not valid XML <broken>',
+    );
+
+    $xml = $this->builder->toXml();
+
+    // Record should still be emitted (with empty metadata)
+    expect($xml)->toContain('<record')
+        ->and($xml)->toContain('<header')
+        ->and($xml)->toContain('<metadata');
+});
+
+it('builds Dublin Core XML with proper namespaces', function () {
+    $dcElements = [
+        'title' => ['Test Title'],
+        'creator' => ['Doe, John'],
+        'identifier' => ['https://doi.org/10.5880/test'],
+    ];
+
+    $xml = $this->builder->buildDublinCoreXml($dcElements);
+
+    expect($xml)->toContain('oai_dc:dc')
+        ->and($xml)->toContain('dc:title')
+        ->and($xml)->toContain('Test Title')
+        ->and($xml)->toContain('dc:creator')
+        ->and($xml)->toContain('Doe, John');
+});
+
+it('adds error element with correct code and message', function () {
+    $this->builder->createEnvelope('ListRecords');
+    $this->builder->addError('noRecordsMatch', 'No records match the given criteria');
+
+    $xml = $this->builder->toXml();
+    $parsed = simplexml_load_string($xml);
+
+    expect((string) $parsed->error['code'])->toBe('noRecordsMatch')
+        ->and((string) $parsed->error)->toBe('No records match the given criteria');
+});
+
+it('adds resumption token with all attributes', function () {
+    $this->builder->createEnvelope('ListRecords', ['metadataPrefix' => 'oai_dc']);
+    $container = $this->builder->beginListRecords();
+    $this->builder->addResumptionToken($container, 'test-token-123', 500, 100, '2025-01-01T00:00:00Z');
+
+    $xml = $this->builder->toXml();
+    $parsed = simplexml_load_string($xml);
+
+    expect((string) $parsed->ListRecords->resumptionToken)->toBe('test-token-123')
+        ->and((string) $parsed->ListRecords->resumptionToken['completeListSize'])->toBe('500')
+        ->and((string) $parsed->ListRecords->resumptionToken['cursor'])->toBe('100')
+        ->and((string) $parsed->ListRecords->resumptionToken['expirationDate'])->toBe('2025-01-01T00:00:00Z');
+});
+
+it('adds empty resumption token to signal end of list', function () {
+    $this->builder->createEnvelope('ListRecords', ['metadataPrefix' => 'oai_dc']);
+    $container = $this->builder->beginListRecords();
+    $this->builder->addResumptionToken($container, null, 100, 100);
+
+    $xml = $this->builder->toXml();
+    $parsed = simplexml_load_string($xml);
+
+    expect((string) $parsed->ListRecords->resumptionToken)->toBe('')
+        ->and((string) $parsed->ListRecords->resumptionToken['completeListSize'])->toBe('100');
+});
+
+it('adds deleted record with status attribute', function () {
+    $this->builder->createEnvelope('ListRecords', ['metadataPrefix' => 'oai_dc']);
+    $container = $this->builder->beginListRecords();
+    $this->builder->addDeletedRecord(
+        $container,
+        'oai:ernie.gfz.de:10.5880/deleted',
+        '2024-06-15T00:00:00Z',
+        ['resourcetype:Dataset'],
+    );
+
+    $xml = $this->builder->toXml();
+
+    expect($xml)->toContain('status="deleted"')
+        ->and($xml)->toContain('oai:ernie.gfz.de:10.5880/deleted');
+});
+
+it('derives repositoryIdentifier from config in Identify', function () {
+    $this->builder->createEnvelope('Identify');
+    $this->builder->addIdentifyContent('2000-01-01T00:00:00Z', 'oai:ernie.gfz.de:10.5880/example');
+
+    $xml = $this->builder->toXml();
+
+    $expectedId = str_replace('oai:', '', (string) config('oaipmh.identifier_prefix'));
+    expect($xml)->toContain("<repositoryIdentifier>{$expectedId}</repositoryIdentifier>");
+});

--- a/tests/pest/Unit/OaiPmh/OaiPmhXmlResponseBuilderTest.php
+++ b/tests/pest/Unit/OaiPmh/OaiPmhXmlResponseBuilderTest.php
@@ -17,7 +17,7 @@ it('handles malformed metadata XML gracefully in addRecord', function () {
         $container,
         'oai:ernie.gfz.de:10.5880/test',
         '2024-01-01T00:00:00Z',
-        ['resourcetype:Dataset'],
+        ['resourcetype:dataset'],
         'this is not valid XML <broken>',
     );
 
@@ -89,7 +89,7 @@ it('adds deleted record with status attribute', function () {
         $container,
         'oai:ernie.gfz.de:10.5880/deleted',
         '2024-06-15T00:00:00Z',
-        ['resourcetype:Dataset'],
+        ['resourcetype:dataset'],
     );
 
     $xml = $this->builder->toXml();

--- a/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
+++ b/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import OaiPmhDocs from '@/pages/oai-pmh/docs';
+
+vi.mock('@/layouts/public-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+const defaultProps = {
+    baseUrl: 'https://ernie.gfz.de/oai-pmh',
+    adminEmail: 'datapub@gfz.de',
+    metadataFormats: {
+        oai_dc: {
+            schema: 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+            namespace: 'http://www.openarchives.org/OAI/2.0/oai_dc/',
+        },
+        oai_datacite: {
+            schema: 'https://schema.datacite.org/meta/kernel-4.7/metadata.xsd',
+            namespace: 'http://datacite.org/schema/kernel-4',
+        },
+    },
+};
+
+describe('OaiPmhDocs', () => {
+    it('renders the page heading', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        expect(screen.getByRole('heading', { name: /oai-pmh harvesting endpoint/i })).toBeInTheDocument();
+    });
+
+    it('renders the base URL', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        expect(screen.getByText(defaultProps.baseUrl)).toBeInTheDocument();
+    });
+
+    it('renders the admin email link', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        const emailLink = screen.getByRole('link', { name: defaultProps.adminEmail });
+        expect(emailLink).toHaveAttribute('href', `mailto:${defaultProps.adminEmail}`);
+    });
+
+    it('renders all six OAI-PMH verb badges', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        for (const verb of ['Identify', 'ListMetadataFormats', 'ListSets', 'ListIdentifiers', 'ListRecords', 'GetRecord']) {
+            expect(screen.getByText(verb, { selector: '[data-slot="badge"]' })).toBeInTheDocument();
+        }
+    });
+
+    it('renders metadata format prefixes', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        expect(screen.getAllByText('oai_dc').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('oai_datacite').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders section headings', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        expect(screen.getByText('Supported Verbs')).toBeInTheDocument();
+        expect(screen.getByText('Metadata Formats')).toBeInTheDocument();
+        expect(screen.getByText('Sets (Selective Harvesting)')).toBeInTheDocument();
+        expect(screen.getByText('Example Requests')).toBeInTheDocument();
+        expect(screen.getByText('Resumption Tokens (Pagination)')).toBeInTheDocument();
+        expect(screen.getByText('Selective Harvesting')).toBeInTheDocument();
+        expect(screen.getByText('Deleted Records')).toBeInTheDocument();
+        expect(screen.getByText('Best Practices for Harvesters')).toBeInTheDocument();
+        expect(screen.getByText('OAI Identifier Format')).toBeInTheDocument();
+    });
+
+    it('renders resource type set badges', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        expect(screen.getByText('resourcetype:Dataset')).toBeInTheDocument();
+        expect(screen.getByText('resourcetype:PhysicalObject')).toBeInTheDocument();
+    });
+
+    it('renders OAI identifier example', () => {
+        render(<OaiPmhDocs {...defaultProps} />);
+        expect(screen.getByText('oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001')).toBeInTheDocument();
+    });
+});

--- a/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
+++ b/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
@@ -25,6 +25,7 @@ const defaultProps = {
         },
     },
     resourceTypeSlugs: ['collection', 'dataset', 'image', 'physical-object', 'software', 'text'],
+    identifierPrefix: 'oai:ernie.gfz.de',
 };
 
 describe('OaiPmhDocs', () => {
@@ -78,6 +79,6 @@ describe('OaiPmhDocs', () => {
 
     it('renders OAI identifier example', () => {
         render(<OaiPmhDocs {...defaultProps} />);
-        expect(screen.getByText('oai:ernie.gfz.de:10.5880/GFZ.1.2.2024.001')).toBeInTheDocument();
+        expect(screen.getByText(`${defaultProps.identifierPrefix}:10.5880/GFZ.1.2.2024.001`)).toBeInTheDocument();
     });
 });

--- a/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
+++ b/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
@@ -1,6 +1,4 @@
-import '@testing-library/jest-dom/vitest';
-
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@tests/vitest/utils/render';
 import { describe, expect, it, vi } from 'vitest';
 
 import OaiPmhDocs from '@/pages/oai-pmh/docs';

--- a/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
+++ b/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
             namespace: 'http://datacite.org/schema/kernel-4',
         },
     },
+    resourceTypeSlugs: ['collection', 'dataset', 'image', 'physical-object', 'software', 'text'],
 };
 
 describe('OaiPmhDocs', () => {
@@ -69,10 +70,10 @@ describe('OaiPmhDocs', () => {
         expect(screen.getByText('OAI Identifier Format')).toBeInTheDocument();
     });
 
-    it('renders resource type set badges', () => {
+    it('renders resource type set badges from props', () => {
         render(<OaiPmhDocs {...defaultProps} />);
-        expect(screen.getByText('resourcetype:Dataset')).toBeInTheDocument();
-        expect(screen.getByText('resourcetype:PhysicalObject')).toBeInTheDocument();
+        expect(screen.getByText('resourcetype:dataset')).toBeInTheDocument();
+        expect(screen.getByText('resourcetype:physical-object')).toBeInTheDocument();
     });
 
     it('renders OAI identifier example', () => {

--- a/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
+++ b/tests/vitest/pages/__tests__/oai-pmh-docs.test.tsx
@@ -26,6 +26,8 @@ const defaultProps = {
     },
     resourceTypeSlugs: ['collection', 'dataset', 'image', 'physical-object', 'software', 'text'],
     identifierPrefix: 'oai:ernie.gfz.de',
+    pageSize: 100,
+    tokenTtlHours: 24,
 };
 
 describe('OaiPmhDocs', () => {


### PR DESCRIPTION
This pull request introduces comprehensive support for OAI-PMH (Open Archives Initiative Protocol for Metadata Harvesting) in the application. It adds OAI-PMH endpoints, implements persistent deletion tracking for harvested records, manages resumption tokens for pagination, and ensures proper model observation for publish/depublish events. The changes are grouped below by theme.

**OAI-PMH Endpoint and Documentation**

* Added `OaiPmhController` to serve as the main OAI-PMH 2.0 harvesting endpoint, handling all OAI-PMH verbs and returning XML responses.
* Added `OaiPmhDocsController` to provide a documentation page for OAI-PMH harvesters, including resource type slugs and configuration details.

**OAI-PMH Data Models and Services**

* Introduced `OaiPmhResumptionToken` and `OaiPmhDeletedRecord` models to support OAI-PMH pagination and persistent deletion, respectively. [[1]](diffhunk://#diff-a5e998e03cb1e6bd1d8e8254efeb39917d6c0a8dd5afcc5f767def031aa765b6R1-R58) [[2]](diffhunk://#diff-93c29c2256326c98cff813c6b26a323088b0f9ac0f02f26741cb158127adeeafR1-R44)
* Added `OaiPmhResumptionTokenService` for creating, resolving, consuming, and purging resumption tokens.
* Added `DublinCoreMapper` service to map resources to Dublin Core elements for OAI-PMH metadata output.

**Model Observers for OAI-PMH Deletion Tracking**

* Updated `ResourceObserver` to track resource deletions in OAI-PMH, ensuring only published resources with DOIs are recorded as deleted for harvesters. [[1]](diffhunk://#diff-93a860fc918936f8748fdffcbeb754fffc188375f25e246e01f2012ba1454553R7-R10) [[2]](diffhunk://#diff-93a860fc918936f8748fdffcbeb754fffc188375f25e246e01f2012ba1454553R30) [[3]](diffhunk://#diff-93a860fc918936f8748fdffcbeb754fffc188375f25e246e01f2012ba1454553R175-R200) [[4]](diffhunk://#diff-93a860fc918936f8748fdffcbeb754fffc188375f25e246e01f2012ba1454553R216-R247)
* Added `LandingPageObserver` to handle publish/depublish events and update OAI-PMH deleted records accordingly.
* Registered the new observer in `AppServiceProvider`. [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR12-R15) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR49)

**Command-Line and Rate Limiting**

* Added a new Artisan command `PurgeExpiredOaiPmhTokens` to clean up expired OAI-PMH resumption tokens.
* Introduced a dedicated rate limiter for the OAI-PMH endpoint (120 requests/minute per IP) to balance harvester access and abuse prevention.