### PR TITLE
Feature: Abbreviate given names in citations on landing pages

### DIFF
--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -154,12 +154,16 @@ class DataCiteApiService
         $authors = $metadata['author'] ?? [];
         $authorStrings = [];
         foreach ($authors as $author) {
-            if (isset($author['family']) && isset($author['given'])) {
-                $authorStrings[] = $author['family'].', '.$this->abbreviateGivenName($author['given']);
-            } elseif (isset($author['literal'])) {
-                $authorStrings[] = $author['literal'];
-            } elseif (isset($author['family'])) {
-                $authorStrings[] = $author['family'];
+            $family = isset($author['family']) && is_string($author['family']) ? $author['family'] : null;
+            $given = isset($author['given']) && is_string($author['given']) ? $author['given'] : null;
+            $literal = isset($author['literal']) && is_string($author['literal']) ? $author['literal'] : null;
+
+            if ($family !== null && $given !== null) {
+                $authorStrings[] = $family.', '.$this->abbreviateGivenName($given);
+            } elseif ($literal !== null) {
+                $authorStrings[] = $literal;
+            } elseif ($family !== null) {
+                $authorStrings[] = $family;
             }
         }
         $authorsString = ! empty($authorStrings) ? implode('; ', $authorStrings) : 'Unknown Author';

--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -155,7 +155,7 @@ class DataCiteApiService
         $authorStrings = [];
         foreach ($authors as $author) {
             if (isset($author['family']) && isset($author['given'])) {
-                $authorStrings[] = $author['family'].', '.$author['given'];
+                $authorStrings[] = $author['family'].', '.$this->abbreviateGivenName($author['given']);
             } elseif (isset($author['literal'])) {
                 $authorStrings[] = $author['literal'];
             } elseif (isset($author['family'])) {
@@ -268,5 +268,35 @@ class DataCiteApiService
 
             return self::CACHE_TRANSIENT_FAILURE;
         }
+    }
+
+    /**
+     * Abbreviate a given name to initials for citation display.
+     *
+     * Each space-separated part is abbreviated independently.
+     * Hyphenated parts preserve the hyphen (e.g. Jean-Pierre → J.-P.).
+     */
+    private function abbreviateGivenName(string $givenName): string
+    {
+        $givenName = trim($givenName);
+
+        if ($givenName === '') {
+            return '';
+        }
+
+        $parts = preg_split('/\\s+/', $givenName) ?: [$givenName];
+
+        $abbreviated = array_map(function (string $part): string {
+            return implode('-', array_map(function (string $sub): string {
+                // Already abbreviated (e.g. "A." or "A")
+                if (mb_strlen($sub) <= 2 && (mb_strlen($sub) === 1 || str_ends_with($sub, '.'))) {
+                    return str_ends_with($sub, '.') ? $sub : $sub.'.';
+                }
+
+                return mb_strtoupper(mb_substr($sub, 0, 1)).'.';
+            }, explode('-', $part)));
+        }, $parts);
+
+        return implode(' ', $abbreviated);
     }
 }

--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -275,6 +275,8 @@ class DataCiteApiService
      *
      * Each space-separated part is abbreviated independently.
      * Hyphenated parts preserve the hyphen (e.g. Jean-Pierre → J.-P.).
+     * Already-abbreviated names with dot pass through unchanged.
+     * Single letters without dot get a dot appended (e.g. "A" → "A.").
      */
     private function abbreviateGivenName(string $givenName): string
     {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0dev",
-        "date": "2026-04-10",
+        "date": "2026-04-11",
         "features": [
             {
                 "title": "OAI-PMH 2.0 Harvesting Endpoint",
@@ -45,6 +45,10 @@
             }
         ],
         "improvements": [
+            {
+                "title": "Abbreviated First Names in Citations",
+                "description": "First names in the citation section on landing pages are now abbreviated to initials following standard academic citation practice (e.g. Bobcat, Alice → Bobcat, A.). Hyphenated names preserve their structure (e.g. Jean-Pierre → J.-P.). Full names remain stored in the database and are displayed in the creators list. The same abbreviation is applied to citations from external DOI lookups."
+            },
             {
                 "title": "Larger GFZ Logo on Landing Pages",
                 "description": "The GFZ Data Services logo in the landing page header is now displayed at a larger size for improved branding visibility."

--- a/resources/js/pages/LandingPages/lib/abbreviateGivenName.ts
+++ b/resources/js/pages/LandingPages/lib/abbreviateGivenName.ts
@@ -4,7 +4,8 @@
  * Rules:
  * - Each space-separated part is abbreviated independently
  * - Hyphenated parts preserve the hyphen (Jean-Pierre → J.-P.)
- * - Already-abbreviated names (single letter or letter+dot) pass through unchanged
+ * - Already-abbreviated names with dot (e.g. "A.") pass through unchanged
+ * - Single letters without dot get a dot appended (e.g. "A" → "A.")
  * - Null/empty input returns empty string
  *
  * @example

--- a/resources/js/pages/LandingPages/lib/abbreviateGivenName.ts
+++ b/resources/js/pages/LandingPages/lib/abbreviateGivenName.ts
@@ -1,0 +1,38 @@
+/**
+ * Abbreviates a given name to initials for citation display.
+ *
+ * Rules:
+ * - Each space-separated part is abbreviated independently
+ * - Hyphenated parts preserve the hyphen (Jean-Pierre → J.-P.)
+ * - Already-abbreviated names (single letter or letter+dot) pass through unchanged
+ * - Null/empty input returns empty string
+ *
+ * @example
+ * abbreviateGivenName("Alice")          // "A."
+ * abbreviateGivenName("Alice Marie")    // "A. M."
+ * abbreviateGivenName("Jean-Pierre")    // "J.-P."
+ * abbreviateGivenName("Hans-Jürgen Peter") // "H.-J. P."
+ * abbreviateGivenName(null)             // ""
+ */
+export function abbreviateGivenName(givenName: string | null | undefined): string {
+    if (!givenName || givenName.trim() === '') {
+        return '';
+    }
+
+    return givenName
+        .trim()
+        .split(/\s+/)
+        .map((part) =>
+            part
+                .split('-')
+                .map((sub) => {
+                    // Already abbreviated (e.g. "A." or "A")
+                    if (sub.length <= 2 && (sub.length === 1 || sub.endsWith('.'))) {
+                        return sub.endsWith('.') ? sub : `${sub}.`;
+                    }
+                    return `${sub.charAt(0).toUpperCase()}.`;
+                })
+                .join('-'),
+        )
+        .join(' ');
+}

--- a/resources/js/pages/LandingPages/lib/buildCitation.ts
+++ b/resources/js/pages/LandingPages/lib/buildCitation.ts
@@ -1,3 +1,5 @@
+import { abbreviateGivenName } from './abbreviateGivenName';
+
 interface Creatorable {
     type: string;
     given_name?: string | null;
@@ -43,7 +45,7 @@ export function buildCitation(resource: Resource): string {
                     }
                     if (creator.creatorable.type === 'Person') {
                         if (creator.creatorable.family_name && creator.creatorable.given_name) {
-                            return `${creator.creatorable.family_name}, ${creator.creatorable.given_name}`;
+                            return `${creator.creatorable.family_name}, ${abbreviateGivenName(creator.creatorable.given_name)}`;
                         }
                         if (creator.creatorable.family_name) {
                             return creator.creatorable.family_name;
@@ -56,7 +58,7 @@ export function buildCitation(resource: Resource): string {
                     return creator.institution_name;
                 }
                 if (creator.family_name && creator.given_name) {
-                    return `${creator.family_name}, ${creator.given_name}`;
+                    return `${creator.family_name}, ${abbreviateGivenName(creator.given_name)}`;
                 }
                 if (creator.family_name) {
                     return creator.family_name;

--- a/tests/pest/Feature/Services/DataCiteApiServiceTest.php
+++ b/tests/pest/Feature/Services/DataCiteApiServiceTest.php
@@ -116,8 +116,8 @@ describe('DataCiteApiService', function () {
 
             $citation = $this->service->buildCitationFromMetadata($metadata);
 
-            expect($citation)->toContain('Doe, John')
-                ->and($citation)->toContain('Smith, Jane')
+            expect($citation)->toContain('Doe, J.')
+                ->and($citation)->toContain('Smith, J.')
                 ->and($citation)->toContain('2025')
                 ->and($citation)->toContain('Test Publication');
         });

--- a/tests/pest/Unit/Services/DataCiteApiServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteApiServiceTest.php
@@ -351,6 +351,104 @@ describe('buildCitationFromMetadata', function (): void {
 
         expect($result)->not->toContain('https://doi.org/');
     });
+
+    it('abbreviates multiple space-separated given names', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Doe', 'given' => 'Alice Marie']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Doe, A. M. (2024)');
+    });
+
+    it('abbreviates hyphenated given names preserving hyphen', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Dupont', 'given' => 'Jean-Pierre']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Dupont, J.-P. (2024)');
+    });
+
+    it('abbreviates combined hyphenated and space-separated given names', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Mueller', 'given' => 'Hans-Jürgen Peter']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Mueller, H.-J. P. (2024)');
+    });
+
+    it('passes through already abbreviated given name with dot', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Doe', 'given' => 'A.']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Doe, A. (2024)');
+    });
+
+    it('appends dot to single letter given name without dot', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Doe', 'given' => 'A']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Doe, A. (2024)');
+    });
+
+    it('passes through already abbreviated multi-part given name', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Doe', 'given' => 'A. M.']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Doe, A. M. (2024)');
+    });
+
+    it('handles already abbreviated hyphenated given name', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Dupont', 'given' => 'J.-P.']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toStartWith('Dupont, J.-P. (2024)');
+    });
 });
 
 // =========================================================================

--- a/tests/pest/Unit/Services/DataCiteApiServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteApiServiceTest.php
@@ -228,7 +228,7 @@ describe('buildCitationFromMetadata', function (): void {
 
         $result = $this->service->buildCitationFromMetadata($metadata);
 
-        expect($result)->toBe('Doe, John; Smith, Jane (2024): Test Dataset. GFZ. https://doi.org/10.5880/test.2024.001');
+        expect($result)->toBe('Doe, J.; Smith, J. (2024): Test Dataset. GFZ. https://doi.org/10.5880/test.2024.001');
     });
 
     it('handles literal author names', function (): void {

--- a/tests/vitest/lib/__tests__/abbreviateGivenName.test.ts
+++ b/tests/vitest/lib/__tests__/abbreviateGivenName.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { abbreviateGivenName } from '@/pages/LandingPages/lib/abbreviateGivenName';
+
+describe('abbreviateGivenName', () => {
+    it('abbreviates a simple first name', () => {
+        expect(abbreviateGivenName('Alice')).toBe('A.');
+    });
+
+    it('abbreviates multiple space-separated names', () => {
+        expect(abbreviateGivenName('Alice Marie')).toBe('A. M.');
+    });
+
+    it('preserves hyphens in hyphenated names', () => {
+        expect(abbreviateGivenName('Jean-Pierre')).toBe('J.-P.');
+    });
+
+    it('handles combined hyphenated and space-separated names', () => {
+        expect(abbreviateGivenName('Hans-Jürgen Peter')).toBe('H.-J. P.');
+    });
+
+    it('passes through already abbreviated name with dot', () => {
+        expect(abbreviateGivenName('A.')).toBe('A.');
+    });
+
+    it('passes through already abbreviated multi-part name', () => {
+        expect(abbreviateGivenName('A. M.')).toBe('A. M.');
+    });
+
+    it('adds dot to single letter without dot', () => {
+        expect(abbreviateGivenName('A')).toBe('A.');
+    });
+
+    it('returns empty string for null input', () => {
+        expect(abbreviateGivenName(null)).toBe('');
+    });
+
+    it('returns empty string for undefined input', () => {
+        expect(abbreviateGivenName(undefined)).toBe('');
+    });
+
+    it('returns empty string for empty string input', () => {
+        expect(abbreviateGivenName('')).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+        expect(abbreviateGivenName('   ')).toBe('');
+    });
+
+    it('handles name with extra whitespace', () => {
+        expect(abbreviateGivenName('  Alice   Marie  ')).toBe('A. M.');
+    });
+
+    it('uppercases the first letter', () => {
+        expect(abbreviateGivenName('alice')).toBe('A.');
+    });
+
+    it('handles already abbreviated hyphenated name', () => {
+        expect(abbreviateGivenName('J.-P.')).toBe('J.-P.');
+    });
+});

--- a/tests/vitest/lib/__tests__/buildCitation.test.ts
+++ b/tests/vitest/lib/__tests__/buildCitation.test.ts
@@ -31,7 +31,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Ehrmann, Holger (2024): TESTTITLE. GFZ Data Services. https://doi.org/10.5880/GFZ1243'
+            'Ehrmann, H. (2024): TESTTITLE. GFZ Data Services. https://doi.org/10.5880/GFZ1243'
         );
     });
 
@@ -98,7 +98,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Doe, John; Smith, Jane (2025): Collaborative Research. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST.2025'
+            'Doe, J.; Smith, J. (2025): Collaborative Research. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST.2025'
         );
     });
 
@@ -127,7 +127,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (n.d.): Undated Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (n.d.): Undated Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -204,7 +204,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'User, Legacy (2020): Legacy Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.LEGACY'
+            'User, L. (2020): Legacy Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.LEGACY'
         );
     });
 
@@ -234,7 +234,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2022): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (2022): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -258,7 +258,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2024): Test Dataset. GFZ Data Services. DOI not available'
+            'Author, T. (2024): Test Dataset. GFZ Data Services. DOI not available'
         );
     });
 
@@ -283,7 +283,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2024): Untitled. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (2024): Untitled. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -307,7 +307,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2024): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (2024): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -332,7 +332,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2024): New Title. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (2024): New Title. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -357,7 +357,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2024): Alternative Title. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (2024): Alternative Title. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -428,7 +428,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Valid (2024): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, V. (2024): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 
@@ -467,7 +467,7 @@ describe('buildCitation', () => {
         const citation = buildCitation(resource);
 
         expect(citation).toBe(
-            'Author, Test (2024): Untitled. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
+            'Author, T. (2024): Untitled. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST'
         );
     });
 });


### PR DESCRIPTION
This pull request updates the citation formatting across both backend (PHP) and frontend (TypeScript) code to abbreviate given (first) names to initials in citations, following standard academic citation practices. It ensures consistent abbreviation logic for space-separated and hyphenated names, and updates tests and documentation to reflect this change.

**Citation formatting improvements:**

* Added a function to abbreviate given names to initials for citations, handling space-separated, hyphenated, and already-abbreviated names, and ensuring correct formatting (e.g., "Jean-Pierre" → "J.-P.", "Alice Marie" → "A. M.") in both PHP (`DataCiteApiService.php`) and TypeScript (`abbreviateGivenName.ts`). [[1]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L157-R166) [[2]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9R276-R307) [[3]](diffhunk://#diff-84dc9e5434e99568c884ea0b70b1341c00ed7943110465cb9c0244c04aeb8a00R1-R39)
* Updated citation-building logic in both backend (`buildCitationFromMetadata`) and frontend (`buildCitation`) to use abbreviated initials instead of full given names. [[1]](diffhunk://#diff-a20ac31323f2650e5651c80031f2b9f5fbbd6e056d38c259ba1ff288e4f74f4eR1-R2) [[2]](diffhunk://#diff-a20ac31323f2650e5651c80031f2b9f5fbbd6e056d38c259ba1ff288e4f74f4eL46-R48) [[3]](diffhunk://#diff-a20ac31323f2650e5651c80031f2b9f5fbbd6e056d38c259ba1ff288e4f74f4eL59-R61)

**Testing and validation:**

* Added comprehensive unit and feature tests in both PHP (Pest) and TypeScript (Vitest) to cover various name abbreviation scenarios, ensuring correct output for edge cases and maintaining citation integrity. [[1]](diffhunk://#diff-72033935415f78d8e101992d314e6ec52bacc2e0a1c56e8d0eff31dd660a30f1L231-R231) [[2]](diffhunk://#diff-72033935415f78d8e101992d314e6ec52bacc2e0a1c56e8d0eff31dd660a30f1R354-R451) [[3]](diffhunk://#diff-04b438e082fcb3becf7be8601445b5a40b576ba410813de32c40aa2a7320865fR1-R61)
* Updated existing citation-related tests to expect abbreviated initials instead of full given names. [[1]](diffhunk://#diff-dbf28c875410def0ba3fd7c369454a34b6754b787873a2d1374fe0ab57f54726L119-R120) [[2]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L34-R34) [[3]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L101-R101) [[4]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L130-R130) [[5]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L207-R207) [[6]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L237-R237) [[7]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L261-R261) [[8]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L286-R286) [[9]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L310-R310) [[10]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L335-R335) [[11]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L360-R360) [[12]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L431-R431) [[13]](diffhunk://#diff-e744a2597e7d6f53b1a71959eacd18c8881a1158027d53d8f2e0183b41f956b7L470-R470)

**Documentation and changelog:**

* Documented the new citation abbreviation behavior in the changelog, clarifying its application and impact on citation display.
* Updated the changelog date to reflect the release of this feature.