### PR TITLE
Fix: Loss of data at XML import

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -2343,12 +2343,21 @@ class UploadXmlController extends Controller
             $endParts = ['date' => '', 'time' => '', 'timezone' => ''];
         }
 
+        // Determine timezone: use explicit timezone from start or end, otherwise
+        // only default to 'UTC' if no time component exists (pure date values)
+        $hasTimeComponent = $startParts['time'] !== '' || $endParts['time'] !== '';
+        $resolvedTimezone = $startParts['timezone'] ?: $endParts['timezone'];
+
+        if ($resolvedTimezone === '' && ! $hasTimeComponent) {
+            $resolvedTimezone = 'UTC';
+        }
+
         return [
             'startDate' => $startParts['date'],
             'endDate' => $endParts['date'],
             'startTime' => $startParts['time'],
             'endTime' => $endParts['time'],
-            'timezone' => $startParts['timezone'] ?: ($endParts['timezone'] ?: 'UTC'),
+            'timezone' => $resolvedTimezone,
         ];
     }
 
@@ -2368,10 +2377,18 @@ class UploadXmlController extends Controller
         // Only attempt full datetime parsing if the value contains a time separator
         if (str_contains($value, 'T')) {
             try {
-                $dt = new \DateTimeImmutable($value);
+                // Detect whether the original string contains an explicit timezone designator
+                // (Z, +HH:MM, -HH:MM) to avoid environment-dependent parsing via php.ini date.timezone
+                $timePart = substr($value, (int) strpos($value, 'T') + 1);
+                $hasExplicitTimezone = (bool) preg_match('/[Zz]$|[+-]\d{2}:\d{2}$/', $timePart);
+
+                $dt = $hasExplicitTimezone
+                    ? new \DateTimeImmutable($value)
+                    : new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
+
                 $date = $dt->format('Y-m-d');
                 $time = (int) $dt->format('s') !== 0 ? $dt->format('H:i:s') : $dt->format('H:i');
-                $timezone = $this->resolveTimezone($dt);
+                $timezone = $hasExplicitTimezone ? $this->resolveTimezone($dt) : '';
 
                 return ['date' => $date, 'time' => $time, 'timezone' => $timezone];
             } catch (\Exception) {

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -2389,14 +2389,18 @@ class UploadXmlController extends Controller
      * Returns the timezone name as-is (IANA name or UTC offset string like "+02:00").
      * Numeric offsets are kept verbatim because mapping them to IANA zones is
      * inherently ambiguous and non-deterministic across PHP versions.
+     * "+00:00" is normalized to "UTC" since they are semantically identical.
      */
     private function resolveTimezone(\DateTimeImmutable $dt): string
     {
         $tz = $dt->getTimezone();
         $tzName = $tz->getName();
 
-        // Return whatever PHP resolved: IANA name, offset like "+02:00", or "Z"
-        return $tzName !== '' ? $tzName : 'UTC';
+        if ($tzName === '' || $tzName === '+00:00' || $tzName === 'Z') {
+            return 'UTC';
+        }
+
+        return $tzName;
     }
 
     /**

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -2370,7 +2370,7 @@ class UploadXmlController extends Controller
             try {
                 $dt = new \DateTimeImmutable($value);
                 $date = $dt->format('Y-m-d');
-                $time = $dt->format('H:i');
+                $time = (int) $dt->format('s') !== 0 ? $dt->format('H:i:s') : $dt->format('H:i');
                 $timezone = $this->resolveTimezone($dt);
 
                 return ['date' => $date, 'time' => $time, 'timezone' => $timezone];

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -151,6 +151,18 @@ class UploadXmlController extends Controller
             $descriptions = $this->extractDescriptions($reader);
             $dates = $this->extractDates($reader);
             $coverages = $this->extractCoverages($reader, $dates);
+
+            // Remove Coverage dates from dates array (they are now in coverages)
+            // and strip the rawValue key used only for coverage time extraction
+            $dates = array_filter(
+                $dates,
+                fn (array $date) => ($date['dateType'] ?? '') !== 'coverage',
+            );
+            $dates = array_values(array_map(
+                fn (array $date) => array_diff_key($date, ['rawValue' => true]),
+                $dates,
+            ));
+
             $gcmdKeywords = $this->extractGcmdKeywords($reader);
 
             // Use dedicated service for keyword extraction
@@ -181,6 +193,7 @@ class UploadXmlController extends Controller
                 $titles[] = [
                     'title' => $element->getContent(),
                     'titleType' => $titleType ? Str::kebab($titleType) : 'main-title',
+                    'language' => $element->getAttribute('xml:lang') ?? null,
                 ];
             }
 
@@ -620,6 +633,7 @@ class UploadXmlController extends Controller
             $descriptions[] = [
                 'type' => $descriptionType ?? 'Other',
                 'description' => $description,
+                'language' => $element->getAttribute('xml:lang') ?? null,
             ];
         }
 
@@ -734,6 +748,7 @@ class UploadXmlController extends Controller
                 'dateType' => Str::kebab($dateType ?? 'other'),
                 'startDate' => $startDate,
                 'endDate' => $endDate,
+                'rawValue' => $dateValue,
             ];
         }
 
@@ -763,6 +778,9 @@ class UploadXmlController extends Controller
             }
         }
 
+        // Parse temporal coverage with full datetime components (time + timezone)
+        $temporalComponents = $this->parseTemporalCoverageComponents($temporalCoverage);
+
         // Extract geoLocations
         $geoLocationElements = $reader
             ->xpathElement('//*[local-name()="resource"]/*[local-name()="geoLocations"]/*[local-name()="geoLocation"]')
@@ -778,11 +796,11 @@ class UploadXmlController extends Controller
                 'lonMin' => '',
                 'lonMax' => '',
                 'polygonPoints' => [],
-                'startDate' => $temporalCoverage['startDate'] ?? '',
-                'endDate' => $temporalCoverage['endDate'] ?? '',
-                'startTime' => '',
-                'endTime' => '',
-                'timezone' => 'UTC',
+                'startDate' => $temporalComponents['startDate'],
+                'endDate' => $temporalComponents['endDate'],
+                'startTime' => $temporalComponents['startTime'],
+                'endTime' => $temporalComponents['endTime'],
+                'timezone' => $temporalComponents['timezone'],
                 'description' => '',
             ];
 
@@ -799,11 +817,11 @@ class UploadXmlController extends Controller
                 'lonMin' => '',
                 'lonMax' => '',
                 'polygonPoints' => [],
-                'startDate' => $temporalCoverage['startDate'] ?? '',
-                'endDate' => $temporalCoverage['endDate'] ?? '',
-                'startTime' => '',
-                'endTime' => '',
-                'timezone' => 'UTC',
+                'startDate' => $temporalComponents['startDate'],
+                'endDate' => $temporalComponents['endDate'],
+                'startTime' => $temporalComponents['startTime'],
+                'endTime' => $temporalComponents['endTime'],
+                'timezone' => $temporalComponents['timezone'],
                 'description' => '',
             ];
 
@@ -1773,15 +1791,21 @@ class UploadXmlController extends Controller
                             stripos($scheme, 'Instruments') !== false;
 
             if (! $isGcmdKeyword) {
-                // Handle unknown schemes that have a classificationCode or valueURI
+                // Handle non-GCMD schemes that have a classificationCode or valueURI
+                // (e.g., International Chronostratigraphic Chart, custom vocabularies)
                 if ($valueUri !== '' || $classificationCode !== '') {
                     $schemeUri = trim((string) $element->getAttribute('schemeURI'));
+
+                    // Parse leaf text from hierarchical path (e.g., "Phanerozoic > Mesozoic > Jurassic" → "Jurassic")
+                    $fullPath = trim($content);
+                    $pathParts = array_map('trim', explode('>', $fullPath));
+                    $leafText = end($pathParts) ?: $fullPath;
 
                     $keyword = [
                         'uuid' => '',
                         'id' => $valueUri !== '' ? $valueUri : $classificationCode,
-                        'text' => trim($content),
-                        'path' => trim($content),
+                        'text' => $leafText,
+                        'path' => $fullPath,
                         'scheme' => $scheme,
                     ];
 
@@ -2270,6 +2294,122 @@ class UploadXmlController extends Controller
             $author['email'] = $author['email'] ?? '';
             $author['website'] = $author['website'] ?? '';
         }
+    }
+
+    /**
+     * Parse temporal coverage components from a Coverage-type date entry.
+     *
+     * Extracts full datetime components (date, time, timezone) from the raw
+     * date value to preserve time information that normalizeDateString() strips.
+     *
+     * @param  array<string, string>|null  $temporalCoverage  Coverage date entry with rawValue
+     * @return array{startDate: string, endDate: string, startTime: string, endTime: string, timezone: string}
+     */
+    private function parseTemporalCoverageComponents(?array $temporalCoverage): array
+    {
+        $default = [
+            'startDate' => '',
+            'endDate' => '',
+            'startTime' => '',
+            'endTime' => '',
+            'timezone' => 'UTC',
+        ];
+
+        if ($temporalCoverage === null) {
+            return $default;
+        }
+
+        $rawValue = $temporalCoverage['rawValue'] ?? '';
+
+        if ($rawValue === '') {
+            return [
+                'startDate' => $temporalCoverage['startDate'] ?? '',
+                'endDate' => $temporalCoverage['endDate'] ?? '',
+                'startTime' => '',
+                'endTime' => '',
+                'timezone' => 'UTC',
+            ];
+        }
+
+        if (str_contains($rawValue, '/')) {
+            [$startRaw, $endRaw] = explode('/', $rawValue, 2);
+            $startParts = $this->parseDateTimeComponents(trim($startRaw));
+            $endParts = $this->parseDateTimeComponents(trim($endRaw));
+        } else {
+            $startParts = $this->parseDateTimeComponents($rawValue);
+            $endParts = ['date' => '', 'time' => '', 'timezone' => ''];
+        }
+
+        return [
+            'startDate' => $startParts['date'],
+            'endDate' => $endParts['date'],
+            'startTime' => $startParts['time'],
+            'endTime' => $endParts['time'],
+            'timezone' => $startParts['timezone'] ?: ($endParts['timezone'] ?: 'UTC'),
+        ];
+    }
+
+    /**
+     * Parse a date/datetime string into separate date, time, and timezone components.
+     *
+     * @return array{date: string, time: string, timezone: string}
+     */
+    private function parseDateTimeComponents(string $value): array
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return ['date' => '', 'time' => '', 'timezone' => ''];
+        }
+
+        // Only attempt full datetime parsing if the value contains a time separator
+        if (str_contains($value, 'T')) {
+            try {
+                $dt = new \DateTimeImmutable($value);
+                $date = $dt->format('Y-m-d');
+                $time = $dt->format('H:i');
+                $timezone = $this->resolveTimezone($dt);
+
+                return ['date' => $date, 'time' => $time, 'timezone' => $timezone];
+            } catch (\Exception) {
+                // Fall through to simple date normalization
+            }
+        }
+
+        // For plain dates without time, use existing normalization
+        return ['date' => $this->normalizeDateString($value), 'time' => '', 'timezone' => ''];
+    }
+
+    /**
+     * Resolve a DateTimeImmutable timezone to an IANA timezone name.
+     *
+     * Falls back to 'UTC' if no matching IANA timezone can be found.
+     * Note: timezone resolution from offsets is inherently ambiguous
+     * (+02:00 could be Europe/Berlin, Africa/Cairo, etc.).
+     */
+    private function resolveTimezone(\DateTimeImmutable $dt): string
+    {
+        $tz = $dt->getTimezone();
+        $tzName = $tz->getName();
+
+        // If already an IANA name (not a numeric offset like "+02:00"), return as-is
+        if (! preg_match('/^[+-]\d{2}:\d{2}$/', $tzName)) {
+            return $tzName;
+        }
+
+        // Try to find a matching IANA timezone for this offset
+        $offset = $dt->getOffset();
+        $abbreviations = \DateTimeZone::listAbbreviations();
+
+        foreach ($abbreviations as $zones) {
+            foreach ($zones as $zone) {
+                if ($zone['offset'] === $offset && is_string($zone['timezone_id']) && $zone['timezone_id'] !== '') {
+                    return $zone['timezone_id'];
+                }
+            }
+        }
+
+        return 'UTC';
     }
 
     /**

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -190,10 +190,11 @@ class UploadXmlController extends Controller
 
             foreach ($titleElements as $element) {
                 $titleType = $element->getAttribute('titleType');
+                $xmlLang = $element->getAttribute('xml:lang');
                 $titles[] = [
                     'title' => $element->getContent(),
                     'titleType' => $titleType ? Str::kebab($titleType) : 'main-title',
-                    'language' => $element->getAttribute('xml:lang') ?? null,
+                    'language' => is_string($xmlLang) && trim($xmlLang) !== '' ? trim($xmlLang) : null,
                 ];
             }
 
@@ -612,7 +613,7 @@ class UploadXmlController extends Controller
     }
 
     /**
-     * @return array<int, array<string, string>>
+     * @return array<int, array<string, string|null>>
      */
     private function extractDescriptions(XmlReader $reader): array
     {
@@ -630,10 +631,12 @@ class UploadXmlController extends Controller
                 continue;
             }
 
+            $descLang = $element->getAttribute('xml:lang');
+
             $descriptions[] = [
                 'type' => $descriptionType ?? 'Other',
                 'description' => $description,
-                'language' => $element->getAttribute('xml:lang') ?? null,
+                'language' => is_string($descLang) && trim($descLang) !== '' ? trim($descLang) : null,
             ];
         }
 
@@ -2381,35 +2384,19 @@ class UploadXmlController extends Controller
     }
 
     /**
-     * Resolve a DateTimeImmutable timezone to an IANA timezone name.
+     * Extract the timezone identifier from a DateTimeImmutable.
      *
-     * Falls back to 'UTC' if no matching IANA timezone can be found.
-     * Note: timezone resolution from offsets is inherently ambiguous
-     * (+02:00 could be Europe/Berlin, Africa/Cairo, etc.).
+     * Returns the timezone name as-is (IANA name or UTC offset string like "+02:00").
+     * Numeric offsets are kept verbatim because mapping them to IANA zones is
+     * inherently ambiguous and non-deterministic across PHP versions.
      */
     private function resolveTimezone(\DateTimeImmutable $dt): string
     {
         $tz = $dt->getTimezone();
         $tzName = $tz->getName();
 
-        // If already an IANA name (not a numeric offset like "+02:00"), return as-is
-        if (! preg_match('/^[+-]\d{2}:\d{2}$/', $tzName)) {
-            return $tzName;
-        }
-
-        // Try to find a matching IANA timezone for this offset
-        $offset = $dt->getOffset();
-        $abbreviations = \DateTimeZone::listAbbreviations();
-
-        foreach ($abbreviations as $zones) {
-            foreach ($zones as $zone) {
-                if ($zone['offset'] === $offset && is_string($zone['timezone_id']) && $zone['timezone_id'] !== '') {
-                    return $zone['timezone_id'];
-                }
-            }
-        }
-
-        return 'UTC';
+        // Return whatever PHP resolved: IANA name, offset like "+02:00", or "Z"
+        return $tzName !== '' ? $tzName : 'UTC';
     }
 
     /**

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -57,6 +57,7 @@ class StoreDraftResourceRequest extends FormRequest
             'titles' => ['required', 'array', 'min:1'],
             'titles.*.title' => ['required', 'string', 'max:255'],
             'titles.*.titleType' => ['required', 'string', 'max:255'],
+            'titles.*.language' => ['nullable', 'string', 'max:10'],
             // Licenses are optional for drafts
             'licenses' => ['nullable', 'array'],
             'licenses.*' => ['string', 'distinct', Rule::exists('rights', 'identifier')],
@@ -99,6 +100,7 @@ class StoreDraftResourceRequest extends FormRequest
                 Rule::in(['abstract', 'methods', 'series-information', 'table-of-contents', 'technical-info', 'other']),
             ],
             'descriptions.*.description' => ['required', 'string'],
+            'descriptions.*.language' => ['nullable', 'string', 'max:10'],
             'dates' => ['nullable', 'array'],
             'dates.*.dateType' => [
                 'required',
@@ -230,9 +232,12 @@ class StoreDraftResourceRequest extends FormRequest
                 }
             }
 
+            $language = isset($title['language']) ? trim((string) $title['language']) : '';
+
             $titles[] = [
                 'title' => isset($title['title']) ? trim((string) $title['title']) : null,
                 'titleType' => $titleType,
+                'language' => $language !== '' ? $language : null,
             ];
         }
 
@@ -492,9 +497,12 @@ class StoreDraftResourceRequest extends FormRequest
 
             $normalizedType = Str::kebab($descriptionType);
 
+            $descriptionLanguage = isset($description['language']) ? trim((string) $description['language']) : '';
+
             $descriptions[] = [
                 'descriptionType' => $normalizedType,
                 'description' => $descriptionText,
+                'language' => $descriptionLanguage !== '' ? $descriptionLanguage : null,
             ];
         }
 

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -224,9 +224,12 @@ class StoreResourceRequest extends FormRequest
                 }
             }
 
+            $language = isset($title['language']) ? trim((string) $title['language']) : '';
+
             $titles[] = [
                 'title' => isset($title['title']) ? trim((string) $title['title']) : null,
                 'titleType' => $titleType,
+                'language' => $language !== '' ? $language : null,
             ];
         }
 
@@ -487,9 +490,12 @@ class StoreResourceRequest extends FormRequest
             // Convert to kebab-case for database storage
             $normalizedType = \Illuminate\Support\Str::kebab($descriptionType);
 
+            $descriptionLanguage = isset($description['language']) ? trim((string) $description['language']) : '';
+
             $descriptions[] = [
                 'descriptionType' => $normalizedType,
                 'description' => $descriptionText,
+                'language' => $descriptionLanguage !== '' ? $descriptionLanguage : null,
             ];
         }
 

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -50,6 +50,7 @@ class StoreResourceRequest extends FormRequest
             'titles.*.title' => ['required', 'string', 'max:255'],
             // Title types are validated in after(): allow 'main-title' even if there is no DB TitleType row.
             'titles.*.titleType' => ['required', 'string', 'max:255'],
+            'titles.*.language' => ['nullable', 'string', 'max:10'],
             'licenses' => ['required', 'array', 'min:1'],
             'licenses.*' => ['string', 'distinct', Rule::exists('rights', 'identifier')],
             'authors' => ['required', 'array', 'min:1'],
@@ -89,6 +90,7 @@ class StoreResourceRequest extends FormRequest
                 Rule::in(['abstract', 'methods', 'series-information', 'table-of-contents', 'technical-info', 'other']),
             ],
             'descriptions.*.description' => ['required', 'string'],
+            'descriptions.*.language' => ['nullable', 'string', 'max:10'],
             'dates' => ['nullable', 'array'],
             'dates.*.dateType' => [
                 'required',

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -271,7 +271,7 @@ class EditorDataTransformer
      * conventions. A future migration could normalize database slugs to kebab-case to simplify
      * this logic.
      *
-    @return array<int, array{type: string, description: string, language: string|null}>
+     * @return array<int, array{type: string, description: string, language: string|null}>
      */
     public function transformDescriptions(Resource $resource): array
     {

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -96,7 +96,7 @@ class EditorDataTransformer
     /**
      * Transform resource titles to frontend format.
      *
-     * @return array<int, array{title: string, titleType: string}>
+     * @return array<int, array{title: string, titleType: string, language: string|null}>
      */
     public function transformTitles(Resource $resource): array
     {
@@ -111,6 +111,7 @@ class EditorDataTransformer
             return [
                 'title' => $title->value,
                 'titleType' => $titleType,
+                'language' => $title->language,
             ];
         })->toArray();
     }
@@ -270,7 +271,7 @@ class EditorDataTransformer
      * conventions. A future migration could normalize database slugs to kebab-case to simplify
      * this logic.
      *
-     * @return array<int, array{type: string, description: string}>
+    @return array<int, array{type: string, description: string, language: string|null}>
      */
     public function transformDescriptions(Resource $resource): array
     {
@@ -284,6 +285,7 @@ class EditorDataTransformer
             return [
                 'type' => $frontendType,
                 'description' => $description->value,
+                'language' => $description->language,
             ];
         })->toArray();
     }

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -198,6 +198,7 @@ class ResourceStorageService
             $resourceTitles[] = [
                 'value' => $title['title'],
                 'title_type_id' => $titleTypeId,
+                'language' => $title['language'] ?? null,
             ];
         }
 
@@ -585,11 +586,7 @@ class ResourceStorageService
             $resource->descriptions()->create([
                 'description_type_id' => $descTypeId,
                 'value' => $description['description'],
-                // Language is always null because per-description language selection
-                // is not part of the current API contract. The resource-level language
-                // field (DataCite #9) serves this purpose. Any 'language' key in the
-                // request payload is intentionally ignored.
-                'language' => null,
+                'language' => $description['language'] ?? null,
             ]);
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -10301,11 +10301,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.47",
+            "version": "2.1.48",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/79015445d8bd79e62b29140f12e5bfced1dcca65",
-                "reference": "79015445d8bd79e62b29140f12e5bfced1dcca65",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/231397213efb7c0a066ee024b5c3c87f2d3adfa0",
+                "reference": "231397213efb7c0a066ee024b5c3c87f2d3adfa0",
                 "shasum": ""
             },
             "require": {
@@ -10350,7 +10350,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-13T15:49:08+00:00"
+            "time": "2026-04-15T20:24:19+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -10354,16 +10354,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.5",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a25bde1f8f83849f441ef5713c6466e470872a71",
-                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -10418,7 +10418,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -10438,7 +10438,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T04:53:32+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -11075,16 +11075,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.4",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
-                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
@@ -11099,7 +11099,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -11127,7 +11127,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
@@ -11147,7 +11147,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-15T07:05:40+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",

--- a/composer.lock
+++ b/composer.lock
@@ -5104,7 +5104,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -5163,7 +5163,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5187,7 +5187,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -5245,7 +5245,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5269,7 +5269,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -5332,7 +5332,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5356,7 +5356,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5417,7 +5417,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5441,7 +5441,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -5502,7 +5502,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5526,7 +5526,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -5586,7 +5586,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5610,7 +5610,7 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
@@ -5666,7 +5666,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5690,7 +5690,7 @@
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
@@ -5746,7 +5746,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5770,7 +5770,7 @@
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.35.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
@@ -5829,7 +5829,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.35.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -9392,16 +9392,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.6.0",
+            "version": "v4.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "4e03cd3edbae9bb9e024660a6380ebb5832a6df9"
+                "reference": "87db0b484788cfde4778b715bb1fed34133685fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/4e03cd3edbae9bb9e024660a6380ebb5832a6df9",
-                "reference": "4e03cd3edbae9bb9e024660a6380ebb5832a6df9",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/87db0b484788cfde4778b715bb1fed34133685fa",
+                "reference": "87db0b484788cfde4778b715bb1fed34133685fa",
                 "shasum": ""
             },
             "require": {
@@ -9413,12 +9413,12 @@
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.16",
+                "phpunit/phpunit": "^12.5.20",
                 "symfony/process": "^7.4.8|^8.0.8"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.16",
+                "phpunit/phpunit": ">12.5.20",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
@@ -9493,7 +9493,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.6.0"
+                "source": "https://github.com/pestphp/pest/tree/v4.6.1"
             },
             "funding": [
                 {
@@ -9505,7 +9505,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-14T17:23:26+00:00"
+            "time": "2026-04-15T16:03:09+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -10699,16 +10699,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.16",
+            "version": "12.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b2429f58ae75cae980b5bb9873abe4de6aac8b58"
+                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b2429f58ae75cae980b5bb9873abe4de6aac8b58",
-                "reference": "b2429f58ae75cae980b5bb9873abe4de6aac8b58",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c2364520611caa03567a8a020f2d59f3f90b115a",
+                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a",
                 "shasum": ""
             },
             "require": {
@@ -10722,13 +10722,13 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.3",
+                "phpunit/php-code-coverage": "^12.5.5",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.4",
+                "sebastian/comparator": "^7.1.6",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.4",
                 "sebastian/exporter": "^7.0.2",
@@ -10777,7 +10777,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.16"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.20"
             },
             "funding": [
                 {
@@ -10785,7 +10785,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-03T05:26:42+00:00"
+            "time": "2026-04-15T05:05:59+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5490,9 +5490,9 @@
       "license": "MIT"
     },
     "node_modules/@types/google.maps": {
-      "version": "3.58.1",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
-      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "version": "3.64.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.64.0.tgz",
+      "integrity": "sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -13037,9 +13037,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13294,9 +13294,9 @@
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.32.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.3.tgz",
-      "integrity": "sha512-uFv9DXtVkuVYzVeCy8vk7m5AVt6GC8iQlTDIN0aZvHl2SOO8OukO3KML/p1s1d5Gpj64OD95h9zUbjGU3UanBQ==",
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.4.tgz",
+      "integrity": "sha512-OsTqKCiDT/o8/oqZbt+p1djPkrOk3unKK/7+wGvP1+WY6pOzFoDLM4D39cNFtpIArtlg9uoK6MKIz3W00WX8qw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,9 +1100,9 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11509,9 +11509,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,14 +105,15 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
-      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0"
       },
@@ -132,6 +133,16 @@
         "css-tree": "^3.2.1",
         "is-potential-custom-element-name": "^1.0.1"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -8033,9 +8044,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.338",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.338.tgz",
+      "integrity": "sha512-KVQQ3xko9/coDX3qXLUEEbqkKT8L+1DyAovrtu0Khtrt9wjSZ+7CZV4GVzxFy9Oe1NbrIU1oVXCwHJruIA1PNg==",
       "dev": true,
       "license": "ISC"
     },

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0dev",
-        "date": "2026-04-14",
+        "date": "2026-04-16",
         "features": [
             {
                 "title": "Analytical Methods for Geochemistry Thesaurus",
@@ -111,6 +111,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "XML Import Data Loss Prevention",
+                "description": "Fixed multiple data loss issues during XML/JSON/JSON-LD upload via the Dashboard. Per-title and per-description xml:lang attributes are now extracted and preserved through the full import-edit-save cycle. Coverage datetime values retain seconds precision and timezone offsets (e.g. +02:00) instead of silently dropping them. Datetimes without an explicit timezone designator are no longer interpreted using the server default timezone. The draft save path now also preserves language metadata. The editor load/transform layer includes language fields so subsequent saves round-trip the values correctly."
+            },
             {
                 "title": "Used Instruments Section Now Expanded by Default",
                 "description": "The 'Used Instruments' section in the Data Editor is now expanded by default when loading the editor, consistent with all other form sections."

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -188,6 +188,7 @@ export default function DataCiteForm({
                     id: crypto.randomUUID(),
                     title: t.title,
                     titleType: MAIN_TITLE_SLUG,
+                    language: t.language ?? null,
                 };
             }
 
@@ -197,6 +198,7 @@ export default function DataCiteForm({
                 // If the first entry had an empty type but a main title is already assigned elsewhere,
                 // fall back to a non-main type instead of keeping it empty.
                 titleType: normalized || defaultSecondaryType,
+                language: t.language ?? null,
             };
         });
     });
@@ -241,6 +243,7 @@ export default function DataCiteForm({
             return initialDescriptions.map((desc) => ({
                 type: desc.type as DescriptionEntry['type'],
                 value: desc.description,
+                language: desc.language ?? null,
             }));
         }
         return [];
@@ -1657,7 +1660,7 @@ export default function DataCiteForm({
             resourceType: number | null;
             version: string | null;
             language: string;
-            titles: { title: string; titleType: string }[];
+            titles: { title: string; titleType: string; language?: string | null }[];
             licenses: string[];
             authors: SerializedAuthor[];
             contributors: SerializedContributor[];
@@ -1667,7 +1670,7 @@ export default function DataCiteForm({
                 affiliation_name: string;
                 affiliation_ror: string | null;
             }[];
-            descriptions: { descriptionType: string; description: string }[];
+            descriptions: { descriptionType: string; description: string; language?: string | null }[];
             dates: { dateType: string; startDate: string | null; endDate: string | null }[];
             freeKeywords: string[];
             gcmdKeywords: {
@@ -1723,6 +1726,7 @@ export default function DataCiteForm({
             titles: titles.map((entry) => ({
                 title: entry.title,
                 titleType: entry.titleType,
+                language: entry.language ?? null,
             })),
             licenses: licenseEntries.map((entry) => entry.license).filter((license): license is string => Boolean(license)),
             authors: serializedAuthors,
@@ -1738,6 +1742,7 @@ export default function DataCiteForm({
                 .map((desc) => ({
                     descriptionType: desc.type,
                     description: desc.value.trim(),
+                    language: desc.language ?? null,
                 })),
             dates: dates.filter(hasValidDateValue).map((date) => ({
                 dateType: date.dateType,

--- a/resources/js/components/curation/fields/description-field.tsx
+++ b/resources/js/components/curation/fields/description-field.tsx
@@ -12,6 +12,7 @@ export type DescriptionType = 'Abstract' | 'Methods' | 'SeriesInformation' | 'Ta
 export interface DescriptionEntry {
     type: DescriptionType;
     value: string;
+    language?: string | null;
 }
 
 interface DescriptionFieldProps {

--- a/resources/js/components/curation/fields/spatial-temporal-coverage/TemporalInputs.tsx
+++ b/resources/js/components/curation/fields/spatial-temporal-coverage/TemporalInputs.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { Label } from '@/components/ui/label';
 
 import InputField from '../input-field';
@@ -52,6 +54,15 @@ const isValidTime = (value: string): boolean => {
 };
 
 export default function TemporalInputs({ startDate, endDate, startTime, endTime, timezone, onChange, showLabels = true }: TemporalInputsProps) {
+    const timezoneOptions = useMemo(() => {
+        if (!timezone || TIMEZONE_OPTIONS.some((opt) => opt.value === timezone)) {
+            return TIMEZONE_OPTIONS;
+        }
+
+        const importedOption = { value: timezone, label: `UTC${timezone} (imported)` };
+        return [importedOption, ...TIMEZONE_OPTIONS];
+    }, [timezone]);
+
     return (
         <div className="space-y-4">
             {showLabels && <Label className="text-sm font-medium">Temporal Information</Label>}
@@ -113,7 +124,7 @@ export default function TemporalInputs({ startDate, endDate, startTime, endTime,
                     label="Timezone (optional)"
                     value={timezone}
                     onValueChange={(value) => onChange('timezone', value)}
-                    options={TIMEZONE_OPTIONS}
+                    options={timezoneOptions}
                 />
             </div>
 

--- a/resources/js/components/curation/fields/spatial-temporal-coverage/TemporalInputs.tsx
+++ b/resources/js/components/curation/fields/spatial-temporal-coverage/TemporalInputs.tsx
@@ -59,7 +59,9 @@ export default function TemporalInputs({ startDate, endDate, startTime, endTime,
             return TIMEZONE_OPTIONS;
         }
 
-        const importedOption = { value: timezone, label: `UTC${timezone} (imported)` };
+        const isOffset = /^[+-]\d{2}:\d{2}$/.test(timezone);
+        const label = isOffset ? `UTC${timezone} (imported)` : `${timezone} (imported)`;
+        const importedOption = { value: timezone, label };
         return [importedOption, ...TIMEZONE_OPTIONS];
     }, [timezone]);
 

--- a/resources/js/components/curation/types/datacite-form-types.ts
+++ b/resources/js/components/curation/types/datacite-form-types.ts
@@ -34,6 +34,7 @@ export interface TitleEntry {
     id: string;
     title: string;
     titleType: string;
+    language?: string | null;
 }
 
 export interface LicenseEntry {
@@ -173,12 +174,12 @@ export interface DataCiteFormProps {
     initialVersion?: string;
     initialLanguage?: string;
     initialResourceType?: string;
-    initialTitles?: { title: string; titleType: string }[];
+    initialTitles?: { title: string; titleType: string; language?: string | null }[];
     initialLicenses?: string[];
     initialResourceId?: string;
     initialAuthors?: InitialAuthor[];
     initialContributors?: InitialContributor[];
-    initialDescriptions?: { type: string; description: string }[];
+    initialDescriptions?: { type: string; description: string; language?: string | null }[];
     initialDates?: { dateType: string; startDate: string; endDate: string }[];
     initialGcmdKeywords?: {
         id: string;

--- a/tests/pest/Feature/Http/Controllers/ResourceControllerFundingReferenceTest.php
+++ b/tests/pest/Feature/Http/Controllers/ResourceControllerFundingReferenceTest.php
@@ -56,8 +56,8 @@ beforeEach(function () {
     $this->language = Language::create([
         'code' => 'en',
         'name' => 'English',
-        'is_active' => true,
-        'is_elmo_active' => true,
+        'active' => true,
+        'elmo_active' => true,
     ]);
     $this->right = Right::create([
         'identifier' => 'cc-by-4',

--- a/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
+++ b/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\ResourceController;
+use App\Models\Datacenter;
+use App\Models\DescriptionType;
+use App\Models\Language;
+use App\Models\Resource;
+use App\Models\ResourceType;
+use App\Models\Right;
+use App\Models\TitleType;
+use App\Models\User;
+
+covers(ResourceController::class);
+
+/**
+ * Helper to build a valid resource payload with language fields.
+ */
+function validPayloadWithLanguage(array $overrides = []): array
+{
+    return array_merge([
+        'year' => 2024,
+        'resourceType' => (string) test()->resourceType->id,
+        'language' => 'en',
+        'titles' => [
+            ['title' => 'Test Resource', 'titleType' => 'main-title', 'language' => 'en'],
+        ],
+        'licenses' => ['cc-by-4'],
+        'datacenters' => [test()->datacenter->id],
+        'authors' => [
+            [
+                'type' => 'person',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'position' => 0,
+                'affiliations' => [],
+            ],
+        ],
+        'descriptions' => [
+            [
+                'descriptionType' => 'abstract',
+                'description' => 'This is a test abstract.',
+                'language' => 'de',
+            ],
+        ],
+    ], $overrides);
+}
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->resourceType = ResourceType::create([
+        'name' => 'Dataset',
+        'slug' => 'dataset',
+    ]);
+    $this->language = Language::create([
+        'code' => 'en',
+        'name' => 'English',
+        'is_active' => true,
+        'is_elmo_active' => true,
+    ]);
+    $this->right = Right::create([
+        'identifier' => 'cc-by-4',
+        'name' => 'Creative Commons Attribution 4.0',
+    ]);
+    $this->titleType = TitleType::create([
+        'name' => 'Main Title',
+        'slug' => 'MainTitle',
+    ]);
+    $this->descriptionType = DescriptionType::create([
+        'name' => 'Abstract',
+        'slug' => 'Abstract',
+    ]);
+    $this->datacenter = Datacenter::create(['name' => 'Test Datacenter']);
+});
+
+describe('Title and description language preservation', function () {
+    it('stores title language through prepareForValidation', function () {
+        $payload = validPayloadWithLanguage([
+            'titles' => [
+                ['title' => 'English Title', 'titleType' => 'main-title', 'language' => 'en'],
+                ['title' => 'Deutscher Titel', 'titleType' => 'main-title', 'language' => 'de'],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::latest()->first();
+        $titles = $resource->titles()->orderBy('id')->get();
+
+        expect($titles)->toHaveCount(2)
+            ->and($titles[0]->language)->toBe('en')
+            ->and($titles[1]->language)->toBe('de');
+    });
+
+    it('stores description language through prepareForValidation', function () {
+        $payload = validPayloadWithLanguage([
+            'descriptions' => [
+                ['descriptionType' => 'abstract', 'description' => 'English abstract.', 'language' => 'en'],
+                ['descriptionType' => 'abstract', 'description' => 'Deutsche Zusammenfassung.', 'language' => 'de'],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::latest()->first();
+        $descriptions = $resource->descriptions()->orderBy('id')->get();
+
+        expect($descriptions)->toHaveCount(2)
+            ->and($descriptions[0]->language)->toBe('en')
+            ->and($descriptions[1]->language)->toBe('de');
+    });
+
+    it('stores null language when not provided', function () {
+        $payload = validPayloadWithLanguage([
+            'titles' => [
+                ['title' => 'No Language Title', 'titleType' => 'main-title'],
+            ],
+            'descriptions' => [
+                ['descriptionType' => 'abstract', 'description' => 'No language abstract.'],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::latest()->first();
+        expect($resource->titles->first()->language)->toBeNull()
+            ->and($resource->descriptions->first()->language)->toBeNull();
+    });
+
+    it('normalizes empty language string to null', function () {
+        $payload = validPayloadWithLanguage([
+            'titles' => [
+                ['title' => 'Empty Language Title', 'titleType' => 'main-title', 'language' => ''],
+            ],
+            'descriptions' => [
+                ['descriptionType' => 'abstract', 'description' => 'Empty language.', 'language' => ''],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::latest()->first();
+        expect($resource->titles->first()->language)->toBeNull()
+            ->and($resource->descriptions->first()->language)->toBeNull();
+    });
+});

--- a/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
+++ b/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
@@ -157,3 +157,57 @@ describe('Title and description language preservation', function () {
             ->and($resource->descriptions->first()->language)->toBeNull();
     });
 });
+
+describe('Draft save language preservation', function () {
+    it('stores title language through draft save', function () {
+        $payload = validPayloadWithLanguage([
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title', 'language' => 'fr'],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertSuccessful();
+
+        $resource = Resource::latest()->first();
+        expect($resource->titles->first()->language)->toBe('fr');
+    });
+
+    it('stores description language through draft save', function () {
+        $payload = validPayloadWithLanguage([
+            'descriptions' => [
+                ['descriptionType' => 'abstract', 'description' => 'French abstract.', 'language' => 'fr'],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertSuccessful();
+
+        $resource = Resource::latest()->first();
+        expect($resource->descriptions->first()->language)->toBe('fr');
+    });
+
+    it('normalizes empty language to null in draft save', function () {
+        $payload = validPayloadWithLanguage([
+            'titles' => [
+                ['title' => 'Draft No Lang', 'titleType' => 'main-title', 'language' => ''],
+            ],
+            'descriptions' => [
+                ['descriptionType' => 'abstract', 'description' => 'No lang.', 'language' => ''],
+            ],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertSuccessful();
+
+        $resource = Resource::latest()->first();
+        expect($resource->titles->first()->language)->toBeNull()
+            ->and($resource->descriptions->first()->language)->toBeNull();
+    });
+});

--- a/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
+++ b/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
@@ -56,8 +56,8 @@ beforeEach(function () {
     $this->language = Language::create([
         'code' => 'en',
         'name' => 'English',
-        'is_active' => true,
-        'is_elmo_active' => true,
+        'active' => true,
+        'elmo_active' => true,
     ]);
     $this->right = Right::create([
         'identifier' => 'cc-by-4',

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -145,6 +145,32 @@ describe('transformTitles', function (): void {
 
         expect($result[0]['titleType'])->toBe('subtitle');
     });
+
+    it('includes language field for titles', function (): void {
+        Title::factory()->create([
+            'resource_id' => $this->resource->id,
+            'value' => 'German Title',
+            'language' => 'de',
+        ]);
+        Title::factory()->alternativeTitle()->create([
+            'resource_id' => $this->resource->id,
+            'value' => 'English Alt',
+            'language' => 'en',
+        ]);
+        Title::factory()->create([
+            'resource_id' => $this->resource->id,
+            'value' => 'No Language Title',
+            'language' => null,
+        ]);
+        $this->resource->load('titles.titleType');
+
+        $result = $this->transformer->transformTitles($this->resource);
+
+        $languages = array_column($result, 'language');
+        expect($languages)->toContain('de')
+            ->and($languages)->toContain('en')
+            ->and($languages)->toContain(null);
+    });
 });
 
 // =========================================================================
@@ -638,6 +664,28 @@ describe('transformDescriptions', function (): void {
         $result = $this->transformer->transformDescriptions($this->resource);
 
         expect($result[0]['type'])->toBe('Other');
+    });
+
+    it('includes language field for descriptions', function (): void {
+        $abstractType = DescriptionType::where('slug', 'Abstract')->first();
+        Description::create([
+            'resource_id' => $this->resource->id,
+            'description_type_id' => $abstractType->id,
+            'value' => 'French abstract',
+            'language' => 'fr',
+        ]);
+        Description::create([
+            'resource_id' => $this->resource->id,
+            'description_type_id' => $abstractType->id,
+            'value' => 'No language abstract',
+            'language' => null,
+        ]);
+        $this->resource->load('descriptions.descriptionType');
+
+        $result = $this->transformer->transformDescriptions($this->resource);
+
+        expect($result[0]['language'])->toBe('fr')
+            ->and($result[1]['language'])->toBeNull();
     });
 });
 

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -169,6 +169,74 @@ XML;
     $response->assertSessionDataPath('coverages.0.timezone', '+02:00');
 });
 
+test('normalizes +00:00 timezone offset to UTC', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-06-15T12:00:00+00:00/2026-06-15T14:00:00+00:00</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>51.5</pointLatitude>
+        <pointLongitude>-0.1</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-utc-offset.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.timezone', 'UTC');
+});
+
+test('normalizes Z timezone designator to UTC', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-06-15T12:00:00Z/2026-06-15T14:00:00Z</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>51.5</pointLatitude>
+        <pointLongitude>-0.1</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-z-timezone.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.timezone', 'UTC');
+});
+
 test('extracts coverage date without time as date-only', function () {
     $this->actingAs(User::factory()->create());
 

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -237,6 +237,75 @@ XML;
     $response->assertSessionDataPath('coverages.0.timezone', 'UTC');
 });
 
+test('preserves seconds in coverage time when present', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-06-15T20:00:30+02:00/2026-06-15T22:15:45+02:00</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>51.5</pointLatitude>
+        <pointLongitude>-0.1</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-with-seconds.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.startTime', '20:00:30');
+    $response->assertSessionDataPath('coverages.0.endTime', '22:15:45');
+});
+
+test('omits seconds when they are zero', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-06-15T14:30:00+02:00</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>51.5</pointLatitude>
+        <pointLongitude>-0.1</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-zero-seconds.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.startTime', '14:30');
+});
+
 test('extracts coverage date without time as date-only', function () {
     $this->actingAs(User::factory()->create());
 

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -306,6 +306,43 @@ XML;
     $response->assertSessionDataPath('coverages.0.startTime', '14:30');
 });
 
+test('datetime without explicit timezone returns empty timezone', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-06-15T20:00:30/2026-06-15T22:15:45</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>51.5</pointLatitude>
+        <pointLongitude>-0.1</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-no-tz.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.startDate', '2026-06-15');
+    $response->assertSessionDataPath('coverages.0.startTime', '20:00:30');
+    $response->assertSessionDataPath('coverages.0.endTime', '22:15:45');
+    $response->assertSessionDataPath('coverages.0.timezone', '');
+});
+
 test('extracts coverage date without time as date-only', function () {
     $this->actingAs(User::factory()->create());
 

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+
+uses(RefreshDatabase::class);
+
+// ──────────────────────────────────────────────────────────────────
+// Fix 1: Title xml:lang attribute is preserved
+// ──────────────────────────────────────────────────────────────────
+
+test('extracts xml:lang attribute from titles', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles>
+    <title xml:lang="en">English Title</title>
+    <title titleType="AlternativeTitle" xml:lang="de">Deutscher Titel</title>
+  </titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('title-lang.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('titles.0.language', 'en');
+    $response->assertSessionDataPath('titles.1.language', 'de');
+    $response->assertSessionDataPath('titles.1.titleType', 'alternative-title');
+});
+
+test('title language is null when xml:lang is not present', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles>
+    <title>No Language Title</title>
+  </titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('title-no-lang.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('titles.0.language', null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Fix 2: Description xml:lang attribute is preserved
+// ──────────────────────────────────────────────────────────────────
+
+test('extracts xml:lang attribute from descriptions', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <descriptions>
+    <description descriptionType="Abstract" xml:lang="en">English abstract</description>
+    <description descriptionType="Methods" xml:lang="de">Deutsche Methoden</description>
+  </descriptions>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('desc-lang.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('descriptions.0.language', 'en');
+    $response->assertSessionDataPath('descriptions.0.type', 'Abstract');
+    $response->assertSessionDataPath('descriptions.1.language', 'de');
+    $response->assertSessionDataPath('descriptions.1.type', 'Methods');
+});
+
+test('description language is null when xml:lang is not present', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <descriptions>
+    <description descriptionType="Abstract">No language abstract</description>
+  </descriptions>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('desc-no-lang.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('descriptions.0.language', null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Fix 3: Coverage date with time and timezone is fully extracted
+// ──────────────────────────────────────────────────────────────────
+
+test('extracts time and timezone from coverage date range', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-03-31T20:00:00+02:00/2026-03-31T21:00:00+02:00</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>52.3</pointLatitude>
+        <pointLongitude>13.0</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-datetime.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.startDate', '2026-03-31');
+    $response->assertSessionDataPath('coverages.0.endDate', '2026-03-31');
+    $response->assertSessionDataPath('coverages.0.startTime', '20:00');
+    $response->assertSessionDataPath('coverages.0.endTime', '21:00');
+
+    // Timezone should be resolved (could be an IANA name matching +02:00)
+    $timezone = $response->sessionData('coverages.0.timezone');
+    expect($timezone)->not->toBe('UTC')
+        ->and($timezone)->not->toBeEmpty();
+});
+
+test('extracts coverage date without time as date-only', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-04-01/2026-04-16</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>52.3</pointLatitude>
+        <pointLongitude>13.0</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-date-only.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.startDate', '2026-04-01');
+    $response->assertSessionDataPath('coverages.0.endDate', '2026-04-16');
+    $response->assertSessionDataPath('coverages.0.startTime', '');
+    $response->assertSessionDataPath('coverages.0.endTime', '');
+    $response->assertSessionDataPath('coverages.0.timezone', 'UTC');
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Fix 4: Coverage dates are removed from the dates array
+// ──────────────────────────────────────────────────────────────────
+
+test('coverage dates are filtered from dates array', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Available">2026-04-26</date>
+    <date dateType="Coverage">2026-03-31T20:00:00+02:00/2026-03-31T21:00:00+02:00</date>
+    <date dateType="Created">2026-04-15</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>52.3</pointLatitude>
+        <pointLongitude>13.0</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-filtered.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    // Coverage date should be in coverages, not in dates
+    $response->assertSessionDataCount(2, 'dates');
+    $response->assertSessionDataPath('dates.0.dateType', 'available');
+    $response->assertSessionDataPath('dates.1.dateType', 'created');
+
+    // No date should have dateType "coverage"
+    $dates = $response->sessionData('dates');
+    $coverageDates = array_filter($dates, fn ($d) => ($d['dateType'] ?? '') === 'coverage');
+    expect($coverageDates)->toBeEmpty();
+
+    // Coverage should exist in coverages
+    $response->assertSessionDataPath('coverages.0.startDate', '2026-03-31');
+    $response->assertSessionDataPath('coverages.0.startTime', '20:00');
+
+    // rawValue key should not be present in dates
+    foreach ($dates as $date) {
+        expect($date)->not->toHaveKey('rawValue');
+    }
+});
+
+// ──────────────────────────────────────────────────────────────────
+// Fix 5: Chronostratigraphic keyword text uses leaf node
+// ──────────────────────────────────────────────────────────────────
+
+test('chronostratigraphic keyword text is leaf node of path', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <subjects>
+    <subject subjectScheme="International Chronostratigraphic Chart"
+             schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020"
+             valueURI="http://resource.geosciml.org/classifier/ics/ischart/Jurassic"
+             xml:lang="en">Phanerozoic &gt; Mesozoic &gt; Jurassic</subject>
+    <subject subjectScheme="International Chronostratigraphic Chart"
+             schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020"
+             valueURI="http://resource.geosciml.org/classifier/ics/ischart/Paleozoic"
+             xml:lang="en">Phanerozoic &gt; Paleozoic</subject>
+  </subjects>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('chronostrat.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $gcmdKeywords = $response->sessionData('gcmdKeywords');
+    expect($gcmdKeywords)->toHaveCount(2);
+
+    // Text should be the leaf node, not the full path
+    expect($gcmdKeywords[0]['text'])->toBe('Jurassic');
+    expect($gcmdKeywords[0]['path'])->toBe('Phanerozoic > Mesozoic > Jurassic');
+    expect($gcmdKeywords[0]['scheme'])->toBe('International Chronostratigraphic Chart');
+    expect($gcmdKeywords[0]['id'])->toBe('http://resource.geosciml.org/classifier/ics/ischart/Jurassic');
+
+    expect($gcmdKeywords[1]['text'])->toBe('Paleozoic');
+    expect($gcmdKeywords[1]['path'])->toBe('Phanerozoic > Paleozoic');
+});
+
+test('chronostratigraphic keyword with single-level path uses text as-is', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <subjects>
+    <subject subjectScheme="International Chronostratigraphic Chart"
+             schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020"
+             valueURI="http://resource.geosciml.org/classifier/ics/ischart/Phanerozoic"
+             xml:lang="en">Phanerozoic</subject>
+  </subjects>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('chronostrat-single.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $gcmdKeywords = $response->sessionData('gcmdKeywords');
+    expect($gcmdKeywords)->toHaveCount(1);
+    expect($gcmdKeywords[0]['text'])->toBe('Phanerozoic');
+    expect($gcmdKeywords[0]['path'])->toBe('Phanerozoic');
+});

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -209,6 +209,114 @@ XML;
     $response->assertSessionDataPath('coverages.0.timezone', 'UTC');
 });
 
+test('extracts single-date coverage without range separator', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-05-01T14:30:00+05:00</date>
+  </dates>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>52.3</pointLatitude>
+        <pointLongitude>13.0</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('coverage-single.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataPath('coverages.0.startDate', '2026-05-01');
+    $response->assertSessionDataPath('coverages.0.startTime', '14:30');
+    $response->assertSessionDataPath('coverages.0.endDate', '');
+    $response->assertSessionDataPath('coverages.0.endTime', '');
+
+    $timezone = $response->sessionData('coverages.0.timezone');
+    expect($timezone)->not->toBe('UTC');
+});
+
+test('temporal-only coverage without geoLocations preserves time', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <dates>
+    <date dateType="Coverage">2026-06-01T08:00:00+02:00/2026-06-01T18:00:00+02:00</date>
+  </dates>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('temporal-only.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataCount(1, 'coverages');
+    $response->assertSessionDataPath('coverages.0.startDate', '2026-06-01');
+    $response->assertSessionDataPath('coverages.0.endDate', '2026-06-01');
+    $response->assertSessionDataPath('coverages.0.startTime', '08:00');
+    $response->assertSessionDataPath('coverages.0.endTime', '18:00');
+    $response->assertSessionDataPath('coverages.0.latMin', '');
+    $response->assertSessionDataPath('coverages.0.lonMin', '');
+});
+
+test('geoLocation without coverage date has empty time fields', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLatitude>52.3</pointLatitude>
+        <pointLongitude>13.0</pointLongitude>
+      </geoLocationPoint>
+    </geoLocation>
+  </geoLocations>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('geo-no-coverage.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataCount(1, 'coverages');
+    $response->assertSessionDataPath('coverages.0.startDate', '');
+    $response->assertSessionDataPath('coverages.0.endDate', '');
+    $response->assertSessionDataPath('coverages.0.startTime', '');
+    $response->assertSessionDataPath('coverages.0.endTime', '');
+    $response->assertSessionDataPath('coverages.0.timezone', 'UTC');
+});
+
 // ──────────────────────────────────────────────────────────────────
 // Fix 4: Coverage dates are removed from the dates array
 // ──────────────────────────────────────────────────────────────────

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -165,10 +165,8 @@ XML;
     $response->assertSessionDataPath('coverages.0.startTime', '20:00');
     $response->assertSessionDataPath('coverages.0.endTime', '21:00');
 
-    // Timezone should be resolved (could be an IANA name matching +02:00)
-    $timezone = $response->sessionData('coverages.0.timezone');
-    expect($timezone)->not->toBe('UTC')
-        ->and($timezone)->not->toBeEmpty();
+    // Timezone should be the original offset string from the XML
+    $response->assertSessionDataPath('coverages.0.timezone', '+02:00');
 });
 
 test('extracts coverage date without time as date-only', function () {
@@ -245,8 +243,7 @@ XML;
     $response->assertSessionDataPath('coverages.0.endDate', '');
     $response->assertSessionDataPath('coverages.0.endTime', '');
 
-    $timezone = $response->sessionData('coverages.0.timezone');
-    expect($timezone)->not->toBe('UTC');
+    $response->assertSessionDataPath('coverages.0.timezone', '+05:00');
 });
 
 test('temporal-only coverage without geoLocations preserves time', function () {

--- a/tests/pest/dataset-examples/dataset_20260415_084119.xml
+++ b/tests/pest/dataset-examples/dataset_20260415_084119.xml
@@ -1,0 +1,586 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<envelope>
+    
+<resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 https://schema.datacite.org/meta/kernel-4.7/metadata.xsd">
+  <identifier identifierType="DOI">10.5880/GFZ1243</identifier>
+  <creators>
+    <creator>
+      <creatorName nameType="Personal">Garcia, Sofia</creatorName>
+      <givenName>Sofia</givenName>
+      <familyName>Garcia</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">0000-0001-5727-2427</nameIdentifier>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org/" affiliationIdentifier="https://ror.org/04z8jg394">GFZ Helmholtz Centre for Geosciences</affiliation>
+    </creator>
+    <creator>
+      <creatorName nameType="Personal">Ehrmann, Holger</creatorName>
+      <givenName>Holger</givenName>
+      <familyName>Ehrmann</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">0009-0000-1235-6950</nameIdentifier>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org/" affiliationIdentifier="https://ror.org/04z8jg394">GFZ Helmholtz Centre for Geosciences</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org/" affiliationIdentifier="https://ror.org/012m9bp23">University of Applied Sciences Potsdam</affiliation>
+    </creator>
+    <creator>
+      <creatorName nameType="Organizational">TESTAUHROINSTITUTION Sec 5.1</creatorName>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org/" affiliationIdentifier="https://ror.org/04z8jg394">GFZ Helmholtz Centre for Geosciences</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org/" affiliationIdentifier="https://ror.org/03e8s1d88">Potsdam Institute for Climate Impact Research</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org/" affiliationIdentifier="https://ror.org/0433rew55">Haut- und Lasercentrum Potsdam</affiliation>
+    </creator>
+  </creators>
+  <titles>
+    <title xml:lang="en">TESTTITLE1</title>
+    <title titleType="AlternativeTitle">TESTTITLE2</title>
+  </titles>
+  <publisher xml:lang="en">GFZ Data Services</publisher>
+  <publicationYear>2009</publicationYear>
+  <resourceType resourceTypeGeneral="Event">Event</resourceType>
+  <subjects>
+    <subject subjectScheme="NASA/GCMD Earth Science Keywords" schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords" valueURI="https://gcmd.earthdata.nasa.gov/kms/concept/40d4ba89-0e3d-4c6c-adef-87e08737d4db" xml:lang="en">Science Keywords &gt; EARTH SCIENCE SERVICES &gt; DATA MANAGEMENT/DATA HANDLING &gt; DATA CUSTOMIZATION &gt; REPROJECTION</subject>
+    <subject subjectScheme="NASA/GCMD Earth Platforms Keywords" schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms" valueURI="https://gcmd.earthdata.nasa.gov/kms/concept/1cc11f32-9643-4fa4-9384-18cab2852604" xml:lang="en">Platforms &gt; Space-based Platforms &gt; Interplanetary Spacecraft &gt; FLYBY &gt; VOYAGER 1</subject>
+    <subject subjectScheme="NASA/GCMD Earth Platforms Keywords" schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms" valueURI="https://gcmd.earthdata.nasa.gov/kms/concept/2351e160-5a9c-4d1c-81f0-775bbae1848e" xml:lang="en">Platforms &gt; Space-based Platforms &gt; Interplanetary Spacecraft &gt; FLYBY &gt; MARINER 2</subject>
+    <subject subjectScheme="NASA/GCMD Instruments" schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments" valueURI="https://gcmd.earthdata.nasa.gov/kms/concept/91923fed-61c3-4125-b69d-1eeccafce52c" xml:lang="en">Instruments &gt; Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Spectrometers &gt; OMPS-N</subject>
+    <subject subjectScheme="NASA/GCMD Instruments" schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments" valueURI="https://gcmd.earthdata.nasa.gov/kms/concept/a0b0fd02-9952-4110-bac9-940a1b6e996f" xml:lang="en">Instruments &gt; Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Spectrometers &gt; GOME</subject>
+    <subject subjectScheme="NASA/GCMD Instruments" schemeURI="https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments" valueURI="https://gcmd.earthdata.nasa.gov/kms/concept/2d17f6d1-6a60-48e7-aa37-d3942286e6a1" xml:lang="en">Instruments &gt; Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Spectrometers &gt; UV OZONE DETECTORS</subject>
+    <subject subjectScheme="International Chronostratigraphic Chart" schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020" valueURI="http://resource.geosciml.org/classifier/ics/ischart/Jurassic" xml:lang="en">Phanerozoic &gt; Mesozoic &gt; Jurassic</subject>
+    <subject subjectScheme="International Chronostratigraphic Chart" schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020" valueURI="http://resource.geosciml.org/classifier/ics/ischart/Cretaceous" xml:lang="en">Phanerozoic &gt; Mesozoic &gt; Cretaceous</subject>
+    <subject subjectScheme="International Chronostratigraphic Chart" schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020" valueURI="http://resource.geosciml.org/classifier/ics/ischart/Triassic" xml:lang="en">Phanerozoic &gt; Mesozoic &gt; Triassic</subject>
+    <subject subjectScheme="International Chronostratigraphic Chart" schemeURI="http://resource.geosciml.org/vocabulary/timescale/gts2020" valueURI="http://resource.geosciml.org/classifier/ics/ischart/Paleozoic" xml:lang="en">Phanerozoic &gt; Paleozoic</subject>
+    <subject>testkeyword1</subject>
+    <subject>testkeyword2</subject>
+    <subject>testkeyword3</subject>
+  </subjects>
+  <contributors>
+    <contributor contributorType="ContactPerson">
+      <contributorName>Garcia, Sofia</contributorName>
+      <givenName>Sofia</givenName>
+      <familyName>Garcia</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">0000-0001-5727-2427</nameIdentifier>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/04z8jg394">GFZ Helmholtz Centre for Geosciences</affiliation>
+    </contributor>
+    <contributor contributorType="DataCollector">
+      <contributorName nameType="Personal">Mohammed, Ali</contributorName>
+      <givenName>Ali</givenName>
+      <familyName>Mohammed</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">0009-0007-2910-0469</nameIdentifier>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/04z8jg394">Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/012m9bp23">University of Applied Sciences Potsdam</affiliation>
+    </contributor>
+    <contributor contributorType="DataManager">
+      <contributorName nameType="Personal">Mohammed, Ali</contributorName>
+      <givenName>Ali</givenName>
+      <familyName>Mohammed</familyName>
+      <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org/">0009-0007-2910-0469</nameIdentifier>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/04z8jg394">Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/012m9bp23">University of Applied Sciences Potsdam</affiliation>
+    </contributor>
+    <contributor contributorType="Distributor">
+      <contributorName nameType="Organizational">Bib</contributorName>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/04z8jg394">GFZ Helmholtz Centre for Geosciences</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/02xx9xx26">Dresdner Grundwasserforschungszentrum</affiliation>
+    </contributor>
+    <contributor contributorType="RegistrationAgency">
+      <contributorName nameType="Organizational">Bib</contributorName>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/04z8jg394">GFZ Helmholtz Centre for Geosciences</affiliation>
+      <affiliation affiliationIdentifierScheme="ROR" schemeURI="https://ror.org" affiliationIdentifier="https://ror.org/02xx9xx26">Dresdner Grundwasserforschungszentrum</affiliation>
+    </contributor>
+  </contributors>
+  <dates>
+    <date dateType="Available">2026-04-26</date>
+    <date dateType="Coverage">2026-03-31T20:00:00+02:00/2026-03-31T21:00:00+02:00</date>
+    <date dateType="Created">2026-04-15</date>
+  </dates>
+  <language>en</language>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Is Cited By">10.1371/journal.pbio.0020449</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="ARK" relationType="Cites">ark:/13030/tqb3kh97gh8w</relatedIdentifier>
+  </relatedIdentifiers>
+  <version>1.1</version>
+  <rightsList>
+    <rights rightsURI="https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt" rightsIdentifier="EUPL-1.2" rightsIdentifierScheme="SPDX" schemeURI="https://spdx.org/licenses/" xml:lang="en">European Union Public License 1.2</rights>
+  </rightsList>
+  <descriptions>
+    <description descriptionType="Abstract" xml:lang="en">TESTABSTRACT</description>
+    <description descriptionType="Methods" xml:lang="en">TESTMETHOD</description>
+    <description descriptionType="Other" xml:lang="en">TESTOTHER</description>
+    <description descriptionType="TechnicalInfo" xml:lang="en">TESTTECHNICALINFORMATION</description>
+  </descriptions>
+  <geoLocations>
+    <geoLocation>
+      <geoLocationPoint>
+        <pointLongitude>13.7691</pointLongitude>
+        <pointLatitude>63.7074</pointLatitude>
+      </geoLocationPoint>
+    </geoLocation>
+    <geoLocation>
+      <geoLocationPlace>TESTDESCRIPTION</geoLocationPlace>
+      <geoLocationBox>
+        <westBoundLongitude>12.7404</westBoundLongitude>
+        <eastBoundLongitude>18.0578</eastBoundLongitude>
+        <southBoundLatitude>62.5594</southBoundLatitude>
+        <northBoundLatitude>63.5158</northBoundLatitude>
+      </geoLocationBox>
+    </geoLocation>
+  </geoLocations>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>GFZ Helmholtz-Zentrum für Geoforschung</funderName>
+      <funderIdentifier schemeURI="https://www.crossref.org/services/funder-registry/" funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/1100010956</funderIdentifier>
+      <awardNumber awardURI="https://testawarduri1.de">12345</awardNumber>
+      <awardTitle>TESTGRANTNAME1</awardTitle>
+    </fundingReference>
+    <fundingReference>
+      <funderName>RIFS Forschungsinstitut für Nachhaltigkeit, GFZ Helmholtz-Zentrum für Geoforschung</funderName>
+      <funderIdentifier schemeURI="https://www.crossref.org/services/funder-registry/" funderIdentifierType="Crossref Funder ID">https://doi.org/10.13039/1100024777</funderIdentifier>
+      <awardNumber awardURI="https://testawarduri2.de">54321</awardNumber>
+      <awardTitle>TESTGRANTNAME2</awardTitle>
+    </fundingReference>
+  </fundingReferences>
+</resource>
+
+
+    
+<MD_Metadata xmlns="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd file:///C:/xampp/htdocs/msl-mde/schemas/ISO/gmd.xsd">
+  <fileIdentifier>
+    <gco:CharacterString>doi:10.5880/GFZ1243</gco:CharacterString>
+  </fileIdentifier>
+  <language>
+    <LanguageCode codeList="http://www.loc.gov/standards/iso639-1/" codeListValue="en">en</LanguageCode>
+  </language>
+  <characterSet>
+    <MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_CharacterSetCode" codeListValue="utf8"/>
+  </characterSet>
+  <hierarchyLevel>
+    <MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</MD_ScopeCode>
+  </hierarchyLevel>
+  <contact>
+    <CI_ResponsibleParty>
+      <organisationName>
+        <gco:CharacterString>GFZ Helmholtz Centre for Geosciences</gco:CharacterString>
+      </organisationName>
+      <contactInfo>
+        <CI_Contact>
+          <address>
+            <CI_Address>
+              <electronicMailAddress>
+                <gco:CharacterString>lis-it@gfz.de</gco:CharacterString>
+              </electronicMailAddress>
+            </CI_Address>
+          </address>
+          <onlineResource>
+            <CI_OnlineResource>
+              <linkage>
+                <URL>https://www.gfz.de/</URL>
+              </linkage>
+              <name>
+                <gco:CharacterString>GFZ Helmholtz Centre for Geosciences</gco:CharacterString>
+              </name>
+              <description>
+                <gco:CharacterString>GFZ Helmholtz Centre for Geosciences</gco:CharacterString>
+              </description>
+              <function>
+                <CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</CI_OnLineFunctionCode>
+              </function>
+            </CI_OnlineResource>
+          </onlineResource>
+        </CI_Contact>
+      </contactInfo>
+      <role>
+        <CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</CI_RoleCode>
+      </role>
+    </CI_ResponsibleParty>
+  </contact>
+  <dateStamp>
+    <gco:Date>2026-04-15</gco:Date>
+  </dateStamp>
+  <referenceSystemInfo>
+    <MD_ReferenceSystem>
+      <referenceSystemIdentifier>
+        <RS_Identifier>
+          <code>
+            <gco:CharacterString>urn:ogc:def:crs:EPSG:4326</gco:CharacterString>
+          </code>
+        </RS_Identifier>
+      </referenceSystemIdentifier>
+    </MD_ReferenceSystem>
+  </referenceSystemInfo>
+  <identificationInfo>
+    <MD_DataIdentification>
+      <citation>
+        <CI_Citation>
+          <title>
+            <gco:CharacterString>TESTTITLE1</gco:CharacterString>
+          </title>
+          <alternateTitle>
+            <gco:CharacterString>TESTTITLE2</gco:CharacterString>
+          </alternateTitle>
+          <date>
+            <CI_Date>
+              <date>
+                <gco:Date>2026-04-15</gco:Date>
+              </date>
+              <dateType>
+                <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</CI_DateTypeCode>
+              </dateType>
+            </CI_Date>
+          </date>
+        </CI_Citation>
+      </citation>
+      <abstract>
+        <gco:CharacterString>TESTABSTRACT</gco:CharacterString>
+      </abstract>
+      <pointOfContact>
+        <CI_ResponsibleParty>
+          <individualName>
+            <gco:CharacterString>Garcia, Sofia</gco:CharacterString>
+          </individualName>
+          <organisationName>
+            <gco:CharacterString>GFZ Helmholtz Centre for Geosciences</gco:CharacterString>
+          </organisationName>
+          <contactInfo>
+            <CI_Contact>
+              <address>
+                <CI_Address>
+                  <electronicMailAddress>
+                    <gco:CharacterString>test@test.de</gco:CharacterString>
+                  </electronicMailAddress>
+                </CI_Address>
+              </address>
+              <onlineResource>
+                <CI_OnlineResource>
+                  <linkage>
+                    <URL>test.de</URL>
+                  </linkage>
+                  <function>
+                    <CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</CI_OnLineFunctionCode>
+                  </function>
+                </CI_OnlineResource>
+              </onlineResource>
+            </CI_Contact>
+          </contactInfo>
+          <role>
+            <CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</CI_RoleCode>
+          </role>
+        </CI_ResponsibleParty>
+      </pointOfContact>
+      <descriptiveKeywords/>
+      <descriptiveKeywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>Science Keywords &gt; EARTH SCIENCE SERVICES &gt; DATA MANAGEMENT/DATA HANDLING &gt; DATA CUSTOMIZATION &gt; REPROJECTION</gco:CharacterString>
+          </keyword>
+          <thesaurusName>
+            <CI_Citation>
+              <title>
+                <gco:CharacterString>NASA/GCMD Earth Science Keywords</gco:CharacterString>
+              </title>
+              <date>
+                <CI_Date>
+                  <date>
+                    <gco:Date>2026-04-15</gco:Date>
+                  </date>
+                  <dateType>
+                    <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="lastUpdate">lastUpdate</CI_DateTypeCode>
+                  </dateType>
+                </CI_Date>
+              </date>
+            </CI_Citation>
+          </thesaurusName>
+        </MD_Keywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>Platforms &gt; Space-based Platforms &gt; Interplanetary Spacecraft &gt; FLYBY &gt; VOYAGER 1</gco:CharacterString>
+          </keyword>
+          <thesaurusName>
+            <CI_Citation>
+              <title>
+                <gco:CharacterString>NASA/GCMD Earth Platforms Keywords</gco:CharacterString>
+              </title>
+              <date>
+                <CI_Date>
+                  <date>
+                    <gco:Date>2026-04-15</gco:Date>
+                  </date>
+                  <dateType>
+                    <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="lastUpdate">lastUpdate</CI_DateTypeCode>
+                  </dateType>
+                </CI_Date>
+              </date>
+            </CI_Citation>
+          </thesaurusName>
+        </MD_Keywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>Platforms &gt; Space-based Platforms &gt; Interplanetary Spacecraft &gt; FLYBY &gt; MARINER 2</gco:CharacterString>
+          </keyword>
+          <thesaurusName>
+            <CI_Citation>
+              <title>
+                <gco:CharacterString>NASA/GCMD Earth Platforms Keywords</gco:CharacterString>
+              </title>
+              <date>
+                <CI_Date>
+                  <date>
+                    <gco:Date>2026-04-15</gco:Date>
+                  </date>
+                  <dateType>
+                    <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="lastUpdate">lastUpdate</CI_DateTypeCode>
+                  </dateType>
+                </CI_Date>
+              </date>
+            </CI_Citation>
+          </thesaurusName>
+        </MD_Keywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>Instruments &gt; Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Spectrometers &gt; OMPS-N</gco:CharacterString>
+          </keyword>
+          <thesaurusName>
+            <CI_Citation>
+              <title>
+                <gco:CharacterString>NASA/GCMD Instruments</gco:CharacterString>
+              </title>
+              <date>
+                <CI_Date>
+                  <date>
+                    <gco:Date>2026-04-15</gco:Date>
+                  </date>
+                  <dateType>
+                    <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="lastUpdate">lastUpdate</CI_DateTypeCode>
+                  </dateType>
+                </CI_Date>
+              </date>
+            </CI_Citation>
+          </thesaurusName>
+        </MD_Keywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>Instruments &gt; Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Spectrometers &gt; GOME</gco:CharacterString>
+          </keyword>
+          <thesaurusName>
+            <CI_Citation>
+              <title>
+                <gco:CharacterString>NASA/GCMD Instruments</gco:CharacterString>
+              </title>
+              <date>
+                <CI_Date>
+                  <date>
+                    <gco:Date>2026-04-15</gco:Date>
+                  </date>
+                  <dateType>
+                    <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="lastUpdate">lastUpdate</CI_DateTypeCode>
+                  </dateType>
+                </CI_Date>
+              </date>
+            </CI_Citation>
+          </thesaurusName>
+        </MD_Keywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>Instruments &gt; Earth Remote Sensing Instruments &gt; Passive Remote Sensing &gt; Spectrometers/Radiometers &gt; Spectrometers &gt; UV OZONE DETECTORS</gco:CharacterString>
+          </keyword>
+          <thesaurusName>
+            <CI_Citation>
+              <title>
+                <gco:CharacterString>NASA/GCMD Instruments</gco:CharacterString>
+              </title>
+              <date>
+                <CI_Date>
+                  <date>
+                    <gco:Date>2026-04-15</gco:Date>
+                  </date>
+                  <dateType>
+                    <CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="lastUpdate">lastUpdate</CI_DateTypeCode>
+                  </dateType>
+                </CI_Date>
+              </date>
+            </CI_Citation>
+          </thesaurusName>
+        </MD_Keywords>
+      </descriptiveKeywords>
+      <descriptiveKeywords>
+        <MD_Keywords>
+          <keyword>
+            <gco:CharacterString>testkeyword1</gco:CharacterString>
+          </keyword>
+          <keyword>
+            <gco:CharacterString>testkeyword2</gco:CharacterString>
+          </keyword>
+          <keyword>
+            <gco:CharacterString>testkeyword3</gco:CharacterString>
+          </keyword>
+        </MD_Keywords>
+      </descriptiveKeywords>
+      <resourceConstraints xlink:href="https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt">
+        <MD_Constraints>
+          <useLimitation>
+            <gco:CharacterString>European Union Public License 1.2</gco:CharacterString>
+          </useLimitation>
+        </MD_Constraints>
+      </resourceConstraints>
+      <resourceConstraints>
+        <MD_LegalConstraints>
+          <accessConstraints>
+            <MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_RestrictionCode" codeListValue="otherRestrictions"/>
+          </accessConstraints>
+          <otherConstraints>
+            <gco:CharacterString>European Union Public License 1.2</gco:CharacterString>
+          </otherConstraints>
+        </MD_LegalConstraints>
+      </resourceConstraints>
+      <resourceConstraints>
+        <MD_SecurityConstraints>
+          <classification>
+            <MD_ClassificationCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_ClassificationCode" codeListValue="unclassified"/>
+          </classification>
+        </MD_SecurityConstraints>
+      </resourceConstraints>
+      <aggregationInfo>
+        <MD_AggregateInformation>
+          <aggregateDataSetIdentifier>
+            <RS_Identifier>
+              <code>
+                <gco:CharacterString>10.1371/journal.pbio.0020449</gco:CharacterString>
+              </code>
+              <codeSpace>
+                <gco:CharacterString>DOI</gco:CharacterString>
+              </codeSpace>
+            </RS_Identifier>
+          </aggregateDataSetIdentifier>
+          <associationType>
+            <DS_AssociationTypeCode codeList="http://datacite.org/schema/kernel-4" codeListValue="Is Cited By">Is Cited By</DS_AssociationTypeCode>
+          </associationType>
+        </MD_AggregateInformation>
+      </aggregationInfo>
+      <aggregationInfo>
+        <MD_AggregateInformation>
+          <aggregateDataSetIdentifier>
+            <RS_Identifier>
+              <code>
+                <gco:CharacterString>ark:/13030/tqb3kh97gh8w</gco:CharacterString>
+              </code>
+              <codeSpace>
+                <gco:CharacterString>ARK</gco:CharacterString>
+              </codeSpace>
+            </RS_Identifier>
+          </aggregateDataSetIdentifier>
+          <associationType>
+            <DS_AssociationTypeCode codeList="http://datacite.org/schema/kernel-4" codeListValue="Cites">Cites</DS_AssociationTypeCode>
+          </associationType>
+        </MD_AggregateInformation>
+      </aggregationInfo>
+      <language>
+        <gco:CharacterString>en</gco:CharacterString>
+      </language>
+      <characterSet>
+        <MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_CharacterSetCode" codeListValue="utf8"/>
+      </characterSet>
+      <topicCategory>
+        <MD_TopicCategoryCode>geoscientificInformation</MD_TopicCategoryCode>
+      </topicCategory>
+      <extent>
+        <EX_Extent>
+          <description/>
+          <geographicElement>
+            <EX_GeographicBoundingBox>
+              <westBoundLongitude>
+                <gco:Decimal>13.7691</gco:Decimal>
+              </westBoundLongitude>
+              <eastBoundLongitude>
+                <gco:Decimal>13.7691</gco:Decimal>
+              </eastBoundLongitude>
+              <southBoundLatitude>
+                <gco:Decimal>63.7074</gco:Decimal>
+              </southBoundLatitude>
+              <northBoundLatitude>
+                <gco:Decimal>63.7074</gco:Decimal>
+              </northBoundLatitude>
+            </EX_GeographicBoundingBox>
+          </geographicElement>
+          <temporalElement>
+            <EX_TemporalExtent>
+              <extent>
+                <gml:TimePeriod gml:id="timePeriod-1">
+                  <gml:beginPosition>2026-03-31T20:00:00+02:00</gml:beginPosition>
+                  <gml:endPosition>2026-03-31T21:00:00+02:00</gml:endPosition>
+                </gml:TimePeriod>
+              </extent>
+            </EX_TemporalExtent>
+          </temporalElement>
+        </EX_Extent>
+      </extent>
+      <extent>
+        <EX_Extent>
+          <description>
+            <gco:CharacterString>TESTDESCRIPTION</gco:CharacterString>
+          </description>
+          <geographicElement>
+            <EX_GeographicBoundingBox>
+              <westBoundLongitude>
+                <gco:Decimal>12.7404</gco:Decimal>
+              </westBoundLongitude>
+              <eastBoundLongitude>
+                <gco:Decimal>18.0578</gco:Decimal>
+              </eastBoundLongitude>
+              <southBoundLatitude>
+                <gco:Decimal>62.5594</gco:Decimal>
+              </southBoundLatitude>
+              <northBoundLatitude>
+                <gco:Decimal>63.5158</gco:Decimal>
+              </northBoundLatitude>
+            </EX_GeographicBoundingBox>
+          </geographicElement>
+          <temporalElement>
+            <EX_TemporalExtent>
+              <extent>
+                <gml:TimePeriod gml:id="timePeriod-2">
+                  <gml:beginPosition>2026-04-01</gml:beginPosition>
+                  <gml:endPosition>2026-04-16</gml:endPosition>
+                </gml:TimePeriod>
+              </extent>
+            </EX_TemporalExtent>
+          </temporalElement>
+        </EX_Extent>
+      </extent>
+    </MD_DataIdentification>
+  </identificationInfo>
+  <distributionInfo>
+    <MD_Distribution>
+      <transferOptions>
+        <MD_DigitalTransferOptions>
+          <onLine>
+            <CI_OnlineResource>
+              <linkage>
+                <URL>http://doi.org/10.5880/GFZ1243</URL>
+              </linkage>
+              <protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </protocol>
+              <name>
+                <gco:CharacterString>Download</gco:CharacterString>
+              </name>
+              <description>
+                <gco:CharacterString>Download</gco:CharacterString>
+              </description>
+              <function>
+                <CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</CI_OnLineFunctionCode>
+              </function>
+            </CI_OnlineResource>
+          </onLine>
+        </MD_DigitalTransferOptions>
+      </transferOptions>
+    </MD_Distribution>
+  </distributionInfo>
+  <dataQualityInfo>
+    <DQ_DataQuality>
+      <scope>
+        <DQ_Scope>
+          <level>
+            <MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
+          </level>
+        </DQ_Scope>
+      </scope>
+    </DQ_DataQuality>
+  </dataQualityInfo>
+</MD_Metadata>
+
+
+</envelope>

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2879,6 +2879,7 @@ describe('DataCiteForm', () => {
         expect(requestBody.descriptions[0]).toEqual({
             descriptionType: 'Abstract',
             description: 'This is a test abstract',
+            language: null,
         });
     });
 
@@ -3677,7 +3678,7 @@ describe('DataCiteForm', () => {
             const [url, data] = mockedAxios.post.mock.calls[0];
             expect(url).toBe('/editor/resources/draft');
             expect(data.titles).toEqual([
-                { title: 'Draft Dataset', titleType: 'main-title' },
+                { title: 'Draft Dataset', titleType: 'main-title', language: null },
             ]);
         });
 

--- a/tests/vitest/components/curation/fields/__tests__/TemporalInputs.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/TemporalInputs.test.tsx
@@ -345,6 +345,7 @@ describe('TemporalInputs', () => {
             render(<TemporalInputs {...props} />);
 
             expect(screen.getByText(/Europe\/Berlin \(CET\/CEST\)/)).toBeInTheDocument();
+            expect(screen.queryByText(/\(imported\)/)).not.toBeInTheDocument();
         });
     });
 });

--- a/tests/vitest/components/curation/fields/__tests__/TemporalInputs.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/TemporalInputs.test.tsx
@@ -312,4 +312,28 @@ describe('TemporalInputs', () => {
             expect(screen.queryByText(/start date must be before/i)).not.toBeInTheDocument();
         });
     });
+
+    describe('Imported Timezone Offset', () => {
+        test('shows imported offset timezone as selected value', () => {
+            const props = {
+                ...defaultProps,
+                timezone: '+02:00',
+            };
+
+            render(<TemporalInputs {...props} />);
+
+            expect(screen.getByText(/UTC\+02:00 \(imported\)/)).toBeInTheDocument();
+        });
+
+        test('does not add duplicate option for known IANA timezone', () => {
+            const props = {
+                ...defaultProps,
+                timezone: 'Europe/Berlin',
+            };
+
+            render(<TemporalInputs {...props} />);
+
+            expect(screen.getByText(/Europe\/Berlin \(CET\/CEST\)/)).toBeInTheDocument();
+        });
+    });
 });

--- a/tests/vitest/components/curation/fields/__tests__/TemporalInputs.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/TemporalInputs.test.tsx
@@ -314,7 +314,7 @@ describe('TemporalInputs', () => {
     });
 
     describe('Imported Timezone Offset', () => {
-        test('shows imported offset timezone as selected value', () => {
+        test('shows imported offset timezone with UTC prefix', () => {
             const props = {
                 ...defaultProps,
                 timezone: '+02:00',
@@ -323,6 +323,17 @@ describe('TemporalInputs', () => {
             render(<TemporalInputs {...props} />);
 
             expect(screen.getByText(/UTC\+02:00 \(imported\)/)).toBeInTheDocument();
+        });
+
+        test('shows imported IANA timezone without UTC prefix', () => {
+            const props = {
+                ...defaultProps,
+                timezone: 'Africa/Cairo',
+            };
+
+            render(<TemporalInputs {...props} />);
+
+            expect(screen.getByText(/Africa\/Cairo \(imported\)/)).toBeInTheDocument();
         });
 
         test('does not add duplicate option for known IANA timezone', () => {

--- a/tests/vitest/hooks/__tests__/use-nprogress.test.ts
+++ b/tests/vitest/hooks/__tests__/use-nprogress.test.ts
@@ -35,8 +35,8 @@ import { useNProgress } from '@/hooks/use-nprogress';
 import { useReducedMotion } from '@/hooks/use-reduced-motion';
 
 describe('useNProgress', () => {
-    let startCallback: (event?: unknown) => void;
-    let finishCallback: (event?: unknown) => void;
+    let startCallback: (event: CustomEvent) => void;
+    let finishCallback: (event: CustomEvent) => void;
     const removeStart = vi.fn();
     const removeFinish = vi.fn();
 
@@ -45,13 +45,13 @@ describe('useNProgress', () => {
         vi.clearAllMocks();
         vi.mocked(useReducedMotion).mockReturnValue(false);
 
-        vi.mocked(router.on).mockImplementation(((event: string, cb: (...args: unknown[]) => unknown) => {
+        vi.mocked(router.on).mockImplementation(((event: string, cb: (event: CustomEvent) => void) => {
             if (event === 'start') {
-                startCallback = cb as () => void;
+                startCallback = cb;
                 return removeStart;
             }
             if (event === 'finish') {
-                finishCallback = cb as () => void;
+                finishCallback = cb;
                 return removeFinish;
             }
             return vi.fn();
@@ -77,7 +77,7 @@ describe('useNProgress', () => {
     it('starts NProgress after 250 ms delay on Inertia start event', () => {
         renderHook(() => useNProgress());
 
-        startCallback({ detail: { visit: { showProgress: true } } });
+        startCallback(new CustomEvent('inertia:start', { detail: { visit: { showProgress: true } } }));
         expect(NProgress.start).not.toHaveBeenCalled();
 
         vi.advanceTimersByTime(250);
@@ -87,9 +87,9 @@ describe('useNProgress', () => {
     it('does not start NProgress if finish arrives before delay', () => {
         renderHook(() => useNProgress());
 
-        startCallback({ detail: { visit: { showProgress: true } } });
+        startCallback(new CustomEvent('inertia:start', { detail: { visit: { showProgress: true } } }));
         vi.advanceTimersByTime(100);
-        finishCallback({ detail: { visit: { showProgress: true } } });
+        finishCallback(new CustomEvent('inertia:finish', { detail: { visit: { showProgress: true } } }));
 
         vi.advanceTimersByTime(200);
         expect(NProgress.start).not.toHaveBeenCalled();
@@ -99,9 +99,9 @@ describe('useNProgress', () => {
     it('finishes NProgress on Inertia finish event', () => {
         renderHook(() => useNProgress());
 
-        startCallback({ detail: { visit: { showProgress: true } } });
+        startCallback(new CustomEvent('inertia:start', { detail: { visit: { showProgress: true } } }));
         vi.advanceTimersByTime(250);
-        finishCallback({ detail: { visit: { showProgress: true } } });
+        finishCallback(new CustomEvent('inertia:finish', { detail: { visit: { showProgress: true } } }));
         expect(NProgress.done).toHaveBeenCalled();
     });
 

--- a/tests/vitest/hooks/__tests__/use-nprogress.test.ts
+++ b/tests/vitest/hooks/__tests__/use-nprogress.test.ts
@@ -35,8 +35,8 @@ import { useNProgress } from '@/hooks/use-nprogress';
 import { useReducedMotion } from '@/hooks/use-reduced-motion';
 
 describe('useNProgress', () => {
-    let startCallback: () => void;
-    let finishCallback: () => void;
+    let startCallback: (event?: unknown) => void;
+    let finishCallback: (event?: unknown) => void;
     const removeStart = vi.fn();
     const removeFinish = vi.fn();
 
@@ -77,7 +77,7 @@ describe('useNProgress', () => {
     it('starts NProgress after 250 ms delay on Inertia start event', () => {
         renderHook(() => useNProgress());
 
-        startCallback();
+        startCallback({ detail: { visit: { showProgress: true } } });
         expect(NProgress.start).not.toHaveBeenCalled();
 
         vi.advanceTimersByTime(250);
@@ -87,9 +87,9 @@ describe('useNProgress', () => {
     it('does not start NProgress if finish arrives before delay', () => {
         renderHook(() => useNProgress());
 
-        startCallback();
+        startCallback({ detail: { visit: { showProgress: true } } });
         vi.advanceTimersByTime(100);
-        finishCallback();
+        finishCallback({ detail: { visit: { showProgress: true } } });
 
         vi.advanceTimersByTime(200);
         expect(NProgress.start).not.toHaveBeenCalled();
@@ -99,9 +99,9 @@ describe('useNProgress', () => {
     it('finishes NProgress on Inertia finish event', () => {
         renderHook(() => useNProgress());
 
-        startCallback();
+        startCallback({ detail: { visit: { showProgress: true } } });
         vi.advanceTimersByTime(250);
-        finishCallback();
+        finishCallback({ detail: { visit: { showProgress: true } } });
         expect(NProgress.done).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
This pull request adds support for per-title and per-description language fields throughout the resource ingestion, validation, and storage pipeline. It also improves temporal coverage extraction by preserving full datetime and timezone information, and enhances the parsing of non-GCMD keyword paths. The most important changes are summarized below.

**Language support for titles and descriptions:**

* Added a nullable `language` field for each title and description in both resource and draft resource request validation (`StoreResourceRequest.php`, `StoreDraftResourceRequest.php`) and ensured language values are trimmed and normalized during validation preparation. [[1]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R53) [[2]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R93) [[3]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R227-R232) [[4]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R493-R498) [[5]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R60) [[6]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R103) [[7]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R235-R240) [[8]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R500-R505)
* Updated the `EditorDataTransformer` to include the `language` field when transforming titles and descriptions for the frontend. [[1]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4L99-R99) [[2]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R114) [[3]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4L273-R274) [[4]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R288)
* Modified resource storage to persist the `language` field for titles and descriptions, instead of always setting it to null. [[1]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16R201) [[2]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16L588-R589)

**Temporal coverage and date handling:**

* Refactored date extraction to retain a `rawValue` for coverage dates, moved coverage-type dates out of the main dates array, and added a new parser to extract start/end date, time, and timezone components for temporal coverage (ensuring time and timezone are preserved). [[1]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R154-R165) [[2]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R754) [[3]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R784-R786) [[4]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09L781-R806) [[5]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09L802-R827) [[6]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R2302-R2422)

**Keyword extraction improvements:**

* Improved non-GCMD keyword parsing to extract the leaf text from hierarchical paths (e.g., "Phanerozoic > Mesozoic > Jurassic" now extracts "Jurassic" as the keyword text).

**Miscellaneous:**

* Updated PHPDoc return types to reflect the addition of nullable language fields.
* Added extraction of the `xml:lang` attribute for titles and descriptions during XML upload parsing. [[1]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R193-R197) [[2]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R634-R639)