### PR TITLE
Feature: EuroSciVoc thesaurus support

### DIFF
--- a/app/Console/Commands/GetEuroSciVoc.php
+++ b/app/Console/Commands/GetEuroSciVoc.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\EuroSciVocParser;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Fetch the European Science Vocabulary (EuroSciVoc) from the
+ * EU Publications Office and save as hierarchical JSON file.
+ */
+#[Description('Fetch European Science Vocabulary (EuroSciVoc) from EU Publications Office and save as hierarchical JSON')]
+#[Signature('get-euroscivoc')]
+class GetEuroSciVoc extends Command
+{
+    private const OUTPUT_FILE = 'euroscivoc.json';
+
+    public function handle(): int
+    {
+        $this->info('Fetching European Science Vocabulary (EuroSciVoc)...');
+
+        try {
+            $downloadUrl = (string) config('euroscivoc.download_url');
+            $conceptSchemeUri = (string) config('euroscivoc.concept_scheme_uri');
+            $schemeName = (string) config('euroscivoc.scheme_name');
+
+            // Step 1: Download RDF file
+            $this->info('Downloading RDF from EU Publications Office...');
+            $response = Http::timeout(120)
+                ->withOptions(['allow_redirects' => true])
+                ->get($downloadUrl);
+
+            if (! $response->successful()) {
+                $this->error("Failed to download EuroSciVoc RDF: HTTP {$response->status()}");
+
+                return Command::FAILURE;
+            }
+
+            $rdfContent = $response->body();
+            $this->info('Downloaded '.number_format(strlen($rdfContent)).' bytes');
+
+            // Step 2: Parse concepts
+            $this->info('Parsing RDF/SKOS concepts...');
+            $parser = new EuroSciVocParser;
+            $concepts = $parser->extractConcepts($rdfContent, $conceptSchemeUri);
+            $this->info('Extracted '.count($concepts).' concepts');
+
+            if ($concepts === []) {
+                $this->error('No concepts found in the RDF file. The file format may have changed.');
+
+                return Command::FAILURE;
+            }
+
+            // Step 3: Build hierarchy
+            $this->info('Building hierarchical structure...');
+            $hierarchicalData = $parser->buildHierarchy($concepts, $schemeName, $conceptSchemeUri);
+
+            $totalInHierarchy = $parser->countConcepts($hierarchicalData['data']);
+            $this->info("Built hierarchy with {$totalInHierarchy} concepts");
+
+            // Step 4: Save as JSON
+            $this->info('Saving to '.self::OUTPUT_FILE.'...');
+            $json = json_encode($hierarchicalData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+            if ($json === false) {
+                $this->error('Failed to encode data as JSON');
+
+                return Command::FAILURE;
+            }
+
+            Storage::put(self::OUTPUT_FILE, $json);
+
+            // Invalidate vocabulary caches
+            $this->call('cache:clear-app', ['category' => 'vocabularies']);
+
+            $filePath = Storage::path(self::OUTPUT_FILE);
+            $fileSize = Storage::size(self::OUTPUT_FILE);
+
+            $this->newLine();
+            $this->components->twoColumnDetail(
+                '<fg=green>✓</fg=green> Successfully saved European Science Vocabulary (EuroSciVoc)',
+                ''
+            );
+            $this->components->twoColumnDetail('File', $filePath);
+            $this->components->twoColumnDetail('Size', number_format($fileSize).' bytes');
+            $this->components->twoColumnDetail('Last Updated', $hierarchicalData['lastUpdated']);
+            $this->components->twoColumnDetail('Total Concepts', number_format($totalInHierarchy));
+
+            return Command::SUCCESS;
+
+        } catch (\Exception $e) {
+            $this->error('Error: '.$e->getMessage());
+            $this->error('Trace: '.$e->getTraceAsString());
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Enums/CacheKey.php
+++ b/app/Enums/CacheKey.php
@@ -29,6 +29,7 @@ enum CacheKey: string
     case CHRONOSTRAT_TIMESCALE = 'vocabularies:chronostrat:timescale';
     case GEMET_THESAURUS = 'vocabularies:gemet:thesaurus';
     case ANALYTICAL_METHODS = 'vocabularies:analytical_methods';
+    case EUROSCIVOC = 'vocabularies:euroscivoc';
 
     // ROR affiliation cache keys
     case ROR_AFFILIATION = 'ror:affiliation';
@@ -100,7 +101,8 @@ enum CacheKey: string
             self::PID4INST_INSTRUMENTS,
             self::CHRONOSTRAT_TIMESCALE,
             self::GEMET_THESAURUS,
-            self::ANALYTICAL_METHODS => 86400,
+            self::ANALYTICAL_METHODS,
+            self::EUROSCIVOC => 86400,
 
             // ROR affiliations are relatively stable - 7 days
             self::ROR_AFFILIATION => 604800,
@@ -155,7 +157,8 @@ enum CacheKey: string
             self::PID4INST_INSTRUMENTS,
             self::CHRONOSTRAT_TIMESCALE,
             self::GEMET_THESAURUS,
-            self::ANALYTICAL_METHODS => ['vocabularies'],
+            self::ANALYTICAL_METHODS,
+            self::EUROSCIVOC => ['vocabularies'],
 
             self::ROR_AFFILIATION => ['ror', 'affiliations'],
 
@@ -221,6 +224,7 @@ enum CacheKey: string
             self::CHRONOSTRAT_TIMESCALE,
             self::GEMET_THESAURUS,
             self::ANALYTICAL_METHODS,
+            self::EUROSCIVOC,
         ];
     }
 }

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -92,6 +92,7 @@ class DocsController extends Controller
                 $chronostratSetting = $thesauri->get(ThesaurusSetting::TYPE_CHRONOSTRAT);
                 $gemetSetting = $thesauri->get(ThesaurusSetting::TYPE_GEMET);
                 $analyticalMethodsSetting = $thesauri->get(ThesaurusSetting::TYPE_ANALYTICAL_METHODS);
+                $euroSciVocSetting = $thesauri->get(ThesaurusSetting::TYPE_EUROSCIVOC);
 
                 $scienceKeywordsActive = $scienceKeywordsSetting !== null ? $scienceKeywordsSetting->is_active : false;
                 $platformsActive = $platformsSetting !== null ? $platformsSetting->is_active : false;
@@ -99,6 +100,7 @@ class DocsController extends Controller
                 $chronostratActive = $chronostratSetting !== null ? $chronostratSetting->is_active : false;
                 $gemetActive = $gemetSetting !== null ? $gemetSetting->is_active : false;
                 $analyticalMethodsActive = $analyticalMethodsSetting !== null ? $analyticalMethodsSetting->is_active : false;
+                $euroSciVocActive = $euroSciVocSetting !== null ? $euroSciVocSetting->is_active : false;
 
                 // Check if MSL vocabulary file exists (indicates MSL is available)
                 $hasMslVocabulary = Storage::exists('msl-vocabulary.json');
@@ -111,6 +113,7 @@ class DocsController extends Controller
                         'chronostratigraphy' => $chronostratActive,
                         'gemet' => $gemetActive,
                         'analyticalMethods' => $analyticalMethodsActive,
+                        'euroSciVoc' => $euroSciVocActive,
                     ],
                     'features' => [
                         'hasActiveGcmd' => $scienceKeywordsActive || $platformsActive || $instrumentsActive,
@@ -118,6 +121,7 @@ class DocsController extends Controller
                         'hasActiveChronostrat' => $chronostratActive,
                         'hasActiveGemet' => $gemetActive,
                         'hasActiveAnalyticalMethods' => $analyticalMethodsActive,
+                        'hasActiveEuroSciVoc' => $euroSciVocActive,
                         'hasActiveLicenses' => Right::where('is_active', true)->exists(),
                         'hasActiveResourceTypes' => ResourceType::where('is_active', true)->exists(),
                         'hasActiveTitleTypes' => TitleType::where('is_active', true)->exists(),

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -57,13 +57,17 @@ class DocsController extends Controller
      *         platforms: bool,
      *         instruments: bool,
      *         chronostratigraphy: bool,
-     *         gemet: bool
+     *         gemet: bool,
+     *         analyticalMethods: bool,
+     *         euroSciVoc: bool
      *     },
      *     features: array{
      *         hasActiveGcmd: bool,
      *         hasActiveMsl: bool,
      *         hasActiveChronostrat: bool,
      *         hasActiveGemet: bool,
+     *         hasActiveAnalyticalMethods: bool,
+     *         hasActiveEuroSciVoc: bool,
      *         hasActiveLicenses: bool,
      *         hasActiveResourceTypes: bool,
      *         hasActiveTitleTypes: bool,

--- a/app/Http/Controllers/VocabularyController.php
+++ b/app/Http/Controllers/VocabularyController.php
@@ -217,6 +217,22 @@ class VocabularyController extends Controller
     }
 
     /**
+     * Return European Science Vocabulary (EuroSciVoc).
+     */
+    public function euroSciVoc(): JsonResponse
+    {
+        if (!$this->isThesaurusActive(ThesaurusSetting::TYPE_EUROSCIVOC)) {
+            return response()->json(['error' => 'Thesaurus is disabled'], 404);
+        }
+
+        return $this->getCachedVocabulary(
+            CacheKey::EUROSCIVOC,
+            'euroscivoc.json',
+            'php artisan get-euroscivoc'
+        );
+    }
+
+    /**
      * Return ROR affiliations vocabulary for ELMO.
      *
      * Returns the complete ROR data with metadata wrapper

--- a/app/Models/ThesaurusSetting.php
+++ b/app/Models/ThesaurusSetting.php
@@ -35,6 +35,8 @@ class ThesaurusSetting extends Model
 
     public const TYPE_ANALYTICAL_METHODS = 'analytical_methods';
 
+    public const TYPE_EUROSCIVOC = 'euroscivoc';
+
     /**
      * @return array<string, string>
      */
@@ -58,6 +60,7 @@ class ThesaurusSetting extends Model
             self::TYPE_CHRONOSTRAT => 'chronostrat-timescale.json',
             self::TYPE_GEMET => 'gemet-thesaurus.json',
             self::TYPE_ANALYTICAL_METHODS => 'analytical-methods.json',
+            self::TYPE_EUROSCIVOC => 'euroscivoc.json',
             default => throw new \InvalidArgumentException("Unknown thesaurus type: {$this->type}"),
         };
     }
@@ -74,6 +77,7 @@ class ThesaurusSetting extends Model
             self::TYPE_CHRONOSTRAT => 'get-chronostrat-timescale',
             self::TYPE_GEMET => 'get-gemet-thesaurus',
             self::TYPE_ANALYTICAL_METHODS => 'get-analytical-methods',
+            self::TYPE_EUROSCIVOC => 'get-euroscivoc',
             default => throw new \InvalidArgumentException("Unknown thesaurus type: {$this->type}"),
         };
     }
@@ -106,6 +110,7 @@ class ThesaurusSetting extends Model
             self::TYPE_CHRONOSTRAT => CacheKey::CHRONOSTRAT_TIMESCALE,
             self::TYPE_GEMET => CacheKey::GEMET_THESAURUS,
             self::TYPE_ANALYTICAL_METHODS => CacheKey::ANALYTICAL_METHODS,
+            self::TYPE_EUROSCIVOC => CacheKey::EUROSCIVOC,
             default => throw new \InvalidArgumentException("Unknown thesaurus type: {$this->type}"),
         };
     }
@@ -136,6 +141,7 @@ class ThesaurusSetting extends Model
             self::TYPE_CHRONOSTRAT,
             self::TYPE_GEMET,
             self::TYPE_ANALYTICAL_METHODS,
+            self::TYPE_EUROSCIVOC,
         ];
     }
 

--- a/app/Services/ThesaurusStatusService.php
+++ b/app/Services/ThesaurusStatusService.php
@@ -272,8 +272,15 @@ class ThesaurusStatusService
             }
 
             $data = $response->json();
+            $countValue = $data['results']['bindings'][0]['count']['value'] ?? null;
 
-            return (int) ($data['results']['bindings'][0]['count']['value'] ?? 0);
+            if ($countValue === null) {
+                throw new \RuntimeException(
+                    'Unexpected EuroSciVoc SPARQL response format: missing results.bindings[0].count.value'
+                );
+            }
+
+            return (int) $countValue;
         });
     }
 

--- a/app/Services/ThesaurusStatusService.php
+++ b/app/Services/ThesaurusStatusService.php
@@ -99,6 +99,10 @@ class ThesaurusStatusService
             return $this->getAnalyticalMethodsRemoteCount($thesaurus);
         }
 
+        if ($thesaurus->type === ThesaurusSetting::TYPE_EUROSCIVOC) {
+            return $this->getEuroSciVocRemoteCount();
+        }
+
         throw new \RuntimeException("Unsupported thesaurus type for remote check: {$thesaurus->type}");
     }
 
@@ -222,6 +226,54 @@ class ThesaurusStatusService
             $conceptCount = array_sum($conceptCounts);
 
             return count($superGroups) + count($groups) + $conceptCount;
+        });
+    }
+
+    /**
+     * Get concept count from the EU Publications Office SPARQL endpoint for EuroSciVoc.
+     *
+     * Uses a SPARQL COUNT query against the public endpoint to determine the
+     * current number of concepts. Uses caching (1 hour TTL) to avoid repeated
+     * SPARQL queries per status check.
+     *
+     * @throws \RuntimeException If the SPARQL request fails
+     */
+    private function getEuroSciVocRemoteCount(): int
+    {
+        $cacheKey = CacheKey::EUROSCIVOC->key('remote_count');
+        $cache = $this->supportsTagging()
+            ? Cache::tags(CacheKey::EUROSCIVOC->tags())
+            : Cache::store();
+
+        /** @var int */
+        return $cache->remember($cacheKey, 3600, function (): int {
+            $conceptSchemeUri = (string) config('euroscivoc.concept_scheme_uri');
+            $sparqlEndpoint = 'https://publications.europa.eu/webapi/rdf/sparql';
+
+            $query = <<<SPARQL
+                PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+                SELECT (COUNT(DISTINCT ?concept) AS ?count) WHERE {
+                    ?concept a skos:Concept .
+                    ?concept skos:inScheme <{$conceptSchemeUri}> .
+                }
+                SPARQL;
+
+            $response = Http::timeout(30)
+                ->accept('application/sparql-results+json')
+                ->get($sparqlEndpoint, [
+                    'query' => $query,
+                    'format' => 'application/sparql-results+json',
+                ]);
+
+            if (! $response->successful()) {
+                throw new \RuntimeException(
+                    "Failed to query EuroSciVoc SPARQL endpoint: HTTP {$response->status()}"
+                );
+            }
+
+            $data = $response->json();
+
+            return (int) ($data['results']['bindings'][0]['count']['value'] ?? 0);
         });
     }
 

--- a/app/Services/VocabularyCacheService.php
+++ b/app/Services/VocabularyCacheService.php
@@ -85,6 +85,19 @@ class VocabularyCacheService
     }
 
     /**
+     * Cache EuroSciVoc vocabulary.
+     *
+     * @template TValue
+     *
+     * @param  \Closure(): TValue  $callback  Callback to load vocabulary
+     * @return TValue
+     */
+    public function cacheEuroSciVoc(\Closure $callback): mixed
+    {
+        return $this->cacheVocabulary(CacheKey::EUROSCIVOC, $callback);
+    }
+
+    /**
      * Generic method to cache any vocabulary.
      *
      * @template TValue

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -141,8 +141,7 @@ class EuroSciVocParser
         }
 
         // If no explicit top concepts found, derive them:
-        // - concepts that are never referenced as a child of another concept, OR
-        // - concepts whose broaderId points to a parent not in the concept set
+        // - concepts that are never referenced as a child of another concept
         if ($topConceptIds === []) {
             $allChildIds = [];
             foreach ($childrenByParentId as $childIds) {

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -316,10 +316,15 @@ class EuroSciVocParser
                 }
             }
 
-            // If no language-tagged English label, try the first untagged one
-            $firstLabel = (string) $skosNs->prefLabel;
-            if ($firstLabel !== '') {
-                return $firstLabel;
+            // If no language-tagged English label, try the first label without xml:lang attribute
+            foreach ($skosNs->prefLabel as $candidate) {
+                $candidateLang = $candidate->attributes(self::XML_NS);
+                if (! isset($candidateLang['lang']) || (string) $candidateLang['lang'] === '') {
+                    $text = (string) $candidate;
+                    if ($text !== '') {
+                        return $text;
+                    }
+                }
             }
         }
 

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use RuntimeException;
+
+/**
+ * Parser for the European Science Vocabulary (EuroSciVoc) RDF/SKOS-XL file.
+ *
+ * Extracts concepts from the EuroSciVoc taxonomy and builds a hierarchical
+ * tree structure. Supports both SKOS-XL (skosxl:prefLabel → skosxl:literalForm)
+ * and plain SKOS (skos:prefLabel) label patterns.
+ */
+class EuroSciVocParser
+{
+    private const SKOS_NS = 'http://www.w3.org/2004/02/skos/core#';
+
+    private const SKOSXL_NS = 'http://www.w3.org/2008/05/skos-xl#';
+
+    private const RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+
+    private const XML_NS = 'http://www.w3.org/XML/1998/namespace';
+
+    /**
+     * Extract concepts from RDF/XML content.
+     *
+     * Parses SKOS concepts from the EuroSciVoc RDF file, extracting their
+     * URIs, English labels, and broader concept relationships.
+     *
+     * @return array<int, array{id: string, text: string, language: string, broaderId: string|null, isTopConcept: bool}>
+     *
+     * @throws RuntimeException If the RDF content cannot be parsed
+     */
+    public function extractConcepts(string $rdfContent, string $conceptSchemeUri): array
+    {
+        try {
+            $xml = new \SimpleXMLElement($rdfContent);
+        } catch (\Exception $e) {
+            throw new RuntimeException('Failed to parse EuroSciVoc RDF/XML: '.$e->getMessage());
+        }
+
+        $xml->registerXPathNamespace('rdf', self::RDF_NS);
+        $xml->registerXPathNamespace('skos', self::SKOS_NS);
+        $xml->registerXPathNamespace('skosxl', self::SKOSXL_NS);
+
+        // First, build a map of SKOS-XL label URIs → literal forms (English only)
+        $xlLabelMap = $this->buildXlLabelMap($xml);
+
+        $conceptElements = $xml->xpath('//skos:Concept');
+
+        if ($conceptElements === false || $conceptElements === null) {
+            return [];
+        }
+
+        $concepts = [];
+
+        foreach ($conceptElements as $concept) {
+            $rdfAttrs = $concept->attributes(self::RDF_NS);
+            $id = (string) ($rdfAttrs['about'] ?? '');
+
+            if ($id === '') {
+                continue;
+            }
+
+            // Check if this concept belongs to the EuroSciVoc scheme
+            if (! $this->conceptBelongsToScheme($concept, $conceptSchemeUri)) {
+                continue;
+            }
+
+            // Get English label: try SKOS-XL first, then plain SKOS
+            $text = $this->getEnglishLabel($concept, $xlLabelMap);
+
+            if ($text === '') {
+                continue;
+            }
+
+            // Get broader concept URI
+            $broaderId = $this->getBroaderConceptUri($concept);
+
+            // Check if this is a top concept
+            $isTopConcept = $this->isTopConcept($concept, $conceptSchemeUri);
+
+            $concepts[] = [
+                'id' => $id,
+                'text' => $text,
+                'language' => 'en',
+                'broaderId' => $broaderId,
+                'isTopConcept' => $isTopConcept,
+            ];
+        }
+
+        return $concepts;
+    }
+
+    /**
+     * Build hierarchical structure from flat concept array.
+     *
+     * @param  array<int, array{id: string, text: string, language: string, broaderId: string|null, isTopConcept: bool}>  $concepts
+     * @return array{lastUpdated: string, data: array<int, array<string, mixed>>}
+     */
+    public function buildHierarchy(array $concepts, string $schemeName, string $schemeUri): array
+    {
+        /** @var array<string, array<string, mixed>> $conceptsById */
+        $conceptsById = [];
+        /** @var array<string, list<string>> $childrenByParentId */
+        $childrenByParentId = [];
+        /** @var list<string> $topConceptIds */
+        $topConceptIds = [];
+
+        // First pass: index all concepts
+        foreach ($concepts as $concept) {
+            $id = $concept['id'];
+
+            $conceptsById[$id] = [
+                'id' => $id,
+                'text' => $concept['text'],
+                'language' => $concept['language'],
+                'scheme' => $schemeName,
+                'schemeURI' => $schemeUri,
+                'description' => '',
+                'children' => [],
+            ];
+
+            if ($concept['isTopConcept']) {
+                $topConceptIds[] = $id;
+            }
+
+            if ($concept['broaderId'] !== null && $concept['broaderId'] !== '') {
+                $childrenByParentId[$concept['broaderId']][] = $id;
+            }
+        }
+
+        // If no explicit top concepts found, derive them (concepts with no broader or missing broader)
+        if ($topConceptIds === []) {
+            $allChildIds = [];
+            foreach ($childrenByParentId as $childIds) {
+                $allChildIds = array_merge($allChildIds, $childIds);
+            }
+            $allChildIds = array_unique($allChildIds);
+
+            foreach ($conceptsById as $id => $concept) {
+                if (! in_array($id, $allChildIds, true)) {
+                    $topConceptIds[] = $id;
+                }
+            }
+        }
+
+        // Build tree from top concepts
+        $rootConcepts = [];
+        foreach ($topConceptIds as $rootId) {
+            $rootNode = $this->buildTreeNode($rootId, $conceptsById, $childrenByParentId);
+            if ($rootNode !== null) {
+                $rootConcepts[] = $rootNode;
+            }
+        }
+
+        // Sort root concepts alphabetically
+        usort($rootConcepts, fn (array $a, array $b): int => strcasecmp((string) $a['text'], (string) $b['text']));
+
+        return [
+            'lastUpdated' => now()->toIso8601String(),
+            'data' => $rootConcepts,
+        ];
+    }
+
+    /**
+     * Recursively count all concepts in the hierarchy.
+     *
+     * @param  array<int, array<string, mixed>>  $data
+     */
+    public function countConcepts(array $data): int
+    {
+        $count = count($data);
+
+        foreach ($data as $item) {
+            if (isset($item['children']) && is_array($item['children']) && count($item['children']) > 0) {
+                $count += $this->countConcepts($item['children']);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Build a map of SKOS-XL label URIs to their English literal forms.
+     *
+     * @return array<string, string> Map of label URI → English literal form
+     */
+    private function buildXlLabelMap(\SimpleXMLElement $xml): array
+    {
+        $map = [];
+
+        $labelElements = $xml->xpath('//skosxl:Label');
+
+        if ($labelElements === false || $labelElements === null) {
+            return $map;
+        }
+
+        foreach ($labelElements as $label) {
+            $rdfAttrs = $label->attributes(self::RDF_NS);
+            $labelUri = (string) ($rdfAttrs['about'] ?? '');
+
+            if ($labelUri === '') {
+                continue;
+            }
+
+            $skosxlNs = $label->children(self::SKOSXL_NS);
+
+            if (! isset($skosxlNs->literalForm)) {
+                continue;
+            }
+
+            // Check all literalForm children for English
+            foreach ($skosxlNs->literalForm as $literalForm) {
+                $langAttr = $literalForm->attributes(self::XML_NS);
+                $lang = (string) ($langAttr['lang'] ?? '');
+
+                if ($lang === 'en') {
+                    $map[$labelUri] = (string) $literalForm;
+                    break;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Check if a concept belongs to the EuroSciVoc concept scheme.
+     */
+    private function conceptBelongsToScheme(\SimpleXMLElement $concept, string $schemeUri): bool
+    {
+        $skosNs = $concept->children(self::SKOS_NS);
+
+        // Check skos:inScheme
+        if (isset($skosNs->inScheme)) {
+            foreach ($skosNs->inScheme as $inScheme) {
+                $rdfAttrs = $inScheme->attributes(self::RDF_NS);
+                if ((string) ($rdfAttrs['resource'] ?? '') === $schemeUri) {
+                    return true;
+                }
+            }
+        }
+
+        // Check skos:topConceptOf
+        if (isset($skosNs->topConceptOf)) {
+            foreach ($skosNs->topConceptOf as $topConceptOf) {
+                $rdfAttrs = $topConceptOf->attributes(self::RDF_NS);
+                if ((string) ($rdfAttrs['resource'] ?? '') === $schemeUri) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the English label for a concept.
+     *
+     * Tries SKOS-XL label resolution first (via xlLabelMap), then falls
+     * back to plain skos:prefLabel.
+     *
+     * @param  array<string, string>  $xlLabelMap
+     */
+    private function getEnglishLabel(\SimpleXMLElement $concept, array $xlLabelMap): string
+    {
+        // Strategy 1: SKOS-XL – resolve via label URI
+        $skosxlNs = $concept->children(self::SKOSXL_NS);
+        if (isset($skosxlNs->prefLabel)) {
+            foreach ($skosxlNs->prefLabel as $prefLabel) {
+                $rdfAttrs = $prefLabel->attributes(self::RDF_NS);
+                $labelUri = (string) ($rdfAttrs['resource'] ?? '');
+
+                if ($labelUri !== '' && isset($xlLabelMap[$labelUri])) {
+                    return $xlLabelMap[$labelUri];
+                }
+            }
+        }
+
+        // Strategy 2: Plain SKOS – direct literal
+        $skosNs = $concept->children(self::SKOS_NS);
+        if (isset($skosNs->prefLabel)) {
+            foreach ($skosNs->prefLabel as $prefLabel) {
+                $langAttr = $prefLabel->attributes(self::XML_NS);
+                $lang = (string) ($langAttr['lang'] ?? '');
+
+                if ($lang === 'en') {
+                    return (string) $prefLabel;
+                }
+            }
+
+            // If no language-tagged English label, try the first untagged one
+            $firstLabel = (string) $skosNs->prefLabel;
+            if ($firstLabel !== '') {
+                return $firstLabel;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the broader concept URI from a concept element.
+     */
+    private function getBroaderConceptUri(\SimpleXMLElement $concept): ?string
+    {
+        $skosNs = $concept->children(self::SKOS_NS);
+
+        if (! isset($skosNs->broader)) {
+            return null;
+        }
+
+        $rdfAttrs = $skosNs->broader->attributes(self::RDF_NS);
+        $broaderUri = (string) ($rdfAttrs['resource'] ?? '');
+
+        return $broaderUri !== '' ? $broaderUri : null;
+    }
+
+    /**
+     * Check if a concept is a top concept of the given scheme.
+     */
+    private function isTopConcept(\SimpleXMLElement $concept, string $schemeUri): bool
+    {
+        $skosNs = $concept->children(self::SKOS_NS);
+
+        if (isset($skosNs->topConceptOf)) {
+            foreach ($skosNs->topConceptOf as $topConceptOf) {
+                $rdfAttrs = $topConceptOf->attributes(self::RDF_NS);
+                if ((string) ($rdfAttrs['resource'] ?? '') === $schemeUri) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Recursively build a tree node and all its descendants.
+     *
+     * @param  array<string, array<string, mixed>>  $conceptsById
+     * @param  array<string, list<string>>  $childrenByParentId
+     * @return array<string, mixed>|null
+     */
+    private function buildTreeNode(string $nodeId, array &$conceptsById, array &$childrenByParentId): ?array
+    {
+        if (! isset($conceptsById[$nodeId])) {
+            return null;
+        }
+
+        $node = $conceptsById[$nodeId];
+        $childIds = $childrenByParentId[$nodeId] ?? [];
+
+        $node['children'] = [];
+        foreach ($childIds as $childId) {
+            $childNode = $this->buildTreeNode($childId, $conceptsById, $childrenByParentId);
+            if ($childNode !== null) {
+                $node['children'][] = $childNode;
+            }
+        }
+
+        // Sort children alphabetically
+        if ($node['children'] !== []) {
+            usort($node['children'], fn (array $a, array $b): int => strcasecmp((string) $a['text'], (string) $b['text']));
+        }
+
+        return $node;
+    }
+}

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -35,11 +35,19 @@ class EuroSciVocParser
      */
     public function extractConcepts(string $rdfContent, string $conceptSchemeUri): array
     {
+        $previousUseErrors = libxml_use_internal_errors(true);
+
         try {
-            $xml = new \SimpleXMLElement($rdfContent);
+            $xml = new \SimpleXMLElement($rdfContent, LIBXML_NONET | LIBXML_NOENT);
         } catch (\Exception $e) {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousUseErrors);
+
             throw new RuntimeException('Failed to parse EuroSciVoc RDF/XML: '.$e->getMessage());
         }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousUseErrors);
 
         $xml->registerXPathNamespace('rdf', self::RDF_NS);
         $xml->registerXPathNamespace('skos', self::SKOS_NS);

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -140,7 +140,9 @@ class EuroSciVocParser
             }
         }
 
-        // If no explicit top concepts found, derive them (concepts with no broader or missing broader)
+        // If no explicit top concepts found, derive them:
+        // - concepts that are never referenced as a child of another concept, OR
+        // - concepts whose broaderId points to a parent not in the concept set
         if ($topConceptIds === []) {
             $allChildIds = [];
             foreach ($childrenByParentId as $childIds) {
@@ -151,6 +153,20 @@ class EuroSciVocParser
             foreach ($conceptsById as $id => $concept) {
                 if (! in_array($id, $allChildIds, true)) {
                     $topConceptIds[] = $id;
+                }
+            }
+        }
+
+        // Rescue orphans: concepts whose broaderId points to a parent outside
+        // the concept set would otherwise be silently dropped. Promote them to roots.
+        $topConceptIdSet = array_flip($topConceptIds);
+        foreach ($childrenByParentId as $parentId => $childIds) {
+            if (! isset($conceptsById[$parentId])) {
+                foreach ($childIds as $childId) {
+                    if (! isset($topConceptIdSet[$childId])) {
+                        $topConceptIds[] = $childId;
+                        $topConceptIdSet[$childId] = true;
+                    }
                 }
             }
         }

--- a/config/euroscivoc.php
+++ b/config/euroscivoc.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | European Science Vocabulary (EuroSciVoc) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the EuroSciVoc vocabulary provided by the
+    | Publications Office of the European Union.
+    |
+    | EuroSciVoc is a taxonomy of fields of science based on OECD's
+    | 2015 Frascati Manual taxonomy, extended with fields of science
+    | categories extracted from CORDIS content via NLP.
+    |
+    */
+
+    'download_url' => env(
+        'EUROSCIVOC_DOWNLOAD_URL',
+        'https://op.europa.eu/o/opportal-service/euvoc-download-handler?cellarURI=http%3A%2F%2Fpublications.europa.eu%2Fresource%2Fdistribution%2Feuroscivoc%2F20250924-0%2Frdf%2Fskos_xl%2FEuroSciVoc.rdf&fileName=EuroSciVoc.rdf'
+    ),
+
+    'concept_scheme_uri' => env(
+        'EUROSCIVOC_CONCEPT_SCHEME_URI',
+        'http://data.europa.eu/8mn/euroscivoc/40c0f173-baa3-48a3-9fe6-d6e8fb366a00'
+    ),
+
+    'scheme_name' => 'European Science Vocabulary (EuroSciVoc)',
+
+];

--- a/database/migrations/2026_04_16_000001_add_euroscivoc_thesaurus.php
+++ b/database/migrations/2026_04_16_000001_add_euroscivoc_thesaurus.php
@@ -9,14 +9,20 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::table('thesaurus_settings')->insert([
-            'type' => 'euroscivoc',
-            'display_name' => 'European Science Vocabulary (EuroSciVoc)',
-            'is_active' => true,
-            'is_elmo_active' => true,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        $exists = DB::table('thesaurus_settings')
+            ->where('type', 'euroscivoc')
+            ->exists();
+
+        if (! $exists) {
+            DB::table('thesaurus_settings')->insert([
+                'type' => 'euroscivoc',
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+                'is_active' => true,
+                'is_elmo_active' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
     }
 
     public function down(): void

--- a/database/migrations/2026_04_16_000001_add_euroscivoc_thesaurus.php
+++ b/database/migrations/2026_04_16_000001_add_euroscivoc_thesaurus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('thesaurus_settings')->insert([
+            'type' => 'euroscivoc',
+            'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+            'is_active' => true,
+            'is_elmo_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('thesaurus_settings')->where('type', 'euroscivoc')->delete();
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,12 +122,13 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
-      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.10.tgz",
+      "integrity": "sha512-KyOb19eytNSELkmdqzZZUXWCU25byIlOld5qVFg0RYdS0T3tt7jeDByxk9hIAC73frclD8GKrHttr0SUjKCCdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-04-16",
         "features": [
             {
+                "title": "European Science Vocabulary (EuroSciVoc) Thesaurus",
+                "description": "A new controlled vocabulary 'European Science Vocabulary (EuroSciVoc)' has been integrated from the Publications Office of the European Union. EuroSciVoc is a taxonomy of fields of science based on OECD's 2015 Frascati Manual, extended with categories extracted from CORDIS content. The vocabulary provides a hierarchical tree of scientific disciplines (e.g., Natural Sciences > Physical Sciences > Astronomy). It appears in the keyword editor alongside existing vocabularies and is available via the API. Administrators and group leaders can activate/deactivate and update the vocabulary in Editor Settings."
+            },
+            {
                 "title": "Analytical Methods for Geochemistry Thesaurus",
                 "description": "A new controlled vocabulary 'Analytical Methods for Geochemistry and Cosmochemistry' has been integrated from the ARDC (Australian Research Data Commons) Linked Data API. The vocabulary provides a hierarchical tree of analytical methods (e.g., Mass Spectrometry > ICP-MS) with notation codes and definitions. It appears as a new tab in the keyword editor alongside existing vocabularies. Administrators and group leaders can configure the vocabulary version in the thesaurus settings page."
             },

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -1409,6 +1409,7 @@
             "EuroSciVocVocabulary": {
                 "type": "object",
                 "description": "European Science Vocabulary (EuroSciVoc) from the Publications Office of the European Union",
+                "required": ["lastUpdated", "data"],
                 "properties": {
                     "lastUpdated": {
                         "type": "string",

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -827,6 +827,49 @@
                 }
             }
         },
+        "/api/v1/vocabularies/euroscivoc": {
+            "get": {
+                "tags": ["Vocabularies"],
+                "summary": "Get European Science Vocabulary (EuroSciVoc)",
+                "description": "Returns the European Science Vocabulary (EuroSciVoc) as a hierarchical JSON structure. EuroSciVoc is a taxonomy of fields of science based on OECD's 2015 Frascati Manual, extended with categories from CORDIS content. The vocabulary is published by the Publications Office of the European Union. Provide the API key via the `X-API-Key` header.",
+                "security": [
+                    {
+                        "ElmoApiKey": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "EuroSciVoc vocabulary",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/EuroSciVocVocabulary"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Thesaurus is disabled or vocabulary file not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Vocabulary file not found. Please run: php artisan get-euroscivoc"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/vocabularies/pid4inst-instruments": {
             "get": {
                 "tags": ["Vocabularies"],
@@ -1362,6 +1405,71 @@
                     }
                 },
                 "required": ["id", "text", "notation", "language", "scheme", "schemeURI", "description", "children"]
+            },
+            "EuroSciVocVocabulary": {
+                "type": "object",
+                "description": "European Science Vocabulary (EuroSciVoc) from the Publications Office of the European Union",
+                "properties": {
+                    "lastUpdated": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the vocabulary was last updated",
+                        "example": "2026-04-16T12:00:00Z"
+                    },
+                    "data": {
+                        "type": "array",
+                        "description": "Hierarchical array of EuroSciVoc concepts organized by fields of science",
+                        "items": {
+                            "$ref": "#/components/schemas/EuroSciVocConcept"
+                        }
+                    }
+                }
+            },
+            "EuroSciVocConcept": {
+                "type": "object",
+                "description": "A concept from the European Science Vocabulary (EuroSciVoc), representing a field of science or research topic",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Unique identifier (URI) for the concept",
+                        "example": "http://data.europa.eu/8mn/euroscivoc/3d76a7f4-5a16-411e-ae44-7b712d5222ee"
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Preferred label for the concept in English",
+                        "example": "natural sciences"
+                    },
+                    "language": {
+                        "type": "string",
+                        "description": "Language code of the concept label",
+                        "example": "en"
+                    },
+                    "scheme": {
+                        "type": "string",
+                        "description": "Name of the vocabulary scheme",
+                        "example": "European Science Vocabulary (EuroSciVoc)"
+                    },
+                    "schemeURI": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "URI of the EuroSciVoc concept scheme",
+                        "example": "http://data.europa.eu/8mn/euroscivoc/40c0f173-baa3-48a3-9fe6-d6e8fb366a00"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the concept (empty string if not available)",
+                        "example": ""
+                    },
+                    "children": {
+                        "type": "array",
+                        "description": "Child concepts in the hierarchy",
+                        "items": {
+                            "$ref": "#/components/schemas/EuroSciVocConcept"
+                        }
+                    }
+                },
+                "required": ["id", "text", "language", "scheme", "schemeURI", "description", "children"]
             },
             "GcmdKeywordConcept": {
                 "type": "object",

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -270,7 +270,7 @@ export default function Docs({ userRole, editorSettings }: DocsProps) {
                             </li>
                             <li>
                                 <strong>Thesauri:</strong> Manage GCMD vocabularies (Science Keywords, Platforms, Instruments), ICS Chronostratigraphy, GEMET,
-                                and Analytical Methods for Geochemistry and Cosmochemistry
+                                Analytical Methods for Geochemistry and Cosmochemistry, and European Science Vocabulary (EuroSciVoc)
                             </li>
                             <li>
                                 <strong>Persistent Identifiers:</strong> Manage PID registries like PID4INST (b2inst) for
@@ -375,6 +375,14 @@ export default function Docs({ userRole, editorSettings }: DocsProps) {
                             Downloads the Analytical Methods for Geochemistry and Cosmochemistry vocabulary from the
                             ARDC Linked Data API (EarthChem/GEOROC). The vocabulary version can be configured in
                             Editor Settings. Can also be triggered from Editor Settings.
+                        </p>
+
+                        <h4>Update European Science Vocabulary (CLI)</h4>
+                        <DocsCodeBlock code="php artisan get-euroscivoc" />
+                        <p className="text-sm text-muted-foreground">
+                            Downloads the European Science Vocabulary (EuroSciVoc) from the Publications Office of the
+                            European Union. EuroSciVoc is a taxonomy of fields of science based on the OECD Frascati
+                            Manual. Can also be triggered from Editor Settings.
                         </p>
 
                         <h4>Update PID4INST Instruments (CLI)</h4>
@@ -590,7 +598,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 <p>Verify author information, add ORCID iDs, and confirm ROR affiliations.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={3} title="Add Keywords">
-                                <p>Add controlled keywords (GCMD, MSL, GEMET, Analytical Methods) and free-form keywords as needed.</p>
+                                <p>Add controlled keywords (GCMD, MSL, GEMET, Analytical Methods, EuroSciVoc) and free-form keywords as needed.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={4} title="Complete Coverage">
                                 <p>Fill in spatial and temporal coverage using the interactive tools.</p>
@@ -799,7 +807,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                 title: 'Controlled Keywords',
                 icon: Tags,
                 minRole: 'beginner',
-                showIf: (settings) => settings.features.hasActiveGcmd || settings.features.hasActiveMsl || settings.features.hasActiveChronostrat || settings.features.hasActiveGemet || settings.features.hasActiveAnalyticalMethods,
+                showIf: (settings) => settings.features.hasActiveGcmd || settings.features.hasActiveMsl || settings.features.hasActiveChronostrat || settings.features.hasActiveGemet || settings.features.hasActiveAnalyticalMethods || settings.features.hasActiveEuroSciVoc,
                 content: (
                     <>
                         <h3>Controlled Vocabularies</h3>
@@ -856,6 +864,21 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                     research (e.g. mass spectrometry, X-ray diffraction). Concepts include optional
                                     notation codes. Sourced from the ARDC Linked Data API (EarthChem/GEOROC).
                                     The vocabulary version is configurable by administrators and group leaders.
+                                </p>
+                            </>
+                        )}
+
+                        {editorSettings.features.hasActiveEuroSciVoc && (
+                            <>
+                                <h4>European Science Vocabulary (EuroSciVoc)</h4>
+                                <p>
+                                    The European Science Vocabulary (EuroSciVoc) is a taxonomy of fields of science
+                                    published by the Publications Office of the European Union. It is based on the
+                                    OECD&apos;s 2015 Frascati Manual taxonomy and extended with categories extracted
+                                    from CORDIS content. The vocabulary covers six top-level domains: Natural Sciences,
+                                    Engineering and Technology, Medical and Health Sciences, Agricultural Sciences,
+                                    Social Sciences, and Humanities. Keywords are mapped to DataCite with
+                                    subjectScheme &quot;European Science Vocabulary (EuroSciVoc)&quot;.
                                 </p>
                             </>
                         )}

--- a/resources/js/types/docs.ts
+++ b/resources/js/types/docs.ts
@@ -19,6 +19,8 @@ export interface EditorSettings {
         gemet: boolean;
         /** Is Analytical Methods thesaurus active? */
         analyticalMethods: boolean;
+        /** Is European Science Vocabulary (EuroSciVoc) thesaurus active? */
+        euroSciVoc: boolean;
     };
     /**
      * Feature availability flags
@@ -34,6 +36,8 @@ export interface EditorSettings {
         hasActiveGemet: boolean;
         /** Is Analytical Methods thesaurus active? */
         hasActiveAnalyticalMethods: boolean;
+        /** Is European Science Vocabulary (EuroSciVoc) thesaurus active? */
+        hasActiveEuroSciVoc: boolean;
         /** Is at least one license active? */
         hasActiveLicenses: boolean;
         /** Is at least one resource type active? */

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,6 +81,7 @@ Route::middleware('ernie.api-key')->get('/v1/vocabularies/pid4inst-instruments',
 Route::middleware('ernie.api-key')->get('/v1/vocabularies/chronostrat-timescale', [VocabularyController::class, 'chronostratTimescale']);
 Route::middleware('ernie.api-key')->get('/v1/vocabularies/gemet', [VocabularyController::class, 'gemetThesaurus']);
 Route::middleware('ernie.api-key')->get('/v1/vocabularies/analytical-methods', [VocabularyController::class, 'analyticalMethods']);
+Route::middleware('ernie.api-key')->get('/v1/vocabularies/euroscivoc', [VocabularyController::class, 'euroSciVoc']);
 Route::middleware('ernie.api-key')->get('/v1/ror-affiliations/elmo', [VocabularyController::class, 'rorAffiliations']);
 
 // Thesauri/PID availability - dual routes: without auth for ERNIE frontend, with API key for ELMO

--- a/tests/pest/Feature/Api/EuroSciVocApiTest.php
+++ b/tests/pest/Feature/Api/EuroSciVocApiTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\VocabularyController;
+use App\Models\ThesaurusSetting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\getJson;
+
+covers(VocabularyController::class);
+
+beforeEach(function (): void {
+    config(['services.ernie.api_key' => 'test-api-key']);
+    Storage::fake();
+    Cache::flush();
+});
+
+function createTestEuroSciVocVocabularyFile(): void
+{
+    $testData = [
+        'lastUpdated' => '2026-04-16T10:00:00+00:00',
+        'data' => [
+            [
+                'id' => 'http://data.europa.eu/8mn/euroscivoc/concept-1',
+                'text' => 'natural sciences',
+                'language' => 'en',
+                'scheme' => 'European Science Vocabulary (EuroSciVoc)',
+                'schemeURI' => 'http://data.europa.eu/8mn/euroscivoc/40c0f173-baa3-48a3-9fe6-d6e8fb366a00',
+                'description' => '',
+                'children' => [
+                    [
+                        'id' => 'http://data.europa.eu/8mn/euroscivoc/concept-2',
+                        'text' => 'physical sciences',
+                        'language' => 'en',
+                        'scheme' => 'European Science Vocabulary (EuroSciVoc)',
+                        'schemeURI' => 'http://data.europa.eu/8mn/euroscivoc/40c0f173-baa3-48a3-9fe6-d6e8fb366a00',
+                        'description' => '',
+                        'children' => [],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    Storage::put('euroscivoc.json', json_encode($testData));
+}
+
+it('returns EuroSciVoc vocabulary via API with valid key', function (): void {
+    createTestEuroSciVocVocabularyFile();
+
+    $response = getJson('/api/v1/vocabularies/euroscivoc', ['X-API-Key' => 'test-api-key'])
+        ->assertOk()
+        ->assertJsonStructure([
+            'lastUpdated',
+            'data' => [
+                '*' => [
+                    'id',
+                    'text',
+                    'language',
+                    'scheme',
+                    'schemeURI',
+                    'description',
+                    'children',
+                ],
+            ],
+        ]);
+
+    expect($response->json('lastUpdated'))->toBe('2026-04-16T10:00:00+00:00');
+    expect($response->json('data.0.text'))->toBe('natural sciences');
+    expect($response->json('data.0.children.0.text'))->toBe('physical sciences');
+});
+
+it('returns 404 when vocabulary file does not exist', function (): void {
+    getJson('/api/v1/vocabularies/euroscivoc', ['X-API-Key' => 'test-api-key'])
+        ->assertStatus(404)
+        ->assertJson([
+            'error' => 'Vocabulary file not found. Please run: php artisan get-euroscivoc',
+        ]);
+});
+
+it('rejects requests without an API key', function (): void {
+    createTestEuroSciVocVocabularyFile();
+
+    getJson('/api/v1/vocabularies/euroscivoc')
+        ->assertStatus(401)
+        ->assertJson(['message' => 'Invalid API key.']);
+});
+
+it('rejects requests with an invalid API key', function (): void {
+    createTestEuroSciVocVocabularyFile();
+
+    getJson('/api/v1/vocabularies/euroscivoc', ['X-API-Key' => 'wrong-key'])
+        ->assertStatus(401)
+        ->assertJson(['message' => 'Invalid API key.']);
+});
+
+it('returns 404 when thesaurus is disabled for ELMO', function (): void {
+    createTestEuroSciVocVocabularyFile();
+
+    ThesaurusSetting::updateOrCreate(
+        ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+        [
+            'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+            'is_active' => true,
+            'is_elmo_active' => false,
+        ]
+    );
+
+    getJson('/api/v1/vocabularies/euroscivoc', ['X-API-Key' => 'test-api-key'])
+        ->assertStatus(404)
+        ->assertJson(['error' => 'Thesaurus is disabled']);
+});
+
+it('returns data when thesaurus is active for ELMO', function (): void {
+    createTestEuroSciVocVocabularyFile();
+
+    ThesaurusSetting::updateOrCreate(
+        ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+        [
+            'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+            'is_active' => false,
+            'is_elmo_active' => true,
+        ]
+    );
+
+    getJson('/api/v1/vocabularies/euroscivoc', ['X-API-Key' => 'test-api-key'])
+        ->assertOk();
+});

--- a/tests/pest/Feature/Commands/GetEuroSciVocCommandTest.php
+++ b/tests/pest/Feature/Commands/GetEuroSciVocCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\GetEuroSciVoc;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+covers(GetEuroSciVoc::class);
+
+/**
+ * Build a minimal valid EuroSciVoc RDF/XML string for testing.
+ * Contains 2 concepts: one top-level, one child.
+ */
+function buildMinimalEuroSciVocRdf(): string
+{
+    $schemeUri = config('euroscivoc.concept_scheme_uri');
+
+    return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skosxl:Label rdf:about="http://example.org/label/1">
+        <skosxl:literalForm xml:lang="en">natural sciences</skosxl:literalForm>
+    </skosxl:Label>
+    <skosxl:Label rdf:about="http://example.org/label/2">
+        <skosxl:literalForm xml:lang="en">physics</skosxl:literalForm>
+    </skosxl:Label>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:topConceptOf rdf:resource="{$schemeUri}"/>
+        <skos:inScheme rdf:resource="{$schemeUri}"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/1"/>
+    </skos:Concept>
+    <skos:Concept rdf:about="http://example.org/concept/2">
+        <skos:inScheme rdf:resource="{$schemeUri}"/>
+        <skos:broader rdf:resource="http://example.org/concept/1"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/2"/>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+}
+
+it('successfully fetches and saves EuroSciVoc vocabulary', function (): void {
+    Storage::fake('local');
+
+    Http::fake([
+        config('euroscivoc.download_url') => Http::response(buildMinimalEuroSciVocRdf(), 200),
+    ]);
+
+    Artisan::call('get-euroscivoc');
+    $output = Artisan::output();
+
+    expect($output)
+        ->toContain('Fetching European Science Vocabulary')
+        ->toContain('Downloading RDF')
+        ->toContain('Extracted 2 concepts')
+        ->toContain('Built hierarchy with 2 concepts')
+        ->toContain('Successfully saved');
+
+    Storage::assertExists('euroscivoc.json');
+});
+
+it('builds correct hierarchical structure', function (): void {
+    Storage::fake('local');
+
+    Http::fake([
+        config('euroscivoc.download_url') => Http::response(buildMinimalEuroSciVocRdf(), 200),
+    ]);
+
+    Artisan::call('get-euroscivoc');
+
+    $json = json_decode(Storage::get('euroscivoc.json'), true);
+
+    expect($json)->toHaveKeys(['lastUpdated', 'data'])
+        ->and($json['data'])->toHaveCount(1)
+        ->and($json['data'][0]['text'])->toBe('natural sciences')
+        ->and($json['data'][0]['scheme'])->toBe(config('euroscivoc.scheme_name'))
+        ->and($json['data'][0]['children'])->toHaveCount(1)
+        ->and($json['data'][0]['children'][0]['text'])->toBe('physics');
+});
+
+it('fails gracefully on HTTP error', function (): void {
+    Storage::fake('local');
+
+    Http::fake([
+        config('euroscivoc.download_url') => Http::response('Server Error', 500),
+    ]);
+
+    $exitCode = Artisan::call('get-euroscivoc');
+    $output = Artisan::output();
+
+    expect($exitCode)->toBe(1)
+        ->and($output)->toContain('Failed to download EuroSciVoc RDF: HTTP 500');
+
+    Storage::assertMissing('euroscivoc.json');
+});
+
+it('fails when no concepts are found', function (): void {
+    Storage::fake('local');
+
+    $emptyRdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+</rdf:RDF>
+XML;
+
+    Http::fake([
+        config('euroscivoc.download_url') => Http::response($emptyRdf, 200),
+    ]);
+
+    $exitCode = Artisan::call('get-euroscivoc');
+    $output = Artisan::output();
+
+    expect($exitCode)->toBe(1)
+        ->and($output)->toContain('No concepts found');
+});
+
+it('fails when RDF content is invalid XML', function (): void {
+    Storage::fake('local');
+
+    Http::fake([
+        config('euroscivoc.download_url') => Http::response('not valid xml at all', 200),
+    ]);
+
+    $exitCode = Artisan::call('get-euroscivoc');
+    $output = Artisan::output();
+
+    expect($exitCode)->toBe(1)
+        ->and($output)->toContain('Error:');
+});
+
+it('saves valid JSON with required structure', function (): void {
+    Storage::fake('local');
+
+    Http::fake([
+        config('euroscivoc.download_url') => Http::response(buildMinimalEuroSciVocRdf(), 200),
+    ]);
+
+    Artisan::call('get-euroscivoc');
+
+    $json = json_decode(Storage::get('euroscivoc.json'), true);
+
+    expect($json)->toBeArray()
+        ->and($json['lastUpdated'])->toBeString()->not->toBeEmpty()
+        ->and($json['data'])->toBeArray()
+        ->and($json['data'][0])->toHaveKeys(['id', 'text', 'language', 'scheme', 'schemeURI', 'description', 'children']);
+});

--- a/tests/pest/Feature/Http/Controllers/VocabularyControllerTest.php
+++ b/tests/pest/Feature/Http/Controllers/VocabularyControllerTest.php
@@ -217,6 +217,30 @@ describe('gemet thesaurus', function () {
     });
 });
 
+describe('euroscivoc', function () {
+    it('returns vocabulary when thesaurus is active', function () {
+        ThesaurusSetting::firstOrCreate(
+            ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+            [
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ],
+        );
+
+        Storage::put('euroscivoc.json', json_encode([
+            'lastUpdated' => '2026-04-16T10:00:00+00:00',
+            'data' => [['id' => 'http://example.org/1', 'text' => 'natural sciences', 'language' => 'en', 'scheme' => 'European Science Vocabulary (EuroSciVoc)', 'schemeURI' => 'http://data.europa.eu/8mn/euroscivoc/test', 'description' => '', 'children' => []]],
+        ]));
+
+        $response = $this->getJson('/api/v1/vocabularies/euroscivoc', [
+            'X-API-Key' => config('services.ernie.api_key'),
+        ]);
+
+        $response->assertOk();
+    });
+});
+
 describe('ror affiliations', function () {
     it('returns 404 when ROR is disabled', function () {
         PidSetting::create([

--- a/tests/pest/Feature/Migrations/AddEuroSciVocThesaurusTest.php
+++ b/tests/pest/Feature/Migrations/AddEuroSciVocThesaurusTest.php
@@ -40,4 +40,13 @@ describe('add_euroscivoc_thesaurus migration', function () {
 
         expect(DB::table('thesaurus_settings')->where('type', 'euroscivoc')->exists())->toBeTrue();
     });
+
+    it('is idempotent and does not fail when row already exists', function () {
+        $migration = getEuroSciVocThesaurusMigration();
+
+        // Row already exists from RefreshDatabase; running up() again should not throw
+        $migration->up();
+
+        expect(DB::table('thesaurus_settings')->where('type', 'euroscivoc')->count())->toBe(1);
+    });
 });

--- a/tests/pest/Feature/Migrations/AddEuroSciVocThesaurusTest.php
+++ b/tests/pest/Feature/Migrations/AddEuroSciVocThesaurusTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Require the migration file and return its anonymous class instance.
+ */
+function getEuroSciVocThesaurusMigration(): Migration
+{
+    return require database_path('migrations/2026_04_16_000001_add_euroscivoc_thesaurus.php');
+}
+
+describe('add_euroscivoc_thesaurus migration', function () {
+    it('seeds the euroscivoc thesaurus setting', function () {
+        // The migration runs as part of RefreshDatabase, so the row should exist
+        $row = DB::table('thesaurus_settings')->where('type', 'euroscivoc')->first();
+
+        expect($row)->not->toBeNull()
+            ->and($row->display_name)->toBe('European Science Vocabulary (EuroSciVoc)')
+            ->and((bool) $row->is_active)->toBeTrue()
+            ->and((bool) $row->is_elmo_active)->toBeTrue();
+    });
+
+    it('can rollback and re-apply the euroscivoc thesaurus setting', function () {
+        $migration = getEuroSciVocThesaurusMigration();
+
+        // Rollback
+        $migration->down();
+
+        expect(DB::table('thesaurus_settings')->where('type', 'euroscivoc')->exists())->toBeFalse();
+
+        // Re-apply
+        $migration->up();
+
+        expect(DB::table('thesaurus_settings')->where('type', 'euroscivoc')->exists())->toBeTrue();
+    });
+});

--- a/tests/pest/Feature/Services/ThesaurusStatusServiceTest.php
+++ b/tests/pest/Feature/Services/ThesaurusStatusServiceTest.php
@@ -432,6 +432,26 @@ describe('getRemoteConceptCount', function () {
         expect(fn () => $service->getRemoteConceptCount($thesaurus))
             ->toThrow(RuntimeException::class, 'Failed to query EuroSciVoc SPARQL endpoint');
     });
+
+    test('throws on unexpected EuroSciVoc SPARQL response format', function () {
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+            [
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ]
+        );
+
+        Http::fake([
+            'publications.europa.eu/*' => Http::response(['unexpected' => 'format'], 200),
+        ]);
+
+        $service = new ThesaurusStatusService;
+
+        expect(fn () => $service->getRemoteConceptCount($thesaurus))
+            ->toThrow(RuntimeException::class, 'Unexpected EuroSciVoc SPARQL response format');
+    });
 });
 
 describe('compareWithRemote', function () {

--- a/tests/pest/Feature/Services/ThesaurusStatusServiceTest.php
+++ b/tests/pest/Feature/Services/ThesaurusStatusServiceTest.php
@@ -6,6 +6,7 @@ use App\Models\ThesaurusSetting;
 use App\Services\ThesaurusStatusService;
 use App\Support\GcmdVocabularyParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
@@ -13,6 +14,7 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     Storage::fake();
+    Cache::flush();
 });
 
 describe('getLocalStatus', function () {
@@ -186,6 +188,39 @@ describe('getLocalStatus', function () {
             'lastUpdated' => null,
         ]);
     });
+
+    test('returns local status for EuroSciVoc vocabulary', function () {
+        Storage::put('euroscivoc.json', json_encode([
+            'lastUpdated' => '2026-04-16T10:00:00+00:00',
+            'data' => [
+                [
+                    'id' => 'http://example.org/1',
+                    'text' => 'natural sciences',
+                    'children' => [
+                        ['id' => 'http://example.org/2', 'text' => 'physics', 'children' => []],
+                    ],
+                ],
+            ],
+        ]));
+
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+            [
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ]
+        );
+
+        $service = new ThesaurusStatusService;
+        $status = $service->getLocalStatus($thesaurus);
+
+        expect($status)->toBe([
+            'exists' => true,
+            'conceptCount' => 2,
+            'lastUpdated' => '2026-04-16T10:00:00+00:00',
+        ]);
+    });
 });
 
 describe('getRemoteConceptCount', function () {
@@ -350,6 +385,52 @@ describe('getRemoteConceptCount', function () {
         Http::assertSent(function ($request) {
             return str_contains($request->url(), '/2-0/concept.json');
         });
+    });
+
+    test('fetches EuroSciVoc remote count via SPARQL endpoint', function () {
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+            [
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ]
+        );
+
+        Http::fake([
+            'publications.europa.eu/*' => Http::response([
+                'results' => [
+                    'bindings' => [
+                        ['count' => ['value' => '1064']],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $service = new ThesaurusStatusService;
+        $count = $service->getRemoteConceptCount($thesaurus);
+
+        expect($count)->toBe(1064);
+    });
+
+    test('throws on EuroSciVoc SPARQL endpoint failure', function () {
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_EUROSCIVOC],
+            [
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ]
+        );
+
+        Http::fake([
+            'publications.europa.eu/*' => Http::response('Server Error', 500),
+        ]);
+
+        $service = new ThesaurusStatusService;
+
+        expect(fn () => $service->getRemoteConceptCount($thesaurus))
+            ->toThrow(RuntimeException::class, 'Failed to query EuroSciVoc SPARQL endpoint');
     });
 });
 

--- a/tests/pest/Feature/Settings/EditorSettingsTest.php
+++ b/tests/pest/Feature/Settings/EditorSettingsTest.php
@@ -170,8 +170,8 @@ test('thesaurus settings are auto-created when missing', function () {
     Setting::create(['key' => 'max_titles', 'value' => (string) Setting::DEFAULT_LIMIT]);
     Setting::create(['key' => 'max_licenses', 'value' => (string) Setting::DEFAULT_LIMIT]);
 
-    // Verify only the migration-seeded chronostrat, gemet, and analytical_methods settings exist initially
-    expect(ThesaurusSetting::count())->toBe(3);
+    // Verify only the migration-seeded chronostrat, gemet, analytical_methods, and euroscivoc settings exist initially
+    expect(ThesaurusSetting::count())->toBe(4);
     expect(ThesaurusSetting::where('type', ThesaurusSetting::TYPE_CHRONOSTRAT)->exists())->toBeTrue();
     expect(ThesaurusSetting::where('type', ThesaurusSetting::TYPE_GEMET)->exists())->toBeTrue();
     expect(ThesaurusSetting::where('type', ThesaurusSetting::TYPE_ANALYTICAL_METHODS)->exists())->toBeTrue();
@@ -182,8 +182,8 @@ test('thesaurus settings are auto-created when missing', function () {
     // Access the settings page - this should auto-create missing thesaurus settings
     $response = $this->get(route('settings'))->assertOk();
 
-    // Verify all six thesaurus settings now exist (3 GCMD auto-created + 1 chronostrat + 1 gemet + 1 analytical_methods from migration)
-    expect(ThesaurusSetting::count())->toBe(6);
+    // Verify all seven thesaurus settings now exist (3 GCMD auto-created + 1 chronostrat + 1 gemet + 1 analytical_methods + 1 euroscivoc from migration)
+    expect(ThesaurusSetting::count())->toBe(7);
 
     $this->assertDatabaseHas('thesaurus_settings', [
         'type' => ThesaurusSetting::TYPE_SCIENCE_KEYWORDS,
@@ -204,16 +204,17 @@ test('thesaurus settings are auto-created when missing', function () {
         'is_elmo_active' => true,
     ]);
 
-    // Verify thesauri are returned in the response (6 total: 3 GCMD + GEMET + Chronostrat + Analytical Methods)
+    // Verify thesauri are returned in the response (7 total: 3 GCMD + GEMET + Chronostrat + Analytical Methods + EuroSciVoc)
     $response->assertInertia(fn (Assert $page) => $page
         ->component('settings/index')
-        ->has('thesauri', 6)
+        ->has('thesauri', 7)
         ->where('thesauri', fn ($thesauri) => $thesauri->contains('type', ThesaurusSetting::TYPE_SCIENCE_KEYWORDS)
             && $thesauri->contains('type', ThesaurusSetting::TYPE_PLATFORMS)
             && $thesauri->contains('type', ThesaurusSetting::TYPE_INSTRUMENTS)
             && $thesauri->contains('type', ThesaurusSetting::TYPE_CHRONOSTRAT)
             && $thesauri->contains('type', ThesaurusSetting::TYPE_GEMET)
-            && $thesauri->contains('type', ThesaurusSetting::TYPE_ANALYTICAL_METHODS))
+            && $thesauri->contains('type', ThesaurusSetting::TYPE_ANALYTICAL_METHODS)
+            && $thesauri->contains('type', ThesaurusSetting::TYPE_EUROSCIVOC))
     );
 });
 

--- a/tests/pest/Feature/Settings/ThesaurusSettingsTest.php
+++ b/tests/pest/Feature/Settings/ThesaurusSettingsTest.php
@@ -54,7 +54,7 @@ describe('ThesaurusSettingsController', function () {
         $this->actingAs($admin)
             ->getJson('/thesauri')
             ->assertOk()
-            ->assertJsonCount(6)
+            ->assertJsonCount(7)
             ->assertJsonFragment([
                 'type' => 'science_keywords',
                 'displayName' => 'Science Keywords',
@@ -197,11 +197,12 @@ describe('EditorSettings with Thesauri', function () {
         $response = $this->get(route('settings'));
 
         $response->assertInertia(fn ($assert) => $assert
-            ->has('thesauri', 6)
+            ->has('thesauri', 7)
             ->where('thesauri', fn ($thesauri) => $thesauri->contains('type', 'science_keywords')
                 && $thesauri->contains('type', 'chronostratigraphy')
                 && $thesauri->contains('type', 'gemet')
-                && $thesauri->contains('type', 'analytical_methods'))
+                && $thesauri->contains('type', 'analytical_methods')
+                && $thesauri->contains('type', 'euroscivoc'))
         );
     });
 

--- a/tests/pest/Unit/Enums/CacheKeyTest.php
+++ b/tests/pest/Unit/Enums/CacheKeyTest.php
@@ -84,7 +84,7 @@ it('returns all vocabulary keys', function () {
     $vocabularyKeys = CacheKey::vocabularyKeys();
 
     expect($vocabularyKeys)->toBeArray()
-        ->toHaveCount(9)
+        ->toHaveCount(10)
         ->each->toBeInstanceOf(CacheKey::class);
 
     $expectedKeys = [
@@ -97,6 +97,7 @@ it('returns all vocabulary keys', function () {
         CacheKey::CHRONOSTRAT_TIMESCALE,
         CacheKey::GEMET_THESAURUS,
         CacheKey::ANALYTICAL_METHODS,
+        CacheKey::EUROSCIVOC,
     ];
 
     expect($vocabularyKeys)->toEqual($expectedKeys);

--- a/tests/pest/Unit/Models/ThesaurusSettingEuroSciVocTest.php
+++ b/tests/pest/Unit/Models/ThesaurusSettingEuroSciVocTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CacheKey;
+use App\Models\ThesaurusSetting;
+
+covers(ThesaurusSetting::class);
+
+describe('EuroSciVoc type mappings', function (): void {
+    beforeEach(function (): void {
+        $this->setting = new ThesaurusSetting;
+        $this->setting->type = ThesaurusSetting::TYPE_EUROSCIVOC;
+    });
+
+    it('has correct type constant value', function (): void {
+        expect(ThesaurusSetting::TYPE_EUROSCIVOC)->toBe('euroscivoc');
+    });
+
+    it('returns correct file path', function (): void {
+        expect($this->setting->getFilePath())->toBe('euroscivoc.json');
+    });
+
+    it('returns correct artisan command', function (): void {
+        expect($this->setting->getArtisanCommand())->toBe('get-euroscivoc');
+    });
+
+    it('returns correct cache key', function (): void {
+        expect($this->setting->getCacheKey())->toBe(CacheKey::EUROSCIVOC);
+    });
+
+    it('is not GCMD type', function (): void {
+        expect($this->setting->isGcmd())->toBeFalse();
+    });
+
+    it('is not ARDC type', function (): void {
+        expect($this->setting->usesArdcApi())->toBeFalse();
+    });
+
+    it('is included in valid types', function (): void {
+        expect(ThesaurusSetting::getValidTypes())->toContain(ThesaurusSetting::TYPE_EUROSCIVOC);
+    });
+
+    it('throws on getVocabularyType for non-GCMD type', function (): void {
+        $this->setting->getVocabularyType();
+    })->throws(\InvalidArgumentException::class);
+});
+
+describe('CacheKey EUROSCIVOC', function (): void {
+    it('has correct key value', function (): void {
+        expect(CacheKey::EUROSCIVOC->key())->toBe('vocabularies:euroscivoc');
+    });
+
+    it('has correct TTL', function (): void {
+        expect(CacheKey::EUROSCIVOC->ttl())->toBe(86400);
+    });
+
+    it('is tagged under vocabularies', function (): void {
+        expect(CacheKey::EUROSCIVOC->tags())->toContain('vocabularies');
+    });
+
+    it('is in vocabulary keys', function (): void {
+        expect(CacheKey::vocabularyKeys())->toContain(CacheKey::EUROSCIVOC);
+    });
+});

--- a/tests/pest/Unit/Services/VocabularyCacheServiceTest.php
+++ b/tests/pest/Unit/Services/VocabularyCacheServiceTest.php
@@ -78,6 +78,30 @@ describe('VocabularyCacheService', function () {
         });
     });
 
+    describe('cacheEuroSciVoc', function () {
+        it('caches and returns EuroSciVoc vocabulary', function () {
+            $vocabulary = [['text' => 'natural sciences', 'children' => []]];
+
+            $result = $this->service->cacheEuroSciVoc(fn () => $vocabulary);
+
+            expect($result)->toBe($vocabulary);
+        });
+
+        it('returns cached value on subsequent calls', function () {
+            $callCount = 0;
+            $callback = function () use (&$callCount) {
+                $callCount++;
+
+                return ['euroscivoc_data'];
+            };
+
+            $this->service->cacheEuroSciVoc($callback);
+            $this->service->cacheEuroSciVoc($callback);
+
+            expect($callCount)->toBe(1);
+        });
+    });
+
     describe('cacheVocabulary', function () {
         it('caches arbitrary vocabulary using CacheKey enum', function () {
             $data = ['test' => 'data'];

--- a/tests/pest/Unit/Services/VocabularyCacheServiceTest.php
+++ b/tests/pest/Unit/Services/VocabularyCacheServiceTest.php
@@ -130,7 +130,7 @@ describe('VocabularyCacheService', function () {
             $results = $this->service->touchAllVocabularyCaches();
 
             expect($results)->toBeArray()
-                ->toHaveCount(9);
+                ->toHaveCount(10);
 
             foreach (CacheKey::vocabularyKeys() as $key) {
                 expect($results)->toHaveKey($key->value);

--- a/tests/pest/Unit/Support/EuroSciVocParserTest.php
+++ b/tests/pest/Unit/Support/EuroSciVocParserTest.php
@@ -228,6 +228,24 @@ XML;
             ->and($concepts[0]['text'])->toBe('untagged label');
     });
 
+    it('does not return non-English tagged labels as fallback', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel xml:lang="de">nur Deutsch</skos:prefLabel>
+        <skos:prefLabel xml:lang="fr">seulement français</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(0);
+    });
+
     it('skips SKOS-XL labels without rdf:about attribute', function (): void {
         $rdf = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/pest/Unit/Support/EuroSciVocParserTest.php
+++ b/tests/pest/Unit/Support/EuroSciVocParserTest.php
@@ -402,10 +402,9 @@ describe('buildHierarchy', function (): void {
             ->and($result['lastUpdated'])->toBeString();
     });
 
-    it('handles orphan children whose parent is outside the scheme', function (): void {
+    it('promotes orphan children whose parent is outside the scheme to roots', function (): void {
         // Child references a broaderId that is not in the concepts array.
-        // Since the child is not a top concept and its parent is missing,
-        // it is silently omitted from the hierarchy.
+        // The orphan rescue logic promotes it to a root concept.
         $concepts = [
             ['id' => 'http://example.org/root', 'text' => 'root', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
             ['id' => 'http://example.org/child', 'text' => 'child', 'language' => 'en', 'broaderId' => 'http://example.org/missing-parent', 'isTopConcept' => false],
@@ -413,10 +412,10 @@ describe('buildHierarchy', function (): void {
 
         $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
 
-        // Only the explicit top concept is included; the orphan child is dropped
-        expect($result['data'])->toHaveCount(1)
-            ->and($result['data'][0]['text'])->toBe('root')
-            ->and($result['data'][0]['children'])->toBeEmpty();
+        expect($result['data'])->toHaveCount(2);
+        $texts = array_column($result['data'], 'text');
+        expect($texts)->toContain('root')
+            ->and($texts)->toContain('child');
     });
 });
 

--- a/tests/pest/Unit/Support/EuroSciVocParserTest.php
+++ b/tests/pest/Unit/Support/EuroSciVocParserTest.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\EuroSciVocParser;
+
+covers(EuroSciVocParser::class);
+
+beforeEach(function (): void {
+    $this->parser = new EuroSciVocParser;
+    $this->conceptSchemeUri = 'http://data.europa.eu/8mn/euroscivoc/test-scheme';
+});
+
+// =========================================================================
+// extractConcepts
+// =========================================================================
+
+describe('extractConcepts', function (): void {
+    it('extracts concepts with SKOS-XL labels', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#"
+         xml:lang="en">
+    <skosxl:Label rdf:about="http://example.org/label/1">
+        <skosxl:literalForm xml:lang="en">natural sciences</skosxl:literalForm>
+        <skosxl:literalForm xml:lang="de">Naturwissenschaften</skosxl:literalForm>
+    </skosxl:Label>
+    <skosxl:Label rdf:about="http://example.org/label/2">
+        <skosxl:literalForm xml:lang="en">physics</skosxl:literalForm>
+    </skosxl:Label>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:topConceptOf rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/1"/>
+    </skos:Concept>
+    <skos:Concept rdf:about="http://example.org/concept/2">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:broader rdf:resource="http://example.org/concept/1"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/2"/>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(2)
+            ->and($concepts[0])->toMatchArray([
+                'id' => 'http://example.org/concept/1',
+                'text' => 'natural sciences',
+                'language' => 'en',
+                'isTopConcept' => true,
+                'broaderId' => null,
+            ])
+            ->and($concepts[1])->toMatchArray([
+                'id' => 'http://example.org/concept/2',
+                'text' => 'physics',
+                'language' => 'en',
+                'isTopConcept' => false,
+                'broaderId' => 'http://example.org/concept/1',
+            ]);
+    });
+
+    it('falls back to plain SKOS prefLabel when no SKOS-XL labels exist', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:topConceptOf rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel xml:lang="en">engineering and technology</skos:prefLabel>
+        <skos:prefLabel xml:lang="de">Ingenieurwissenschaften und Technologie</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('engineering and technology')
+            ->and($concepts[0]['language'])->toBe('en');
+    });
+
+    it('skips concepts not belonging to the target scheme', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel xml:lang="en">natural sciences</skos:prefLabel>
+    </skos:Concept>
+    <skos:Concept rdf:about="http://example.org/concept/other">
+        <skos:inScheme rdf:resource="http://example.org/other-scheme"/>
+        <skos:prefLabel xml:lang="en">should be skipped</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('natural sciences');
+    });
+
+    it('skips concepts without English labels', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skosxl:Label rdf:about="http://example.org/label/de-only">
+        <skosxl:literalForm xml:lang="de">nur Deutsch</skosxl:literalForm>
+    </skosxl:Label>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/de-only"/>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(0);
+    });
+
+    it('skips concepts without rdf:about attribute', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <skos:Concept>
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel xml:lang="en">no id concept</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(0);
+    });
+
+    it('returns empty array for RDF with no concepts', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toBeArray()->toBeEmpty();
+    });
+
+    it('throws RuntimeException for invalid XML', function (): void {
+        $this->parser->extractConcepts('not valid xml', $this->conceptSchemeUri);
+    })->throws(RuntimeException::class, 'Failed to parse EuroSciVoc RDF/XML');
+
+    it('detects top concepts via topConceptOf', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <skos:Concept rdf:about="http://example.org/concept/root">
+        <skos:topConceptOf rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel xml:lang="en">root concept</skos:prefLabel>
+    </skos:Concept>
+    <skos:Concept rdf:about="http://example.org/concept/child">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:broader rdf:resource="http://example.org/concept/root"/>
+        <skos:prefLabel xml:lang="en">child concept</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        $root = collect($concepts)->firstWhere('id', 'http://example.org/concept/root');
+        $child = collect($concepts)->firstWhere('id', 'http://example.org/concept/child');
+
+        expect($root['isTopConcept'])->toBeTrue()
+            ->and($child['isTopConcept'])->toBeFalse()
+            ->and($child['broaderId'])->toBe('http://example.org/concept/root');
+    });
+
+    it('prefers SKOS-XL label over plain SKOS when both exist', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skosxl:Label rdf:about="http://example.org/label/xl">
+        <skosxl:literalForm xml:lang="en">SKOS-XL label</skosxl:literalForm>
+    </skosxl:Label>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/xl"/>
+        <skos:prefLabel xml:lang="en">plain SKOS label</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('SKOS-XL label');
+    });
+});
+
+// =========================================================================
+// buildHierarchy
+// =========================================================================
+
+describe('buildHierarchy', function (): void {
+    it('builds hierarchical tree from flat concepts', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/root', 'text' => 'natural sciences', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+            ['id' => 'http://example.org/child1', 'text' => 'physics', 'language' => 'en', 'broaderId' => 'http://example.org/root', 'isTopConcept' => false],
+            ['id' => 'http://example.org/child2', 'text' => 'chemistry', 'language' => 'en', 'broaderId' => 'http://example.org/root', 'isTopConcept' => false],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'European Science Vocabulary (EuroSciVoc)', 'http://example.org/scheme');
+
+        expect($result)->toHaveKeys(['lastUpdated', 'data'])
+            ->and($result['data'])->toHaveCount(1)
+            ->and($result['data'][0]['text'])->toBe('natural sciences')
+            ->and($result['data'][0]['scheme'])->toBe('European Science Vocabulary (EuroSciVoc)')
+            ->and($result['data'][0]['schemeURI'])->toBe('http://example.org/scheme')
+            ->and($result['data'][0]['children'])->toHaveCount(2)
+            ->and($result['data'][0]['children'][0]['text'])->toBe('chemistry')
+            ->and($result['data'][0]['children'][1]['text'])->toBe('physics');
+    });
+
+    it('sorts root concepts alphabetically', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/c', 'text' => 'social sciences', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+            ['id' => 'http://example.org/a', 'text' => 'humanities', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+            ['id' => 'http://example.org/b', 'text' => 'natural sciences', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['data'][0]['text'])->toBe('humanities')
+            ->and($result['data'][1]['text'])->toBe('natural sciences')
+            ->and($result['data'][2]['text'])->toBe('social sciences');
+    });
+
+    it('sorts children alphabetically', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/root', 'text' => 'root', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+            ['id' => 'http://example.org/z', 'text' => 'zoology', 'language' => 'en', 'broaderId' => 'http://example.org/root', 'isTopConcept' => false],
+            ['id' => 'http://example.org/a', 'text' => 'astronomy', 'language' => 'en', 'broaderId' => 'http://example.org/root', 'isTopConcept' => false],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['data'][0]['children'][0]['text'])->toBe('astronomy')
+            ->and($result['data'][0]['children'][1]['text'])->toBe('zoology');
+    });
+
+    it('derives top concepts when none are explicitly marked', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/root', 'text' => 'root', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => false],
+            ['id' => 'http://example.org/child', 'text' => 'child', 'language' => 'en', 'broaderId' => 'http://example.org/root', 'isTopConcept' => false],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['data'])->toHaveCount(1)
+            ->and($result['data'][0]['text'])->toBe('root')
+            ->and($result['data'][0]['children'])->toHaveCount(1)
+            ->and($result['data'][0]['children'][0]['text'])->toBe('child');
+    });
+
+    it('builds multi-level hierarchy', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/l1', 'text' => 'natural sciences', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+            ['id' => 'http://example.org/l2', 'text' => 'physical sciences', 'language' => 'en', 'broaderId' => 'http://example.org/l1', 'isTopConcept' => false],
+            ['id' => 'http://example.org/l3', 'text' => 'astronomy', 'language' => 'en', 'broaderId' => 'http://example.org/l2', 'isTopConcept' => false],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['data'])->toHaveCount(1)
+            ->and($result['data'][0]['children'])->toHaveCount(1)
+            ->and($result['data'][0]['children'][0]['text'])->toBe('physical sciences')
+            ->and($result['data'][0]['children'][0]['children'])->toHaveCount(1)
+            ->and($result['data'][0]['children'][0]['children'][0]['text'])->toBe('astronomy')
+            ->and($result['data'][0]['children'][0]['children'][0]['children'])->toBeEmpty();
+    });
+
+    it('includes description field as empty string', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/c1', 'text' => 'test', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['data'][0]['description'])->toBe('');
+    });
+
+    it('includes lastUpdated timestamp', function (): void {
+        $concepts = [
+            ['id' => 'http://example.org/c1', 'text' => 'test', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['lastUpdated'])->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns empty data for empty concepts array', function (): void {
+        $result = $this->parser->buildHierarchy([], 'EuroSciVoc', 'http://example.org/scheme');
+
+        expect($result['data'])->toBeArray()->toBeEmpty()
+            ->and($result['lastUpdated'])->toBeString();
+    });
+});
+
+// =========================================================================
+// countConcepts
+// =========================================================================
+
+describe('countConcepts', function (): void {
+    it('counts flat list of concepts', function (): void {
+        $data = [
+            ['text' => 'a', 'children' => []],
+            ['text' => 'b', 'children' => []],
+            ['text' => 'c', 'children' => []],
+        ];
+
+        expect($this->parser->countConcepts($data))->toBe(3);
+    });
+
+    it('counts nested concepts recursively', function (): void {
+        $data = [
+            [
+                'text' => 'natural sciences',
+                'children' => [
+                    [
+                        'text' => 'physics',
+                        'children' => [
+                            ['text' => 'astronomy', 'children' => []],
+                        ],
+                    ],
+                    ['text' => 'chemistry', 'children' => []],
+                ],
+            ],
+        ];
+
+        expect($this->parser->countConcepts($data))->toBe(4);
+    });
+
+    it('returns 0 for empty array', function (): void {
+        expect($this->parser->countConcepts([]))->toBe(0);
+    });
+});

--- a/tests/pest/Unit/Support/EuroSciVocParserTest.php
+++ b/tests/pest/Unit/Support/EuroSciVocParserTest.php
@@ -209,6 +209,88 @@ XML;
         expect($concepts)->toHaveCount(1)
             ->and($concepts[0]['text'])->toBe('SKOS-XL label');
     });
+
+    it('falls back to untagged plain SKOS label when no language attribute exists', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel>untagged label</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('untagged label');
+    });
+
+    it('skips SKOS-XL labels without rdf:about attribute', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skosxl:Label>
+        <skosxl:literalForm xml:lang="en">orphan label</skosxl:literalForm>
+    </skosxl:Label>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:prefLabel xml:lang="en">direct label</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('direct label');
+    });
+
+    it('skips SKOS-XL labels without literalForm element', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skosxl:Label rdf:about="http://example.org/label/empty">
+    </skosxl:Label>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/empty"/>
+        <skos:prefLabel xml:lang="en">fallback label</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('fallback label');
+    });
+
+    it('falls back to plain SKOS when SKOS-XL reference is not in label map', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/nonexistent"/>
+        <skos:prefLabel xml:lang="en">plain fallback</skos:prefLabel>
+    </skos:Concept>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('plain fallback');
+    });
 });
 
 // =========================================================================
@@ -318,6 +400,23 @@ describe('buildHierarchy', function (): void {
 
         expect($result['data'])->toBeArray()->toBeEmpty()
             ->and($result['lastUpdated'])->toBeString();
+    });
+
+    it('handles orphan children whose parent is outside the scheme', function (): void {
+        // Child references a broaderId that is not in the concepts array.
+        // Since the child is not a top concept and its parent is missing,
+        // it is silently omitted from the hierarchy.
+        $concepts = [
+            ['id' => 'http://example.org/root', 'text' => 'root', 'language' => 'en', 'broaderId' => null, 'isTopConcept' => true],
+            ['id' => 'http://example.org/child', 'text' => 'child', 'language' => 'en', 'broaderId' => 'http://example.org/missing-parent', 'isTopConcept' => false],
+        ];
+
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', 'http://example.org/scheme');
+
+        // Only the explicit top concept is included; the orphan child is dropped
+        expect($result['data'])->toHaveCount(1)
+            ->and($result['data'][0]['text'])->toBe('root')
+            ->and($result['data'][0]['children'])->toBeEmpty();
     });
 });
 

--- a/tests/vitest/pages/__tests__/docs.integration.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.integration.test.tsx
@@ -40,6 +40,7 @@ const defaultEditorSettings: EditorSettings = {
         chronostratigraphy: true,
         gemet: true,
         analyticalMethods: true,
+        euroSciVoc: true,
     },
     features: {
         hasActiveGcmd: true,
@@ -47,6 +48,7 @@ const defaultEditorSettings: EditorSettings = {
         hasActiveChronostrat: true,
         hasActiveGemet: true,
         hasActiveAnalyticalMethods: true,
+        hasActiveEuroSciVoc: true,
         hasActiveLicenses: true,
         hasActiveResourceTypes: true,
         hasActiveTitleTypes: true,

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -38,6 +38,7 @@ const defaultEditorSettings: EditorSettings = {
         chronostratigraphy: true,
         gemet: true,
         analyticalMethods: true,
+        euroSciVoc: true,
     },
     features: {
         hasActiveGcmd: true,
@@ -45,6 +46,7 @@ const defaultEditorSettings: EditorSettings = {
         hasActiveChronostrat: true,
         hasActiveGemet: true,
         hasActiveAnalyticalMethods: true,
+        hasActiveEuroSciVoc: true,
         hasActiveLicenses: true,
         hasActiveResourceTypes: true,
         hasActiveTitleTypes: true,
@@ -117,6 +119,7 @@ describe('Docs page', () => {
                 hasActiveChronostrat: false,
                 hasActiveGemet: false,
                 hasActiveAnalyticalMethods: false,
+                hasActiveEuroSciVoc: false,
             },
         };
         render(<Docs userRole="beginner" editorSettings={settingsWithoutGcmd} />);


### PR DESCRIPTION
This pull request introduces full support for the European Science Vocabulary (EuroSciVoc) as a new controlled vocabulary in the application. It adds the ability to fetch, store, cache, and serve the EuroSciVoc taxonomy, as well as manage its activation status and settings. EuroSciVoc now appears alongside other vocabularies in the API, admin settings, and documentation, and is available for use by administrators and group leaders.

Key changes include:

**EuroSciVoc Integration and Fetching:**

* Added a new Artisan command `get-euroscivoc` (`GetEuroSciVoc.php`) to download, parse, and store the EuroSciVoc RDF as hierarchical JSON, including cache invalidation and error handling.
* Introduced a configuration file `euroscivoc.php` for EuroSciVoc download URL, scheme URI, and scheme name.
* Added a migration to insert EuroSciVoc into the `thesaurus_settings` table, enabling admin/group leader control.

**API and Controller Enhancements:**

* Added a new API endpoint in `VocabularyController` to serve the EuroSciVoc vocabulary, with activation checks and caching.
* Updated `DocsController` to document EuroSciVoc presence and activation in the API and UI, including feature flags. [[1]](diffhunk://#diff-48f945261010b557b702c1efbcff6fad3e9d0ee2ac7c192c5ee3eb3de5d492d4L60-R70) [[2]](diffhunk://#diff-48f945261010b557b702c1efbcff6fad3e9d0ee2ac7c192c5ee3eb3de5d492d4R99-R107) [[3]](diffhunk://#diff-48f945261010b557b702c1efbcff6fad3e9d0ee2ac7c192c5ee3eb3de5d492d4R120-R128)

**Model and Enum Support:**

* Extended `ThesaurusSetting` and related methods to support the EuroSciVoc type, file path, command, cache key, and valid types. [[1]](diffhunk://#diff-d5a426b750ea0f8bec8dd6b78dab7141d534c2561dc176104e75c8063903147cR38-R39) [[2]](diffhunk://#diff-d5a426b750ea0f8bec8dd6b78dab7141d534c2561dc176104e75c8063903147cR63) [[3]](diffhunk://#diff-d5a426b750ea0f8bec8dd6b78dab7141d534c2561dc176104e75c8063903147cR80) [[4]](diffhunk://#diff-d5a426b750ea0f8bec8dd6b78dab7141d534c2561dc176104e75c8063903147cR113) [[5]](diffhunk://#diff-d5a426b750ea0f8bec8dd6b78dab7141d534c2561dc176104e75c8063903147cR144)
* Added `EUROSCIVOC` to the `CacheKey` enum, including TTL, tags, and vocabulary key listings. [[1]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfR32) [[2]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfL103-R105) [[3]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfL158-R161) [[4]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfR227)

**Caching and Remote Status:**

* Implemented a caching method for EuroSciVoc in `VocabularyCacheService`.
* Added remote concept count retrieval for EuroSciVoc using the EU Publications Office SPARQL endpoint, with error handling and caching. [[1]](diffhunk://#diff-1fbc303eca865efdfdbd2acf5f720c351611e7efaf689aa8b097ebd5a9a9423bR102-R105) [[2]](diffhunk://#diff-1fbc303eca865efdfdbd2acf5f720c351611e7efaf689aa8b097ebd5a9a9423bR232-R286)

**Documentation and Changelog:**

* Updated the changelog to announce EuroSciVoc as a new integrated vocabulary, describing its source, structure, and availability in the UI and API.

These changes collectively enable robust support for EuroSciVoc, making it manageable, discoverable, and consumable throughout the application.