### PR TITLE
Fix: GEMET thesaurus not loading all concepts and wrong error message

### DIFF
--- a/app/Services/GemetApiService.php
+++ b/app/Services/GemetApiService.php
@@ -128,6 +128,11 @@ class GemetApiService
                 $firstParent = array_is_list($data) ? $data[0] : $data;
                 $parentUri = $firstParent['uri'] ?? null;
                 if (is_string($parentUri) && $parentUri !== '') {
+                    // The GEMET API returns broader relations with the group/
+                    // URI prefix even when the target is a SuperGroup.
+                    // Normalize to the supergroup/ namespace so the hierarchy
+                    // builder can match Groups to their parent SuperGroups.
+                    $parentUri = $this->normalizeSuperGroupUri($parentUri);
                     $mapping[$group['uri']] = $parentUri;
                 }
             }
@@ -345,5 +350,22 @@ class GemetApiService
         }
 
         return $entities;
+    }
+
+    /**
+     * Normalize a group/ URI to a supergroup/ URI.
+     *
+     * The GEMET REST API returns broader relations with the group/ namespace
+     * even when the referenced entity is actually a SuperGroup. This method
+     * replaces the group/ prefix with supergroup/ so the URIs can be matched
+     * against the SuperGroup URIs returned by getTopmostConcepts.
+     */
+    private function normalizeSuperGroupUri(string $uri): string
+    {
+        if (str_starts_with($uri, self::GROUP_URI)) {
+            return self::SUPERGROUP_URI.substr($uri, strlen(self::GROUP_URI));
+        }
+
+        return $uri;
     }
 }

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -116,6 +116,14 @@
         ],
         "fixes": [
             {
+                "title": "GEMET Thesaurus Loading Only 4 Concepts",
+                "description": "Fixed a bug where the GEMET thesaurus import loaded only 4 top-level concepts instead of the full ~5,669 entries. The root cause was a URI prefix mismatch: the GEMET API returns broader relations with a 'group/' prefix, but SuperGroups use a 'supergroup/' prefix with the same numeric IDs. The hierarchy builder could not match groups to their parent supergroups, resulting in empty child arrays. A URI normalization step now converts 'group/' prefixes to 'supergroup/' in the group-to-supergroup mapping."
+            },
+            {
+                "title": "Thesaurus Update Message Showing Wrong Name",
+                "description": "Fixed a bug where the thesaurus settings page displayed 'NASA/GCMD' as the vocabulary name in update check messages for all thesauri, including GEMET. The message now dynamically uses each thesaurus's actual display name."
+            },
+            {
                 "title": "XML Import Data Loss Prevention",
                 "description": "Fixed multiple data loss issues during XML/JSON/JSON-LD upload via the Dashboard. Per-title and per-description xml:lang attributes are now extracted and preserved through the full import-edit-save cycle. Coverage datetime values retain seconds precision and timezone offsets (e.g. +02:00) instead of silently dropping them. Datetimes without an explicit timezone designator are no longer interpreted using the server default timezone. The draft save path now also preserves language metadata. The editor load/transform layer includes language fields so subsequent saves round-trip the values correctly."
             },

--- a/resources/js/components/settings/thesaurus-card.tsx
+++ b/resources/js/components/settings/thesaurus-card.tsx
@@ -423,7 +423,7 @@ function ThesaurusRow({ thesaurus, onActiveChange, onElmoActiveChange, onUpdateC
                                 <>
                                     <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
                                     <span>
-                                        ERNIE contains {updateInfo.localCount.toLocaleString()} concepts, but NASA/GCMD contains{' '}
+                                        ERNIE contains {updateInfo.localCount.toLocaleString()} concepts, but {thesaurus.displayName} contains{' '}
                                         {updateInfo.remoteCount.toLocaleString()} concepts. Would you like to update the thesaurus?
                                     </span>
                                 </>

--- a/tests/pest/Feature/Commands/GetGemetThesaurusCommandTest.php
+++ b/tests/pest/Feature/Commands/GetGemetThesaurusCommandTest.php
@@ -29,7 +29,10 @@ function fakeGemetApiResponses(): void
     ];
 
     $broaderConcept = [
-            'uri' => 'http://www.eionet.europa.eu/gemet/supergroup/1234',
+            // The real GEMET API returns broader relations with the group/ prefix
+            // even when referencing a SuperGroup. The GemetApiService normalizes
+            // this to supergroup/ automatically.
+            'uri' => 'http://www.eionet.europa.eu/gemet/group/1234',
             'preferredLabel' => ['string' => 'THE ENVIRONMENT, MAN AND NATURE', 'language' => 'en'],
         ];
 

--- a/tests/pest/Feature/Services/ThesaurusStatusServiceTest.php
+++ b/tests/pest/Feature/Services/ThesaurusStatusServiceTest.php
@@ -611,3 +611,150 @@ describe('compareWithRemote', function () {
         expect($result['lastUpdated'])->toBeNull();
     });
 });
+
+describe('GEMET thesaurus', function () {
+    test('getLocalStatus returns correct count for GEMET hierarchy', function () {
+        $gemetData = [
+            'lastUpdated' => '2026-04-16T00:00:00+00:00',
+            'data' => [
+                [
+                    'text' => 'SuperGroup1',
+                    'children' => [
+                        [
+                            'text' => 'Group1',
+                            'children' => [
+                                ['text' => 'Concept1', 'children' => []],
+                                ['text' => 'Concept2', 'children' => []],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        Storage::put('gemet-thesaurus.json', json_encode($gemetData));
+
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_GEMET],
+            [
+                'display_name' => 'GEMET',
+                'is_active' => true,
+                'is_elmo_active' => false,
+            ],
+        );
+
+        $service = new ThesaurusStatusService;
+        $status = $service->getLocalStatus($thesaurus);
+
+        // 1 supergroup + 1 group + 2 concepts = 4
+        expect($status['exists'])->toBeTrue()
+            ->and($status['conceptCount'])->toBe(4)
+            ->and($status['lastUpdated'])->toBe('2026-04-16T00:00:00+00:00');
+    });
+
+    test('getRemoteConceptCount returns count from GEMET API', function () {
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_GEMET],
+            [
+                'display_name' => 'GEMET',
+                'is_active' => true,
+                'is_elmo_active' => false,
+            ],
+        );
+
+        Http::fake(function (\Illuminate\Http\Client\Request $request) {
+            $url = $request->url();
+            $params = $request->data();
+            $thesaurusUri = $params['thesaurus_uri'] ?? '';
+
+            // SuperGroups
+            if (str_contains($url, 'getTopmostConcepts') && str_contains($thesaurusUri, 'supergroup')) {
+                return Http::response([
+                    ['uri' => 'http://gemet/supergroup/1', 'preferredLabel' => ['string' => 'SG1', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                    ['uri' => 'http://gemet/supergroup/2', 'preferredLabel' => ['string' => 'SG2', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                ], 200);
+            }
+
+            // Groups
+            if (str_contains($url, 'getTopmostConcepts') && str_contains($thesaurusUri, 'group')) {
+                return Http::response([
+                    ['uri' => 'http://gemet/group/10', 'preferredLabel' => ['string' => 'G1', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                    ['uri' => 'http://gemet/group/20', 'preferredLabel' => ['string' => 'G2', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                    ['uri' => 'http://gemet/group/30', 'preferredLabel' => ['string' => 'G3', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                ], 200);
+            }
+
+            // Concept counts per group (via pool)
+            if (str_contains($url, 'getRelatedConcepts')) {
+                return Http::response([
+                    ['uri' => 'http://gemet/concept/1', 'preferredLabel' => ['string' => 'C1', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                    ['uri' => 'http://gemet/concept/2', 'preferredLabel' => ['string' => 'C2', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                ], 200);
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new ThesaurusStatusService;
+        $count = $service->getRemoteConceptCount($thesaurus);
+
+        // 2 supergroups + 3 groups + (3 groups × 2 concepts each) = 11
+        expect($count)->toBe(11);
+    });
+
+    test('compareWithRemote detects GEMET update available', function () {
+        $gemetData = [
+            'lastUpdated' => '2026-01-01T00:00:00+00:00',
+            'data' => [
+                ['text' => 'SG1', 'children' => []],
+            ],
+        ];
+
+        Storage::put('gemet-thesaurus.json', json_encode($gemetData));
+
+        $thesaurus = ThesaurusSetting::updateOrCreate(
+            ['type' => ThesaurusSetting::TYPE_GEMET],
+            [
+                'display_name' => 'GEMET',
+                'is_active' => true,
+                'is_elmo_active' => false,
+            ],
+        );
+
+        Http::fake(function (\Illuminate\Http\Client\Request $request) {
+            $url = $request->url();
+            $params = $request->data();
+            $thesaurusUri = $params['thesaurus_uri'] ?? '';
+
+            if (str_contains($url, 'getTopmostConcepts') && str_contains($thesaurusUri, 'supergroup')) {
+                return Http::response([
+                    ['uri' => 'http://gemet/supergroup/1', 'preferredLabel' => ['string' => 'SG1', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                ], 200);
+            }
+
+            if (str_contains($url, 'getTopmostConcepts') && str_contains($thesaurusUri, 'group')) {
+                return Http::response([
+                    ['uri' => 'http://gemet/group/10', 'preferredLabel' => ['string' => 'G1', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                ], 200);
+            }
+
+            if (str_contains($url, 'getRelatedConcepts')) {
+                return Http::response([
+                    ['uri' => 'http://gemet/concept/1', 'preferredLabel' => ['string' => 'C1', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                    ['uri' => 'http://gemet/concept/2', 'preferredLabel' => ['string' => 'C2', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                    ['uri' => 'http://gemet/concept/3', 'preferredLabel' => ['string' => 'C3', 'language' => 'en'], 'definition' => ['string' => '', 'language' => 'en']],
+                ], 200);
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new ThesaurusStatusService;
+        $result = $service->compareWithRemote($thesaurus);
+
+        // Local: 1 node. Remote: 1 supergroup + 1 group + 3 concepts = 5
+        expect($result['updateAvailable'])->toBeTrue()
+            ->and($result['localCount'])->toBe(1)
+            ->and($result['remoteCount'])->toBe(5);
+    });
+});

--- a/tests/pest/Unit/Services/GemetApiServiceTest.php
+++ b/tests/pest/Unit/Services/GemetApiServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Services\GemetApiService;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 
 covers(GemetApiService::class);
@@ -62,5 +63,126 @@ describe('fetchGroups', function (): void {
 
         $service = new GemetApiService;
         $service->fetchGroups();
+    })->throws(RuntimeException::class);
+});
+
+describe('fetchGroupToSuperGroupMapping', function (): void {
+    test('normalizes group URI prefix to supergroup URI prefix', function (): void {
+        Http::fake(function (Request $request) {
+            if (str_contains($request->url(), 'getRelatedConcepts')) {
+                return Http::response([
+                    'uri' => 'http://www.eionet.europa.eu/gemet/group/1234',
+                    'preferredLabel' => ['string' => 'Parent', 'language' => 'en'],
+                ]);
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new GemetApiService;
+        $groups = [
+            ['uri' => 'http://www.eionet.europa.eu/gemet/group/5678', 'label' => 'Test', 'definition' => ''],
+        ];
+
+        $mapping = $service->fetchGroupToSuperGroupMapping($groups);
+
+        expect($mapping)->toHaveKey('http://www.eionet.europa.eu/gemet/group/5678')
+            ->and($mapping['http://www.eionet.europa.eu/gemet/group/5678'])
+            ->toBe('http://www.eionet.europa.eu/gemet/supergroup/1234');
+    });
+
+    test('preserves URIs already using supergroup prefix', function (): void {
+        Http::fake(function (Request $request) {
+            if (str_contains($request->url(), 'getRelatedConcepts')) {
+                return Http::response([
+                    'uri' => 'http://www.eionet.europa.eu/gemet/supergroup/1234',
+                    'preferredLabel' => ['string' => 'Parent', 'language' => 'en'],
+                ]);
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new GemetApiService;
+        $groups = [
+            ['uri' => 'http://www.eionet.europa.eu/gemet/group/5678', 'label' => 'Test', 'definition' => ''],
+        ];
+
+        $mapping = $service->fetchGroupToSuperGroupMapping($groups);
+
+        expect($mapping['http://www.eionet.europa.eu/gemet/group/5678'])
+            ->toBe('http://www.eionet.europa.eu/gemet/supergroup/1234');
+    });
+
+    test('maps multiple groups to their parent supergroups', function (): void {
+        Http::fake(function (Request $request) {
+            if (str_contains($request->url(), 'getRelatedConcepts')) {
+                $conceptUri = $request->data()['concept_uri'] ?? '';
+
+                return match ($conceptUri) {
+                    'http://www.eionet.europa.eu/gemet/group/100' => Http::response([
+                        'uri' => 'http://www.eionet.europa.eu/gemet/group/2894',
+                        'preferredLabel' => ['string' => 'Parent A', 'language' => 'en'],
+                    ]),
+                    'http://www.eionet.europa.eu/gemet/group/200' => Http::response([
+                        'uri' => 'http://www.eionet.europa.eu/gemet/group/4044',
+                        'preferredLabel' => ['string' => 'Parent B', 'language' => 'en'],
+                    ]),
+                    default => Http::response([], 404),
+                };
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new GemetApiService;
+        $groups = [
+            ['uri' => 'http://www.eionet.europa.eu/gemet/group/100', 'label' => 'G1', 'definition' => ''],
+            ['uri' => 'http://www.eionet.europa.eu/gemet/group/200', 'label' => 'G2', 'definition' => ''],
+        ];
+
+        $mapping = $service->fetchGroupToSuperGroupMapping($groups);
+
+        expect($mapping)->toHaveCount(2)
+            ->and($mapping['http://www.eionet.europa.eu/gemet/group/100'])
+            ->toBe('http://www.eionet.europa.eu/gemet/supergroup/2894')
+            ->and($mapping['http://www.eionet.europa.eu/gemet/group/200'])
+            ->toBe('http://www.eionet.europa.eu/gemet/supergroup/4044');
+    });
+
+    test('handles empty broader response gracefully', function (): void {
+        Http::fake(function (Request $request) {
+            if (str_contains($request->url(), 'getRelatedConcepts')) {
+                return Http::response([], 200);
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new GemetApiService;
+        $groups = [
+            ['uri' => 'http://www.eionet.europa.eu/gemet/group/5678', 'label' => 'Test', 'definition' => ''],
+        ];
+
+        $mapping = $service->fetchGroupToSuperGroupMapping($groups);
+
+        expect($mapping)->toBeEmpty();
+    });
+
+    test('throws on API failure', function (): void {
+        Http::fake(function (Request $request) {
+            if (str_contains($request->url(), 'getRelatedConcepts')) {
+                return Http::response(null, 500);
+            }
+
+            return Http::response([], 404);
+        });
+
+        $service = new GemetApiService;
+        $groups = [
+            ['uri' => 'http://www.eionet.europa.eu/gemet/group/5678', 'label' => 'Test', 'definition' => ''],
+        ];
+
+        $service->fetchGroupToSuperGroupMapping($groups);
     })->throws(RuntimeException::class);
 });

--- a/tests/vitest/components/settings/thesaurus-card.test.tsx
+++ b/tests/vitest/components/settings/thesaurus-card.test.tsx
@@ -447,6 +447,88 @@ describe('ThesaurusCard', () => {
             // Wait for the error
             expect(await screen.findByText(/Connection failed/i)).toBeInTheDocument();
         });
+
+        it('should display thesaurus display name instead of hardcoded NASA/GCMD in update message', async () => {
+            const user = userEvent.setup();
+            const gemetThesauri: ThesaurusData[] = [
+                {
+                    type: 'gemet',
+                    displayName: 'GEMET',
+                    isActive: true,
+                    isElmoActive: false,
+                    exists: true,
+                    conceptCount: 4,
+                    lastUpdated: '2026-04-16T00:00:00Z',
+                },
+            ];
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        localCount: 4,
+                        remoteCount: 5669,
+                        updateAvailable: true,
+                        lastUpdated: '2026-04-16T00:00:00Z',
+                    }),
+            });
+
+            render(
+                <ThesaurusCard
+                    thesauri={gemetThesauri}
+                    onActiveChange={mockOnActiveChange}
+                    onElmoActiveChange={mockOnElmoActiveChange}
+                />,
+            );
+
+            const checkButton = screen.getByRole('button', { name: /check for updates/i });
+            await user.click(checkButton);
+
+            const updateMessage = await screen.findByText(/GEMET contains/);
+            expect(updateMessage).toBeInTheDocument();
+            expect(updateMessage.textContent).toContain('GEMET contains');
+            expect(updateMessage.textContent).not.toContain('NASA/GCMD');
+        });
+
+        it('should display correct display name for each thesaurus type in update message', async () => {
+            const user = userEvent.setup();
+            const scienceThesauri: ThesaurusData[] = [
+                {
+                    type: 'science_keywords',
+                    displayName: 'Science Keywords',
+                    isActive: true,
+                    isElmoActive: true,
+                    exists: true,
+                    conceptCount: 2500,
+                    lastUpdated: '2024-01-15T10:30:00Z',
+                },
+            ];
+
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        localCount: 2500,
+                        remoteCount: 2600,
+                        updateAvailable: true,
+                        lastUpdated: '2024-01-15T10:30:00Z',
+                    }),
+            });
+
+            render(
+                <ThesaurusCard
+                    thesauri={scienceThesauri}
+                    onActiveChange={mockOnActiveChange}
+                    onElmoActiveChange={mockOnElmoActiveChange}
+                />,
+            );
+
+            const checkButton = screen.getByRole('button', { name: /check for updates/i });
+            await user.click(checkButton);
+
+            const updateMessage = await screen.findByText(/Science Keywords contains/);
+            expect(updateMessage).toBeInTheDocument();
+        });
     });
 
     describe('Empty state', () => {


### PR DESCRIPTION
This pull request addresses two main issues: a critical bug in the GEMET thesaurus import logic and a user interface bug in the thesaurus update messaging. The GEMET fix ensures the correct loading of all ~5,669 top-level concepts by normalizing URI prefixes so group-to-supergroup relationships are correctly recognized. The UI fix makes sure the update message displays the actual thesaurus name instead of a hardcoded value. Comprehensive tests have been added for both the backend normalization logic and the frontend display behavior.

**GEMET Thesaurus Import and Hierarchy Fixes:**

- Added normalization of `group/` URIs to `supergroup/` URIs in `GemetApiService`, ensuring the hierarchy builder correctly matches groups to their parent supergroups and loads all concepts as expected. [[1]](diffhunk://#diff-287f8546824f0314d426f7d0027aa551f476ee3d4c8990ddcece56307a82afbdR131-R135) [[2]](diffhunk://#diff-287f8546824f0314d426f7d0027aa551f476ee3d4c8990ddcece56307a82afbdR354-R370)
- Updated tests and test data to reflect the real GEMET API behavior, validating that group-to-supergroup mapping works as intended, including edge cases and error handling. [[1]](diffhunk://#diff-f3bd9053ad9c794e9d6f9db9649b0a38a8e87b15dd793da2dfa53ef860d1033bL32-R35) [[2]](diffhunk://#diff-4c577a1a265ae4431b788dd934fe5ce7bd449ff738735344f98eb0ef60bbec47R68-R188)
- Added new tests for GEMET hierarchy and remote concept counting in `ThesaurusStatusServiceTest`, verifying that local and remote counts are accurate and that update detection works.

**User Interface and Messaging:**

- Fixed the thesaurus update message in `thesaurus-card.tsx` to display the actual thesaurus display name instead of the hardcoded 'NASA/GCMD'.
- Added frontend tests to verify that the correct thesaurus name is shown for each type in update messages.

**Documentation and Changelog:**

- Updated the changelog to document the GEMET import fix and the update message correction.