### PR TITLE
Fix: EuroSciVoc thesaurus updates not working

### DIFF
--- a/app/Jobs/UpdateThesaurusJob.php
+++ b/app/Jobs/UpdateThesaurusJob.php
@@ -166,6 +166,7 @@ class UpdateThesaurusJob implements ShouldQueue
         return match ($this->thesaurusType) {
             ThesaurusSetting::TYPE_CHRONOSTRAT, ThesaurusSetting::TYPE_ANALYTICAL_METHODS => 'Fetching data from ARDC Linked Data API...',
             ThesaurusSetting::TYPE_GEMET => 'Fetching data from GEMET REST API...',
+            ThesaurusSetting::TYPE_EUROSCIVOC => 'Fetching data from EU Publications Office SPARQL endpoint...',
             default => 'Fetching data from NASA KMS API...',
         };
     }
@@ -182,6 +183,7 @@ class UpdateThesaurusJob implements ShouldQueue
             ThesaurusSetting::TYPE_CHRONOSTRAT => 'get-chronostrat-timescale',
             ThesaurusSetting::TYPE_GEMET => 'get-gemet-thesaurus',
             ThesaurusSetting::TYPE_ANALYTICAL_METHODS => 'get-analytical-methods',
+            ThesaurusSetting::TYPE_EUROSCIVOC => 'get-euroscivoc',
             default => throw new \InvalidArgumentException("Unknown thesaurus type: {$this->thesaurusType}"),
         };
     }

--- a/app/Jobs/UpdateThesaurusJob.php
+++ b/app/Jobs/UpdateThesaurusJob.php
@@ -173,19 +173,13 @@ class UpdateThesaurusJob implements ShouldQueue
 
     /**
      * Get the artisan command for this thesaurus type.
+     *
+     * Delegates to {@see ThesaurusSetting::getArtisanCommand()} to maintain
+     * a single source of truth for the type→command mapping.
      */
     private function getArtisanCommand(): string
     {
-        return match ($this->thesaurusType) {
-            ThesaurusSetting::TYPE_SCIENCE_KEYWORDS => 'get-gcmd-science-keywords',
-            ThesaurusSetting::TYPE_PLATFORMS => 'get-gcmd-platforms',
-            ThesaurusSetting::TYPE_INSTRUMENTS => 'get-gcmd-instruments',
-            ThesaurusSetting::TYPE_CHRONOSTRAT => 'get-chronostrat-timescale',
-            ThesaurusSetting::TYPE_GEMET => 'get-gemet-thesaurus',
-            ThesaurusSetting::TYPE_ANALYTICAL_METHODS => 'get-analytical-methods',
-            ThesaurusSetting::TYPE_EUROSCIVOC => 'get-euroscivoc',
-            default => throw new \InvalidArgumentException("Unknown thesaurus type: {$this->thesaurusType}"),
-        };
+        return (new ThesaurusSetting(['type' => $this->thesaurusType]))->getArtisanCommand();
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -6734,23 +6734,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "d870a33f0f79d2b4579740b0620200221ee44aeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/d870a33f0f79d2b4579740b0620200221ee44aeb",
+                "reference": "d870a33f0f79d2b4579740b0620200221ee44aeb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -6780,7 +6780,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.0"
             },
             "funding": [
                 {
@@ -6804,7 +6804,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-16T23:10:39+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -10301,11 +10301,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.48",
+            "version": "2.1.49",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/231397213efb7c0a066ee024b5c3c87f2d3adfa0",
-                "reference": "231397213efb7c0a066ee024b5c3c87f2d3adfa0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d0082955396e7f5ba19cf298224b85e1099f0ed8",
+                "reference": "d0082955396e7f5ba19cf298224b85e1099f0ed8",
                 "shasum": ""
             },
             "require": {
@@ -10350,7 +10350,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-15T20:24:19+00:00"
+            "time": "2026-04-16T21:10:58+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/database/seeders/ThesaurusSettingSeeder.php
+++ b/database/seeders/ThesaurusSettingSeeder.php
@@ -36,6 +36,10 @@ class ThesaurusSettingSeeder extends Seeder
                 'type' => ThesaurusSetting::TYPE_ANALYTICAL_METHODS,
                 'display_name' => 'Analytical Methods for Geochemistry',
             ],
+            [
+                'type' => ThesaurusSetting::TYPE_EUROSCIVOC,
+                'display_name' => 'European Science Vocabulary (EuroSciVoc)',
+            ],
         ];
 
         foreach ($thesauri as $thesaurus) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,10 +1129,377 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.126.0.tgz",
+      "integrity": "sha512-svyoHt25J4741QJ5aa4R+h0iiBeSRt63Lr3aAZcxy2c/NeSE1IfDeMnSij6rIg7EjxkdlXzz613wUjeCeilBNA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.126.0.tgz",
+      "integrity": "sha512-hPEBRKgplp1mG9GkINFsr4JVMDNrGJLOqfDaadTWpAoTnzYR5Rmv8RMvB3hJZpiNvbk1aacopdHUP1pggMQ/cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.126.0.tgz",
+      "integrity": "sha512-ccRpu9sdYmznePJQG5halhs0FW5tw5a8zRSoZXOzM1OjoeZ4jiRRruFiPclsD59edoVAK1l83dvfjWz1nQi6lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.126.0.tgz",
+      "integrity": "sha512-CHB4zVjNSKqx8Fw9pHowzQQnjjuq04i4Ng0Avj+DixlwhwAoMYqlFbocYIlbg+q3zOLGlm7vEHm83jqEMitnyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.126.0.tgz",
+      "integrity": "sha512-RQ3nEJdcDKBfBjmLJ3Vl1d0KQERPV1P8eUrnBm7+VTYyoaJSPLVFuPg1mlD1hk3n0/879VLFMfusFkBal4ssWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.126.0.tgz",
+      "integrity": "sha512-onipc2wCDA7Bauzb4KK1mab0GsEDf4ujiIfWECdnmY/2LlzAoX3xdQRLAUyEDB1kn3yilHBrkmXDdHluyHXxiw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.126.0.tgz",
+      "integrity": "sha512-5BuJJPohrV5NJ8lmcYOMbfRCUGoYH5J9HZHeuqOLwkHXWAuPMN3X1h8bC/2mWjmosdbfTtmyIdX3spS/TkqKNg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.126.0.tgz",
+      "integrity": "sha512-r2KApRgm2pOJaduRm6GOT8x0whcr67AyejNkSdzPt34GJ+Y3axcXN2mwlTs+8lfO/SSmpO5ZJGYiHYnxEE0jkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.126.0.tgz",
+      "integrity": "sha512-FQ+MMh7MT0Dr/u8+RWmWKlfoeWPQyHDbhhxJShJlYtROXXPHsRs9EvmQOZZ3sx4Nn7JU8NX+oyw2YzQ7anBJcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.126.0.tgz",
+      "integrity": "sha512-Wv/T8C98hRQhGTlx2XFyLn5raRMp9U1lOQD+YnXNgAr7wHbJJpZ8mDBU7Rw+M3WytGcGTFcr6kqgfyQeHVtLbQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.126.0.tgz",
+      "integrity": "sha512-DHx1rT1zauW0ZbLHOiQh5AC9Xs3UkWx2XmfZHs+7nnWYr3sagrufoUQC+/XPwwjMIlCFXiFGM0sFh3TyOCZwqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.126.0.tgz",
+      "integrity": "sha512-umDc2mTShH0U2zcEYf8mIJ163seLJNn54ZUZYeI5jD4qlg9izPwoLrC2aNPKlMJTu6u/ysmQWiEvIiaAG+INkw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.126.0.tgz",
+      "integrity": "sha512-PXXeWayclRtO1pxQEeCpiqIglQdhK2mAI2VX5xnsWdImzSB5GpoQ8TNw7vTCKk2k+GZuxl+q1knncidjCyUP9w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.126.0.tgz",
+      "integrity": "sha512-wzocjxm34TbB3bFlqG65JiLtvf6ZDg2ZxRkLLbgXwDQUNU+0MPjQN8zy/0jBKNA5fnPLk3XeVdZ7Uin+7+CVkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.126.0.tgz",
+      "integrity": "sha512-e83uftP60jmkPs2+CW6T6A1GYzN2H6IumDAiTntv9WyHR73PI3ImHNBkYqnA3ukeKI3xjcCbhSh9QeJWmufxGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.126.0.tgz",
+      "integrity": "sha512-4WiOILHnPrTDY2/L4mE6PZCYwLN1d3ghma6BuTJ452CCgzRMt3uFplCtR+o3r9zdUWJYb370UizpI9CUcWXr1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.126.0.tgz",
+      "integrity": "sha512-Y17hhnrQTrxgAxAyAq401vnN9URsAL4s5AjqpG1NDsXSlhe1yBNnns+rC2P6xcMoitgX5nKH2ryYt9oiFRlzLw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.126.0.tgz",
+      "integrity": "sha512-Znug1u1iRvT4VC3jANz6nhGBHsFwEFMxuimYpJFwMtsB6H5FcEoZRMmH26tHkSTD03JvDmG+gB65W3ajLjPcSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.126.0.tgz",
+      "integrity": "sha512-qrw7mx5hFFTxVSXToOA40hpnjgNB/DJprZchtB4rDKNLKqkD3F26HbzaQeH1nxAKej0efSZfJd5Sw3qdtOLGhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.126.0.tgz",
+      "integrity": "sha512-ibB1s+mPUFXvS7MFJO2jpw/aCNs/P6ifnWlRyTYB+WYBpniOiCcHQQskZneJtwcjQMDRol3RGG3ihoYnzXSY4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -5901,28 +6268,29 @@
       }
     },
     "node_modules/@vitejs/devtools": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools/-/devtools-0.1.13.tgz",
-      "integrity": "sha512-0PWKOrYyDiP+UFI0Sfqn3uTxRwQMnvFyA6t4vnj+0SpCEk+XNEP2igqjCp7/F9wU0JDH3SiWhfMe41za9BtwkA==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools/-/devtools-0.1.14.tgz",
+      "integrity": "sha512-WBpd8R5brzxSWKYsIfPtYxpjBxNhoCUgzk/OhCjPW2XC+MBLOzOXg4rHWY0OSXEw9w2XHtF3eTTgoc/Mcg+IHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitejs/devtools-kit": "0.1.13",
-        "@vitejs/devtools-rolldown": "0.1.13",
-        "@vitejs/devtools-rpc": "0.1.13",
+        "@vitejs/devtools-kit": "0.1.14",
+        "@vitejs/devtools-rolldown": "0.1.14",
+        "@vitejs/devtools-rpc": "0.1.14",
         "birpc": "^4.0.0",
         "cac": "^7.0.0",
         "h3": "^1.15.11",
         "immer": "^11.1.4",
         "launch-editor": "^2.13.2",
+        "logs-sdk": "^0.0.6",
         "mlly": "^1.8.2",
         "obug": "^2.1.1",
         "open": "^11.0.0",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.1.0",
         "sirv": "^3.0.2",
-        "tinyexec": "^1.0.4",
-        "vue": "^3.5.31",
+        "tinyexec": "^1.1.1",
+        "vue": "^3.5.32",
         "ws": "^8.20.0"
       },
       "bin": {
@@ -5933,13 +6301,13 @@
       }
     },
     "node_modules/@vitejs/devtools-kit": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.1.13.tgz",
-      "integrity": "sha512-8TqyrrPTB8KNGb2ukVHNo4aMhGYJgUypVNMnqOvxaWYln3QAXK6CFxifK3lZGOHWKAUqWAiTmZUsYzV4S0Kn7g==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.1.14.tgz",
+      "integrity": "sha512-XvDzZaBigEO2c4EdT9hVRYKqEWU4zW37ao2DmD2W69/nrp+pwVdRNE/tu8fXKnvhCQtoqkI5g3H3Df1VYCUTfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitejs/devtools-rpc": "0.1.13",
+        "@vitejs/devtools-rpc": "0.1.14",
         "birpc": "^4.0.0",
         "ohash": "^2.0.11"
       },
@@ -5948,24 +6316,25 @@
       }
     },
     "node_modules/@vitejs/devtools-rolldown": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rolldown/-/devtools-rolldown-0.1.13.tgz",
-      "integrity": "sha512-VScSr/0+1+s3TBt5RFhv1dcRJSjWDUH3yJ8nc9+8zTOijzuKTjVo5yqfx0ISBro9CCeoPyXHuXntPqBSIhTTCA==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rolldown/-/devtools-rolldown-0.1.14.tgz",
+      "integrity": "sha512-xhuLAhmDmzHCdbmYvn1rTlV1fe7hvaDHN3kp1CtKCiSM86QsDE8pBFCbcGpZeawqZgQ8MtkmUGJm09uCqaqCGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@pnpm/read-project-manifest": "^1001.2.6",
-        "@rolldown/debug": "^1.0.0-rc.13",
-        "@vitejs/devtools-kit": "0.1.13",
-        "@vitejs/devtools-rpc": "0.1.13",
+        "@rolldown/debug": "^1.0.0-rc.15",
+        "@vitejs/devtools-kit": "0.1.14",
+        "@vitejs/devtools-rpc": "0.1.14",
         "ansis": "^4.2.0",
         "birpc": "^4.0.0",
         "cac": "^7.0.0",
         "d3-shape": "^3.2.0",
-        "diff": "^8.0.4",
+        "diff": "^9.0.0",
         "get-port-please": "^3.2.0",
         "h3": "^1.15.11",
+        "logs-sdk": "^0.0.6",
         "mlly": "^1.8.2",
         "mrmime": "^2.0.1",
         "ohash": "^2.0.11",
@@ -5975,33 +6344,27 @@
         "sirv": "^3.0.2",
         "split2": "^4.2.0",
         "structured-clone-es": "^2.0.0",
-        "tinyglobby": "^0.2.15",
+        "tinyglobby": "^0.2.16",
         "unconfig": "^7.5.0",
         "unstorage": "^1.17.5",
-        "vue-virtual-scroller": "^2.0.0",
+        "vue-virtual-scroller": "^2.0.1",
         "ws": "^8.20.0"
       }
     },
     "node_modules/@vitejs/devtools-rpc": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rpc/-/devtools-rpc-0.1.13.tgz",
-      "integrity": "sha512-IbYRlvVJMdlQiRPU5fDnIAwgTu43O7v5/a1cUFp8t77zXLvg+3g2hbqrYzoqxIgAyLTr2KMY7HoYm6j/kIMB6Q==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rpc/-/devtools-rpc-0.1.14.tgz",
+      "integrity": "sha512-xRxH/tmIXN/IegUebu53pkLb4rA87qwiBkgx7dtj2BmtzLXg88EiG/VtW5PThJh0AcvU6B8vCT/9+2QRQMKmzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "birpc": "^4.0.0",
+        "logs-sdk": "^0.0.6",
         "ohash": "^2.0.11",
         "p-limit": "^7.3.0",
         "structured-clone-es": "^2.0.0",
-        "valibot": "^1.3.1"
-      },
-      "peerDependencies": {
-        "ws": "*"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        }
+        "valibot": "^1.3.1",
+        "ws": "^8.20.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -7963,9 +8326,9 @@
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -8411,9 +8774,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0.tgz",
+      "integrity": "sha512-LDicyhrRFrIaheDYryeM2W8gWyZXnAs4zIr2WVPiOSeTmIu2RjR4x/9N0xLaRWZ+9hssBDGo3AadcohuzAvSvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8427,7 +8790,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/balanced-match": {
@@ -10582,6 +10945,18 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/logs-sdk": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/logs-sdk/-/logs-sdk-0.0.6.tgz",
+      "integrity": "sha512-G4M1C9aLLBOIWpmw/Lqk4zrap/T2IJsoUOuUDjRcVSLy6lHQqxr3wCqIT1FvvpYTUYpEwvu4utsMY42jTNvx8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "oxc-parser": "^0.126.0",
+        "unplugin": "^3.0.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -11252,6 +11627,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.126.0.tgz",
+      "integrity": "sha512-FktCvLby/mOHyuijZt22+nOt10dS24gGUZE3XwIbUg7Kf4+rer3/5T7RgwzazlNuVsCjPloZ3p8E+4ONT3A8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.126.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.126.0",
+        "@oxc-parser/binding-android-arm64": "0.126.0",
+        "@oxc-parser/binding-darwin-arm64": "0.126.0",
+        "@oxc-parser/binding-darwin-x64": "0.126.0",
+        "@oxc-parser/binding-freebsd-x64": "0.126.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.126.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.126.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.126.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.126.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.126.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.126.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.126.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.126.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.126.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.126.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.126.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.126.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.126.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.126.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.126.0"
       }
     },
     "node_modules/p-limit": {
@@ -12569,6 +12982,15 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
@@ -13829,6 +14251,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unplugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/unraw": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
@@ -14391,6 +14828,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",

--- a/tests/pest/Feature/Jobs/UpdateThesaurusJobTest.php
+++ b/tests/pest/Feature/Jobs/UpdateThesaurusJobTest.php
@@ -22,6 +22,8 @@ describe('constructor validation', function () {
             ThesaurusSetting::TYPE_INSTRUMENTS,
             ThesaurusSetting::TYPE_CHRONOSTRAT,
             ThesaurusSetting::TYPE_GEMET,
+            ThesaurusSetting::TYPE_ANALYTICAL_METHODS,
+            ThesaurusSetting::TYPE_EUROSCIVOC,
         ];
 
         foreach ($validTypes as $type) {
@@ -183,6 +185,9 @@ describe('handle', function () {
             ThesaurusSetting::TYPE_PLATFORMS => 'get-gcmd-platforms',
             ThesaurusSetting::TYPE_INSTRUMENTS => 'get-gcmd-instruments',
             ThesaurusSetting::TYPE_CHRONOSTRAT => 'get-chronostrat-timescale',
+            ThesaurusSetting::TYPE_GEMET => 'get-gemet-thesaurus',
+            ThesaurusSetting::TYPE_ANALYTICAL_METHODS => 'get-analytical-methods',
+            ThesaurusSetting::TYPE_EUROSCIVOC => 'get-euroscivoc',
         ];
 
         foreach ($mapping as $type => $expectedCommand) {
@@ -197,6 +202,49 @@ describe('handle', function () {
             $job->handle();
         }
     });
+    it('maps EuroSciVoc type to correct artisan command', function () {
+        $uuid = (string) Str::uuid();
+        $cacheKey = UpdateThesaurusJob::getCacheKey($uuid);
+
+        Artisan::shouldReceive('call')
+            ->with('get-euroscivoc')
+            ->once()
+            ->andReturn(0);
+
+        Artisan::shouldReceive('output')->never();
+
+        $job = new UpdateThesaurusJob(ThesaurusSetting::TYPE_EUROSCIVOC, $uuid);
+        $job->handle();
+
+        $cached = Cache::get($cacheKey);
+
+        expect($cached)
+            ->toBeArray()
+            ->and($cached['status'])->toBe('completed')
+            ->and($cached['thesaurusType'])->toBe(ThesaurusSetting::TYPE_EUROSCIVOC);
+    });
+
+    it('uses EU Publications Office progress message for EuroSciVoc type', function () {
+        $uuid = (string) Str::uuid();
+        $cacheKey = UpdateThesaurusJob::getCacheKey($uuid);
+
+        Artisan::shouldReceive('call')
+            ->with('get-euroscivoc')
+            ->once()
+            ->andReturnUsing(function () use ($cacheKey) {
+                $cached = Cache::get($cacheKey);
+                expect($cached)
+                    ->toBeArray()
+                    ->and($cached['status'])->toBe('running')
+                    ->and($cached['progress'])->toBe('Fetching data from EU Publications Office SPARQL endpoint...');
+
+                return 0;
+            });
+
+        $job = new UpdateThesaurusJob(ThesaurusSetting::TYPE_EUROSCIVOC, $uuid);
+        $job->handle();
+    });
+
     it('uses ARDC progress message for chronostrat type', function () {
         $uuid = (string) Str::uuid();
         $cacheKey = UpdateThesaurusJob::getCacheKey($uuid);

--- a/tests/pest/Feature/Jobs/UpdateThesaurusJobTest.php
+++ b/tests/pest/Feature/Jobs/UpdateThesaurusJobTest.php
@@ -202,28 +202,6 @@ describe('handle', function () {
             $job->handle();
         }
     });
-    it('maps EuroSciVoc type to correct artisan command', function () {
-        $uuid = (string) Str::uuid();
-        $cacheKey = UpdateThesaurusJob::getCacheKey($uuid);
-
-        Artisan::shouldReceive('call')
-            ->with('get-euroscivoc')
-            ->once()
-            ->andReturn(0);
-
-        Artisan::shouldReceive('output')->never();
-
-        $job = new UpdateThesaurusJob(ThesaurusSetting::TYPE_EUROSCIVOC, $uuid);
-        $job->handle();
-
-        $cached = Cache::get($cacheKey);
-
-        expect($cached)
-            ->toBeArray()
-            ->and($cached['status'])->toBe('completed')
-            ->and($cached['thesaurusType'])->toBe(ThesaurusSetting::TYPE_EUROSCIVOC);
-    });
-
     it('uses EU Publications Office progress message for EuroSciVoc type', function () {
         $uuid = (string) Str::uuid();
         $cacheKey = UpdateThesaurusJob::getCacheKey($uuid);


### PR DESCRIPTION
This pull request adds support for the EuroSciVoc thesaurus type throughout the application. The main updates include registering the new type in the database seeders, handling it in the `UpdateThesaurusJob` logic, and expanding the test coverage to ensure correct behavior and messaging.

**Support for EuroSciVoc thesaurus type:**

* Added `ThesaurusSetting::TYPE_EUROSCIVOC` to the list of thesauri seeded by `ThesaurusSettingSeeder`, with a display name of "European Science Vocabulary (EuroSciVoc)".
* Updated `UpdateThesaurusJob` to return a specific progress message ("Fetching data from EU Publications Office SPARQL endpoint...") when handling the EuroSciVoc type.
* Refactored `UpdateThesaurusJob::getArtisanCommand()` to delegate to `ThesaurusSetting::getArtisanCommand()`, ensuring a single source of truth for type-to-command mapping and supporting the new EuroSciVoc type.

**Test coverage improvements:**

* Extended tests in `UpdateThesaurusJobTest.php` to include the EuroSciVoc type in the list of valid types and to verify the correct artisan command and progress message are used for this type. [[1]](diffhunk://#diff-e5bada44af86bcae1d64b7cf2ea3c199f5c16bf64fadad6587c498af99366730R25-R26) [[2]](diffhunk://#diff-e5bada44af86bcae1d64b7cf2ea3c199f5c16bf64fadad6587c498af99366730R188-R190) [[3]](diffhunk://#diff-e5bada44af86bcae1d64b7cf2ea3c199f5c16bf64fadad6587c498af99366730R205-R225)