### PR TITLE
Feature: Clickable ORCID and ROR suggestions

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -58,6 +58,10 @@
         ],
         "improvements": [
             {
+                "title": "Clickable ORCID and ROR Links in Assistance Suggestions",
+                "description": "Suggested ORCIDs and ROR-IDs on the Assistance page are now clickable links that open the corresponding profile on orcid.org or ror.org in a new browser tab. This allows curators to quickly verify a suggested identifier without manually navigating to the external service."
+            },
+            {
                 "title": "Editable Affiliation Names with ROR-ID Preservation",
                 "description": "Affiliation names in the Authors and Contributors sections can now be edited after selecting an entry from the ROR autocomplete. For example, after selecting 'GFZ Helmholtz Centre for Geosciences', the name can be changed to 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany' while the linked ROR identifier is preserved. Commas can be used freely during editing without splitting the tag."
             },

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -124,7 +124,15 @@ function OrcidSuggestionCard({
 
                     <div className="space-y-1">
                         <p className="font-mono text-sm">
-                            ORCID: {suggestion.suggested_orcid}
+                            ORCID:{' '}
+                            <a
+                                href={`https://orcid.org/${suggestion.suggested_orcid}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary underline hover:text-primary/80"
+                            >
+                                {suggestion.suggested_orcid}
+                            </a>
                         </p>
                         {candidateName && (
                             <p className="text-sm text-muted-foreground">
@@ -221,7 +229,15 @@ function RorSuggestionCard({
                             &rarr; {suggestion.suggested_name}
                         </p>
                         <p className="font-mono text-xs text-muted-foreground">
-                            ROR: {suggestion.suggested_ror_id}
+                            ROR:{' '}
+                            <a
+                                href={suggestion.suggested_ror_id}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary underline hover:text-primary/80"
+                            >
+                                {suggestion.suggested_ror_id}
+                            </a>
                         </p>
                         {suggestion.ror_aliases.length > 0 && (
                             <p className="text-xs text-muted-foreground">

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -39,6 +39,21 @@ function similarityColor(score: number): string {
     return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
 }
 
+const ORCID_ID_PATTERN = /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/;
+
+function isValidOrcidId(id: string): boolean {
+    return ORCID_ID_PATTERN.test(id);
+}
+
+function isValidRorUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url);
+        return parsed.protocol === 'https:' && parsed.hostname === 'ror.org';
+    } catch {
+        return false;
+    }
+}
+
 function SuggestionCard({
     suggestion,
     onAccept,
@@ -125,14 +140,18 @@ function OrcidSuggestionCard({
                     <div className="space-y-1">
                         <p className="font-mono text-sm">
                             ORCID:{' '}
-                            <a
-                                href={`https://orcid.org/${suggestion.suggested_orcid}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-primary underline hover:text-primary/80"
-                            >
-                                {suggestion.suggested_orcid}
-                            </a>
+                            {isValidOrcidId(suggestion.suggested_orcid) ? (
+                                <a
+                                    href={`https://orcid.org/${suggestion.suggested_orcid}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary underline hover:text-primary/80"
+                                >
+                                    {suggestion.suggested_orcid}
+                                </a>
+                            ) : (
+                                suggestion.suggested_orcid
+                            )}
                         </p>
                         {candidateName && (
                             <p className="text-sm text-muted-foreground">
@@ -230,14 +249,18 @@ function RorSuggestionCard({
                         </p>
                         <p className="font-mono text-xs text-muted-foreground">
                             ROR:{' '}
-                            <a
-                                href={suggestion.suggested_ror_id}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-primary underline hover:text-primary/80"
-                            >
-                                {suggestion.suggested_ror_id}
-                            </a>
+                            {isValidRorUrl(suggestion.suggested_ror_id) ? (
+                                <a
+                                    href={suggestion.suggested_ror_id}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary underline hover:text-primary/80"
+                                >
+                                    {suggestion.suggested_ror_id}
+                                </a>
+                            ) : (
+                                suggestion.suggested_ror_id
+                            )}
                         </p>
                         {suggestion.ror_aliases.length > 0 && (
                             <p className="text-xs text-muted-foreground">

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -4,6 +4,8 @@ import { AlertTriangle, Building2, Check, RefreshCw, User, X } from 'lucide-reac
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { validateORCID } from '@/utils/validation-rules';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -39,16 +41,16 @@ function similarityColor(score: number): string {
     return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
 }
 
-const ORCID_ID_PATTERN = /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$/;
+const ROR_ID_PATTERN = /^\/0[a-z0-9]{6}\d{2}$/;
 
 function isValidOrcidId(id: string): boolean {
-    return ORCID_ID_PATTERN.test(id);
+    return validateORCID(id).isValid;
 }
 
 function isValidRorUrl(url: string): boolean {
     try {
         const parsed = new URL(url);
-        return parsed.protocol === 'https:' && parsed.hostname === 'ror.org';
+        return parsed.protocol === 'https:' && parsed.hostname === 'ror.org' && ROR_ID_PATTERN.test(parsed.pathname);
     } catch {
         return false;
     }

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom/vitest';
-
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -122,7 +120,7 @@ describe('OrcidSuggestionCard – ORCID link', () => {
     });
 
     it('links to the correct orcid.org profile URL', () => {
-        const suggestion = makeOrcidSuggestion({ suggested_orcid: '0000-0002-9999-0001' });
+        const suggestion = makeOrcidSuggestion({ suggested_orcid: '0000-0002-9999-0002' });
 
         render(
             <AssistancePage
@@ -131,8 +129,8 @@ describe('OrcidSuggestionCard – ORCID link', () => {
             />,
         );
 
-        const link = screen.getByRole('link', { name: '0000-0002-9999-0001' });
-        expect(link).toHaveAttribute('href', 'https://orcid.org/0000-0002-9999-0001');
+        const link = screen.getByRole('link', { name: '0000-0002-9999-0002' });
+        expect(link).toHaveAttribute('href', 'https://orcid.org/0000-0002-9999-0002');
     });
 
     it('opens the ORCID profile in a new tab', () => {
@@ -166,7 +164,7 @@ describe('OrcidSuggestionCard – ORCID link', () => {
     });
 
     it('displays only the ORCID ID as link text (not the full URL)', () => {
-        const orcid = '0000-0003-1111-2222';
+        const orcid = '0000-0003-1111-222X';
         const suggestion = makeOrcidSuggestion({ suggested_orcid: orcid });
 
         render(
@@ -183,8 +181,8 @@ describe('OrcidSuggestionCard – ORCID link', () => {
 
     it('renders multiple ORCID suggestions with unique links', () => {
         const suggestions = [
-            makeOrcidSuggestion({ id: 1, suggested_orcid: '0000-0001-0000-0001' }),
-            makeOrcidSuggestion({ id: 2, suggested_orcid: '0000-0001-0000-0002', person_name: 'John Smith' }),
+            makeOrcidSuggestion({ id: 1, suggested_orcid: '0000-0001-0000-0009' }),
+            makeOrcidSuggestion({ id: 2, suggested_orcid: '0000-0002-0000-0006', person_name: 'John Smith' }),
         ];
 
         render(
@@ -194,11 +192,11 @@ describe('OrcidSuggestionCard – ORCID link', () => {
             />,
         );
 
-        const link1 = screen.getByRole('link', { name: '0000-0001-0000-0001' });
-        const link2 = screen.getByRole('link', { name: '0000-0001-0000-0002' });
+        const link1 = screen.getByRole('link', { name: '0000-0001-0000-0009' });
+        const link2 = screen.getByRole('link', { name: '0000-0002-0000-0006' });
 
-        expect(link1).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0001');
-        expect(link2).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0002');
+        expect(link1).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0009');
+        expect(link2).toHaveAttribute('href', 'https://orcid.org/0000-0002-0000-0006');
     });
 
     it('renders plain text instead of a link for a malformed ORCID ID', () => {
@@ -226,6 +224,21 @@ describe('OrcidSuggestionCard – ORCID link', () => {
         );
 
         expect(screen.queryByRole('link', { name: /script/ })).not.toBeInTheDocument();
+    });
+
+    it('renders plain text for an ORCID that matches the format but fails the checksum', () => {
+        // 0000-0001-2345-6780 has valid format but invalid checksum (correct would be 6789)
+        const suggestion = makeOrcidSuggestion({ suggested_orcid: '0000-0001-2345-6780' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: '0000-0001-2345-6780' })).not.toBeInTheDocument();
+        expect(screen.getByText(/0000-0001-2345-6780/)).toBeInTheDocument();
     });
 });
 
@@ -349,5 +362,19 @@ describe('RorSuggestionCard – ROR link', () => {
 
         expect(screen.queryByRole('link', { name: 'http://ror.org/04t3en479' })).not.toBeInTheDocument();
         expect(screen.getByText(/ror\.org/)).toBeInTheDocument();
+    });
+
+    it('renders plain text for a ror.org URL with a non-identifier path', () => {
+        const suggestion = makeRorSuggestion({ suggested_ror_id: 'https://ror.org/search' });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: 'https://ror.org/search' })).not.toBeInTheDocument();
+        expect(screen.getByText(/ror\.org\/search/)).toBeInTheDocument();
     });
 });

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -160,7 +160,9 @@ describe('OrcidSuggestionCard – ORCID link', () => {
         );
 
         const link = screen.getByRole('link', { name: '0000-0001-2345-6789' });
-        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        const rel = link.getAttribute('rel') ?? '';
+        expect(rel).toContain('noopener');
+        expect(rel).toContain('noreferrer');
     });
 
     it('displays only the ORCID ID as link text (not the full URL)', () => {
@@ -255,7 +257,9 @@ describe('RorSuggestionCard – ROR link', () => {
         );
 
         const link = screen.getByRole('link', { name: 'https://ror.org/04t3en479' });
-        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        const rel = link.getAttribute('rel') ?? '';
+        expect(rel).toContain('noopener');
+        expect(rel).toContain('noreferrer');
     });
 
     it('renders multiple ROR suggestions with unique links', () => {

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -200,6 +200,33 @@ describe('OrcidSuggestionCard – ORCID link', () => {
         expect(link1).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0001');
         expect(link2).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0002');
     });
+
+    it('renders plain text instead of a link for a malformed ORCID ID', () => {
+        const suggestion = makeOrcidSuggestion({ suggested_orcid: 'not-a-valid-orcid' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: 'not-a-valid-orcid' })).not.toBeInTheDocument();
+        expect(screen.getByText(/not-a-valid-orcid/)).toBeInTheDocument();
+    });
+
+    it('renders plain text instead of a link for an ORCID containing script injection', () => {
+        const suggestion = makeOrcidSuggestion({ suggested_orcid: '"><script>alert(1)</script>' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: /script/ })).not.toBeInTheDocument();
+    });
 });
 
 describe('RorSuggestionCard – ROR link', () => {
@@ -280,5 +307,47 @@ describe('RorSuggestionCard – ROR link', () => {
 
         expect(link1).toHaveAttribute('href', 'https://ror.org/04t3en479');
         expect(link2).toHaveAttribute('href', 'https://ror.org/02nr0ka47');
+    });
+
+    it('renders plain text instead of a link for a javascript: URL', () => {
+        const suggestion = makeRorSuggestion({ suggested_ror_id: 'javascript:alert(1)' });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: 'javascript:alert(1)' })).not.toBeInTheDocument();
+        expect(screen.getByText(/javascript:alert/)).toBeInTheDocument();
+    });
+
+    it('renders plain text instead of a link for a non-ror.org host', () => {
+        const suggestion = makeRorSuggestion({ suggested_ror_id: 'https://evil.com/04t3en479' });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: 'https://evil.com/04t3en479' })).not.toBeInTheDocument();
+        expect(screen.getByText(/evil\.com/)).toBeInTheDocument();
+    });
+
+    it('renders plain text instead of a link for an http (non-https) ROR URL', () => {
+        const suggestion = makeRorSuggestion({ suggested_ror_id: 'http://ror.org/04t3en479' });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        expect(screen.queryByRole('link', { name: 'http://ror.org/04t3en479' })).not.toBeInTheDocument();
+        expect(screen.getByText(/ror\.org/)).toBeInTheDocument();
     });
 });

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AssistancePageProps, PaginatedData, BaseSuggestionItem, SuggestedOrcidItem, SuggestedRorItem } from '@/types/assistance';
+import type { PaginatedData, BaseSuggestionItem, SuggestedOrcidItem, SuggestedRorItem } from '@/types/assistance';
 
 // ── Mocks ────────────────────────────────────────────────────────────
 

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -1,0 +1,280 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AssistancePageProps, PaginatedData, BaseSuggestionItem, SuggestedOrcidItem, SuggestedRorItem } from '@/types/assistance';
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    usePage: () => ({ props: {} }),
+    router: { reload: vi.fn(), get: vi.fn() },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+// ── Import component under test (after mocks) ───────────────────────
+
+// The card components are not exported individually, so we render the
+// full page with minimal props and assert on the rendered output.
+// We import the default export (AssistancePage).
+import AssistancePage from '@/pages/assistance';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+function makeOrcidSuggestion(overrides: Partial<SuggestedOrcidItem> = {}): SuggestedOrcidItem {
+    return {
+        id: 1,
+        resource_id: 10,
+        resource_doi: '10.5880/test.2024.001',
+        resource_title: 'Test Resource',
+        person_id: 100,
+        person_name: 'Jane Doe',
+        person_affiliations: ['GFZ Potsdam'],
+        source_context: 'creator',
+        suggested_orcid: '0000-0001-2345-6789',
+        similarity_score: 0.85,
+        candidate_first_name: 'Jane',
+        candidate_last_name: 'Doe',
+        candidate_affiliations: ['GFZ Helmholtz Centre Potsdam'],
+        discovered_at: '2024-06-15T10:00:00+00:00',
+        ...overrides,
+    };
+}
+
+function makeRorSuggestion(overrides: Partial<SuggestedRorItem> = {}): SuggestedRorItem {
+    return {
+        id: 2,
+        resource_id: 20,
+        resource_doi: '10.5880/test.2024.002',
+        resource_title: 'Another Resource',
+        entity_type: 'affiliation',
+        entity_id: 200,
+        entity_name: 'GFZ Potsdam',
+        suggested_ror_id: 'https://ror.org/04t3en479',
+        suggested_name: 'GFZ German Research Centre for Geosciences',
+        similarity_score: 0.92,
+        ror_aliases: ['GFZ Potsdam', 'Helmholtz-Zentrum Potsdam'],
+        existing_identifier: null,
+        existing_identifier_type: null,
+        discovered_at: '2024-06-15T10:00:00+00:00',
+        ...overrides,
+    };
+}
+
+function makeManifest(id: string, routePrefix: string, name: string) {
+    return {
+        id,
+        name,
+        description: `${name} description`,
+        icon: 'User',
+        version: '1.0.0',
+        routePrefix,
+        sortOrder: id === 'orcid-suggestion' ? 20 : id === 'ror-suggestion' ? 30 : 10,
+        statusLabels: {
+            checking: 'Starting...',
+            completed_with_results: '{count} found.',
+            completed_empty: 'No results.',
+            failed: 'Failed.',
+            already_running: 'Already running.',
+        },
+        emptyState: { title: 'No suggestions', description: 'Click Check to search.' },
+        cardComponent: null,
+    };
+}
+
+function paginated<T>(data: T[]): PaginatedData<BaseSuggestionItem> {
+    return {
+        data: data as unknown as BaseSuggestionItem[],
+        current_page: 1,
+        last_page: 1,
+        per_page: 25,
+        total: data.length,
+        from: data.length > 0 ? 1 : null,
+        to: data.length > 0 ? data.length : null,
+        links: [],
+    };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('OrcidSuggestionCard – ORCID link', () => {
+    it('renders the suggested ORCID as a clickable link', () => {
+        const suggestion = makeOrcidSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '0000-0001-2345-6789' });
+        expect(link).toBeInTheDocument();
+    });
+
+    it('links to the correct orcid.org profile URL', () => {
+        const suggestion = makeOrcidSuggestion({ suggested_orcid: '0000-0002-9999-0001' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '0000-0002-9999-0001' });
+        expect(link).toHaveAttribute('href', 'https://orcid.org/0000-0002-9999-0001');
+    });
+
+    it('opens the ORCID profile in a new tab', () => {
+        const suggestion = makeOrcidSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '0000-0001-2345-6789' });
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('includes noopener noreferrer for security', () => {
+        const suggestion = makeOrcidSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '0000-0001-2345-6789' });
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('displays only the ORCID ID as link text (not the full URL)', () => {
+        const orcid = '0000-0003-1111-2222';
+        const suggestion = makeOrcidSuggestion({ suggested_orcid: orcid });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: orcid });
+        expect(link).toHaveTextContent(orcid);
+        expect(link).not.toHaveTextContent('https://orcid.org/');
+    });
+
+    it('renders multiple ORCID suggestions with unique links', () => {
+        const suggestions = [
+            makeOrcidSuggestion({ id: 1, suggested_orcid: '0000-0001-0000-0001' }),
+            makeOrcidSuggestion({ id: 2, suggested_orcid: '0000-0001-0000-0002', person_name: 'John Smith' }),
+        ];
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated(suggestions) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link1 = screen.getByRole('link', { name: '0000-0001-0000-0001' });
+        const link2 = screen.getByRole('link', { name: '0000-0001-0000-0002' });
+
+        expect(link1).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0001');
+        expect(link2).toHaveAttribute('href', 'https://orcid.org/0000-0001-0000-0002');
+    });
+});
+
+describe('RorSuggestionCard – ROR link', () => {
+    it('renders the suggested ROR ID as a clickable link', () => {
+        const suggestion = makeRorSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: 'https://ror.org/04t3en479' });
+        expect(link).toBeInTheDocument();
+    });
+
+    it('links to the correct ROR profile URL', () => {
+        const rorId = 'https://ror.org/02nr0ka47';
+        const suggestion = makeRorSuggestion({ suggested_ror_id: rorId });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: rorId });
+        expect(link).toHaveAttribute('href', rorId);
+    });
+
+    it('opens the ROR profile in a new tab', () => {
+        const suggestion = makeRorSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: 'https://ror.org/04t3en479' });
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('includes noopener noreferrer for security', () => {
+        const suggestion = makeRorSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: 'https://ror.org/04t3en479' });
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('renders multiple ROR suggestions with unique links', () => {
+        const suggestions = [
+            makeRorSuggestion({ id: 1, suggested_ror_id: 'https://ror.org/04t3en479', entity_name: 'GFZ Potsdam' }),
+            makeRorSuggestion({ id: 2, suggested_ror_id: 'https://ror.org/02nr0ka47', entity_name: 'AWI Bremerhaven' }),
+        ];
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated(suggestions) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        const link1 = screen.getByRole('link', { name: 'https://ror.org/04t3en479' });
+        const link2 = screen.getByRole('link', { name: 'https://ror.org/02nr0ka47' });
+
+        expect(link1).toHaveAttribute('href', 'https://ror.org/04t3en479');
+        expect(link2).toHaveAttribute('href', 'https://ror.org/02nr0ka47');
+    });
+});


### PR DESCRIPTION
This pull request improves the Assistance Suggestions UI by making suggested ORCID and ROR identifiers clickable links, allowing curators to quickly verify suggested identifiers on orcid.org and ror.org. The implementation ensures that only valid, safe identifiers are rendered as links, and includes comprehensive automated tests to verify correct and secure behavior.

Enhancements to clickable links for suggested identifiers:

* Suggested ORCID IDs in the Assistance suggestions are now rendered as clickable links to the corresponding orcid.org profile, but only if the identifier is valid (including checksum validation). The links open in a new tab and use `noopener noreferrer` for security. Invalid or malformed ORCID IDs are displayed as plain text. (`resources/js/pages/assistance.tsx`, `@utils/validation-rules`) [[1]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceR7-R8) [[2]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL127-R156)
* Suggested ROR IDs are now rendered as clickable links to the corresponding ror.org profile, but only if the URL is HTTPS, the host is ror.org, and the path matches a valid ROR identifier pattern. Otherwise, the ROR ID is shown as plain text. (`resources/js/pages/assistance.tsx`) [[1]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceR44-R58) [[2]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL224-R265)

Testing and documentation:

* Added a comprehensive test suite to verify that ORCID and ROR suggestions are rendered as links only when valid, that the links have the correct URLs and security attributes, and that edge cases (malformed, unsafe, or non-canonical identifiers) are handled safely. (`tests/vitest/pages/__tests__/assistance-links.test.tsx`)
* Updated the changelog to document the new clickable ORCID and ROR links feature for curators. (`resources/data/changelog.json`)