### PR TITLE
Feature: Landing page templates management

### DIFF
--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -107,6 +107,7 @@ class LandingPageController extends Controller
 
         $rules = [
             'template' => ['required', 'string', Rule::in(self::ALLOWED_TEMPLATES)],
+            'landing_page_template_id' => ['nullable', 'integer', 'exists:landing_page_templates,id'],
             'ftp_url' => ['nullable', new SafeUrl, 'max:2048'],
             'external_domain_id' => ['required_if:template,external', 'integer', 'exists:landing_page_domains,id'],
             'external_path' => ['required_if:template,external', 'string', 'max:2048'],
@@ -193,6 +194,7 @@ class LandingPageController extends Controller
                 // We don't set them here to avoid redundancy and ensure single source of truth.
                 $createData = [
                     'template' => $validated['template'],
+                    'landing_page_template_id' => $validated['landing_page_template_id'] ?? null,
                     'ftp_url' => $validated['ftp_url'] ?? null,
                     'is_published' => $isPublished,
                     'published_at' => $isPublished ? now() : null,
@@ -296,7 +298,7 @@ class LandingPageController extends Controller
         // handle all exception cases by returning early, so we never reach
         // refresh() after a failed transaction.
         $landingPage->refresh();
-        $landingPage->load(['externalDomain', 'links']);
+        $landingPage->load(['externalDomain', 'links', 'landingPageTemplate']);
 
         // Invalidate keyword suggestions cache if landing page was created as published
         if ($landingPage->is_published) {
@@ -314,6 +316,7 @@ class LandingPageController extends Controller
                 'doi_prefix' => $landingPage->doi_prefix,
                 'slug' => $landingPage->slug,
                 'template' => $landingPage->template,
+                'landing_page_template_id' => $landingPage->landing_page_template_id,
                 'ftp_url' => $landingPage->ftp_url,
                 'external_domain_id' => $landingPage->external_domain_id,
                 'external_path' => $landingPage->external_path,
@@ -345,6 +348,7 @@ class LandingPageController extends Controller
 
         $rules = [
             'template' => ['sometimes', 'string', Rule::in(self::ALLOWED_TEMPLATES)],
+            'landing_page_template_id' => ['nullable', 'integer', 'exists:landing_page_templates,id'],
             'ftp_url' => ['nullable', new SafeUrl, 'max:2048'],
             'external_domain_id' => ['required_if:template,external', 'integer', 'exists:landing_page_domains,id'],
             'external_path' => ['required_if:template,external', 'string', 'max:2048'],
@@ -409,6 +413,9 @@ class LandingPageController extends Controller
             if (isset($validated['template'])) {
                 $landingPage->template = $validated['template'];
             }
+            if (array_key_exists('landing_page_template_id', $validated)) {
+                $landingPage->landing_page_template_id = $validated['landing_page_template_id'];
+            }
             if (array_key_exists('ftp_url', $validated)) {
                 $landingPage->ftp_url = $validated['ftp_url'];
             }
@@ -458,7 +465,7 @@ class LandingPageController extends Controller
         $this->invalidateCache($resource->id);
 
         $freshLandingPage = $landingPage->fresh();
-        $freshLandingPage?->load(['externalDomain', 'files', 'links']);
+        $freshLandingPage?->load(['externalDomain', 'files', 'links', 'landingPageTemplate']);
 
         return response()->json([
             'message' => 'Landing page updated successfully',
@@ -516,7 +523,7 @@ class LandingPageController extends Controller
             ], 404);
         }
 
-        $landingPage->load(['externalDomain', 'files', 'links']);
+        $landingPage->load(['externalDomain', 'files', 'links', 'landingPageTemplate']);
 
         return response()->json([
             'landing_page' => $landingPage,

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -194,7 +194,9 @@ class LandingPageController extends Controller
                 // We don't set them here to avoid redundancy and ensure single source of truth.
                 $createData = [
                     'template' => $validated['template'],
-                    'landing_page_template_id' => $validated['landing_page_template_id'] ?? null,
+                    'landing_page_template_id' => $validated['template'] === 'default_gfz'
+                        ? ($validated['landing_page_template_id'] ?? null)
+                        : null,
                     'ftp_url' => $validated['ftp_url'] ?? null,
                     'is_published' => $isPublished,
                     'published_at' => $isPublished ? now() : null,
@@ -414,7 +416,9 @@ class LandingPageController extends Controller
                 $landingPage->template = $validated['template'];
             }
             if (array_key_exists('landing_page_template_id', $validated)) {
-                $landingPage->landing_page_template_id = $validated['landing_page_template_id'];
+                $landingPage->landing_page_template_id = $effectiveTemplate === 'default_gfz'
+                    ? $validated['landing_page_template_id']
+                    : null;
             }
             if (array_key_exists('ftp_url', $validated)) {
                 $landingPage->ftp_url = $validated['ftp_url'];

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\CacheKey;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Services\DataCiteLinkedDataExporter;
 use App\Services\LandingPageResourceTransformer;
@@ -276,9 +277,22 @@ class LandingPagePublicController extends Controller
             ->findOrFail($landingPage->resource_id);
 
         // Eager-load file and link entries for download URL display
-        $landingPage->loadMissing(['files', 'links']);
+        $landingPage->loadMissing(['files', 'links', 'landingPageTemplate']);
 
         $resourceData = $transformer->transform($resource);
+
+        // Build section order and logo from custom template (if set)
+        $sectionOrder = null;
+        $customLogoUrl = null;
+
+        if ($landingPage->landing_page_template_id !== null && $landingPage->landingPageTemplate !== null) {
+            $tmpl = $landingPage->landingPageTemplate;
+            $sectionOrder = [
+                'rightColumn' => $tmpl->right_column_order,
+                'leftColumn' => $tmpl->left_column_order,
+            ];
+            $customLogoUrl = $tmpl->logo_url;
+        }
 
         // Generate Schema.org JSON-LD for inline SEO embedding (cached per resource)
         $cacheKey = CacheKey::SCHEMA_ORG_JSONLD->key($resource->id);
@@ -294,6 +308,8 @@ class LandingPagePublicController extends Controller
             'landingPage' => $landingPage->toArray(),
             'isPreview' => (bool) $previewToken,
             'schemaOrgJsonLd' => $schemaOrgJsonLd,
+            'sectionOrder' => $sectionOrder,
+            'customLogoUrl' => $customLogoUrl,
         ];
 
         // Use the template specified in landing page configuration

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -176,15 +176,14 @@ class LandingPageTemplateController extends Controller
             return response()->json(['message' => 'No file provided'], 422);
         }
 
-        // Delete old logo if exists
-        if ($landingPageTemplate->logo_path !== null) {
-            Storage::disk('public')->delete($landingPageTemplate->logo_path);
-        }
+        $oldLogoPath = $landingPageTemplate->logo_path;
 
+        // Store new file first to avoid losing the old logo on failure
         $directory = 'landing-page-logos/' . $landingPageTemplate->slug;
-        $path = $file->store($directory, 'public');
 
-        if ($path === false) {
+        try {
+            $path = $file->store($directory, 'public');
+        } catch (\Throwable) {
             return response()->json(['message' => 'Failed to store logo file'], 500);
         }
 
@@ -192,6 +191,11 @@ class LandingPageTemplateController extends Controller
             'logo_path' => $path,
             'logo_filename' => $file->getClientOriginalName(),
         ]);
+
+        // Delete old logo only after new one is persisted
+        if ($oldLogoPath !== null) {
+            Storage::disk('public')->delete($oldLogoPath);
+        }
 
         return response()->json([
             'message' => 'Logo uploaded successfully',

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreLandingPageTemplateRequest;
+use App\Http\Requests\UpdateLandingPageTemplateRequest;
+use App\Models\LandingPageTemplate;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class LandingPageTemplateController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Maximum logo file size in kilobytes.
+     */
+    private const MAX_LOGO_SIZE_KB = 2048;
+
+    /**
+     * Allowed MIME types for logo uploads.
+     *
+     * @var list<string>
+     */
+    private const ALLOWED_LOGO_MIMES = ['png', 'jpg', 'jpeg', 'svg', 'webp'];
+
+    /**
+     * Display the template management page.
+     */
+    public function index(): Response
+    {
+        $this->authorize('viewAny', LandingPageTemplate::class);
+
+        $templates = LandingPageTemplate::query()
+            ->withCount('landingPages')
+            ->orderByDesc('is_default')
+            ->orderBy('name')
+            ->get();
+
+        return Inertia::render('landing-page-templates', [
+            'templates' => $templates,
+        ]);
+    }
+
+    /**
+     * Clone the default template with a new name.
+     */
+    public function store(StoreLandingPageTemplateRequest $request): JsonResponse
+    {
+        $this->authorize('create', LandingPageTemplate::class);
+
+        $validated = $request->validated();
+
+        $defaultTemplate = LandingPageTemplate::where('is_default', true)->firstOrFail();
+
+        $template = LandingPageTemplate::create([
+            'name' => $validated['name'],
+            'slug' => Str::slug($validated['name']) . '-' . Str::random(6),
+            'is_default' => false,
+            'logo_path' => null,
+            'logo_filename' => null,
+            'right_column_order' => $defaultTemplate->right_column_order,
+            'left_column_order' => $defaultTemplate->left_column_order,
+            'created_by' => $request->user()?->id,
+        ]);
+
+        $template->loadCount('landingPages');
+
+        return response()->json([
+            'message' => 'Template created successfully',
+            'template' => $template,
+        ], 201);
+    }
+
+    /**
+     * Update a custom template (name, section order).
+     */
+    public function update(UpdateLandingPageTemplateRequest $request, LandingPageTemplate $landingPageTemplate): JsonResponse
+    {
+        $this->authorize('update', $landingPageTemplate);
+
+        if ($landingPageTemplate->isDefault()) {
+            return response()->json([
+                'message' => 'The default template cannot be modified.',
+                'error' => 'default_template_immutable',
+            ], 403);
+        }
+
+        $validated = $request->validated();
+
+        $updateData = [];
+
+        if (isset($validated['name'])) {
+            $updateData['name'] = $validated['name'];
+        }
+
+        if (isset($validated['right_column_order'])) {
+            $updateData['right_column_order'] = $validated['right_column_order'];
+        }
+
+        if (isset($validated['left_column_order'])) {
+            $updateData['left_column_order'] = $validated['left_column_order'];
+        }
+
+        $landingPageTemplate->update($updateData);
+        $landingPageTemplate->loadCount('landingPages');
+
+        return response()->json([
+            'message' => 'Template updated successfully',
+            'template' => $landingPageTemplate,
+        ]);
+    }
+
+    /**
+     * Delete a custom template.
+     */
+    public function destroy(LandingPageTemplate $landingPageTemplate): JsonResponse
+    {
+        $this->authorize('delete', $landingPageTemplate);
+
+        if ($landingPageTemplate->isDefault()) {
+            return response()->json([
+                'message' => 'The default template cannot be deleted.',
+                'error' => 'default_template_immutable',
+            ], 403);
+        }
+
+        if ($landingPageTemplate->isInUse()) {
+            return response()->json([
+                'message' => 'This template is currently in use by ' . $landingPageTemplate->getUsageCount() . ' landing page(s) and cannot be deleted.',
+                'error' => 'template_in_use',
+            ], 422);
+        }
+
+        // Delete logo file if exists
+        if ($landingPageTemplate->logo_path !== null) {
+            Storage::disk('public')->delete($landingPageTemplate->logo_path);
+        }
+
+        $landingPageTemplate->delete();
+
+        return response()->json([
+            'message' => 'Template deleted successfully',
+        ]);
+    }
+
+    /**
+     * Upload a custom logo for a template.
+     */
+    public function uploadLogo(Request $request, LandingPageTemplate $landingPageTemplate): JsonResponse
+    {
+        $this->authorize('update', $landingPageTemplate);
+
+        if ($landingPageTemplate->isDefault()) {
+            return response()->json([
+                'message' => 'The default template cannot be modified.',
+                'error' => 'default_template_immutable',
+            ], 403);
+        }
+
+        $request->validate([
+            'logo' => ['required', 'file', 'mimes:' . implode(',', self::ALLOWED_LOGO_MIMES), 'max:' . self::MAX_LOGO_SIZE_KB],
+        ]);
+
+        $file = $request->file('logo');
+
+        if ($file === null) {
+            return response()->json(['message' => 'No file provided'], 422);
+        }
+
+        // Delete old logo if exists
+        if ($landingPageTemplate->logo_path !== null) {
+            Storage::disk('public')->delete($landingPageTemplate->logo_path);
+        }
+
+        $directory = 'landing-page-logos/' . $landingPageTemplate->slug;
+        $path = $file->store($directory, 'public');
+
+        if ($path === false) {
+            return response()->json(['message' => 'Failed to store logo file'], 500);
+        }
+
+        $landingPageTemplate->update([
+            'logo_path' => $path,
+            'logo_filename' => $file->getClientOriginalName(),
+        ]);
+
+        return response()->json([
+            'message' => 'Logo uploaded successfully',
+            'template' => $landingPageTemplate,
+        ]);
+    }
+
+    /**
+     * Remove the custom logo and revert to default GFZ logo.
+     */
+    public function deleteLogo(LandingPageTemplate $landingPageTemplate): JsonResponse
+    {
+        $this->authorize('update', $landingPageTemplate);
+
+        if ($landingPageTemplate->isDefault()) {
+            return response()->json([
+                'message' => 'The default template cannot be modified.',
+                'error' => 'default_template_immutable',
+            ], 403);
+        }
+
+        if ($landingPageTemplate->logo_path !== null) {
+            Storage::disk('public')->delete($landingPageTemplate->logo_path);
+        }
+
+        $landingPageTemplate->update([
+            'logo_path' => null,
+            'logo_filename' => null,
+        ]);
+
+        return response()->json([
+            'message' => 'Logo removed successfully',
+            'template' => $landingPageTemplate,
+        ]);
+    }
+
+    /**
+     * List all templates for API dropdown.
+     * Accessible to all authenticated users (needed for template selection in SetupLandingPageModal).
+     */
+    public function list(): JsonResponse
+    {
+        $templates = LandingPageTemplate::query()
+            ->orderByDesc('is_default')
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug', 'is_default', 'logo_path', 'right_column_order', 'left_column_order']);
+
+        return response()->json([
+            'templates' => $templates,
+        ]);
+    }
+}

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -39,6 +39,7 @@ class LandingPageTemplateController extends Controller
         $this->authorize('viewAny', LandingPageTemplate::class);
 
         $templates = LandingPageTemplate::query()
+            ->with('creator:id,name')
             ->withCount('landingPages')
             ->orderByDesc('is_default')
             ->orderBy('name')

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -29,7 +29,7 @@ class LandingPageTemplateController extends Controller
      *
      * @var list<string>
      */
-    private const ALLOWED_LOGO_MIMES = ['png', 'jpg', 'jpeg', 'svg', 'webp'];
+    private const ALLOWED_LOGO_MIMES = ['png', 'jpg', 'jpeg', 'webp'];
 
     /**
      * Display the template management page.

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -72,6 +72,7 @@ class HandleInertiaRequests extends Middleware
                     'can_access_editor_settings' => $request->user()->can('access-editor-settings'),
                     // Landing page management permission (Issue #375)
                     'can_manage_landing_pages' => $request->user()->can('manage-landing-pages'),
+                    'can_manage_landing_page_templates' => $request->user()->can('manage-landing-page-templates'),
                     // Assistance page permission
                     'can_access_assistance' => $request->user()->can('access-assistance'),
                 ] : null,

--- a/app/Http/Requests/StoreLandingPageTemplateRequest.php
+++ b/app/Http/Requests/StoreLandingPageTemplateRequest.php
@@ -24,7 +24,17 @@ class StoreLandingPageTemplateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255', 'unique:landing_page_templates,name'],
+            'name' => ['required', 'filled', 'string', 'max:255', 'unique:landing_page_templates,name'],
         ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('name')) {
+            $this->merge(['name' => trim($this->input('name'))]);
+        }
     }
 }

--- a/app/Http/Requests/StoreLandingPageTemplateRequest.php
+++ b/app/Http/Requests/StoreLandingPageTemplateRequest.php
@@ -33,7 +33,7 @@ class StoreLandingPageTemplateRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
-        if ($this->has('name')) {
+        if ($this->has('name') && is_string($this->input('name'))) {
             $this->merge(['name' => trim($this->input('name'))]);
         }
     }

--- a/app/Http/Requests/StoreLandingPageTemplateRequest.php
+++ b/app/Http/Requests/StoreLandingPageTemplateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreLandingPageTemplateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true; // Authorization handled by policy in controller
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'unique:landing_page_templates,name'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -29,7 +29,7 @@ class UpdateLandingPageTemplateRequest extends FormRequest
         $template = $this->route('landingPageTemplate');
 
         return [
-            'name' => ['sometimes', 'string', 'max:255', Rule::unique('landing_page_templates', 'name')->ignore($template->id)],
+            'name' => ['sometimes', 'string', 'min:1', 'max:255', Rule::unique('landing_page_templates', 'name')->ignore($template->id)],
             'right_column_order' => ['sometimes', 'array'],
             'right_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)],
             'left_column_order' => ['sometimes', 'array'],

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -72,7 +72,7 @@ class UpdateLandingPageTemplateRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
-        if ($this->has('name')) {
+        if ($this->has('name') && is_string($this->input('name'))) {
             $this->merge(['name' => trim($this->input('name'))]);
         }
     }

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -29,7 +29,7 @@ class UpdateLandingPageTemplateRequest extends FormRequest
         $template = $this->route('landingPageTemplate');
 
         return [
-            'name' => ['sometimes', 'string', 'min:1', 'max:255', Rule::unique('landing_page_templates', 'name')->ignore($template->id)],
+            'name' => ['sometimes', 'filled', 'string', 'min:1', 'max:255', Rule::unique('landing_page_templates', 'name')->ignore($template->id)],
             'right_column_order' => ['sometimes', 'array'],
             'right_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)],
             'left_column_order' => ['sometimes', 'array'],
@@ -65,5 +65,15 @@ class UpdateLandingPageTemplateRequest extends FormRequest
                 }
             }
         });
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('name')) {
+            $this->merge(['name' => trim($this->input('name'))]);
+        }
     }
 }

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -44,10 +44,9 @@ class UpdateLandingPageTemplateRequest extends FormRequest
     {
         $validator->after(function (\Illuminate\Validation\Validator $validator): void {
             // Validate right column order contains exactly all valid sections
-            if ($this->has('right_column_order')) {
-                /** @var array<int, string> $rightOrder */
+            if ($this->has('right_column_order') && ! $validator->errors()->has('right_column_order')) {
                 $rightOrder = $this->input('right_column_order', []);
-                if (! LandingPageTemplate::isValidSectionOrder($rightOrder, LandingPageTemplate::RIGHT_COLUMN_SECTIONS)) {
+                if (is_array($rightOrder) && ! LandingPageTemplate::isValidSectionOrder($rightOrder, LandingPageTemplate::RIGHT_COLUMN_SECTIONS)) {
                     $validator->errors()->add(
                         'right_column_order',
                         'Right column order must contain exactly all valid section keys without duplicates.'
@@ -56,10 +55,9 @@ class UpdateLandingPageTemplateRequest extends FormRequest
             }
 
             // Validate left column order contains exactly all valid sections
-            if ($this->has('left_column_order')) {
-                /** @var array<int, string> $leftOrder */
+            if ($this->has('left_column_order') && ! $validator->errors()->has('left_column_order')) {
                 $leftOrder = $this->input('left_column_order', []);
-                if (! LandingPageTemplate::isValidSectionOrder($leftOrder, LandingPageTemplate::LEFT_COLUMN_SECTIONS)) {
+                if (is_array($leftOrder) && ! LandingPageTemplate::isValidSectionOrder($leftOrder, LandingPageTemplate::LEFT_COLUMN_SECTIONS)) {
                     $validator->errors()->add(
                         'left_column_order',
                         'Left column order must contain exactly all valid section keys without duplicates.'

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\LandingPageTemplate;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateLandingPageTemplateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true; // Authorization handled by policy in controller
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        /** @var LandingPageTemplate $template */
+        $template = $this->route('landingPageTemplate');
+
+        return [
+            'name' => ['sometimes', 'string', 'max:255', Rule::unique('landing_page_templates', 'name')->ignore($template->id)],
+            'right_column_order' => ['sometimes', 'array'],
+            'right_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)],
+            'left_column_order' => ['sometimes', 'array'],
+            'left_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::LEFT_COLUMN_SECTIONS)],
+        ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator(\Illuminate\Validation\Validator $validator): void
+    {
+        $validator->after(function (\Illuminate\Validation\Validator $validator): void {
+            // Validate right column order contains exactly all valid sections
+            if ($this->has('right_column_order')) {
+                /** @var array<int, string> $rightOrder */
+                $rightOrder = $this->input('right_column_order', []);
+                if (! LandingPageTemplate::isValidSectionOrder($rightOrder, LandingPageTemplate::RIGHT_COLUMN_SECTIONS)) {
+                    $validator->errors()->add(
+                        'right_column_order',
+                        'Right column order must contain exactly all valid section keys without duplicates.'
+                    );
+                }
+            }
+
+            // Validate left column order contains exactly all valid sections
+            if ($this->has('left_column_order')) {
+                /** @var array<int, string> $leftOrder */
+                $leftOrder = $this->input('left_column_order', []);
+                if (! LandingPageTemplate::isValidSectionOrder($leftOrder, LandingPageTemplate::LEFT_COLUMN_SECTIONS)) {
+                    $validator->errors()->add(
+                        'left_column_order',
+                        'Left column order must contain exactly all valid section keys without duplicates.'
+                    );
+                }
+            }
+        });
+    }
+}

--- a/app/Models/LandingPage.php
+++ b/app/Models/LandingPage.php
@@ -36,7 +36,9 @@ use Illuminate\Support\Str;
  * @property-read string $contact_url Internal contact form URL (computed from internal path)
  * @property-read string $status 'published' or 'draft'
  * @property-read string|null $external_url Composed external URL (domain + path), null for internal pages
+ * @property int|null $landing_page_template_id FK to landing_page_templates table
  * @property-read LandingPageDomain|null $externalDomain The domain used for external landing pages
+ * @property-read LandingPageTemplate|null $landingPageTemplate The custom template configuration
  *
  * ## Slug Immutability
  *
@@ -82,7 +84,7 @@ use Illuminate\Support\Str;
  * @see LandingPageController::store() for API creation endpoint
  * @see LandingPageController::update() for API update endpoint
  */
-#[Fillable(['resource_id', 'doi_prefix', 'slug', 'template', 'ftp_url', 'external_domain_id', 'external_path', 'is_published', 'preview_token', 'published_at', 'view_count', 'last_viewed_at'])]
+#[Fillable(['resource_id', 'doi_prefix', 'slug', 'template', 'landing_page_template_id', 'ftp_url', 'external_domain_id', 'external_path', 'is_published', 'preview_token', 'published_at', 'view_count', 'last_viewed_at'])]
 class LandingPage extends Model
 {
     /** @use HasFactory<\Database\Factories\LandingPageFactory> */
@@ -312,6 +314,22 @@ class LandingPage extends Model
     {
         /** @var BelongsTo<\App\Models\LandingPageDomain, static> $relation */
         $relation = $this->belongsTo(LandingPageDomain::class, 'external_domain_id');
+
+        return $relation;
+    }
+
+    /**
+     * Get the custom template configuration for this landing page.
+     *
+     * When set, this provides custom section ordering and logo overrides.
+     * When null, the built-in default layout is used.
+     *
+     * @return BelongsTo<\App\Models\LandingPageTemplate, static>
+     */
+    public function landingPageTemplate(): BelongsTo
+    {
+        /** @var BelongsTo<\App\Models\LandingPageTemplate, static> $relation */
+        $relation = $this->belongsTo(LandingPageTemplate::class);
 
         return $relation;
     }

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Landing page template configuration for custom landing page layouts.
+ *
+ * Templates define the visual layout of landing pages:
+ * - Custom header logo
+ * - Section ordering for left and right columns
+ *
+ * The default template (is_default=true) is immutable and serves as the
+ * base for cloning new custom templates.
+ *
+ * @property int $id
+ * @property string $name Human-readable template name
+ * @property string $slug URL-friendly unique identifier
+ * @property bool $is_default Whether this is the immutable default template
+ * @property string|null $logo_path Storage path for custom logo file
+ * @property string|null $logo_filename Original filename of the uploaded logo
+ * @property array<int, string> $right_column_order Ordered section keys for right column
+ * @property array<int, string> $left_column_order Ordered section keys for left column
+ * @property int|null $created_by FK to users table
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read string|null $logo_url Full URL for the logo file
+ * @property-read User|null $creator The user who created this template
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, LandingPage> $landingPages
+ */
+class LandingPageTemplate extends Model
+{
+    /** @use HasFactory<\Database\Factories\LandingPageTemplateFactory> */
+    use HasFactory;
+
+    /**
+     * Valid section keys for the right column.
+     *
+     * @var list<string>
+     */
+    public const RIGHT_COLUMN_SECTIONS = [
+        'descriptions',
+        'creators',
+        'contributors',
+        'funders',
+        'keywords',
+        'metadata_download',
+        'location',
+    ];
+
+    /**
+     * Valid section keys for the left column.
+     *
+     * @var list<string>
+     */
+    public const LEFT_COLUMN_SECTIONS = [
+        'files',
+        'contact',
+        'model_description',
+        'related_work',
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+        'is_default',
+        'logo_path',
+        'logo_filename',
+        'right_column_order',
+        'left_column_order',
+        'created_by',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_default' => 'boolean',
+        'right_column_order' => 'array',
+        'left_column_order' => 'array',
+    ];
+
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var list<string>
+     */
+    protected $appends = [
+        'logo_url',
+    ];
+
+    /**
+     * Get the full URL for the logo file.
+     */
+    public function getLogoUrlAttribute(): ?string
+    {
+        if ($this->logo_path === null) {
+            return null;
+        }
+
+        return asset('storage/' . $this->logo_path);
+    }
+
+    /**
+     * Get the user who created this template.
+     *
+     * @return BelongsTo<User, static>
+     */
+    public function creator(): BelongsTo
+    {
+        /** @var BelongsTo<User, static> $relation */
+        $relation = $this->belongsTo(User::class, 'created_by');
+
+        return $relation;
+    }
+
+    /**
+     * Get the landing pages using this template.
+     *
+     * @return HasMany<LandingPage, $this>
+     */
+    public function landingPages(): HasMany
+    {
+        return $this->hasMany(LandingPage::class);
+    }
+
+    /**
+     * Check if this is the immutable default template.
+     */
+    public function isDefault(): bool
+    {
+        return $this->is_default;
+    }
+
+    /**
+     * Check if this template is currently in use by any landing pages.
+     */
+    public function isInUse(): bool
+    {
+        return $this->landingPages()->exists();
+    }
+
+    /**
+     * Get the number of landing pages using this template.
+     */
+    public function getUsageCount(): int
+    {
+        return $this->landingPages()->count();
+    }
+
+    /**
+     * Scope to only custom (non-default) templates.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeCustom(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
+    {
+        return $query->where('is_default', false);
+    }
+
+    /**
+     * Validate that a section order array contains exactly the valid keys.
+     *
+     * @param  array<int, string>  $order
+     * @param  list<string>  $validSections
+     */
+    public static function isValidSectionOrder(array $order, array $validSections): bool
+    {
+        if (count($order) !== count($validSections)) {
+            return false;
+        }
+
+        $sorted = $order;
+        $validSorted = $validSections;
+        sort($sorted);
+        sort($validSorted);
+
+        return $sorted === $validSorted;
+    }
+}

--- a/app/Policies/LandingPageTemplatePolicy.php
+++ b/app/Policies/LandingPageTemplatePolicy.php
@@ -57,7 +57,8 @@ class LandingPageTemplatePolicy
 
     /**
      * Determine whether the user can delete the template.
-     * Default templates and templates in use cannot be deleted.
+     * Default templates cannot be deleted.
+     * In-use check is enforced in the controller's destroy() method.
      */
     public function delete(User $user, LandingPageTemplate $template): bool
     {

--- a/app/Policies/LandingPageTemplatePolicy.php
+++ b/app/Policies/LandingPageTemplatePolicy.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\LandingPageTemplate;
+use App\Models\User;
+
+/**
+ * Policy for LandingPageTemplate model authorization.
+ *
+ * Only Admin and Group Leader roles can manage landing page templates.
+ * The default template (is_default=true) cannot be updated or deleted.
+ */
+class LandingPageTemplatePolicy
+{
+    /**
+     * Roles that are allowed to manage landing page templates.
+     *
+     * @var list<UserRole>
+     */
+    private const MANAGEMENT_ROLES = [
+        UserRole::ADMIN,
+        UserRole::GROUP_LEADER,
+    ];
+
+    /**
+     * Determine whether the user can view the template list.
+     */
+    public function viewAny(User $user): bool
+    {
+        return in_array($user->role, self::MANAGEMENT_ROLES, true);
+    }
+
+    /**
+     * Determine whether the user can create templates (clone from default).
+     */
+    public function create(User $user): bool
+    {
+        return in_array($user->role, self::MANAGEMENT_ROLES, true);
+    }
+
+    /**
+     * Determine whether the user can update the template.
+     * Default templates cannot be modified.
+     */
+    public function update(User $user, LandingPageTemplate $template): bool
+    {
+        if ($template->isDefault()) {
+            return false;
+        }
+
+        return in_array($user->role, self::MANAGEMENT_ROLES, true);
+    }
+
+    /**
+     * Determine whether the user can delete the template.
+     * Default templates and templates in use cannot be deleted.
+     */
+    public function delete(User $user, LandingPageTemplate $template): bool
+    {
+        if ($template->isDefault()) {
+            return false;
+        }
+
+        return in_array($user->role, self::MANAGEMENT_ROLES, true);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -166,6 +166,13 @@ class AppServiceProvider extends ServiceProvider
                 || $user->role === UserRole::CURATOR;
         });
 
+        // Manage landing page templates (create, clone, update, delete)
+        // Only Admin and Group Leader can manage templates
+        Gate::define('manage-landing-page-templates', function (User $user): bool {
+            return $user->role === UserRole::ADMIN
+                || $user->role === UserRole::GROUP_LEADER;
+        });
+
         // Access to Assistance page (Admin, Group Leader)
         Gate::define('access-assistance', function (User $user): bool {
             return $user->role === UserRole::ADMIN

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -437,6 +437,21 @@ entity "alternate_identifiers" as alternate_identifiers {
 ' APPLICATION-SPECIFIC TABLES
 ' ==========================================================================
 
+entity "landing_page_templates" as landing_page_templates {
+    * **id** : BIGINT <<PK>>
+    --
+    * name : VARCHAR <<UK>>
+    * slug : VARCHAR <<UK>>
+    * is_default : BOOLEAN = false
+    logo_path : VARCHAR
+    logo_filename : VARCHAR
+    * right_column_order : JSON
+    * left_column_order : JSON
+    created_by : BIGINT <<FK>>
+    created_at : TIMESTAMP
+    updated_at : TIMESTAMP
+}
+
 entity "landing_pages" as landing_pages {
     * **id** : BIGINT <<PK>>
     --
@@ -444,6 +459,7 @@ entity "landing_pages" as landing_pages {
     doi_prefix : VARCHAR
     * slug : VARCHAR
     * template : VARCHAR(50) = 'default_gfz'
+    landing_page_template_id : BIGINT <<FK>>
     ftp_url : VARCHAR(2048)
     external_domain_id : BIGINT <<FK>>
     external_path : VARCHAR(2048)
@@ -924,10 +940,12 @@ right_resource_type_exclusions }o--|| resource_types
 ' User self-reference
 users }o--o| users : "deactivated_by"
 
-' Landing page domains
+' Landing page relationships
 landing_pages }o--o| landing_page_domains
 landing_pages ||--o{ landing_page_files
 landing_pages ||--o{ landing_page_links
+landing_pages }o--o| landing_page_templates
+landing_page_templates }o--o| users
 
 ' IGSN relationships
 igsn_metadata ||--|| resources

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -383,12 +383,27 @@ erDiagram
     %% APPLICATION-SPECIFIC TABLES
     %% =========================================================================
 
+    landing_page_templates {
+        bigint id PK
+        varchar name UK
+        varchar slug UK
+        boolean is_default "default false"
+        varchar logo_path "nullable"
+        varchar logo_filename "nullable"
+        json right_column_order
+        json left_column_order
+        bigint created_by FK "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
     landing_pages {
         bigint id PK
         bigint resource_id FK "UK, 1:1 with resources"
         varchar doi_prefix
         varchar slug "unique with doi_prefix"
         varchar template
+        bigint landing_page_template_id FK "nullable"
         varchar ftp_url
         bigint external_domain_id FK "nullable"
         varchar external_path "2048, nullable"
@@ -856,10 +871,12 @@ erDiagram
     resource_datacenter }o--|| resources : "resource"
     resource_datacenter }o--|| datacenters : "datacenter"
 
-    %% Landing page domains
+    %% Landing page relationships
     landing_pages }o--o| landing_page_domains : "external domain"
     landing_pages ||--o{ landing_page_files : "has files"
     landing_pages ||--o{ landing_page_links : "has links"
+    landing_pages }o--o| landing_page_templates : "uses template"
+    landing_page_templates }o--o| users : "created by"
 
     %% IGSN relationships
     igsn_metadata ||--|| resources : "extends"

--- a/database/factories/LandingPageTemplateFactory.php
+++ b/database/factories/LandingPageTemplateFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\LandingPageTemplate;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<LandingPageTemplate>
+ */
+class LandingPageTemplateFactory extends Factory
+{
+    protected $model = LandingPageTemplate::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        /** @var string $name */
+        $name = fake()->unique()->words(3, true);
+        $name .= ' Template';
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name) . '-' . Str::random(6),
+            'is_default' => false,
+            'logo_path' => null,
+            'logo_filename' => null,
+            'right_column_order' => LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+            'left_column_order' => LandingPageTemplate::LEFT_COLUMN_SECTIONS,
+            'created_by' => User::factory(),
+        ];
+    }
+
+    /**
+     * Indicate that this is the default template.
+     */
+    public function default(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Default GFZ Data Services',
+            'slug' => 'default_gfz',
+            'is_default' => true,
+            'created_by' => null,
+        ]);
+    }
+
+    /**
+     * Set a custom section order.
+     *
+     * @param  array<int, string>  $rightColumn
+     * @param  array<int, string>  $leftColumn
+     */
+    public function withSectionOrder(array $rightColumn, array $leftColumn): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'right_column_order' => $rightColumn,
+            'left_column_order' => $leftColumn,
+        ]);
+    }
+
+    /**
+     * Set a custom logo.
+     */
+    public function withLogo(string $path = 'landing-page-logos/test/logo.png', string $filename = 'logo.png'): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'logo_path' => $path,
+            'logo_filename' => $filename,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_17_000001_create_landing_page_templates_table.php
+++ b/database/migrations/2026_04_17_000001_create_landing_page_templates_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('landing_page_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->boolean('is_default')->default(false);
+            $table->string('logo_path')->nullable();
+            $table->string('logo_filename')->nullable();
+            $table->json('right_column_order');
+            $table->json('left_column_order');
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('landing_page_templates');
+    }
+};

--- a/database/migrations/2026_04_17_000001_create_landing_page_templates_table.php
+++ b/database/migrations/2026_04_17_000001_create_landing_page_templates_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('landing_page_templates', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('name')->unique();
             $table->string('slug')->unique();
             $table->boolean('is_default')->default(false);
             $table->string('logo_path')->nullable();

--- a/database/migrations/2026_04_17_000002_add_template_id_to_landing_pages_table.php
+++ b/database/migrations/2026_04_17_000002_add_template_id_to_landing_pages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('landing_pages', function (Blueprint $table) {
+            $table->foreignId('landing_page_template_id')
+                ->nullable()
+                ->after('template')
+                ->constrained('landing_page_templates')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('landing_pages', function (Blueprint $table) {
+            $table->dropForeign(['landing_page_template_id']);
+            $table->dropColumn('landing_page_template_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -30,6 +30,7 @@ class DatabaseSeeder extends Seeder
             ThesaurusSettingSeeder::class,
             PidSettingSeeder::class,
             DatacenterSeeder::class,
+            LandingPageTemplateSeeder::class,
         ]);
 
         // Only create test data in testing environment (for automated tests)

--- a/database/seeders/LandingPageTemplateSeeder.php
+++ b/database/seeders/LandingPageTemplateSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\LandingPageTemplate;
+use Illuminate\Database\Seeder;
+
+class LandingPageTemplateSeeder extends Seeder
+{
+    /**
+     * Seed the default landing page template.
+     *
+     * This creates the immutable default GFZ Data Services template
+     * that serves as the base for cloning custom templates.
+     */
+    public function run(): void
+    {
+        LandingPageTemplate::firstOrCreate(
+            ['slug' => 'default_gfz'],
+            [
+                'name' => 'Default GFZ Data Services',
+                'is_default' => true,
+                'logo_path' => null,
+                'logo_filename' => null,
+                'right_column_order' => LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+                'left_column_order' => LandingPageTemplate::LEFT_COLUMN_SECTIONS,
+                'created_by' => null,
+            ]
+        );
+    }
+}

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-04-17",
         "features": [
             {
+                "title": "Landing Page Template Management",
+                "description": "Admins and Group Leaders can now create custom landing page templates by cloning the immutable Default GFZ template. Custom templates allow renaming, replacing the header logo with a custom image, and reordering all content sections via drag-and-drop with a live preview. Templates created this way appear in the template dropdown when setting up a landing page for a resource. Templates that are currently in use by landing pages are protected from deletion."
+            },
+            {
                 "title": "European Science Vocabulary (EuroSciVoc) Thesaurus",
                 "description": "A new controlled vocabulary 'European Science Vocabulary (EuroSciVoc)' has been integrated from the Publications Office of the European Union. EuroSciVoc is a taxonomy of fields of science based on OECD's 2015 Frascati Manual, extended with categories extracted from CORDIS content. The vocabulary provides a hierarchical tree of scientific disciplines (e.g., Natural Sciences > Physical Sciences > Astronomy). It appears in the keyword editor alongside existing vocabularies and is available via the API. Administrators and group leaders can activate/deactivate and update the vocabulary in Editor Settings."
             },

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
     History,
     Layers,
     LayoutGrid,
+    LayoutTemplate,
     MapPin,
     ScrollText,
     Settings,
@@ -50,6 +51,14 @@ export function AppSidebar() {
             icon: Layers,
         },
     ];
+
+    if (auth.user?.can_manage_landing_page_templates) {
+        dataCurationItems.push({
+            title: 'Landing Page Templates',
+            href: '/landing-pages',
+            icon: LayoutTemplate,
+        });
+    }
 
     // IGSN CURATION section
     const igsnCurationItems: NavItem[] = [

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
 
@@ -552,17 +552,20 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                     ))}
                                     {customTemplates.filter((ct) => !ct.is_default).length > 0 && (
                                         <>
-                                            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Custom Templates</div>
-                                            {customTemplates
-                                                .filter((ct) => !ct.is_default)
-                                                .map((ct) => (
-                                                    <SelectItem key={`custom:${ct.id}`} value={`custom:${ct.id}`}>
-                                                        <div className="flex flex-col">
-                                                            <span>{ct.name}</span>
-                                                            <span className="text-xs text-muted-foreground">Custom section order{ct.logo_url ? ' & logo' : ''}</span>
-                                                        </div>
-                                                    </SelectItem>
-                                                ))}
+                                            <SelectSeparator />
+                                            <SelectGroup>
+                                                <SelectLabel>Custom Templates</SelectLabel>
+                                                {customTemplates
+                                                    .filter((ct) => !ct.is_default)
+                                                    .map((ct) => (
+                                                        <SelectItem key={`custom:${ct.id}`} value={`custom:${ct.id}`}>
+                                                            <div className="flex flex-col">
+                                                                <span>{ct.name}</span>
+                                                                <span className="text-xs text-muted-foreground">Custom section order{ct.logo_url ? ' & logo' : ''}</span>
+                                                            </div>
+                                                        </SelectItem>
+                                                    ))}
+                                            </SelectGroup>
                                         </>
                                     )}
                                 </SelectContent>

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -13,7 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink } from '@/types/landing-page';
+import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateConfig } from '@/types/landing-page';
 
 interface Resource {
     id: number;
@@ -97,6 +97,12 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const [externalPath, setExternalPath] = useState<string>(existingConfig?.external_path ?? '');
     const [availableDomains, setAvailableDomains] = useState<LandingPageDomain[]>([]);
 
+    // Custom templates state
+    const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateConfig[]>([]);
+
+    // Landing page template ID (for custom templates)
+    const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(existingConfig?.landing_page_template_id ?? null);
+
     // Additional links state
     const [links, setLinks] = useState<LandingPageLink[]>(existingConfig?.links ?? []);
 
@@ -118,12 +124,15 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 setExternalDomainId(String(existingConfig.external_domain_id ?? ''));
                 setExternalPath(existingConfig.external_path ?? '');
                 setLinks(existingConfig.links ?? []);
+                setLandingPageTemplateId(existingConfig.landing_page_template_id ?? null);
             } else {
                 // Load from server
                 loadLandingPageConfig();
             }
             // Load available domains for external landing pages
             loadAvailableDomains();
+            // Load custom templates for the dropdown
+            loadCustomTemplates();
         } else if (!isOpen) {
             // Reset state when modal closes
             setCurrentConfig(null);
@@ -134,6 +143,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setExternalDomainId('');
             setExternalPath('');
             setLinks([]);
+            setLandingPageTemplateId(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen, resource.id]);
@@ -145,6 +155,15 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         } catch (error) {
             console.error('Failed to load landing page domains:', error);
             // Non-critical: domains will be empty, select will show placeholder
+        }
+    };
+
+    const loadCustomTemplates = async () => {
+        try {
+            const response = await axios.get<{ templates: LandingPageTemplateConfig[] }>('/api/landing-page-templates');
+            setCustomTemplates(response.data.templates);
+        } catch (error) {
+            console.error('Failed to load custom templates:', error);
         }
     };
 
@@ -194,6 +213,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 template,
                 ftp_url: isExternal ? null : ftpUrl || null,
                 status: isPublished ? 'published' : 'draft',
+                landing_page_template_id: landingPageTemplateId,
             };
 
             // Add external fields when template is 'external'
@@ -242,6 +262,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 setExternalDomainId(String(updatedConfig.external_domain_id ?? ''));
                 setExternalPath(updatedConfig.external_path ?? '');
                 setLinks(updatedConfig.links ?? []);
+                setLandingPageTemplateId(updatedConfig.landing_page_template_id ?? null);
             }
 
             // Clear session-based preview if it exists
@@ -317,7 +338,8 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             template !== currentConfig.template ||
             // ftpUrl is irrelevant for external templates (backend forces it to null)
             (!isExternalTemplate && ftpUrl !== (currentConfig.ftp_url ?? '')) ||
-            isPublished !== (currentConfig.status === 'published');
+            isPublished !== (currentConfig.status === 'published') ||
+            landingPageTemplateId !== (currentConfig.landing_page_template_id ?? null);
 
         // Check if links have changed
         const currentLinks = currentConfig.links ?? [];
@@ -336,7 +358,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             );
         }
         return baseChanges || linksChanged;
-    }, [currentConfig, template, ftpUrl, isPublished, externalDomainId, externalPath, links]);
+    }, [currentConfig, template, ftpUrl, isPublished, externalDomainId, externalPath, links, landingPageTemplateId]);
 
     const copyToClipboard = async (text: string, label: string) => {
         try {
@@ -503,7 +525,19 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                         {/* Template Selection */}
                         <div className="space-y-2">
                             <Label htmlFor="template">Landing Page Template</Label>
-                            <Select value={template} onValueChange={setTemplate}>
+                            <Select
+                                value={landingPageTemplateId ? `custom:${landingPageTemplateId}` : template}
+                                onValueChange={(val) => {
+                                    if (val.startsWith('custom:')) {
+                                        const id = Number(val.replace('custom:', ''));
+                                        setLandingPageTemplateId(id);
+                                        setTemplate('default_gfz'); // Custom templates use default_gfz renderer
+                                    } else {
+                                        setLandingPageTemplateId(null);
+                                        setTemplate(val);
+                                    }
+                                }}
+                            >
                                 <SelectTrigger id="template">
                                     <SelectValue placeholder="Select a template" />
                                 </SelectTrigger>
@@ -516,6 +550,21 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                             </div>
                                         </SelectItem>
                                     ))}
+                                    {customTemplates.filter((ct) => !ct.is_default).length > 0 && (
+                                        <>
+                                            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Custom Templates</div>
+                                            {customTemplates
+                                                .filter((ct) => !ct.is_default)
+                                                .map((ct) => (
+                                                    <SelectItem key={`custom:${ct.id}`} value={`custom:${ct.id}`}>
+                                                        <div className="flex flex-col">
+                                                            <span>{ct.name}</span>
+                                                            <span className="text-xs text-muted-foreground">Custom section order{ct.logo_url ? ' & logo' : ''}</span>
+                                                        </div>
+                                                    </SelectItem>
+                                                ))}
+                                        </>
+                                    )}
                                 </SelectContent>
                             </Select>
                             <p className="text-sm text-muted-foreground">Choose the design template for your landing page</p>

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -161,7 +161,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const loadCustomTemplates = async () => {
         try {
             const response = await axios.get<{ templates: LandingPageTemplateConfig[] }>('/api/landing-page-templates');
-            setCustomTemplates(response.data.templates);
+            setCustomTemplates(response.data.templates ?? []);
         } catch (error) {
             console.error('Failed to load custom templates:', error);
         }

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -13,7 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateConfig } from '@/types/landing-page';
+import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
 
 interface Resource {
     id: number;
@@ -98,7 +98,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const [availableDomains, setAvailableDomains] = useState<LandingPageDomain[]>([]);
 
     // Custom templates state
-    const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateConfig[]>([]);
+    const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateSummary[]>([]);
 
     // Landing page template ID (for custom templates)
     const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(existingConfig?.landing_page_template_id ?? null);
@@ -160,7 +160,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
     const loadCustomTemplates = async () => {
         try {
-            const response = await axios.get<{ templates: LandingPageTemplateConfig[] }>('/api/landing-page-templates');
+            const response = await axios.get<{ templates: LandingPageTemplateSummary[] }>('/api/landing-page-templates');
             setCustomTemplates(response.data.templates ?? []);
         } catch (error) {
             console.error('Failed to load custom templates:', error);

--- a/resources/js/pages/LandingPages/default_gfz.tsx
+++ b/resources/js/pages/LandingPages/default_gfz.tsx
@@ -1,6 +1,7 @@
 import { Head, usePage } from '@inertiajs/react';
+import { type ReactNode, useMemo } from 'react';
 
-import type { LandingPageConfig, LandingPageResource } from '@/types/landing-page';
+import type { LandingPageConfig, LandingPageResource, LeftColumnSection, RightColumnSection, SectionOrder } from '@/types/landing-page';
 
 import { AbstractSection } from './components/AbstractSection';
 import { BackToTopButton } from './components/BackToTopButton';
@@ -29,12 +30,18 @@ interface DefaultGfzTemplatePageProps {
     landingPage: LandingPageConfig | null;
     isPreview: boolean;
     schemaOrgJsonLd?: Record<string, unknown>;
+    sectionOrder?: SectionOrder | null;
+    customLogoUrl?: string | null;
     /** Inertia PageProps requires index signature for dynamic SSR props */
     [key: string]: unknown;
 }
 
+/** Default section orders matching the original layout */
+const DEFAULT_RIGHT_ORDER: RightColumnSection[] = ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'];
+const DEFAULT_LEFT_ORDER: LeftColumnSection[] = ['files', 'contact', 'model_description', 'related_work'];
+
 export default function DefaultGfzTemplate() {
-    const { resource, landingPage, isPreview, schemaOrgJsonLd } = usePage<DefaultGfzTemplatePageProps>().props;
+    const { resource, landingPage, isPreview, schemaOrgJsonLd, sectionOrder, customLogoUrl } = usePage<DefaultGfzTemplatePageProps>().props;
     const isDark = useSystemDarkMode();
 
     // Extract data for ResourceHero
@@ -43,6 +50,57 @@ export default function DefaultGfzTemplate() {
     const mainTitle = resource.titles?.find((t) => !t.title_type || t.title_type === 'MainTitle')?.title || 'Untitled';
     const subtitle = resource.titles?.find((t) => t.title_type === 'Subtitle')?.title;
     const citation = buildCitation(resource);
+
+    // Resolve section orders (custom template overrides or defaults)
+    const rightOrder = sectionOrder?.rightColumn ?? DEFAULT_RIGHT_ORDER;
+    const leftOrder = sectionOrder?.leftColumn ?? DEFAULT_LEFT_ORDER;
+
+    // Logo: custom template logo or default GFZ logo
+    const logoSrc = customLogoUrl ?? '/images/gfz-ds-logo.png';
+
+    // Section registry: map section keys to React elements
+    const rightSectionRegistry = useMemo((): Record<RightColumnSection, ReactNode> => {
+        const jsonLdExportUrl = landingPage?.public_url ? `${landingPage.public_url}/jsonld` : undefined;
+        return {
+            descriptions: (
+                <AbstractSection
+                    key="descriptions"
+                    descriptions={resource.descriptions || []}
+                    creators={resource.creators || []}
+                    contributors={resource.contributors || []}
+                    fundingReferences={resource.funding_references || []}
+                    subjects={resource.subjects || []}
+                    resourceId={resource.id}
+                    jsonLdExportUrl={jsonLdExportUrl}
+                />
+            ),
+            creators: null, // Rendered inside AbstractSection
+            contributors: null, // Rendered inside AbstractSection
+            funders: null, // Rendered inside AbstractSection
+            keywords: null, // Rendered inside AbstractSection
+            metadata_download: null, // Rendered inside AbstractSection
+            location: <LocationSection key="location" geoLocations={resource.geo_locations || []} isDark={isDark} />,
+        };
+    }, [resource, landingPage, isDark]);
+
+    const leftSectionRegistry = useMemo((): Record<LeftColumnSection, ReactNode> => {
+        return {
+            files: (
+                <FilesSection
+                    key="files"
+                    downloadUrl={landingPage?.ftp_url}
+                    downloadFiles={landingPage?.files}
+                    licenses={resource.licenses || []}
+                    contactPersons={resource.contact_persons || []}
+                    datasetTitle={mainTitle}
+                    additionalLinks={landingPage?.links}
+                />
+            ),
+            contact: <ContactSection key="contact" contactPersons={resource.contact_persons || []} datasetTitle={mainTitle} />,
+            model_description: <ModelDescriptionSection key="model_description" relatedIdentifiers={resource.related_identifiers || []} />,
+            related_work: <RelatedWorkSection key="related_work" relatedIdentifiers={resource.related_identifiers || []} resource={resource} />,
+        };
+    }, [resource, landingPage, mainTitle]);
 
     return (
         <>
@@ -88,7 +146,7 @@ export default function DefaultGfzTemplate() {
                             </a>
                         </div>
                         <div className="flex justify-center">
-                            <img src="/images/gfz-ds-logo.png" alt="GFZ Data Services" className="h-24 dark:brightness-200 dark:invert" />
+                            <img src={logoSrc} alt="GFZ Data Services" className="h-24 dark:brightness-200 dark:invert" />
                         </div>
                     </header>
 
@@ -100,31 +158,12 @@ export default function DefaultGfzTemplate() {
                         <div className="mx-8 mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
                             {/* Right Column (Abstract, Location) — show first on mobile */}
                             <div className="order-1 space-y-6 lg:order-2 lg:col-span-2">
-                                <AbstractSection
-                                    descriptions={resource.descriptions || []}
-                                    creators={resource.creators || []}
-                                    contributors={resource.contributors || []}
-                                    fundingReferences={resource.funding_references || []}
-                                    subjects={resource.subjects || []}
-                                    resourceId={resource.id}
-                                    jsonLdExportUrl={landingPage?.public_url ? `${landingPage.public_url}/jsonld` : undefined}
-                                />
-                                <LocationSection geoLocations={resource.geo_locations || []} isDark={isDark} />
+                                {rightOrder.map((key) => rightSectionRegistry[key]).filter(Boolean)}
                             </div>
 
                             {/* Left Column (Files, Contact, Related) — show second on mobile */}
                             <div className="order-2 space-y-6 lg:order-1 lg:col-span-1">
-                                <FilesSection
-                                    downloadUrl={landingPage?.ftp_url}
-                                    downloadFiles={landingPage?.files}
-                                    licenses={resource.licenses || []}
-                                    contactPersons={resource.contact_persons || []}
-                                    datasetTitle={mainTitle}
-                                    additionalLinks={landingPage?.links}
-                                />
-                                <ContactSection contactPersons={resource.contact_persons || []} datasetTitle={mainTitle} />
-                                <ModelDescriptionSection relatedIdentifiers={resource.related_identifiers || []} />
-                                <RelatedWorkSection relatedIdentifiers={resource.related_identifiers || []} resource={resource} />
+                                {leftOrder.map((key) => leftSectionRegistry[key]).filter(Boolean)}
                             </div>
                         </div>
                     </main>

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -11,6 +11,7 @@ import {
     Globe,
     HelpCircle,
     Layers,
+    LayoutTemplate,
     Link2,
     MapPin,
     Palette,
@@ -1213,6 +1214,62 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             <p className="text-sm text-blue-900 dark:text-blue-100">
                                 <strong>Note:</strong> Available domains are managed by administrators in Editor Settings. If you need a domain that
                                 is not listed, contact your administrator.
+                            </p>
+                        </div>
+                    </>
+                ),
+            },
+            {
+                id: 'landing-page-templates',
+                title: 'Landing Page Templates',
+                icon: LayoutTemplate,
+                minRole: 'group_leader',
+                content: (
+                    <>
+                        <h3>Custom Landing Page Templates</h3>
+                        <p>
+                            Admins and Group Leaders can create custom landing page templates to control the layout and branding of landing pages.
+                            Custom templates are cloned from the immutable <strong>Default GFZ</strong> template and allow customization of section
+                            order and header logo.
+                        </p>
+
+                        <WorkflowSteps>
+                            <WorkflowSteps.Step number={1} title="Open Template Management">
+                                <p>
+                                    Navigate to <strong>Landing Page Templates</strong> in the sidebar under Data Curation.
+                                </p>
+                            </WorkflowSteps.Step>
+                            <WorkflowSteps.Step number={2} title="Clone Default Template">
+                                <p>
+                                    Click <strong>"New Template"</strong> and enter a unique name. The new template starts as an
+                                    exact copy of the Default GFZ template.
+                                </p>
+                            </WorkflowSteps.Step>
+                            <WorkflowSteps.Step number={3} title="Reorder Sections">
+                                <p>
+                                    Click the edit icon on a template card. Use <strong>drag &amp; drop</strong> to rearrange the
+                                    right column sections (e.g., Descriptions, Creators, Dates) and left column sections (e.g.,
+                                    Files, Details, Map) independently.
+                                </p>
+                            </WorkflowSteps.Step>
+                            <WorkflowSteps.Step number={4} title="Upload Custom Logo (Optional)">
+                                <p>
+                                    Click the image icon on a template card to upload a custom header logo (PNG, JPG, SVG, or
+                                    WebP, max 2 MB). The logo replaces the default GFZ logo on landing pages using this template.
+                                </p>
+                            </WorkflowSteps.Step>
+                            <WorkflowSteps.Step number={5} title="Use in Landing Pages">
+                                <p>
+                                    When setting up a landing page for a resource, custom templates appear in the template dropdown
+                                    alongside the built-in templates. Select a custom template to apply its layout and branding.
+                                </p>
+                            </WorkflowSteps.Step>
+                        </WorkflowSteps>
+
+                        <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
+                            <p className="text-sm text-amber-900 dark:text-amber-100">
+                                <strong>Note:</strong> The Default GFZ template cannot be modified or deleted. Custom templates that
+                                are currently in use by published landing pages are also protected from deletion.
                             </p>
                         </div>
                     </>

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -1,0 +1,529 @@
+import type { DragEndEvent } from '@dnd-kit/core';
+import { closestCenter, DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Head, router, usePage } from '@inertiajs/react';
+import axios, { isAxiosError } from 'axios';
+import { Copy, GripVertical, ImagePlus, LayoutTemplate, Pencil, Plus, Trash2, X } from 'lucide-react';
+import { type ChangeEvent, useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import type { LandingPageTemplateConfig, LeftColumnSection, RightColumnSection } from '@/types/landing-page';
+
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { LoadingButton } from '@/components/ui/loading-button';
+import { Separator } from '@/components/ui/separator';
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Landing Page Templates', href: '/landing-pages' }];
+
+/** Display labels for right column sections */
+const RIGHT_SECTION_LABELS: Record<RightColumnSection, string> = {
+    descriptions: 'Abstract & Descriptions',
+    creators: 'Creators / Authors',
+    contributors: 'Contributors',
+    funders: 'Funding References',
+    keywords: 'Keywords / Subjects',
+    metadata_download: 'Metadata Download',
+    location: 'Location / Map',
+};
+
+/** Display labels for left column sections */
+const LEFT_SECTION_LABELS: Record<LeftColumnSection, string> = {
+    files: 'Files & Downloads',
+    contact: 'Contact Person',
+    model_description: 'Model / Method Description',
+    related_work: 'Related Work',
+};
+
+interface PageProps extends SharedData {
+    templates: LandingPageTemplateConfig[];
+    [key: string]: unknown;
+}
+
+// --- Sortable Section Item ---
+function SortableSectionItem({ id, label }: { id: string; label: string }) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm"
+        >
+            <button
+                type="button"
+                aria-label={`Reorder ${label}`}
+                className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+                {...attributes}
+                {...listeners}
+            >
+                <GripVertical className="size-4" />
+            </button>
+            <span className="flex-1">{label}</span>
+        </div>
+    );
+}
+
+// --- Section Order Editor ---
+function SectionOrderEditor({
+    title,
+    items,
+    labels,
+    onReorder,
+}: {
+    title: string;
+    items: string[];
+    labels: Record<string, string>;
+    onReorder: (items: string[]) => void;
+}) {
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            const { active, over } = event;
+            if (!over || active.id === over.id) return;
+            const oldIndex = items.indexOf(String(active.id));
+            const newIndex = items.indexOf(String(over.id));
+            if (oldIndex === -1 || newIndex === -1) return;
+            onReorder(arrayMove(items, oldIndex, newIndex));
+        },
+        [items, onReorder],
+    );
+
+    return (
+        <div className="space-y-2">
+            <Label className="text-sm font-medium">{title}</Label>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <SortableContext items={items} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-1.5">
+                        {items.map((key) => (
+                            <SortableSectionItem key={key} id={key} label={labels[key] ?? key} />
+                        ))}
+                    </div>
+                </SortableContext>
+            </DndContext>
+        </div>
+    );
+}
+
+export default function LandingPageTemplatesPage() {
+    const { templates } = usePage<PageProps>().props;
+
+    // Clone dialog
+    const [cloneOpen, setCloneOpen] = useState(false);
+    const [cloneName, setCloneName] = useState('');
+    const [cloning, setCloning] = useState(false);
+
+    // Edit dialog
+    const [editOpen, setEditOpen] = useState(false);
+    const [editTemplate, setEditTemplate] = useState<LandingPageTemplateConfig | null>(null);
+    const [editName, setEditName] = useState('');
+    const [editRightOrder, setEditRightOrder] = useState<RightColumnSection[]>([]);
+    const [editLeftOrder, setEditLeftOrder] = useState<LeftColumnSection[]>([]);
+    const [saving, setSaving] = useState(false);
+
+    // Delete dialog
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [deleteTemplate, setDeleteTemplate] = useState<LandingPageTemplateConfig | null>(null);
+    const [deleting, setDeleting] = useState(false);
+
+    // Logo upload
+    const [uploadingLogo, setUploadingLogo] = useState<number | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [logoTargetId, setLogoTargetId] = useState<number | null>(null);
+
+    // --- Clone ---
+    const handleClone = async () => {
+        if (!cloneName.trim()) return;
+        setCloning(true);
+        try {
+            await axios.post('/landing-pages', { name: cloneName.trim() });
+            toast.success('Template cloned successfully');
+            setCloneOpen(false);
+            setCloneName('');
+            router.reload({ only: ['templates'] });
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.data?.errors?.name) {
+                toast.error(error.response.data.errors.name[0]);
+            } else {
+                toast.error('Failed to clone template');
+            }
+        } finally {
+            setCloning(false);
+        }
+    };
+
+    // --- Edit ---
+    const openEdit = (tmpl: LandingPageTemplateConfig) => {
+        setEditTemplate(tmpl);
+        setEditName(tmpl.name);
+        setEditRightOrder([...tmpl.right_column_order]);
+        setEditLeftOrder([...tmpl.left_column_order]);
+        setEditOpen(true);
+    };
+
+    const handleSave = async () => {
+        if (!editTemplate) return;
+        setSaving(true);
+        try {
+            await axios.put(`/landing-pages/${editTemplate.id}`, {
+                name: editName.trim(),
+                right_column_order: editRightOrder,
+                left_column_order: editLeftOrder,
+            });
+            toast.success('Template updated successfully');
+            setEditOpen(false);
+            router.reload({ only: ['templates'] });
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.data?.errors) {
+                const errors = error.response.data.errors;
+                const msg = Object.values(errors).flat().join(', ');
+                toast.error(msg);
+            } else {
+                toast.error('Failed to update template');
+            }
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    // --- Delete ---
+    const handleDelete = async () => {
+        if (!deleteTemplate) return;
+        setDeleting(true);
+        try {
+            await axios.delete(`/landing-pages/${deleteTemplate.id}`);
+            toast.success('Template deleted successfully');
+            setDeleteOpen(false);
+            setDeleteTemplate(null);
+            router.reload({ only: ['templates'] });
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.data?.message) {
+                toast.error(error.response.data.message);
+            } else {
+                toast.error('Failed to delete template');
+            }
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    // --- Logo Upload ---
+    const triggerLogoUpload = (templateId: number) => {
+        setLogoTargetId(templateId);
+        fileInputRef.current?.click();
+    };
+
+    const handleLogoFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file || !logoTargetId) return;
+
+        // Reset file input
+        e.target.value = '';
+
+        setUploadingLogo(logoTargetId);
+        try {
+            const formData = new FormData();
+            formData.append('logo', file);
+            await axios.post(`/landing-pages/${logoTargetId}/logo`, formData, {
+                headers: { 'Content-Type': 'multipart/form-data' },
+            });
+            toast.success('Logo uploaded successfully');
+            router.reload({ only: ['templates'] });
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.data?.errors?.logo) {
+                toast.error(error.response.data.errors.logo[0]);
+            } else {
+                toast.error('Failed to upload logo');
+            }
+        } finally {
+            setUploadingLogo(null);
+            setLogoTargetId(null);
+        }
+    };
+
+    const handleDeleteLogo = async (templateId: number) => {
+        try {
+            await axios.delete(`/landing-pages/${templateId}/logo`);
+            toast.success('Logo removed');
+            router.reload({ only: ['templates'] });
+        } catch {
+            toast.error('Failed to remove logo');
+        }
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Landing Page Templates" />
+
+            {/* Hidden file input for logo upload */}
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/svg+xml,image/webp"
+                className="hidden"
+                onChange={handleLogoFileChange}
+            />
+
+            <div className="mx-auto max-w-5xl space-y-6 p-6">
+                {/* Page Header */}
+                <div className="flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold tracking-tight">Landing Page Templates</h1>
+                        <p className="text-muted-foreground">
+                            Manage custom templates for resource landing pages. Clone the default template and customize section order and logo.
+                        </p>
+                    </div>
+                    <Button onClick={() => { setCloneName(''); setCloneOpen(true); }}>
+                        <Plus className="mr-2 size-4" />
+                        New Template
+                    </Button>
+                </div>
+
+                <Separator />
+
+                {/* Template Cards */}
+                <div className="grid gap-4 md:grid-cols-2">
+                    {templates.map((tmpl) => (
+                        <Card key={tmpl.id} className={tmpl.is_default ? 'border-primary/30' : ''}>
+                            <CardHeader className="pb-3">
+                                <div className="flex items-start justify-between">
+                                    <div className="flex items-center gap-2">
+                                        <LayoutTemplate className="size-5 text-muted-foreground" />
+                                        <div>
+                                            <CardTitle className="text-base">{tmpl.name}</CardTitle>
+                                            <CardDescription className="text-xs">
+                                                {tmpl.is_default ? 'Built-in default template' : `Created by ${tmpl.creator?.name ?? 'Unknown'}`}
+                                            </CardDescription>
+                                        </div>
+                                    </div>
+                                    <div className="flex items-center gap-1">
+                                        {tmpl.is_default && (
+                                            <Badge variant="secondary" className="text-xs">Default</Badge>
+                                        )}
+                                        {(tmpl.landing_pages_count ?? 0) > 0 && (
+                                            <Badge variant="outline" className="text-xs">
+                                                {tmpl.landing_pages_count} {tmpl.landing_pages_count === 1 ? 'page' : 'pages'}
+                                            </Badge>
+                                        )}
+                                    </div>
+                                </div>
+                            </CardHeader>
+
+                            <CardContent className="space-y-3">
+                                {/* Logo Preview */}
+                                {tmpl.logo_url && (
+                                    <div className="flex items-center gap-3 rounded-md border bg-muted/30 p-2">
+                                        <img
+                                            src={tmpl.logo_url}
+                                            alt={`${tmpl.name} logo`}
+                                            className="h-10 max-w-40 object-contain"
+                                        />
+                                        <span className="flex-1 truncate text-xs text-muted-foreground">{tmpl.logo_filename}</span>
+                                        {!tmpl.is_default && (
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="size-7"
+                                                onClick={() => handleDeleteLogo(tmpl.id)}
+                                                aria-label="Remove logo"
+                                            >
+                                                <X className="size-3.5" />
+                                            </Button>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Section Order Summary */}
+                                <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                                    <div>
+                                        <span className="font-medium text-foreground">Right Column:</span>
+                                        <ol className="mt-0.5 list-inside list-decimal space-y-0.5">
+                                            {tmpl.right_column_order.map((key) => (
+                                                <li key={key}>{RIGHT_SECTION_LABELS[key] ?? key}</li>
+                                            ))}
+                                        </ol>
+                                    </div>
+                                    <div>
+                                        <span className="font-medium text-foreground">Left Column:</span>
+                                        <ol className="mt-0.5 list-inside list-decimal space-y-0.5">
+                                            {tmpl.left_column_order.map((key) => (
+                                                <li key={key}>{LEFT_SECTION_LABELS[key] ?? key}</li>
+                                            ))}
+                                        </ol>
+                                    </div>
+                                </div>
+
+                                {/* Actions */}
+                                {!tmpl.is_default && (
+                                    <div className="flex items-center gap-2 pt-1">
+                                        <Button variant="outline" size="sm" onClick={() => openEdit(tmpl)}>
+                                            <Pencil className="mr-1.5 size-3.5" />
+                                            Edit
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => triggerLogoUpload(tmpl.id)}
+                                            disabled={uploadingLogo === tmpl.id}
+                                        >
+                                            <ImagePlus className="mr-1.5 size-3.5" />
+                                            {tmpl.logo_url ? 'Replace Logo' : 'Upload Logo'}
+                                        </Button>
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            className="ml-auto text-destructive hover:text-destructive"
+                                            onClick={() => { setDeleteTemplate(tmpl); setDeleteOpen(true); }}
+                                        >
+                                            <Trash2 className="mr-1.5 size-3.5" />
+                                            Delete
+                                        </Button>
+                                    </div>
+                                )}
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+
+                {templates.length === 0 && (
+                    <div className="py-12 text-center text-muted-foreground">
+                        <LayoutTemplate className="mx-auto mb-4 size-12 opacity-50" />
+                        <p>No templates found. Create one to get started.</p>
+                    </div>
+                )}
+            </div>
+
+            {/* Clone Dialog */}
+            <Dialog open={cloneOpen} onOpenChange={setCloneOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                            <Copy className="size-5" />
+                            Clone Default Template
+                        </DialogTitle>
+                        <DialogDescription>
+                            Create a new template based on the default GFZ template. You can customize the section order and logo afterwards.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="space-y-4 py-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="clone-name">Template Name</Label>
+                            <Input
+                                id="clone-name"
+                                placeholder="e.g. GFZ Geophysics Template"
+                                value={cloneName}
+                                onChange={(e) => setCloneName(e.target.value)}
+                                onKeyDown={(e) => e.key === 'Enter' && handleClone()}
+                                autoFocus
+                            />
+                        </div>
+                    </div>
+
+                    <DialogFooter className="gap-2">
+                        <Button variant="outline" onClick={() => setCloneOpen(false)}>Cancel</Button>
+                        <LoadingButton loading={cloning} disabled={!cloneName.trim()} onClick={handleClone}>
+                            Clone Template
+                        </LoadingButton>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Edit Dialog */}
+            <Dialog open={editOpen} onOpenChange={setEditOpen}>
+                <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                            <Pencil className="size-5" />
+                            Edit Template
+                        </DialogTitle>
+                        <DialogDescription>
+                            Customize the template name and drag sections to reorder them.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="space-y-6 py-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="edit-name">Template Name</Label>
+                            <Input
+                                id="edit-name"
+                                value={editName}
+                                onChange={(e) => setEditName(e.target.value)}
+                            />
+                        </div>
+
+                        <Separator />
+
+                        <div className="grid gap-6 md:grid-cols-2">
+                            <SectionOrderEditor
+                                title="Right Column (main content)"
+                                items={editRightOrder}
+                                labels={RIGHT_SECTION_LABELS}
+                                onReorder={(items) => setEditRightOrder(items as RightColumnSection[])}
+                            />
+                            <SectionOrderEditor
+                                title="Left Column (sidebar)"
+                                items={editLeftOrder}
+                                labels={LEFT_SECTION_LABELS}
+                                onReorder={(items) => setEditLeftOrder(items as LeftColumnSection[])}
+                            />
+                        </div>
+                    </div>
+
+                    <DialogFooter className="gap-2">
+                        <Button variant="outline" onClick={() => setEditOpen(false)}>Cancel</Button>
+                        <LoadingButton loading={saving} disabled={!editName.trim()} onClick={handleSave}>
+                            Save Changes
+                        </LoadingButton>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Delete Confirmation */}
+            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Template</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Are you sure you want to delete &ldquo;{deleteTemplate?.name}&rdquo;?
+                            {(deleteTemplate?.landing_pages_count ?? 0) > 0 && (
+                                <span className="mt-2 block font-medium text-destructive">
+                                    This template is currently used by {deleteTemplate?.landing_pages_count} landing page(s).
+                                    Those pages will revert to the default template.
+                                </span>
+                            )}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                            onClick={handleDelete}
+                            disabled={deleting}
+                        >
+                            {deleting ? 'Deleting...' : 'Delete'}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -64,15 +64,17 @@ function SortableSectionItem({ id, label }: { id: string; label: string }) {
             style={style}
             className="flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm"
         >
-            <button
+            <Button
+                variant="ghost"
+                size="icon"
                 type="button"
                 aria-label={`Reorder ${label}`}
-                className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+                className="size-6 cursor-grab touch-none text-muted-foreground hover:text-foreground"
                 {...attributes}
                 {...listeners}
             >
                 <GripVertical className="size-4" />
-            </button>
+            </Button>
             <span className="flex-1">{label}</span>
         </div>
     );
@@ -506,8 +508,8 @@ export default function LandingPageTemplatesPage() {
                             Are you sure you want to delete &ldquo;{deleteTemplate?.name}&rdquo;?
                             {(deleteTemplate?.landing_pages_count ?? 0) > 0 && (
                                 <span className="mt-2 block font-medium text-destructive">
-                                    This template is currently used by {deleteTemplate?.landing_pages_count} landing page(s).
-                                    Those pages will revert to the default template.
+                                    This template is currently used by {deleteTemplate?.landing_pages_count} landing page(s) and cannot be deleted.
+                                    Please reassign those pages to a different template first.
                                 </span>
                             )}
                         </AlertDialogDescription>

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -519,7 +519,7 @@ export default function LandingPageTemplatesPage() {
                         <AlertDialogAction
                             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                             onClick={handleDelete}
-                            disabled={deleting}
+                            disabled={deleting || (deleteTemplate?.landing_pages_count ?? 0) > 0}
                         >
                             {deleting ? 'Deleting...' : 'Delete'}
                         </AlertDialogAction>

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -279,7 +279,7 @@ export default function LandingPageTemplatesPage() {
             <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/svg+xml,image/webp"
+                accept="image/png,image/jpeg,image/webp"
                 className="hidden"
                 onChange={handleLogoFileChange}
             />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -63,6 +63,7 @@ export interface User {
     can_access_editor_settings?: boolean;
     // Landing page management permission (Issue #375)
     can_manage_landing_pages?: boolean;
+    can_manage_landing_page_templates?: boolean;
     // Assistance page permission
     can_access_assistance?: boolean;
     deactivated_at?: string | null;

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -1,4 +1,70 @@
 /**
+ * Right column section identifiers for landing page templates.
+ */
+export type RightColumnSection = 'descriptions' | 'creators' | 'contributors' | 'funders' | 'keywords' | 'metadata_download' | 'location';
+
+/**
+ * Left column section identifiers for landing page templates.
+ */
+export type LeftColumnSection = 'files' | 'contact' | 'model_description' | 'related_work';
+
+/**
+ * Section order configuration for landing page templates.
+ */
+export interface SectionOrder {
+    rightColumn: RightColumnSection[];
+    leftColumn: LeftColumnSection[];
+}
+
+/**
+ * Custom Landing Page Template
+ *
+ * Represents a user-created template configuration (cloned from default).
+ * Templates define section order and optional custom logo.
+ */
+export interface LandingPageTemplateConfig {
+    /** Primary key */
+    id: number;
+
+    /** Template display name */
+    name: string;
+
+    /** URL-safe slug (unique) */
+    slug: string;
+
+    /** Whether this is the immutable default template */
+    is_default: boolean;
+
+    /** Storage path for custom logo */
+    logo_path: string | null;
+
+    /** Original filename of uploaded logo */
+    logo_filename: string | null;
+
+    /** Computed URL to logo image */
+    logo_url: string | null;
+
+    /** Ordered right column sections */
+    right_column_order: RightColumnSection[];
+
+    /** Ordered left column sections */
+    left_column_order: LeftColumnSection[];
+
+    /** ID of user who created this template */
+    created_by: number | null;
+
+    /** Creator user object (when loaded) */
+    creator?: { id: number; name: string } | null;
+
+    /** Number of landing pages using this template */
+    landing_pages_count?: number;
+
+    /** Timestamps */
+    created_at: string;
+    updated_at: string;
+}
+
+/**
  * Landing Page Domain
  *
  * Represents a domain entry for external landing page URLs.
@@ -66,6 +132,9 @@ export interface LandingPageConfig {
 
     /** Template identifier (e.g., 'default_gfz') */
     template: string;
+
+    /** FK to landing_page_templates table (null = use built-in default) */
+    landing_page_template_id?: number | null;
 
     /** FTP URL for dataset downloads (optional) */
     ftp_url?: string | null;
@@ -377,6 +446,10 @@ export interface LandingPageTemplateProps {
     landingPage: LandingPageConfig;
     /** Whether this is a preview (draft mode) */
     isPreview: boolean;
+    /** Custom section order from template (null = use default) */
+    sectionOrder?: SectionOrder | null;
+    /** Custom logo URL from template (null = use default GFZ logo) */
+    customLogoUrl?: string | null;
 }
 
 /**

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -65,6 +65,22 @@ export interface LandingPageTemplateConfig {
 }
 
 /**
+ * Lightweight template summary returned by `/api/landing-page-templates`.
+ *
+ * Only the fields the API actually returns – used in the SetupLandingPageModal dropdown.
+ */
+export interface LandingPageTemplateSummary {
+    id: number;
+    name: string;
+    slug: string;
+    is_default: boolean;
+    logo_path: string | null;
+    logo_url: string | null;
+    right_column_order: RightColumnSection[];
+    left_column_order: LeftColumnSection[];
+}
+
+/**
  * Landing Page Domain
  *
  * Represents a domain entry for external landing page URLs.

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\IgsnMapController;
 use App\Http\Controllers\LandingPageController;
 use App\Http\Controllers\LandingPagePreviewController;
 use App\Http\Controllers\LandingPagePublicController;
+use App\Http\Controllers\LandingPageTemplateController;
 use App\Http\Controllers\OaiPmh\OaiPmhController;
 use App\Http\Controllers\OaiPmh\OaiPmhDocsController;
 use App\Http\Controllers\OldDatasetController;
@@ -321,6 +322,26 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Landing Page Management (Admin)
     Route::post('resources/{resource}/landing-page', [LandingPageController::class, 'store'])
         ->name('landing-page.store');
+
+    // Landing Page Template Management (Admin, Group Leader)
+    Route::middleware(['can:manage-landing-page-templates'])->group(function () {
+        Route::get('landing-pages', [LandingPageTemplateController::class, 'index'])
+            ->name('landing-page-templates.index');
+        Route::post('landing-pages', [LandingPageTemplateController::class, 'store'])
+            ->name('landing-page-templates.store');
+        Route::put('landing-pages/{landingPageTemplate}', [LandingPageTemplateController::class, 'update'])
+            ->name('landing-page-templates.update');
+        Route::delete('landing-pages/{landingPageTemplate}', [LandingPageTemplateController::class, 'destroy'])
+            ->name('landing-page-templates.destroy');
+        Route::post('landing-pages/{landingPageTemplate}/logo', [LandingPageTemplateController::class, 'uploadLogo'])
+            ->name('landing-page-templates.upload-logo');
+        Route::delete('landing-pages/{landingPageTemplate}/logo', [LandingPageTemplateController::class, 'deleteLogo'])
+            ->name('landing-page-templates.delete-logo');
+    });
+
+    // Landing Page Templates API - accessible to all authenticated users (for template dropdown)
+    Route::get('api/landing-page-templates', [LandingPageTemplateController::class, 'list'])
+        ->name('landing-page-templates.list');
 
     Route::put('resources/{resource}/landing-page', [LandingPageController::class, 'update'])
         ->name('landing-page.update');

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -412,3 +412,80 @@ describe('External Landing Page Update', function () {
             ->external_path->toBeNull();
     });
 });
+
+describe('Landing Page Template Assignment', function () {
+    test('can create landing page with custom template', function () {
+        $template = \App\Models\LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        $response = $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertStatus(201);
+
+        $landingPage = $this->resource->fresh()->landingPage;
+        expect($landingPage->landing_page_template_id)->toBe($template->id);
+    });
+
+    test('can update landing page template assignment', function () {
+        $template = \App\Models\LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'landing_page_template_id' => null,
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertOk();
+
+        $landingPage = $this->resource->fresh()->landingPage;
+        expect($landingPage->landing_page_template_id)->toBe($template->id);
+    });
+
+    test('can clear template assignment by setting null', function () {
+        $template = \App\Models\LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => null,
+        ]);
+
+        $response->assertOk();
+
+        $landingPage = $this->resource->fresh()->landingPage;
+        expect($landingPage->landing_page_template_id)->toBeNull();
+    });
+
+    test('rejects invalid template id', function () {
+        $response = $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => 99999,
+        ]);
+
+        $response->assertJsonValidationErrors(['landing_page_template_id']);
+    });
+});

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -452,3 +452,57 @@ describe('External Landing Page Redirect', function () {
         $response->assertRedirect('https://example.org/leading/slash/path');
     });
 });
+
+describe('Landing Page with Custom Template', function () {
+    test('renders landing page with custom template section order and logo', function () {
+        $template = \App\Models\LandingPageTemplate::factory()->create([
+            'created_by' => \App\Models\User::factory()->admin()->create()->id,
+            'right_column_order' => ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
+            'logo_path' => 'landing-page-logos/test/custom-logo.png',
+        ]);
+
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'template-test',
+                'template' => 'default_gfz',
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz')
+                ->has('sectionOrder', fn ($order) => $order
+                    ->has('rightColumn')
+                    ->has('leftColumn')
+                )
+                ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/custom-logo.png'))
+            );
+    });
+
+    test('renders landing page without custom template (default)', function () {
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'no-template-test',
+                'template' => 'default_gfz',
+                'landing_page_template_id' => null,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz')
+                ->where('sectionOrder', null)
+                ->where('customLogoUrl', null)
+            );
+    });
+});

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -14,7 +14,6 @@ use Database\Factories\LandingPageTemplateFactory;
 use Database\Seeders\LandingPageTemplateSeeder;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
 
 covers(
     LandingPageTemplateController::class,

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -750,12 +750,15 @@ describe('Delete with Logo Cleanup', function (): void {
 
         $file = UploadedFile::fake()->image('logo.png', 200, 100);
 
-        // Mock Storage facade - putFileAs returns false to simulate storage failure
-        $fakeDisk = Mockery::mock(\Illuminate\Contracts\Filesystem\Filesystem::class);
-        $fakeDisk->shouldReceive('delete')->andReturn(true);
-        $fakeDisk->shouldReceive('putFileAs')->once()->andReturn(false);
+        // Mock Storage facade to throw exception simulating disk failure
+        Storage::shouldReceive('disk')
+            ->with('public')
+            ->andReturnUsing(function () {
+                $mock = \Mockery::mock(\Illuminate\Contracts\Filesystem\Filesystem::class);
+                $mock->shouldReceive('putFileAs')->andThrow(new \RuntimeException('Disk full'));
 
-        Storage::shouldReceive('disk')->with('public')->andReturn($fakeDisk);
+                return $mock;
+            });
 
         $this->actingAs($this->admin)
             ->postJson("/landing-pages/{$template->id}/logo", [

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -14,6 +14,7 @@ use Database\Factories\LandingPageTemplateFactory;
 use Database\Seeders\LandingPageTemplateSeeder;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Mockery;
 
 covers(
     LandingPageTemplateController::class,
@@ -746,16 +747,16 @@ describe('Delete with Logo Cleanup', function (): void {
     });
 
     it('returns 500 when logo storage fails', function (): void {
-        Storage::fake('public');
-
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
 
-        // Make the store method return false to simulate storage failure
-        Storage::disk('public')->shouldReceive('putFileAs')->andReturn(false);
-        Storage::disk('public')->shouldReceive('putFile')->andReturn(false);
-        Storage::disk('public')->shouldReceive('put')->andReturn(false);
-
         $file = UploadedFile::fake()->image('logo.png', 200, 100);
+
+        // Mock Storage facade - putFileAs returns false to simulate storage failure
+        $fakeDisk = Mockery::mock(\Illuminate\Contracts\Filesystem\Filesystem::class);
+        $fakeDisk->shouldReceive('delete')->andReturn(true);
+        $fakeDisk->shouldReceive('putFileAs')->once()->andReturn(false);
+
+        Storage::shouldReceive('disk')->with('public')->andReturn($fakeDisk);
 
         $this->actingAs($this->admin)
             ->postJson("/landing-pages/{$template->id}/logo", [

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -3,14 +3,23 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\LandingPageTemplateController;
+use App\Http\Requests\StoreLandingPageTemplateRequest;
+use App\Http\Requests\UpdateLandingPageTemplateRequest;
 use App\Models\LandingPage;
 use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\User;
+use App\Policies\LandingPageTemplatePolicy;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
-covers(LandingPageTemplateController::class);
+covers(
+    LandingPageTemplateController::class,
+    LandingPageTemplate::class,
+    LandingPageTemplatePolicy::class,
+    StoreLandingPageTemplateRequest::class,
+    UpdateLandingPageTemplateRequest::class,
+);
 
 uses()->group('landing-page-templates');
 
@@ -347,5 +356,388 @@ describe('API List', function (): void {
     it('rejects unauthenticated access to API list', function (): void {
         $this->getJson('/api/landing-page-templates')
             ->assertUnauthorized();
+    });
+});
+
+// ─── Model ───────────────────────────────────────────────────────────────────
+
+describe('Model', function (): void {
+    it('returns null logo_url when no logo is set', function (): void {
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->admin->id,
+            'logo_path' => null,
+        ]);
+
+        expect($template->logo_url)->toBeNull();
+    });
+
+    it('returns full logo_url when logo_path is set', function (): void {
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->admin->id,
+            'logo_path' => 'landing-page-logos/test/logo.png',
+        ]);
+
+        expect($template->logo_url)->toContain('storage/landing-page-logos/test/logo.png');
+    });
+
+    it('identifies default template correctly', function (): void {
+        expect($this->defaultTemplate->isDefault())->toBeTrue();
+
+        $custom = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+        expect($custom->isDefault())->toBeFalse();
+    });
+
+    it('detects when template is in use', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        expect($template->isInUse())->toBeFalse();
+
+        $resource = Resource::factory()->create();
+        LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        expect($template->isInUse())->toBeTrue();
+    });
+
+    it('returns correct usage count', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        expect($template->getUsageCount())->toBe(0);
+
+        $resources = Resource::factory()->count(3)->create();
+        foreach ($resources as $resource) {
+            LandingPage::factory()->create([
+                'resource_id' => $resource->id,
+                'landing_page_template_id' => $template->id,
+            ]);
+        }
+
+        expect($template->getUsageCount())->toBe(3);
+    });
+
+    it('scopes custom templates excluding default', function (): void {
+        LandingPageTemplate::factory()->count(2)->create(['created_by' => $this->admin->id]);
+
+        $custom = LandingPageTemplate::custom()->get();
+
+        expect($custom)->toHaveCount(2)
+            ->and($custom->pluck('is_default')->unique()->toArray())->toBe([false]);
+    });
+
+    it('validates section order with valid input', function (): void {
+        $valid = LandingPageTemplate::isValidSectionOrder(
+            ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+        );
+
+        expect($valid)->toBeTrue();
+    });
+
+    it('validates section order with reordered input', function (): void {
+        $valid = LandingPageTemplate::isValidSectionOrder(
+            ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+        );
+
+        expect($valid)->toBeTrue();
+    });
+
+    it('rejects section order with wrong count', function (): void {
+        $valid = LandingPageTemplate::isValidSectionOrder(
+            ['descriptions', 'creators'],
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+        );
+
+        expect($valid)->toBeFalse();
+    });
+
+    it('rejects section order with invalid keys', function (): void {
+        $valid = LandingPageTemplate::isValidSectionOrder(
+            ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'invalid_key'],
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+        );
+
+        expect($valid)->toBeFalse();
+    });
+
+    it('rejects section order with duplicate keys', function (): void {
+        $valid = LandingPageTemplate::isValidSectionOrder(
+            ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'descriptions'],
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+        );
+
+        expect($valid)->toBeFalse();
+    });
+
+    it('has creator relationship', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        expect($template->creator)->toBeInstanceOf(User::class)
+            ->and($template->creator->id)->toBe($this->admin->id);
+    });
+
+    it('has landingPages relationship', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $resource = Resource::factory()->create();
+        LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        expect($template->landingPages)->toHaveCount(1);
+    });
+
+    it('casts right_column_order as array', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        expect($template->right_column_order)->toBeArray()
+            ->and($template->left_column_order)->toBeArray();
+    });
+
+    it('casts is_default as boolean', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        expect($template->is_default)->toBeBool();
+    });
+
+    it('appends logo_url attribute', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+        $json = $template->toArray();
+
+        expect($json)->toHaveKey('logo_url');
+    });
+});
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+describe('Factory', function (): void {
+    it('creates a valid template with defaults', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        expect($template->name)->toBeString()
+            ->and($template->slug)->toBeString()
+            ->and($template->is_default)->toBeFalse()
+            ->and($template->logo_path)->toBeNull()
+            ->and($template->logo_filename)->toBeNull()
+            ->and($template->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::LEFT_COLUMN_SECTIONS);
+    });
+
+    it('creates a default template via state', function (): void {
+        $template = LandingPageTemplate::factory()->default()->make();
+
+        expect($template->name)->toBe('Default GFZ Data Services')
+            ->and($template->slug)->toBe('default_gfz')
+            ->and($template->is_default)->toBeTrue()
+            ->and($template->created_by)->toBeNull();
+    });
+
+    it('creates a template with custom section order', function (): void {
+        $rightOrder = ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'];
+        $leftOrder = ['contact', 'files', 'model_description', 'related_work'];
+
+        $template = LandingPageTemplate::factory()
+            ->withSectionOrder($rightOrder, $leftOrder)
+            ->create(['created_by' => $this->admin->id]);
+
+        expect($template->right_column_order)->toBe($rightOrder)
+            ->and($template->left_column_order)->toBe($leftOrder);
+    });
+
+    it('creates a template with logo via state', function (): void {
+        $template = LandingPageTemplate::factory()
+            ->withLogo('custom/path/logo.svg', 'my-logo.svg')
+            ->create(['created_by' => $this->admin->id]);
+
+        expect($template->logo_path)->toBe('custom/path/logo.svg')
+            ->and($template->logo_filename)->toBe('my-logo.svg')
+            ->and($template->logo_url)->toContain('storage/custom/path/logo.svg');
+    });
+});
+
+// ─── Seeder ──────────────────────────────────────────────────────────────────
+
+describe('Seeder', function (): void {
+    it('seeds the default template', function (): void {
+        // Default template already seeded in beforeEach, verify it exists
+        $default = LandingPageTemplate::where('slug', 'default_gfz')->first();
+
+        expect($default)->not->toBeNull()
+            ->and($default->name)->toBe('Default GFZ Data Services')
+            ->and($default->is_default)->toBeTrue()
+            ->and($default->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
+            ->and($default->left_column_order)->toBe(LandingPageTemplate::LEFT_COLUMN_SECTIONS);
+    });
+
+    it('does not duplicate default template when seeder runs again', function (): void {
+        // Run the seeder a second time
+        $this->seed(\Database\Seeders\LandingPageTemplateSeeder::class);
+
+        $count = LandingPageTemplate::where('slug', 'default_gfz')->count();
+
+        expect($count)->toBe(1);
+    });
+});
+
+// ─── Update Edge Cases ───────────────────────────────────────────────────────
+
+describe('Update Edge Cases', function (): void {
+    it('updates only the name without section order', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+        $originalRightOrder = $template->right_column_order;
+        $originalLeftOrder = $template->left_column_order;
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", ['name' => 'Only Name Changed'])
+            ->assertOk();
+
+        $template->refresh();
+
+        expect($template->name)->toBe('Only Name Changed')
+            ->and($template->right_column_order)->toBe($originalRightOrder)
+            ->and($template->left_column_order)->toBe($originalLeftOrder);
+    });
+
+    it('updates only right column order', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+        $originalName = $template->name;
+        $originalLeftOrder = $template->left_column_order;
+
+        $newRightOrder = ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'];
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", ['right_column_order' => $newRightOrder])
+            ->assertOk();
+
+        $template->refresh();
+
+        expect($template->name)->toBe($originalName)
+            ->and($template->right_column_order)->toBe($newRightOrder)
+            ->and($template->left_column_order)->toBe($originalLeftOrder);
+    });
+
+    it('allows group leaders to update custom templates', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->groupLeader)
+            ->putJson("/landing-pages/{$template->id}", ['name' => 'GL Update'])
+            ->assertOk();
+
+        expect($template->fresh()->name)->toBe('GL Update');
+    });
+
+    it('rejects duplicate name when updating', function (): void {
+        $template1 = LandingPageTemplate::factory()->create([
+            'name' => 'First Template',
+            'created_by' => $this->admin->id,
+        ]);
+        $template2 = LandingPageTemplate::factory()->create([
+            'name' => 'Second Template',
+            'created_by' => $this->admin->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template2->id}", ['name' => 'First Template'])
+            ->assertJsonValidationErrors(['name']);
+    });
+
+    it('allows updating template with its own name', function (): void {
+        $template = LandingPageTemplate::factory()->create([
+            'name' => 'My Template',
+            'created_by' => $this->admin->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", ['name' => 'My Template'])
+            ->assertOk();
+    });
+
+    it('validates left column section order completeness', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        // Only 2 of 4 required left column sections
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'left_column_order' => ['files', 'contact'],
+            ])
+            ->assertJsonValidationErrors(['left_column_order']);
+    });
+});
+
+// ─── Delete with Logo Cleanup ────────────────────────────────────────────────
+
+describe('Delete with Logo Cleanup', function (): void {
+    it('deletes logo file when deleting a template with logo', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        // Upload a logo
+        $file = UploadedFile::fake()->image('logo.png', 200, 100);
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", ['logo' => $file])
+            ->assertOk();
+
+        $template->refresh();
+        $logoPath = $template->logo_path;
+
+        Storage::disk('public')->assertExists($logoPath);
+
+        // Delete the template
+        $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$template->id}")
+            ->assertOk();
+
+        Storage::disk('public')->assertMissing($logoPath);
+    });
+
+    it('replaces old logo when uploading new one', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        // Upload first logo
+        $file1 = UploadedFile::fake()->image('old-logo.png', 200, 100);
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", ['logo' => $file1])
+            ->assertOk();
+
+        $template->refresh();
+        $oldLogoPath = $template->logo_path;
+
+        // Upload replacement logo
+        $file2 = UploadedFile::fake()->image('new-logo.png', 300, 150);
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", ['logo' => $file2])
+            ->assertOk();
+
+        $template->refresh();
+
+        Storage::disk('public')->assertMissing($oldLogoPath);
+        Storage::disk('public')->assertExists($template->logo_path);
+        expect($template->logo_filename)->toBe('new-logo.png');
+    });
+
+    it('handles deleting logo when no logo exists', function (): void {
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->admin->id,
+            'logo_path' => null,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$template->id}/logo")
+            ->assertOk();
+
+        $template->refresh();
+        expect($template->logo_path)->toBeNull();
+    });
+
+    it('denies logo deletion for default template', function (): void {
+        $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$this->defaultTemplate->id}/logo")
+            ->assertForbidden();
     });
 });

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -10,6 +10,8 @@ use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\User;
 use App\Policies\LandingPageTemplatePolicy;
+use Database\Factories\LandingPageTemplateFactory;
+use Database\Seeders\LandingPageTemplateSeeder;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
@@ -19,6 +21,8 @@ covers(
     LandingPageTemplatePolicy::class,
     StoreLandingPageTemplateRequest::class,
     UpdateLandingPageTemplateRequest::class,
+    LandingPageTemplateFactory::class,
+    LandingPageTemplateSeeder::class,
 );
 
 uses()->group('landing-page-templates');
@@ -739,5 +743,33 @@ describe('Delete with Logo Cleanup', function (): void {
         $this->actingAs($this->admin)
             ->deleteJson("/landing-pages/{$this->defaultTemplate->id}/logo")
             ->assertForbidden();
+    });
+
+    it('returns 500 when logo storage fails', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        // Make the store method return false to simulate storage failure
+        Storage::disk('public')->shouldReceive('putFileAs')->andReturn(false);
+        Storage::disk('public')->shouldReceive('putFile')->andReturn(false);
+        Storage::disk('public')->shouldReceive('put')->andReturn(false);
+
+        $file = UploadedFile::fake()->image('logo.png', 200, 100);
+
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", [
+                'logo' => $file,
+            ])
+            ->assertStatus(500)
+            ->assertJson(['message' => 'Failed to store logo file']);
+    });
+
+    it('handles logo upload without file gracefully', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", [])
+            ->assertJsonValidationErrors(['logo']);
     });
 });

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\LandingPageTemplateController;
+use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
+use App\Models\Resource;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+covers(LandingPageTemplateController::class);
+
+uses()->group('landing-page-templates');
+
+beforeEach(function (): void {
+    $this->admin = User::factory()->admin()->create();
+    $this->groupLeader = User::factory()->groupLeader()->create();
+    $this->curator = User::factory()->curator()->create();
+    $this->beginner = User::factory()->beginner()->create();
+
+    // Seed default template
+    $this->defaultTemplate = LandingPageTemplate::factory()->default()->create();
+});
+
+// ─── Authorization ───────────────────────────────────────────────────────────
+
+describe('Authorization', function (): void {
+    it('allows admins to view template index', function (): void {
+        $this->actingAs($this->admin)
+            ->get('/landing-pages')
+            ->assertOk();
+    });
+
+    it('allows group leaders to view template index', function (): void {
+        $this->actingAs($this->groupLeader)
+            ->get('/landing-pages')
+            ->assertOk();
+    });
+
+    it('denies curators access to template index', function (): void {
+        $this->actingAs($this->curator)
+            ->get('/landing-pages')
+            ->assertForbidden();
+    });
+
+    it('denies beginners access to template index', function (): void {
+        $this->actingAs($this->beginner)
+            ->get('/landing-pages')
+            ->assertForbidden();
+    });
+
+    it('denies curator from creating templates', function (): void {
+        $this->actingAs($this->curator)
+            ->postJson('/landing-pages', ['name' => 'Test'])
+            ->assertForbidden();
+    });
+
+    it('denies curator from updating templates', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->curator)
+            ->putJson("/landing-pages/{$template->id}", ['name' => 'Updated'])
+            ->assertForbidden();
+    });
+
+    it('denies curator from deleting templates', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->curator)
+            ->deleteJson("/landing-pages/{$template->id}")
+            ->assertForbidden();
+    });
+});
+
+// ─── Index Page ──────────────────────────────────────────────────────────────
+
+describe('Index', function (): void {
+    it('returns template list via Inertia', function (): void {
+        LandingPageTemplate::factory()->count(2)->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->admin)
+            ->get('/landing-pages')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('landing-page-templates')
+                ->has('templates', 3) // default + 2 custom
+            );
+    });
+});
+
+// ─── Clone (Store) ───────────────────────────────────────────────────────────
+
+describe('Clone', function (): void {
+    it('clones the default template with a new name', function (): void {
+        $response = $this->actingAs($this->admin)
+            ->postJson('/landing-pages', ['name' => 'My Custom Template']);
+
+        $response->assertCreated();
+
+        $template = LandingPageTemplate::where('name', 'My Custom Template')->first();
+
+        expect($template)->not->toBeNull()
+            ->and($template->is_default)->toBeFalse()
+            ->and($template->created_by)->toBe($this->admin->id)
+            ->and($template->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::LEFT_COLUMN_SECTIONS);
+    });
+
+    it('rejects duplicate names', function (): void {
+        LandingPageTemplate::factory()->create([
+            'name' => 'Existing Template',
+            'created_by' => $this->admin->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->postJson('/landing-pages', ['name' => 'Existing Template'])
+            ->assertJsonValidationErrors(['name']);
+    });
+
+    it('rejects empty name', function (): void {
+        $this->actingAs($this->admin)
+            ->postJson('/landing-pages', ['name' => ''])
+            ->assertJsonValidationErrors(['name']);
+    });
+
+    it('generates a unique slug', function (): void {
+        $this->actingAs($this->admin)
+            ->postJson('/landing-pages', ['name' => 'My Template']);
+
+        $template = LandingPageTemplate::where('name', 'My Template')->first();
+
+        expect($template->slug)->toStartWith('my-template');
+    });
+});
+
+// ─── Update ──────────────────────────────────────────────────────────────────
+
+describe('Update', function (): void {
+    it('updates template name and section order', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $newRightOrder = ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'];
+        $newLeftOrder = ['contact', 'files', 'model_description', 'related_work'];
+
+        $response = $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'name' => 'Updated Name',
+                'right_column_order' => $newRightOrder,
+                'left_column_order' => $newLeftOrder,
+            ]);
+
+        $response->assertOk();
+
+        $template->refresh();
+
+        expect($template->name)->toBe('Updated Name')
+            ->and($template->right_column_order)->toBe($newRightOrder)
+            ->and($template->left_column_order)->toBe($newLeftOrder);
+    });
+
+    it('prevents updating the default template', function (): void {
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$this->defaultTemplate->id}", ['name' => 'Hacked'])
+            ->assertForbidden();
+    });
+
+    it('rejects invalid section keys in right column', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'name' => 'Valid Name',
+                'right_column_order' => ['descriptions', 'invalid_section'],
+            ])
+            ->assertJsonValidationErrors(['right_column_order']);
+    });
+
+    it('rejects right column with missing sections', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        // Missing some sections
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'name' => 'Valid Name',
+                'right_column_order' => ['descriptions', 'creators'],
+            ])
+            ->assertJsonValidationErrors(['right_column_order']);
+    });
+
+    it('rejects left column with invalid sections', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'name' => 'Valid Name',
+                'left_column_order' => ['files', 'nonexistent'],
+            ])
+            ->assertJsonValidationErrors(['left_column_order']);
+    });
+});
+
+// ─── Delete ──────────────────────────────────────────────────────────────────
+
+describe('Delete', function (): void {
+    it('deletes a custom template', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$template->id}");
+
+        $response->assertOk();
+
+        expect(LandingPageTemplate::find($template->id))->toBeNull();
+    });
+
+    it('prevents deleting the default template', function (): void {
+        $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$this->defaultTemplate->id}")
+            ->assertForbidden();
+    });
+
+    it('rejects deletion when template is in use', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        // Create a landing page using this template
+        $resource = Resource::factory()->create();
+        LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$template->id}")
+            ->assertStatus(422);
+    });
+});
+
+// ─── Logo Upload ─────────────────────────────────────────────────────────────
+
+describe('Logo Upload', function (): void {
+    it('uploads a logo to a custom template', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $file = UploadedFile::fake()->image('logo.png', 200, 100);
+
+        $response = $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", [
+                'logo' => $file,
+            ]);
+
+        $response->assertOk();
+
+        $template->refresh();
+
+        expect($template->logo_path)->not->toBeNull()
+            ->and($template->logo_filename)->toBe('logo.png');
+
+        Storage::disk('public')->assertExists($template->logo_path);
+    });
+
+    it('rejects logo upload for default template', function (): void {
+        Storage::fake('public');
+
+        $file = UploadedFile::fake()->image('logo.png');
+
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$this->defaultTemplate->id}/logo", [
+                'logo' => $file,
+            ])
+            ->assertForbidden();
+    });
+
+    it('rejects non-image files', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $file = UploadedFile::fake()->create('document.pdf', 100, 'application/pdf');
+
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", [
+                'logo' => $file,
+            ])
+            ->assertJsonValidationErrors(['logo']);
+    });
+
+    it('rejects oversized logo', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $file = UploadedFile::fake()->image('huge-logo.png')->size(3000); // 3MB > 2MB limit
+
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", [
+                'logo' => $file,
+            ])
+            ->assertJsonValidationErrors(['logo']);
+    });
+
+    it('deletes a logo from a custom template', function (): void {
+        Storage::fake('public');
+
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->admin->id,
+        ]);
+
+        // Upload a logo first
+        $file = UploadedFile::fake()->image('logo.png', 200, 100);
+        $this->actingAs($this->admin)
+            ->postJson("/landing-pages/{$template->id}/logo", ['logo' => $file]);
+
+        $template->refresh();
+
+        expect($template->logo_path)->not->toBeNull();
+
+        // Delete the logo
+        $response = $this->actingAs($this->admin)
+            ->deleteJson("/landing-pages/{$template->id}/logo");
+
+        $response->assertOk();
+
+        $template->refresh();
+
+        expect($template->logo_path)->toBeNull()
+            ->and($template->logo_filename)->toBeNull();
+    });
+});
+
+// ─── API List ────────────────────────────────────────────────────────────────
+
+describe('API List', function (): void {
+    it('returns all templates for authenticated users', function (): void {
+        LandingPageTemplate::factory()->count(2)->create(['created_by' => $this->admin->id]);
+
+        $response = $this->actingAs($this->curator) // Even curators can list templates
+            ->getJson('/api/landing-page-templates');
+
+        $response->assertOk()
+            ->assertJsonCount(3, 'templates'); // default + 2 custom
+    });
+
+    it('rejects unauthenticated access to API list', function (): void {
+        $this->getJson('/api/landing-page-templates')
+            ->assertUnauthorized();
+    });
+});

--- a/tests/vitest/components/__tests__/app-sidebar.test.tsx
+++ b/tests/vitest/components/__tests__/app-sidebar.test.tsx
@@ -19,7 +19,6 @@ let mockUser = {
     can_access_users: true,
     can_access_editor_settings: true,
     can_manage_landing_page_templates: false,
-    can_manage_landing_page_templates: false,
 };
 
 // Helper to set mock user for each test
@@ -31,6 +30,7 @@ const setMockUser = (
         can_access_old_datasets: boolean;
         can_access_statistics: boolean;
         can_access_users: boolean;
+        can_access_editor_settings: boolean;
         can_manage_landing_page_templates: boolean;
     }> = {}
 ) => {

--- a/tests/vitest/components/__tests__/app-sidebar.test.tsx
+++ b/tests/vitest/components/__tests__/app-sidebar.test.tsx
@@ -18,6 +18,8 @@ let mockUser = {
     can_access_statistics: true,
     can_access_users: true,
     can_access_editor_settings: true,
+    can_manage_landing_page_templates: false,
+    can_manage_landing_page_templates: false,
 };
 
 // Helper to set mock user for each test
@@ -29,7 +31,7 @@ const setMockUser = (
         can_access_old_datasets: boolean;
         can_access_statistics: boolean;
         can_access_users: boolean;
-        can_access_editor_settings: boolean;
+        can_manage_landing_page_templates: boolean;
     }> = {}
 ) => {
     mockUser = {
@@ -44,6 +46,7 @@ const setMockUser = (
         can_access_statistics: true,
         can_access_users: true,
         can_access_editor_settings: true,
+        can_manage_landing_page_templates: false,
         ...overrides,
     };
 };
@@ -306,5 +309,37 @@ describe('AppSidebar', () => {
         const footerArgs = NavFooterMock.mock.calls[0][0];
         const footerTitles = footerArgs.items.map((i: NavItem) => i.title);
         expect(footerTitles).toContain('Editor Settings');
+    });
+
+    it('shows Landing Page Templates in Data Curation when user has permission', () => {
+        setMockUser({
+            role: 'admin',
+            can_manage_landing_page_templates: true,
+        });
+
+        render(<AppSidebar />);
+
+        const sectionCalls = NavSectionMock.mock.calls;
+        const dataCurationSection = sectionCalls.find((call) => call[0].label === 'Data Curation');
+        expect(dataCurationSection).toBeDefined();
+
+        const items = dataCurationSection![0].items.map((i: NavItem) => i.title);
+        expect(items).toContain('Landing Page Templates');
+    });
+
+    it('does not show Landing Page Templates when user lacks permission', () => {
+        setMockUser({
+            role: 'curator',
+            can_manage_landing_page_templates: false,
+        });
+
+        render(<AppSidebar />);
+
+        const sectionCalls = NavSectionMock.mock.calls;
+        const dataCurationSection = sectionCalls.find((call) => call[0].label === 'Data Curation');
+        expect(dataCurationSection).toBeDefined();
+
+        const items = dataCurationSection![0].items.map((i: NavItem) => i.title);
+        expect(items).not.toContain('Landing Page Templates');
     });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1134,8 +1134,6 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('prevents removal of published landing page with error toast', async () => {
-            const { toast } = await import('sonner');
-
             // Published config cannot be removed
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-templates')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -666,4 +666,130 @@ describe('SetupLandingPageModal', () => {
             expect(mockOnClose).toHaveBeenCalled();
         });
     });
+
+    describe('Custom Templates', () => {
+        it('loads custom templates from API on open', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                {
+                                    id: 1,
+                                    name: 'Default GFZ Data Services',
+                                    slug: 'default_gfz',
+                                    is_default: true,
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                                {
+                                    id: 2,
+                                    name: 'Custom Geophysics',
+                                    slug: 'custom-geophysics',
+                                    is_default: false,
+                                    logo_url: 'http://localhost/storage/logos/geo.png',
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                            ],
+                        },
+                    });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(mockedAxiosGet).toHaveBeenCalledWith(
+                    expect.stringContaining('/api/landing-page-templates'),
+                );
+            });
+        });
+
+        it('handles custom template API failure gracefully', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.reject(new Error('API error'));
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            // Should still render without crashing
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            consoleSpy.mockRestore();
+        });
+
+        it('passes landing_page_template_id when saving with existing config prop', async () => {
+            const configWithTemplate: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                landing_page_template_id: 5,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: configWithTemplate } });
+            });
+            mockedAxiosPut.mockResolvedValue({ data: { landing_page: configWithTemplate } });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    existingConfig={configWithTemplate}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            const updateButton = screen.getByRole('button', { name: /Update/i });
+            await user.click(updateButton);
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        landing_page_template_id: 5,
+                    }),
+                );
+            });
+        });
+    });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -791,5 +791,376 @@ describe('SetupLandingPageModal', () => {
                 );
             });
         });
+
+        it('renders custom templates in dropdown when loaded', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                {
+                                    id: 1,
+                                    name: 'Default GFZ Data Services',
+                                    slug: 'default_gfz',
+                                    is_default: true,
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                                {
+                                    id: 2,
+                                    name: 'Custom Geophysics',
+                                    slug: 'custom-geophysics',
+                                    is_default: false,
+                                    logo_url: 'http://localhost/storage/logos/geo.png',
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                            ],
+                        },
+                    });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            // Open the template select dropdown
+            const templateSelect = screen.getByLabelText(/Landing Page Template/i);
+            await user.click(templateSelect);
+
+            // Custom templates section should be visible
+            await waitFor(() => {
+                expect(screen.getByText('Custom Templates')).toBeInTheDocument();
+                expect(screen.getByText('Custom Geophysics')).toBeInTheDocument();
+            });
+        });
+
+        it('selects a custom template and sets landing_page_template_id', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                {
+                                    id: 1,
+                                    name: 'Default GFZ Data Services',
+                                    slug: 'default_gfz',
+                                    is_default: true,
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                                {
+                                    id: 3,
+                                    name: 'Custom Hydrology',
+                                    slug: 'custom-hydrology',
+                                    is_default: false,
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                            ],
+                        },
+                    });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: { ...mockExistingConfig, status: 'draft', landing_page_template_id: 3 },
+                    preview_url: '/preview',
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            // Open dropdown and select a custom template
+            const templateSelect = screen.getByLabelText(/Landing Page Template/i);
+            await user.click(templateSelect);
+
+            await waitFor(() => {
+                expect(screen.getByText('Custom Hydrology')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('Custom Hydrology'));
+
+            // Save - should include the custom template ID
+            const saveButton = screen.getByRole('button', { name: /Create Preview/i });
+            await user.click(saveButton);
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        landing_page_template_id: 3,
+                    }),
+                );
+            });
+        });
+
+        it('resets landing_page_template_id when switching to built-in template', async () => {
+            const configWithCustomTemplate: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                landing_page_template_id: 2,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                {
+                                    id: 1,
+                                    name: 'Default GFZ Data Services',
+                                    slug: 'default_gfz',
+                                    is_default: true,
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                                {
+                                    id: 2,
+                                    name: 'Custom Geophysics',
+                                    slug: 'custom-geophysics',
+                                    is_default: false,
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                            ],
+                        },
+                    });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: configWithCustomTemplate } });
+            });
+            mockedAxiosPut.mockResolvedValue({ data: { landing_page: configWithCustomTemplate } });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    existingConfig={configWithCustomTemplate}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            // Open the template select and choose "External Landing Page" (a built-in template)
+            const templateSelect = screen.getByLabelText(/Landing Page Template/i);
+            await user.click(templateSelect);
+
+            await waitFor(() => {
+                const externalOption = screen.getByText('External Landing Page');
+                expect(externalOption).toBeInTheDocument();
+                return externalOption;
+            });
+
+            await user.click(screen.getByText('External Landing Page'));
+
+            // Save and verify landing_page_template_id is null (not custom)
+            const updateButton = screen.getByRole('button', { name: /Update/i });
+            await user.click(updateButton);
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+
+        it('calls onSuccess callback after successful save', async () => {
+            const onSuccess = vi.fn();
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: { ...mockExistingConfig, status: 'draft' },
+                    preview_url: '/preview',
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    onSuccess={onSuccess}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            const saveButton = screen.getByRole('button', { name: /Create Preview/i });
+            await user.click(saveButton);
+
+            await waitFor(() => {
+                expect(onSuccess).toHaveBeenCalled();
+            });
+        });
+
+        it('shows validation errors from server on save failure', async () => {
+            const { toast } = await import('sonner');
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockRejectedValue({
+                isAxiosError: true,
+                response: {
+                    data: {
+                        errors: {
+                            template: ['Invalid template'],
+                            ftp_url: ['Invalid URL format'],
+                        },
+                    },
+                },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            const saveButton = screen.getByRole('button', { name: /Create Preview/i });
+            await user.click(saveButton);
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Invalid template, Invalid URL format');
+            });
+        });
+
+        it('handles non-404 fetch error with toast', async () => {
+            const { toast } = await import('sonner');
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                // Non-404 error - should show toast
+                return Promise.reject({
+                    isAxiosError: true,
+                    response: { status: 500, data: { message: 'Server error' } },
+                });
+            });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Failed to load landing page configuration');
+            });
+        });
+
+        it('prevents removal of published landing page with error toast', async () => {
+            const { toast } = await import('sonner');
+
+            // Published config cannot be removed
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: mockExistingConfig } });
+            });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            // Published landing pages should not have a Remove Preview button
+            expect(screen.queryByRole('button', { name: /Remove Preview/i })).not.toBeInTheDocument();
+        });
     });
 });

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -1,0 +1,683 @@
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LandingPageTemplateConfig } from '@/types/landing-page';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const routerMock = vi.hoisted(() => ({ reload: vi.fn() }));
+
+vi.mock('axios', () => {
+    const post = vi.fn();
+    const put = vi.fn();
+    const deleteMethod = vi.fn();
+    const isAxiosError = vi.fn((value: unknown): value is { isAxiosError: true } => {
+        return typeof value === 'object' && value !== null && (value as { isAxiosError?: boolean }).isAxiosError === true;
+    });
+    return { default: { post, put, delete: deleteMethod, isAxiosError }, post, put, delete: deleteMethod, isAxiosError };
+});
+
+const mockedAxiosPost = axios.post as Mock;
+const mockedAxiosPut = axios.put as Mock;
+const mockedAxiosDelete = axios.delete as Mock;
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    router: routerMock,
+    usePage: () => ({
+        props: {
+            auth: { user: { can_manage_landing_page_templates: true } },
+            templates: mockTemplates,
+        },
+    }),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div data-testid="app-layout">{children}</div>,
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// DnD mocks - simplify to avoid complex sensor setup
+vi.mock('@dnd-kit/core', () => ({
+    closestCenter: vi.fn(),
+    DndContext: ({ children }: { children: React.ReactNode }) => <div data-testid="dnd-context">{children}</div>,
+    KeyboardSensor: vi.fn(),
+    PointerSensor: vi.fn(),
+    useSensor: vi.fn(),
+    useSensors: vi.fn(() => []),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+    arrayMove: vi.fn((arr: string[], from: number, to: number) => {
+        const result = [...arr];
+        const [item] = result.splice(from, 1);
+        result.splice(to, 0, item);
+        return result;
+    }),
+    SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    sortableKeyboardCoordinates: vi.fn(),
+    useSortable: vi.fn(() => ({
+        attributes: {},
+        listeners: {},
+        setNodeRef: vi.fn(),
+        transform: null,
+        transition: null,
+        isDragging: false,
+    })),
+    verticalListSortingStrategy: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/utilities', () => ({
+    CSS: { Transform: { toString: vi.fn(() => '') } },
+}));
+
+// ─── Test Data ───────────────────────────────────────────────────────────────
+
+const defaultTemplate: LandingPageTemplateConfig = {
+    id: 1,
+    name: 'Default GFZ Data Services',
+    slug: 'default_gfz',
+    is_default: true,
+    logo_path: null,
+    logo_filename: null,
+    logo_url: null,
+    right_column_order: ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+    left_column_order: ['files', 'contact', 'model_description', 'related_work'],
+    created_by: null,
+    creator: null,
+    landing_pages_count: 5,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+};
+
+const customTemplate: LandingPageTemplateConfig = {
+    id: 2,
+    name: 'Geophysics Template',
+    slug: 'geophysics-template-abc123',
+    is_default: false,
+    logo_path: 'landing-page-logos/geophysics/logo.png',
+    logo_filename: 'logo.png',
+    logo_url: 'http://localhost/storage/landing-page-logos/geophysics/logo.png',
+    right_column_order: ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+    left_column_order: ['contact', 'files', 'model_description', 'related_work'],
+    created_by: 1,
+    creator: { id: 1, name: 'Admin User' },
+    landing_pages_count: 2,
+    created_at: '2025-03-15T10:00:00Z',
+    updated_at: '2025-03-15T10:00:00Z',
+};
+
+const customTemplateNoLogo: LandingPageTemplateConfig = {
+    id: 3,
+    name: 'Minimal Template',
+    slug: 'minimal-template-xyz789',
+    is_default: false,
+    logo_path: null,
+    logo_filename: null,
+    logo_url: null,
+    right_column_order: ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+    left_column_order: ['files', 'contact', 'model_description', 'related_work'],
+    created_by: 1,
+    creator: { id: 1, name: 'Admin User' },
+    landing_pages_count: 0,
+    created_at: '2025-04-01T00:00:00Z',
+    updated_at: '2025-04-01T00:00:00Z',
+};
+
+let mockTemplates: LandingPageTemplateConfig[] = [];
+
+import LandingPageTemplatesPage from '@/pages/landing-page-templates';
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('LandingPageTemplatesPage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockTemplates = [defaultTemplate, customTemplate, customTemplateNoLogo];
+    });
+
+    // ─── Rendering ───────────────────────────────────────────────────────
+
+    describe('Rendering', () => {
+        it('renders page title and description', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText('Landing Page Templates')).toBeInTheDocument();
+            expect(screen.getByText(/Manage custom templates/i)).toBeInTheDocument();
+        });
+
+        it('renders New Template button', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByRole('button', { name: /New Template/i })).toBeInTheDocument();
+        });
+
+        it('renders all template cards', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText('Default GFZ Data Services')).toBeInTheDocument();
+            expect(screen.getByText('Geophysics Template')).toBeInTheDocument();
+            expect(screen.getByText('Minimal Template')).toBeInTheDocument();
+        });
+
+        it('shows Default badge on default template', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText('Default')).toBeInTheDocument();
+        });
+
+        it('shows usage count badges', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText('5 pages')).toBeInTheDocument();
+            expect(screen.getByText('2 pages')).toBeInTheDocument();
+        });
+
+        it('shows "Built-in default template" for default template', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText('Built-in default template')).toBeInTheDocument();
+        });
+
+        it('shows creator name for custom templates', () => {
+            render(<LandingPageTemplatesPage />);
+            const creatorTexts = screen.getAllByText(/Created by Admin User/);
+            expect(creatorTexts.length).toBe(2);
+        });
+
+        it('shows logo preview for templates with logo', () => {
+            render(<LandingPageTemplatesPage />);
+            const logoImg = screen.getByAltText('Geophysics Template logo');
+            expect(logoImg).toBeInTheDocument();
+            expect(logoImg).toHaveAttribute('src', customTemplate.logo_url);
+        });
+
+        it('shows section order lists', () => {
+            render(<LandingPageTemplatesPage />);
+            // Check section labels are rendered
+            expect(screen.getAllByText('Abstract & Descriptions').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Creators / Authors').length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('shows Edit, Upload Logo, and Delete buttons for custom templates', () => {
+            render(<LandingPageTemplatesPage />);
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            expect(editButtons.length).toBe(2); // 2 custom templates
+            expect(deleteButtons.length).toBe(2);
+        });
+
+        it('does not show action buttons for default template', () => {
+            mockTemplates = [defaultTemplate];
+            render(<LandingPageTemplatesPage />);
+            expect(screen.queryByRole('button', { name: /Edit/i })).not.toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: /Delete/i })).not.toBeInTheDocument();
+        });
+
+        it('shows empty state when no templates exist', () => {
+            mockTemplates = [];
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText(/No templates found/i)).toBeInTheDocument();
+        });
+
+        it('shows Upload Logo button for template without logo', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByRole('button', { name: /Upload Logo/i })).toBeInTheDocument();
+        });
+
+        it('shows Replace Logo button for template with logo', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByRole('button', { name: /Replace Logo/i })).toBeInTheDocument();
+        });
+
+        it('shows Remove logo button inside logo preview', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByRole('button', { name: /Remove logo/i })).toBeInTheDocument();
+        });
+    });
+
+    // ─── Clone Dialog ────────────────────────────────────────────────────
+
+    describe('Clone Dialog', () => {
+        it('opens clone dialog when New Template is clicked', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+
+            expect(screen.getByText('Clone Default Template')).toBeInTheDocument();
+            expect(screen.getByLabelText('Template Name')).toBeInTheDocument();
+        });
+
+        it('clones template successfully', async () => {
+            mockedAxiosPost.mockResolvedValue({ data: { message: 'Created', template: {} } });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+            await user.type(screen.getByLabelText('Template Name'), 'My New Template');
+            await user.click(screen.getByRole('button', { name: /Clone Template/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith('/landing-pages', { name: 'My New Template' });
+            });
+        });
+
+        it('disables Clone button when name is empty', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+
+            const cloneButton = screen.getByRole('button', { name: /Clone Template/i });
+            expect(cloneButton).toBeDisabled();
+        });
+
+        it('shows validation error on duplicate name', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosPost.mockRejectedValue({
+                isAxiosError: true,
+                response: { data: { errors: { name: ['The name has already been taken.'] } } },
+            });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+            await user.type(screen.getByLabelText('Template Name'), 'Duplicate Name');
+            await user.click(screen.getByRole('button', { name: /Clone Template/i }));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('The name has already been taken.');
+            });
+        });
+
+        it('shows generic error on clone failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosPost.mockRejectedValue(new Error('Network error'));
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+            await user.type(screen.getByLabelText('Template Name'), 'Test');
+            await user.click(screen.getByRole('button', { name: /Clone Template/i }));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Failed to clone template');
+            });
+        });
+
+        it('clones via Enter key', async () => {
+            mockedAxiosPost.mockResolvedValue({ data: { message: 'Created', template: {} } });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+            const nameInput = screen.getByLabelText('Template Name');
+            await user.type(nameInput, 'Enter Template');
+            await user.keyboard('{Enter}');
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith('/landing-pages', { name: 'Enter Template' });
+            });
+        });
+
+        it('closes clone dialog via Cancel', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /New Template/i }));
+            expect(screen.getByText('Clone Default Template')).toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+            await waitFor(() => {
+                expect(screen.queryByText('Clone Default Template')).not.toBeInTheDocument();
+            });
+        });
+    });
+
+    // ─── Edit Dialog ─────────────────────────────────────────────────────
+
+    describe('Edit Dialog', () => {
+        it('opens edit dialog with template data', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+
+            expect(screen.getByText('Edit Template')).toBeInTheDocument();
+            const nameInput = screen.getByLabelText('Template Name') as HTMLInputElement;
+            expect(nameInput.value).toBe('Geophysics Template');
+        });
+
+        it('saves template changes', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+
+            const nameInput = screen.getByLabelText('Template Name');
+            await user.clear(nameInput);
+            await user.type(nameInput, 'Updated Template');
+
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    `/landing-pages/${customTemplate.id}`,
+                    expect.objectContaining({ name: 'Updated Template' }),
+                );
+            });
+        });
+
+        it('shows validation errors on save failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosPut.mockRejectedValue({
+                isAxiosError: true,
+                response: { data: { errors: { name: ['Name taken'], right_column_order: ['Invalid'] } } },
+            });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Name taken, Invalid');
+            });
+        });
+
+        it('shows generic error on save failure without validation errors', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosPut.mockRejectedValue(new Error('Network error'));
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Failed to update template');
+            });
+        });
+
+        it('renders section order editors in edit dialog', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+
+            expect(screen.getByText('Right Column (main content)')).toBeInTheDocument();
+            expect(screen.getByText('Left Column (sidebar)')).toBeInTheDocument();
+        });
+
+        it('closes edit dialog via Cancel', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+            expect(screen.getByText('Edit Template')).toBeInTheDocument();
+
+            const cancelButtons = screen.getAllByRole('button', { name: /Cancel/i });
+            await user.click(cancelButtons[cancelButtons.length - 1]);
+
+            await waitFor(() => {
+                expect(screen.queryByText('Edit Template')).not.toBeInTheDocument();
+            });
+        });
+
+        it('disables Save when name is empty', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+
+            const nameInput = screen.getByLabelText('Template Name');
+            await user.clear(nameInput);
+
+            const saveButton = screen.getByRole('button', { name: /Save Changes/i });
+            expect(saveButton).toBeDisabled();
+        });
+    });
+
+    // ─── Delete Dialog ───────────────────────────────────────────────────
+
+    describe('Delete Dialog', () => {
+        it('opens delete confirmation for custom template', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            await user.click(deleteButtons[0]);
+
+            expect(screen.getByText('Delete Template')).toBeInTheDocument();
+            const matches = screen.getAllByText(/Geophysics Template/);
+            expect(matches.length).toBeGreaterThanOrEqual(2); // card + dialog
+        });
+
+        it('shows in-use warning in delete dialog', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            await user.click(deleteButtons[0]); // Geophysics Template has 2 pages
+
+            expect(screen.getByText(/currently used by 2 landing page/i)).toBeInTheDocument();
+        });
+
+        it('deletes template successfully', async () => {
+            mockedAxiosDelete.mockResolvedValue({ data: { message: 'Deleted' } });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            await user.click(deleteButtons[1]); // Minimal Template (no pages)
+
+            // Click the Delete button in the AlertDialog
+            const confirmDelete = screen.getAllByRole('button', { name: /Delete/i });
+            const alertDialogDelete = confirmDelete.find((btn) =>
+                btn.className.includes('destructive') || btn.closest('[role="alertdialog"]'),
+            );
+            if (alertDialogDelete) await user.click(alertDialogDelete);
+
+            await waitFor(() => {
+                expect(mockedAxiosDelete).toHaveBeenCalledWith(`/landing-pages/${customTemplateNoLogo.id}`);
+            });
+        });
+
+        it('shows error on delete failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosDelete.mockRejectedValue({
+                isAxiosError: true,
+                response: { data: { message: 'Template is in use by 2 landing page(s)' } },
+            });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            await user.click(deleteButtons[0]);
+
+            const confirmButtons = screen.getAllByRole('button', { name: /Delete/i });
+            const alertDialogDelete = confirmButtons.find((btn) => btn.closest('[role="alertdialog"]'));
+            if (alertDialogDelete) await user.click(alertDialogDelete);
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Template is in use by 2 landing page(s)');
+            });
+        });
+
+        it('shows generic error on delete failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosDelete.mockRejectedValue(new Error('Network error'));
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            await user.click(deleteButtons[1]);
+
+            const confirmButtons = screen.getAllByRole('button', { name: /Delete/i });
+            const alertDialogDelete = confirmButtons.find((btn) => btn.closest('[role="alertdialog"]'));
+            if (alertDialogDelete) await user.click(alertDialogDelete);
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Failed to delete template');
+            });
+        });
+    });
+
+    // ─── Logo Management ─────────────────────────────────────────────────
+
+    describe('Logo Management', () => {
+        it('triggers file input when Upload Logo is clicked', async () => {
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const uploadButton = screen.getByRole('button', { name: /Upload Logo/i });
+            await user.click(uploadButton);
+
+            // The hidden file input should exist
+            const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+            expect(fileInput).toBeInTheDocument();
+            expect(fileInput).toHaveAttribute('accept', 'image/png,image/jpeg,image/svg+xml,image/webp');
+        });
+
+        it('uploads logo file on selection', async () => {
+            mockedAxiosPost.mockResolvedValue({ data: { message: 'Logo uploaded', template: {} } });
+            render(<LandingPageTemplatesPage />);
+
+            // Click Upload Logo to set logoTargetId
+            const uploadButton = screen.getByRole('button', { name: /Upload Logo/i });
+            fireEvent.click(uploadButton);
+
+            // Simulate file selection on the hidden input
+            const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+            const file = new File(['logo-data'], 'test-logo.png', { type: 'image/png' });
+            fireEvent.change(fileInput, { target: { files: [file] } });
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    `/landing-pages/${customTemplateNoLogo.id}/logo`,
+                    expect.any(FormData),
+                    expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }),
+                );
+            });
+        });
+
+        it('shows error on logo upload failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosPost.mockRejectedValue({
+                isAxiosError: true,
+                response: { data: { errors: { logo: ['File too large'] } } },
+            });
+            render(<LandingPageTemplatesPage />);
+
+            const uploadButton = screen.getByRole('button', { name: /Upload Logo/i });
+            fireEvent.click(uploadButton);
+
+            const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+            const file = new File(['huge-logo-data'], 'huge-logo.png', { type: 'image/png' });
+            fireEvent.change(fileInput, { target: { files: [file] } });
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('File too large');
+            });
+        });
+
+        it('shows generic error on logo upload failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosPost.mockRejectedValue(new Error('Network'));
+            render(<LandingPageTemplatesPage />);
+
+            const uploadButton = screen.getByRole('button', { name: /Upload Logo/i });
+            fireEvent.click(uploadButton);
+
+            const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+            const file = new File(['data'], 'logo.png', { type: 'image/png' });
+            fireEvent.change(fileInput, { target: { files: [file] } });
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Failed to upload logo');
+            });
+        });
+
+        it('deletes logo when remove button is clicked', async () => {
+            mockedAxiosDelete.mockResolvedValue({ data: { message: 'Removed' } });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Remove logo/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosDelete).toHaveBeenCalledWith(`/landing-pages/${customTemplate.id}/logo`);
+            });
+        });
+
+        it('shows error on logo delete failure', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosDelete.mockRejectedValue(new Error('Failed'));
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Remove logo/i }));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Failed to remove logo');
+            });
+        });
+    });
+
+    // ─── Section Labels ──────────────────────────────────────────────────
+
+    describe('Section Labels', () => {
+        it('renders right column section labels', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getAllByText('Abstract & Descriptions').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Creators / Authors').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Contributors').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Funding References').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Keywords / Subjects').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Metadata Download').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Location / Map').length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('renders left column section labels', () => {
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getAllByText('Files & Downloads').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Contact Person').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Model / Method Description').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Related Work').length).toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    // ─── Creator Display ─────────────────────────────────────────────────
+
+    describe('Creator Display', () => {
+        it('shows Unknown when creator is null', () => {
+            mockTemplates = [{
+                ...customTemplateNoLogo,
+                creator: null,
+            }];
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText(/Created by Unknown/i)).toBeInTheDocument();
+        });
+
+        it('shows singular page count', () => {
+            mockTemplates = [{
+                ...customTemplate,
+                landing_pages_count: 1,
+            }];
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByText('1 page')).toBeInTheDocument();
+        });
+    });
+});

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -541,7 +541,7 @@ describe('LandingPageTemplatesPage', () => {
             // The hidden file input should exist
             const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
             expect(fileInput).toBeInTheDocument();
-            expect(fileInput).toHaveAttribute('accept', 'image/png,image/jpeg,image/svg+xml,image/webp');
+            expect(fileInput).toHaveAttribute('accept', 'image/png,image/jpeg,image/webp');
         });
 
         it('uploads logo file on selection', async () => {

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -495,25 +495,18 @@ describe('LandingPageTemplatesPage', () => {
             });
         });
 
-        it('shows error on delete failure', async () => {
-            const { toast } = await import('sonner');
-            mockedAxiosDelete.mockRejectedValue({
-                isAxiosError: true,
-                response: { data: { message: 'Template is in use by 2 landing page(s)' } },
-            });
+        it('disables delete button when template is in use', async () => {
             const user = userEvent.setup();
             render(<LandingPageTemplatesPage />);
 
+            // Open delete dialog for template with landing_pages_count > 0
             const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
             await user.click(deleteButtons[0]);
 
+            // The confirm button inside the AlertDialog should be disabled
             const confirmButtons = screen.getAllByRole('button', { name: /Delete/i });
             const alertDialogDelete = confirmButtons.find((btn) => btn.closest('[role="alertdialog"]'));
-            if (alertDialogDelete) await user.click(alertDialogDelete);
-
-            await waitFor(() => {
-                expect(toast.error).toHaveBeenCalledWith('Template is in use by 2 landing page(s)');
-            });
+            expect(alertDialogDelete).toBeDisabled();
         });
 
         it('shows generic error on delete failure', async () => {


### PR DESCRIPTION
This pull request introduces a new system for managing customizable landing page templates, allowing users to select, create, update, and delete templates, as well as upload custom logos and configure section order. The changes affect both the backend logic and the API, and include the addition of a new controller, request validation classes, and updates to the `LandingPage` model and related controllers to support template selection and configuration.

**Landing Page Template Management**

* Added a new `LandingPageTemplateController` with endpoints for listing, creating (by cloning the default), updating, deleting templates, uploading/removing logos, and listing templates for dropdowns. This controller enforces business rules such as immutability of the default template and preventing deletion if a template is in use.
* Introduced two new request validation classes: `StoreLandingPageTemplateRequest` for creating templates and `UpdateLandingPageTemplateRequest` for updating them, including validation for section order and uniqueness of template names. [[1]](diffhunk://#diff-5acbe53d18c508f31a473b5faf649ac4f10efa8473a79a03d78e61f742fbcacbR1-R40) [[2]](diffhunk://#diff-e976cd81325a09aaa0975eac5721055d597f7efb169781c61512f41f5b7a1df2R1-R79)

**Landing Page Model and API Updates**

* Modified the `LandingPage` model to include a `landing_page_template_id` foreign key and a relationship to `LandingPageTemplate`. Also updated fillable properties and docblocks. [[1]](diffhunk://#diff-5d4d5238ae0c0fcab489aa9e8cead48fadf26bbf9746891eeb5afc8e22c209c1R39-R41) [[2]](diffhunk://#diff-5d4d5238ae0c0fcab489aa9e8cead48fadf26bbf9746891eeb5afc8e22c209c1L85-R87)
* Updated the `LandingPageController` to accept and store the `landing_page_template_id` when creating or updating a landing page (only for the `default_gfz` template), and to load the related template when returning landing page data. [[1]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR110) [[2]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR197-R199) [[3]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL299-R303) [[4]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR321) [[5]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR353) [[6]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR418-R422) [[7]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL461-R472) [[8]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL519-R530)

**Public Landing Page Rendering**

* Enhanced the public landing page controller to eager-load the selected template, and to pass section order and custom logo URL from the template to the frontend for rendering. [[1]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR9) [[2]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cL279-R296) [[3]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR311-R312)

**Authorization and Permissions**

* Added a new permission flag `can_manage_landing_page_templates` to the Inertia shared data, enabling UI controls based on user permissions.