### PR TITLE
Fix: RDF download for thesaurus

### DIFF
--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -223,8 +223,13 @@ class EuroSciVocParser
     {
         // Extract namespace and local name from fragment URI (e.g. "...skos/core#Concept")
         $lastHash = strrpos($typeUri, '#');
-        $namespace = $lastHash !== false ? substr($typeUri, 0, $lastHash + 1) : '';
-        $localName = $lastHash !== false ? substr($typeUri, $lastHash + 1) : $typeUri;
+
+        if ($lastHash === false) {
+            return [];
+        }
+
+        $namespace = substr($typeUri, 0, $lastHash + 1);
+        $localName = substr($typeUri, $lastHash + 1);
 
         // XPath prefixes registered on $xml for abbreviated element matching
         $prefixMap = [

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -57,7 +57,7 @@ class EuroSciVocParser
         $xlLabelMap = $this->buildXlLabelMap($xml);
 
         // Support both abbreviated (<skos:Concept>) and full (<rdf:Description> + rdf:type) RDF/XML
-        $conceptElements = $this->findElementsByType($xml, self::SKOS_NS.'Concept');
+        $conceptElements = $this->findSkosElementsByType($xml, self::SKOS_NS.'Concept');
 
         if ($conceptElements === []) {
             return [];
@@ -208,21 +208,25 @@ class EuroSciVocParser
     }
 
     /**
-     * Find XML elements by their RDF type URI.
+     * Find SKOS or SKOS-XL elements by their RDF type URI.
      *
      * Supports both abbreviated RDF/XML (e.g. `<skos:Concept>`) and
      * full RDF/XML (`<rdf:Description>` with `<rdf:type>` child).
      *
+     * Only supports type URIs with a `#` fragment separator from the
+     * SKOS and SKOS-XL namespaces (the only namespaces used by this parser).
+     *
+     * @param  string  $typeUri  A SKOS or SKOS-XL type URI (e.g. `http://www.w3.org/2004/02/skos/core#Concept`)
      * @return list<\SimpleXMLElement>
      */
-    private function findElementsByType(\SimpleXMLElement $xml, string $typeUri): array
+    private function findSkosElementsByType(\SimpleXMLElement $xml, string $typeUri): array
     {
-        // Determine the namespace prefix registered for the type's namespace
+        // Extract namespace and local name from fragment URI (e.g. "...skos/core#Concept")
         $lastHash = strrpos($typeUri, '#');
         $namespace = $lastHash !== false ? substr($typeUri, 0, $lastHash + 1) : '';
         $localName = $lastHash !== false ? substr($typeUri, $lastHash + 1) : $typeUri;
 
-        // Map namespace URIs to the XPath prefixes registered on $xml
+        // XPath prefixes registered on $xml for abbreviated element matching
         $prefixMap = [
             self::SKOS_NS => 'skos',
             self::SKOSXL_NS => 'skosxl',
@@ -260,7 +264,7 @@ class EuroSciVocParser
         $map = [];
 
         // Support both abbreviated (<skosxl:Label>) and full (<rdf:Description> + rdf:type) RDF/XML
-        $labelElements = $this->findElementsByType($xml, self::SKOSXL_NS.'Label');
+        $labelElements = $this->findSkosElementsByType($xml, self::SKOSXL_NS.'Label');
 
         if ($labelElements === []) {
             return $map;

--- a/app/Support/EuroSciVocParser.php
+++ b/app/Support/EuroSciVocParser.php
@@ -56,9 +56,10 @@ class EuroSciVocParser
         // First, build a map of SKOS-XL label URIs → literal forms (English only)
         $xlLabelMap = $this->buildXlLabelMap($xml);
 
-        $conceptElements = $xml->xpath('//skos:Concept');
+        // Support both abbreviated (<skos:Concept>) and full (<rdf:Description> + rdf:type) RDF/XML
+        $conceptElements = $this->findElementsByType($xml, self::SKOS_NS.'Concept');
 
-        if ($conceptElements === false || $conceptElements === null) {
+        if ($conceptElements === []) {
             return [];
         }
 
@@ -207,6 +208,49 @@ class EuroSciVocParser
     }
 
     /**
+     * Find XML elements by their RDF type URI.
+     *
+     * Supports both abbreviated RDF/XML (e.g. `<skos:Concept>`) and
+     * full RDF/XML (`<rdf:Description>` with `<rdf:type>` child).
+     *
+     * @return list<\SimpleXMLElement>
+     */
+    private function findElementsByType(\SimpleXMLElement $xml, string $typeUri): array
+    {
+        // Determine the namespace prefix registered for the type's namespace
+        $lastHash = strrpos($typeUri, '#');
+        $namespace = $lastHash !== false ? substr($typeUri, 0, $lastHash + 1) : '';
+        $localName = $lastHash !== false ? substr($typeUri, $lastHash + 1) : $typeUri;
+
+        // Map namespace URIs to the XPath prefixes registered on $xml
+        $prefixMap = [
+            self::SKOS_NS => 'skos',
+            self::SKOSXL_NS => 'skosxl',
+        ];
+
+        $elements = [];
+
+        // Strategy 1: Abbreviated RDF/XML – typed element name (e.g. <skos:Concept>)
+        if (isset($prefixMap[$namespace])) {
+            $prefix = $prefixMap[$namespace];
+            $abbreviated = $xml->xpath("//{$prefix}:{$localName}");
+            if ($abbreviated !== false && $abbreviated !== null) {
+                $elements = $abbreviated;
+            }
+        }
+
+        // Strategy 2: Full RDF/XML – <rdf:Description> with <rdf:type rdf:resource="...">
+        $descriptions = $xml->xpath(
+            "//rdf:Description[rdf:type[@rdf:resource='{$typeUri}']]"
+        );
+        if ($descriptions !== false && $descriptions !== null) {
+            $elements = array_merge($elements, $descriptions);
+        }
+
+        return array_values($elements);
+    }
+
+    /**
      * Build a map of SKOS-XL label URIs to their English literal forms.
      *
      * @return array<string, string> Map of label URI → English literal form
@@ -215,9 +259,10 @@ class EuroSciVocParser
     {
         $map = [];
 
-        $labelElements = $xml->xpath('//skosxl:Label');
+        // Support both abbreviated (<skosxl:Label>) and full (<rdf:Description> + rdf:type) RDF/XML
+        $labelElements = $this->findElementsByType($xml, self::SKOSXL_NS.'Label');
 
-        if ($labelElements === false || $labelElements === null) {
+        if ($labelElements === []) {
             return $map;
         }
 

--- a/tests/pest/Unit/Support/EuroSciVocParserTest.php
+++ b/tests/pest/Unit/Support/EuroSciVocParserTest.php
@@ -25,7 +25,7 @@ describe('extractConcepts', function (): void {
          xml:lang="en">
     <skosxl:Label rdf:about="http://example.org/label/1">
         <skosxl:literalForm xml:lang="en">natural sciences</skosxl:literalForm>
-        <skosxl:literalForm xml:lang="de">Naturwissenschaften</skosxl:literalForm>
+        <skosxl:literalForm xml:lang="de">German label</skosxl:literalForm>
     </skosxl:Label>
     <skosxl:Label rdf:about="http://example.org/label/2">
         <skosxl:literalForm xml:lang="en">physics</skosxl:literalForm>
@@ -71,7 +71,7 @@ XML;
         <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
         <skos:topConceptOf rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
         <skos:prefLabel xml:lang="en">engineering and technology</skos:prefLabel>
-        <skos:prefLabel xml:lang="de">Ingenieurwissenschaften und Technologie</skos:prefLabel>
+        <skos:prefLabel xml:lang="de">German label</skos:prefLabel>
     </skos:Concept>
 </rdf:RDF>
 XML;
@@ -317,7 +317,7 @@ XML;
     <rdf:Description rdf:about="http://example.org/label/1">
         <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
         <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">natural sciences</literalForm>
-        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="de">Naturwissenschaften</literalForm>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="de">German label</literalForm>
     </rdf:Description>
     <rdf:Description rdf:about="http://example.org/label/2">
         <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
@@ -366,7 +366,7 @@ XML;
         <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
         <topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
         <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">engineering and technology</prefLabel>
-        <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Ingenieurwissenschaften und Technologie</prefLabel>
+        <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">German label</prefLabel>
     </rdf:Description>
 </rdf:RDF>
 XML;

--- a/tests/pest/Unit/Support/EuroSciVocParserTest.php
+++ b/tests/pest/Unit/Support/EuroSciVocParserTest.php
@@ -309,6 +309,180 @@ XML;
         expect($concepts)->toHaveCount(1)
             ->and($concepts[0]['text'])->toBe('plain fallback');
     });
+
+    it('extracts concepts from rdf:Description format with rdf:type', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="http://example.org/label/1">
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">natural sciences</literalForm>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="de">Naturwissenschaften</literalForm>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/label/2">
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">physics</literalForm>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/concept/1">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <prefLabel xmlns="http://www.w3.org/2008/05/skos-xl#" rdf:resource="http://example.org/label/1"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/concept/2">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <broader xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://example.org/concept/1"/>
+        <prefLabel xmlns="http://www.w3.org/2008/05/skos-xl#" rdf:resource="http://example.org/label/2"/>
+    </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(2)
+            ->and($concepts[0])->toMatchArray([
+                'id' => 'http://example.org/concept/1',
+                'text' => 'natural sciences',
+                'language' => 'en',
+                'isTopConcept' => true,
+                'broaderId' => null,
+            ])
+            ->and($concepts[1])->toMatchArray([
+                'id' => 'http://example.org/concept/2',
+                'text' => 'physics',
+                'language' => 'en',
+                'isTopConcept' => false,
+                'broaderId' => 'http://example.org/concept/1',
+            ]);
+    });
+
+    it('extracts concepts from rdf:Description format with plain SKOS labels', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="http://example.org/concept/1">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">engineering and technology</prefLabel>
+        <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="de">Ingenieurwissenschaften und Technologie</prefLabel>
+    </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('engineering and technology')
+            ->and($concepts[0]['isTopConcept'])->toBeTrue();
+    });
+
+    it('skips rdf:Description concepts not belonging to the target scheme', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="http://example.org/concept/1">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">natural sciences</prefLabel>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/concept/other">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://example.org/other-scheme"/>
+        <prefLabel xmlns="http://www.w3.org/2004/02/skos/core#" xml:lang="en">should be skipped</prefLabel>
+    </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(1)
+            ->and($concepts[0]['text'])->toBe('natural sciences');
+    });
+
+    it('handles mixed abbreviated and rdf:Description formats', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#">
+    <skosxl:Label rdf:about="http://example.org/label/1">
+        <skosxl:literalForm xml:lang="en">abbreviated concept</skosxl:literalForm>
+    </skosxl:Label>
+    <rdf:Description rdf:about="http://example.org/label/2">
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">description concept</literalForm>
+    </rdf:Description>
+    <skos:Concept rdf:about="http://example.org/concept/1">
+        <skos:inScheme rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skos:topConceptOf rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <skosxl:prefLabel rdf:resource="http://example.org/label/1"/>
+    </skos:Concept>
+    <rdf:Description rdf:about="http://example.org/concept/2">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <broader xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://example.org/concept/1"/>
+        <prefLabel xmlns="http://www.w3.org/2008/05/skos-xl#" rdf:resource="http://example.org/label/2"/>
+    </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(2);
+
+        $texts = array_column($concepts, 'text');
+        expect($texts)->toContain('abbreviated concept')
+            ->and($texts)->toContain('description concept');
+    });
+
+    it('builds full hierarchy from rdf:Description format', function (): void {
+        $rdf = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="http://example.org/label/root">
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">natural sciences</literalForm>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/label/child1">
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">physics</literalForm>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/label/child2">
+        <rdf:type rdf:resource="http://www.w3.org/2008/05/skos-xl#Label"/>
+        <literalForm xmlns="http://www.w3.org/2008/05/skos-xl#" xml:lang="en">chemistry</literalForm>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/concept/root">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <topConceptOf xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <prefLabel xmlns="http://www.w3.org/2008/05/skos-xl#" rdf:resource="http://example.org/label/root"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/concept/child1">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <broader xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://example.org/concept/root"/>
+        <prefLabel xmlns="http://www.w3.org/2008/05/skos-xl#" rdf:resource="http://example.org/label/child1"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://example.org/concept/child2">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <inScheme xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://data.europa.eu/8mn/euroscivoc/test-scheme"/>
+        <broader xmlns="http://www.w3.org/2004/02/skos/core#" rdf:resource="http://example.org/concept/root"/>
+        <prefLabel xmlns="http://www.w3.org/2008/05/skos-xl#" rdf:resource="http://example.org/label/child2"/>
+    </rdf:Description>
+</rdf:RDF>
+XML;
+
+        $concepts = $this->parser->extractConcepts($rdf, $this->conceptSchemeUri);
+        $result = $this->parser->buildHierarchy($concepts, 'EuroSciVoc', $this->conceptSchemeUri);
+
+        expect($concepts)->toHaveCount(3)
+            ->and($result['data'])->toHaveCount(1)
+            ->and($result['data'][0]['text'])->toBe('natural sciences')
+            ->and($result['data'][0]['children'])->toHaveCount(2)
+            ->and($result['data'][0]['children'][0]['text'])->toBe('chemistry')
+            ->and($result['data'][0]['children'][1]['text'])->toBe('physics');
+    });
 });
 
 // =========================================================================


### PR DESCRIPTION
This pull request enhances the `EuroSciVocParser` to support parsing both abbreviated and full RDF/XML formats for SKOS and SKOS-XL concepts and labels, ensuring broader compatibility with different RDF data structures. The changes include a new utility method for finding SKOS elements by type, updates to the extraction logic, and comprehensive new tests to validate these improvements.

**Support for multiple RDF/XML formats:**

* Added a new private method `findSkosElementsByType` in `EuroSciVocParser.php` to locate SKOS and SKOS-XL elements by their RDF type, handling both abbreviated (`<skos:Concept>`, `<skosxl:Label>`) and full (`<rdf:Description>` with `<rdf:type>`) RDF/XML syntaxes.
* Updated `extractConcepts` and `buildXlLabelMap` methods to use `findSkosElementsByType`, allowing them to process both RDF/XML formats seamlessly. [[1]](diffhunk://#diff-cf4110212beea0175fe576fb90bafaaf487edf7f8734317e5e7b812cc7079866L59-R62) [[2]](diffhunk://#diff-cf4110212beea0175fe576fb90bafaaf487edf7f8734317e5e7b812cc7079866L218-R274)

**Test coverage improvements:**

* Added multiple new test cases in `EuroSciVocParserTest.php` to verify extraction and hierarchy building from both abbreviated and full RDF/XML, including mixed-format documents and edge cases (e.g., concepts outside the target scheme).
* Updated existing test RDF data to use a generic German label for consistency. [[1]](diffhunk://#diff-f5581c7ef732f7a70b5f575f7005bcf01755ecccbceedc229d3af3dfa5849286L28-R28) [[2]](diffhunk://#diff-f5581c7ef732f7a70b5f575f7005bcf01755ecccbceedc229d3af3dfa5849286L74-R74)