### PR TITLE
Fix: Default GFZ Landing Page template shows in Related Works section only DOIs

### DIFF
--- a/app/Http/Controllers/Api/DataCiteController.php
+++ b/app/Http/Controllers/Api/DataCiteController.php
@@ -106,10 +106,11 @@ class DataCiteController extends Controller
     }
 
     /**
-     * Extract and validate the DOI query parameter.
+     * Extract, normalize, and validate the DOI query parameter.
      *
-     * Trims whitespace and validates the DOI format (must start with "10." followed
-     * by a registrant code and a suffix separated by a slash).
+     * Strips resolver URL prefixes (https://doi.org/, http://dx.doi.org/),
+     * trims whitespace, and validates the DOI format (must start with "10."
+     * followed by a registrant code and a suffix separated by a slash).
      */
     private function extractValidDoi(Request $request): ?string
     {
@@ -120,6 +121,11 @@ class DataCiteController extends Controller
         }
 
         $doi = trim($doi);
+
+        // Strip resolver URL prefixes (https://doi.org/, http://dx.doi.org/)
+        if (preg_match('/^https?:\/\/(?:dx\.)?doi\.org\/?(.*)$/i', $doi, $matches)) {
+            $doi = trim($matches[1]);
+        }
 
         if ($doi === '' || ! preg_match('#^10\.\d{4,9}/.+$#', $doi)) {
             return null;

--- a/app/Http/Controllers/Api/DataCiteController.php
+++ b/app/Http/Controllers/Api/DataCiteController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Services\DataCiteApiService;
 use App\Support\OrcidNormalizer;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 /**
  * Controller für DOI-Zitations-Abruf.
@@ -23,11 +24,22 @@ class DataCiteController extends Controller
     /**
      * Ruft eine formatierte Zitation für eine DOI ab.
      *
-     * @param  string  $doi  Die DOI (kann von jedem Registrar sein)
+     * The DOI is passed as a query parameter (?doi=10.5880/...) to avoid
+     * URL encoding issues with forward slashes in DOIs (%2F) which some
+     * web servers (Nginx, Traefik) reject with 400 Bad Request.
+     *
      * @return JsonResponse JSON mit citation und doi
      */
-    public function getCitation(string $doi): JsonResponse
+    public function getCitation(Request $request): JsonResponse
     {
+        $doi = $request->query('doi');
+
+        if (empty($doi) || ! is_string($doi)) {
+            return response()->json([
+                'error' => 'Missing or invalid doi query parameter',
+            ], 422);
+        }
+
         $metadata = $this->dataCiteService->getMetadata($doi);
 
         if (! $metadata) {
@@ -50,11 +62,20 @@ class DataCiteController extends Controller
      * First tries the DataCite REST API (which includes affiliations and nameType).
      * Falls back to CSL JSON via doi.org Content Negotiation for non-DataCite DOIs.
      *
-     * @param  string  $doi  The DOI (any registrar)
+     * The DOI is passed as a query parameter (?doi=10.5880/...) to avoid
+     * URL encoding issues with forward slashes in DOIs.
+     *
      * @return JsonResponse JSON with doi and authors array
      */
-    public function getAuthors(string $doi): JsonResponse
+    public function getAuthors(Request $request): JsonResponse
     {
+        $doi = $request->query('doi');
+
+        if (empty($doi) || ! is_string($doi)) {
+            return response()->json([
+                'error' => 'Missing or invalid doi query parameter',
+            ], 422);
+        }
         // Try DataCite REST API first (includes affiliations)
         $dataCiteMetadata = $this->dataCiteService->getDataCiteMetadata($doi);
 

--- a/app/Http/Controllers/Api/DataCiteController.php
+++ b/app/Http/Controllers/Api/DataCiteController.php
@@ -11,9 +11,9 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- * Controller für DOI-Zitations-Abruf.
+ * Controller for DOI citation retrieval.
  *
- * Verwendet die doi.org Content Negotiation API über den DataCiteApiService.
+ * Uses the doi.org Content Negotiation API via DataCiteApiService.
  */
 class DataCiteController extends Controller
 {
@@ -22,19 +22,19 @@ class DataCiteController extends Controller
     ) {}
 
     /**
-     * Ruft eine formatierte Zitation für eine DOI ab.
+     * Retrieve a formatted citation for a DOI.
      *
      * The DOI is passed as a query parameter (?doi=10.5880/...) to avoid
      * URL encoding issues with forward slashes in DOIs (%2F) which some
      * web servers (Nginx, Traefik) reject with 400 Bad Request.
      *
-     * @return JsonResponse JSON mit citation und doi
+     * @return JsonResponse JSON with citation and doi
      */
     public function getCitation(Request $request): JsonResponse
     {
-        $doi = $request->query('doi');
+        $doi = $this->extractValidDoi($request);
 
-        if (empty($doi) || ! is_string($doi)) {
+        if ($doi === null) {
             return response()->json([
                 'error' => 'Missing or invalid doi query parameter',
             ], 422);
@@ -69,9 +69,9 @@ class DataCiteController extends Controller
      */
     public function getAuthors(Request $request): JsonResponse
     {
-        $doi = $request->query('doi');
+        $doi = $this->extractValidDoi($request);
 
-        if (empty($doi) || ! is_string($doi)) {
+        if ($doi === null) {
             return response()->json([
                 'error' => 'Missing or invalid doi query parameter',
             ], 422);
@@ -103,6 +103,29 @@ class DataCiteController extends Controller
             'doi' => $doi,
             'authors' => $authors,
         ]);
+    }
+
+    /**
+     * Extract and validate the DOI query parameter.
+     *
+     * Trims whitespace and validates the DOI format (must start with "10." followed
+     * by a registrant code and a suffix separated by a slash).
+     */
+    private function extractValidDoi(Request $request): ?string
+    {
+        $doi = $request->query('doi');
+
+        if (! is_string($doi)) {
+            return null;
+        }
+
+        $doi = trim($doi);
+
+        if ($doi === '' || ! preg_match('#^10\.\d{4,9}/.+$#', $doi)) {
+            return null;
+        }
+
+        return $doi;
     }
 
     /**

--- a/app/Http/Controllers/Api/DataCiteController.php
+++ b/app/Http/Controllers/Api/DataCiteController.php
@@ -108,9 +108,9 @@ class DataCiteController extends Controller
     /**
      * Extract, normalize, and validate the DOI query parameter.
      *
-     * Strips resolver URL prefixes (https://doi.org/, http://dx.doi.org/),
-     * trims whitespace, and validates the DOI format (must start with "10."
-     * followed by a registrant code and a suffix separated by a slash).
+     * Reuses {@see DataCiteApiService::normalizeDoi()} for consistent canonical
+     * form (trim, strip resolver URL prefixes, lowercase). Then validates the
+     * DOI format (must start with "10." followed by a registrant code and suffix).
      */
     private function extractValidDoi(Request $request): ?string
     {
@@ -120,14 +120,9 @@ class DataCiteController extends Controller
             return null;
         }
 
-        $doi = trim($doi);
+        $doi = $this->dataCiteService->normalizeDoi($doi);
 
-        // Strip resolver URL prefixes (https://doi.org/, http://dx.doi.org/)
-        if (preg_match('/^https?:\/\/(?:dx\.)?doi\.org\/?(.*)$/i', $doi, $matches)) {
-            $doi = trim($matches[1]);
-        }
-
-        if ($doi === '' || ! preg_match('#^10\.\d{4,9}/.+$#', $doi)) {
+        if ($doi === null || ! preg_match('#^10\.\d{4,9}/.+$#', $doi)) {
             return null;
         }
 

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -136,6 +136,10 @@
         ],
         "fixes": [
             {
+                "title": "Citation Display on Landing Pages",
+                "description": "Fixed an issue where the Related Work and Model Description sections on landing pages showed raw DOIs (e.g. 'DOI: 10.5880/...') instead of formatted citation strings. The root cause was URL encoding of forward slashes (%2F) in DOI path parameters, which some web servers reject with 400 Bad Request. The DOI citation and author API endpoints now use query parameters instead of URL path segments."
+            },
+            {
                 "title": "GEMET Thesaurus Loading Only 4 Concepts",
                 "description": "Fixed a bug where the GEMET thesaurus import loaded only 4 top-level concepts instead of the full ~5,669 entries. The root cause was a URI prefix mismatch: the GEMET API returns broader relations with a 'group/' prefix, but SuperGroups use a 'supergroup/' prefix with the same numeric IDs. The hierarchy builder could not match groups to their parent supergroups, resulting in empty child arrays. A URI normalization step now converts 'group/' prefixes to 'supergroup/' in the group-to-supergroup mapping."
             },

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -1083,6 +1083,7 @@
                                         },
                                         "doi": {
                                             "type": "string",
+                                            "description": "The normalized DOI in lowercase canonical form",
                                             "example": "10.5880/gfz.test.2024"
                                         }
                                     }
@@ -1152,6 +1153,7 @@
                                     "properties": {
                                         "doi": {
                                             "type": "string",
+                                            "description": "The normalized DOI in lowercase canonical form",
                                             "example": "10.5880/gfz.test.2024"
                                         },
                                         "authors": {

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -34,6 +34,10 @@
         {
             "name": "Vocabularies",
             "description": "Endpoints for accessing controlled vocabularies from NASA GCMD (Global Change Master Directory), PID registries (b2inst), and ROR (Research Organization Registry)"
+        },
+        {
+            "name": "DataCite",
+            "description": "Endpoints for retrieving citation metadata and author information for DOIs via the DataCite API and doi.org Content Negotiation"
         }
     ],
     "paths": {
@@ -1044,6 +1048,208 @@
                     },
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
+                    }
+                }
+            }
+        },
+        "/api/datacite/citation": {
+            "get": {
+                "tags": ["DataCite"],
+                "summary": "Get formatted citation for a DOI",
+                "description": "Returns a formatted citation string for the given DOI. Uses doi.org Content Negotiation API to retrieve CSL JSON metadata and builds a human-readable citation. The DOI can be provided as a bare DOI (10.5880/...) or as a resolver URL (https://doi.org/10.5880/...); resolver prefixes are stripped automatically.",
+                "parameters": [
+                    {
+                        "name": "doi",
+                        "in": "query",
+                        "required": true,
+                        "description": "The DOI to look up. Accepts bare DOIs (10.5880/GFZ.TEST.2024) or resolver URLs (https://doi.org/10.5880/GFZ.TEST.2024).",
+                        "schema": {
+                            "type": "string",
+                            "example": "10.5880/GFZ.TEST.2024"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Citation retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "citation": {
+                                            "type": "string",
+                                            "example": "Smith, John (2024): Test Dataset. GFZ Data Services. https://doi.org/10.5880/GFZ.TEST.2024"
+                                        },
+                                        "doi": {
+                                            "type": "string",
+                                            "example": "10.5880/gfz.test.2024"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Metadata not found for the given DOI",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Metadata not found for DOI"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Missing or invalid DOI query parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Missing or invalid doi query parameter"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/datacite/authors": {
+            "get": {
+                "tags": ["DataCite"],
+                "summary": "Get structured author data for a DOI",
+                "description": "Returns structured author information for the given DOI, including affiliations, ORCID identifiers, and author type (Person/Institution). First tries the DataCite REST API (which includes affiliations and nameType), then falls back to CSL JSON via doi.org Content Negotiation for non-DataCite DOIs. The DOI can be provided as a bare DOI or resolver URL.",
+                "parameters": [
+                    {
+                        "name": "doi",
+                        "in": "query",
+                        "required": true,
+                        "description": "The DOI to look up. Accepts bare DOIs (10.5880/GFZ.TEST.2024) or resolver URLs (https://doi.org/10.5880/GFZ.TEST.2024).",
+                        "schema": {
+                            "type": "string",
+                            "example": "10.5880/GFZ.TEST.2024"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Author data retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "doi": {
+                                            "type": "string",
+                                            "example": "10.5880/gfz.test.2024"
+                                        },
+                                        "authors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "given_name": {
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "example": "John"
+                                                    },
+                                                    "family_name": {
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "example": "Smith"
+                                                    },
+                                                    "name": {
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "description": "Full name for organizational authors"
+                                                    },
+                                                    "orcid": {
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "example": "0000-0002-1234-5678"
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": ["Person", "Institution"],
+                                                        "example": "Person"
+                                                    },
+                                                    "ror_id": {
+                                                        "type": "string",
+                                                        "nullable": true,
+                                                        "example": "https://ror.org/04z8jg394"
+                                                    },
+                                                    "affiliations": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string",
+                                                                    "example": "GFZ Helmholtz Centre"
+                                                                },
+                                                                "identifier": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "example": "https://ror.org/04z8jg394"
+                                                                },
+                                                                "identifier_scheme": {
+                                                                    "type": "string",
+                                                                    "nullable": true,
+                                                                    "example": "ROR"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Metadata not found for the given DOI",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Metadata not found for DOI"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Missing or invalid DOI query parameter",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Missing or invalid doi query parameter"
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/resources/js/pages/LandingPages/components/ModelDescriptionSection.tsx
+++ b/resources/js/pages/LandingPages/components/ModelDescriptionSection.tsx
@@ -38,7 +38,7 @@ export function ModelDescriptionSection({ relatedIdentifiers }: ModelDescription
         const fetchCitation = async () => {
             setLoading(true);
             try {
-                const url = `/api/datacite/citation/${encodeURIComponent(supplementTo.identifier)}`;
+                const url = `/api/datacite/citation?doi=${encodeURIComponent(supplementTo.identifier)}`;
                 const response = await fetch(url, { signal: controller.signal });
 
                 if (response.ok) {

--- a/resources/js/pages/LandingPages/components/RelatedWorkSection.tsx
+++ b/resources/js/pages/LandingPages/components/RelatedWorkSection.tsx
@@ -112,7 +112,7 @@ export function RelatedWorkSection({ relatedIdentifiers, resource }: RelatedWork
 
         // Fetch each new DOI citation, updating individually on resolve
         newDois.forEach((doi) => {
-            fetch(`/api/datacite/citation/${encodeURIComponent(doi)}`, { signal: controller.signal })
+            fetch(`/api/datacite/citation?doi=${encodeURIComponent(doi)}`, { signal: controller.signal })
                 .then((response) => {
                     if (response.ok) {
                         return response.json();

--- a/resources/js/pages/LandingPages/components/relation-browser/use-citation-labels.ts
+++ b/resources/js/pages/LandingPages/components/relation-browser/use-citation-labels.ts
@@ -97,7 +97,7 @@ export function useCitationLabels(
         }
 
         for (const doi of doisToFetch) {
-            fetch(`/api/datacite/citation/${encodeURIComponent(doi)}`, {
+            fetch(`/api/datacite/citation?doi=${encodeURIComponent(doi)}`, {
                 signal: controller.signal,
             })
                 .then((response) => {

--- a/resources/js/pages/LandingPages/components/relation-browser/use-creator-nodes.ts
+++ b/resources/js/pages/LandingPages/components/relation-browser/use-creator-nodes.ts
@@ -205,7 +205,7 @@ function fromApiAuthor(author: ApiAuthor): {
  * Hook that fetches and deduplicates creator data for the Relation Browser graph.
  *
  * Central resource creators come from Inertia props (immediate).
- * Related DOI creators are fetched asynchronously via /api/datacite/authors/{doi}.
+ * Related DOI creators are fetched asynchronously via /api/datacite/authors?doi=...
  * Creators are deduplicated by ORCID first, then by normalized name.
  */
 export function useCreatorNodes(

--- a/resources/js/pages/LandingPages/components/relation-browser/use-creator-nodes.ts
+++ b/resources/js/pages/LandingPages/components/relation-browser/use-creator-nodes.ts
@@ -254,7 +254,7 @@ export function useCreatorNodes(
 
         // Batch all fetches with Promise.allSettled → single state update
         const fetchPromises = uniqueDois.map((doi) =>
-            fetch(`/api/datacite/authors/${encodeURIComponent(doi)}`, {
+            fetch(`/api/datacite/authors?doi=${encodeURIComponent(doi)}`, {
                 signal: controller.signal,
             })
                 .then((response) => {

--- a/routes/api.php
+++ b/routes/api.php
@@ -90,8 +90,8 @@ Route::get('/v1/vocabularies/pid-availability', [VocabularyController::class, 'p
 Route::middleware('ernie.api-key')->get('/v1/elmo/vocabularies/thesauri-availability', [VocabularyController::class, 'thesauriAvailability']);
 Route::middleware('ernie.api-key')->get('/v1/elmo/vocabularies/pid-availability', [VocabularyController::class, 'pidAvailability']);
 
-Route::get('/datacite/citation/{doi}', [DataCiteController::class, 'getCitation'])->where('doi', '.*');
-Route::get('/datacite/authors/{doi}', [DataCiteController::class, 'getAuthors'])->where('doi', '.*');
+Route::get('/datacite/citation', [DataCiteController::class, 'getCitation']);
+Route::get('/datacite/authors', [DataCiteController::class, 'getAuthors']);
 
 // Thesaurus settings API routes (check, update, update-status) are in web.php
 // because they require session-based authentication via can:manage-thesauri gate

--- a/tests/pest/Feature/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Api/DataCiteControllerTest.php
@@ -54,4 +54,18 @@ describe('GET /api/datacite/citation', function (): void {
         $response->assertStatus(422)
             ->assertJsonPath('error', 'Missing or invalid doi query parameter');
     });
+
+    test('returns 422 when doi is whitespace only', function (): void {
+        $response = $this->getJson('/api/datacite/citation?doi=%20%20%20');
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error', 'Missing or invalid doi query parameter');
+    });
+
+    test('returns 422 when doi has invalid format', function (): void {
+        $response = $this->getJson('/api/datacite/citation?doi=not-a-doi');
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error', 'Missing or invalid doi query parameter');
+    });
 });

--- a/tests/pest/Feature/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Api/DataCiteControllerTest.php
@@ -9,7 +9,7 @@ covers(DataCiteController::class);
 
 describe('GET /api/datacite/citation', function (): void {
     test('returns citation for valid DOI', function (): void {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
             ->with('10.5880/test.2024.001')
             ->andReturn([
@@ -35,7 +35,7 @@ describe('GET /api/datacite/citation', function (): void {
     });
 
     test('returns 404 when DOI not found', function (): void {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
             ->with('10.5880/nonexistent')
             ->andReturnNull();

--- a/tests/pest/Feature/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Api/DataCiteControllerTest.php
@@ -7,7 +7,7 @@ use App\Services\DataCiteApiService;
 
 covers(DataCiteController::class);
 
-describe('GET /api/v1/datacite/citation/{doi}', function (): void {
+describe('GET /api/datacite/citation', function (): void {
     test('returns citation for valid DOI', function (): void {
         $mockService = Mockery::mock(DataCiteApiService::class);
         $mockService->shouldReceive('getMetadata')
@@ -27,7 +27,7 @@ describe('GET /api/v1/datacite/citation/{doi}', function (): void {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/citation/10.5880/test.2024.001');
+        $response = $this->getJson('/api/datacite/citation?doi=10.5880/test.2024.001');
 
         $response->assertOk()
             ->assertJsonPath('doi', '10.5880/test.2024.001')
@@ -42,9 +42,16 @@ describe('GET /api/v1/datacite/citation/{doi}', function (): void {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/citation/10.5880/nonexistent');
+        $response = $this->getJson('/api/datacite/citation?doi=10.5880/nonexistent');
 
         $response->assertNotFound()
             ->assertJsonPath('error', 'Metadata not found for DOI');
+    });
+
+    test('returns 422 when doi query parameter is missing', function (): void {
+        $response = $this->getJson('/api/datacite/citation');
+
+        $response->assertStatus(422)
+            ->assertJsonPath('error', 'Missing or invalid doi query parameter');
     });
 });

--- a/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
@@ -29,7 +29,7 @@ describe('getCitation', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/citation/10.5880/GFZ.TEST.2024');
+        $response = $this->getJson('/api/datacite/citation?doi=10.5880/GFZ.TEST.2024');
 
         $response->assertOk()
             ->assertJsonStructure(['citation', 'doi'])
@@ -48,10 +48,50 @@ describe('getCitation', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/citation/10.5880/nonexistent');
+        $response = $this->getJson('/api/datacite/citation?doi=10.5880/nonexistent');
 
         $response->assertNotFound()
             ->assertJson(['error' => 'Metadata not found for DOI']);
+    });
+
+    it('returns 422 when doi query parameter is missing', function () {
+        $response = $this->getJson('/api/datacite/citation');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('returns 422 when doi query parameter is empty', function () {
+        $response = $this->getJson('/api/datacite/citation?doi=');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('handles DOIs with encoded slashes in query parameter correctly', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService->shouldReceive('getMetadata')
+            ->with('10.5880/GFZ.TEST.2024')
+            ->once()
+            ->andReturn([
+                'author' => [['family' => 'Smith', 'given' => 'John']],
+                'issued' => ['date-parts' => [[2024]]],
+                'title' => 'Test Dataset',
+                'publisher' => 'GFZ',
+                'DOI' => '10.5880/GFZ.TEST.2024',
+            ]);
+
+        $mockService->shouldReceive('buildCitationFromMetadata')
+            ->once()
+            ->andReturn('Smith, J. (2024): Test Dataset. GFZ. https://doi.org/10.5880/GFZ.TEST.2024');
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        // URL-encoded slash in query parameter (as browser sends it)
+        $response = $this->getJson('/api/datacite/citation?doi=10.5880%2FGFZ.TEST.2024');
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
     });
 });
 
@@ -87,7 +127,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.TEST.2024');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.TEST.2024');
 
         $response->assertOk()
             ->assertJsonStructure([
@@ -143,7 +183,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.TEST.2024');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.TEST.2024');
 
         $response->assertOk()
             ->assertJson([
@@ -193,7 +233,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/nonexistent');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/nonexistent');
 
         $response->assertNotFound()
             ->assertJson(['error' => 'Metadata not found for DOI']);
@@ -210,7 +250,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.NOAUTHORS');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.NOAUTHORS');
 
         $response->assertOk()
             ->assertJson([
@@ -249,7 +289,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.ORCID');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.ORCID');
 
         $response->assertOk()
             ->assertJson([
@@ -280,7 +320,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.ROR');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.ROR');
 
         $response->assertOk()
             ->assertJson([
@@ -322,7 +362,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.AFFIL');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.AFFIL');
 
         $response->assertOk()
             ->assertJson([
@@ -358,7 +398,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.OLDAFFIL');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.OLDAFFIL');
 
         $response->assertOk()
             ->assertJson([
@@ -394,7 +434,7 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        $response = $this->getJson('/api/datacite/authors/10.5880/GFZ.BAREROR');
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.BAREROR');
 
         // Bare ROR ID is normalized to full URL
         $response->assertOk()
@@ -407,5 +447,45 @@ describe('getAuthors', function () {
                     ],
                 ],
             ]);
+    });
+
+    it('returns 422 when doi query parameter is missing', function () {
+        $response = $this->getJson('/api/datacite/authors');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('returns 422 when doi query parameter is empty', function () {
+        $response = $this->getJson('/api/datacite/authors?doi=');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('handles DOIs with encoded slashes in query parameter correctly', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService->shouldReceive('getDataCiteMetadata')
+            ->with('10.5880/GFZ.TEST.2024')
+            ->once()
+            ->andReturn([
+                'creators' => [
+                    [
+                        'nameType' => 'Personal',
+                        'givenName' => 'John',
+                        'familyName' => 'Smith',
+                        'nameIdentifiers' => [],
+                        'affiliation' => [],
+                    ],
+                ],
+            ]);
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        // URL-encoded slash in query parameter (as browser sends it)
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880%2FGFZ.TEST.2024');
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
     });
 });

--- a/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
@@ -82,6 +82,56 @@ describe('getCitation', function () {
             ->assertJson(['error' => 'Missing or invalid doi query parameter']);
     });
 
+    it('normalizes DOI resolver URLs by stripping https://doi.org/ prefix', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService->shouldReceive('getMetadata')
+            ->with('10.5880/GFZ.TEST.2024')
+            ->once()
+            ->andReturn([
+                'author' => [['family' => 'Smith', 'given' => 'John']],
+                'issued' => ['date-parts' => [[2024]]],
+                'title' => 'Test Dataset',
+                'publisher' => 'GFZ',
+                'DOI' => '10.5880/GFZ.TEST.2024',
+            ]);
+
+        $mockService->shouldReceive('buildCitationFromMetadata')
+            ->once()
+            ->andReturn('Smith, J. (2024)');
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        $response = $this->getJson('/api/datacite/citation?doi=' . urlencode('https://doi.org/10.5880/GFZ.TEST.2024'));
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
+    });
+
+    it('normalizes DOI resolver URLs by stripping http://dx.doi.org/ prefix', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService->shouldReceive('getMetadata')
+            ->with('10.1111/bij.12893')
+            ->once()
+            ->andReturn([
+                'author' => [['family' => 'Doe', 'given' => 'Jane']],
+                'issued' => ['date-parts' => [[2023]]],
+                'title' => 'Test',
+                'publisher' => 'Wiley',
+                'DOI' => '10.1111/bij.12893',
+            ]);
+
+        $mockService->shouldReceive('buildCitationFromMetadata')
+            ->once()
+            ->andReturn('Doe, J. (2023)');
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        $response = $this->getJson('/api/datacite/citation?doi=' . urlencode('http://dx.doi.org/10.1111/bij.12893'));
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.1111/bij.12893');
+    });
+
     it('handles DOIs with encoded slashes in query parameter correctly', function () {
         $mockService = Mockery::mock(DataCiteApiService::class);
         $mockService->shouldReceive('getMetadata')
@@ -489,6 +539,31 @@ describe('getAuthors', function () {
 
         $response->assertStatus(422)
             ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('normalizes DOI resolver URLs by stripping https://doi.org/ prefix', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService->shouldReceive('getDataCiteMetadata')
+            ->with('10.5880/GFZ.TEST.2024')
+            ->once()
+            ->andReturn([
+                'creators' => [
+                    [
+                        'nameType' => 'Personal',
+                        'givenName' => 'John',
+                        'familyName' => 'Smith',
+                        'nameIdentifiers' => [],
+                        'affiliation' => [],
+                    ],
+                ],
+            ]);
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        $response = $this->getJson('/api/datacite/authors?doi=' . urlencode('https://doi.org/10.5880/GFZ.TEST.2024'));
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
     });
 
     it('handles DOIs with encoded slashes in query parameter correctly', function () {

--- a/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
@@ -68,6 +68,20 @@ describe('getCitation', function () {
             ->assertJson(['error' => 'Missing or invalid doi query parameter']);
     });
 
+    it('returns 422 when doi query parameter is whitespace only', function () {
+        $response = $this->getJson('/api/datacite/citation?doi=%20%20%20');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('returns 422 when doi query parameter has invalid format', function () {
+        $response = $this->getJson('/api/datacite/citation?doi=not-a-doi');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
     it('handles DOIs with encoded slashes in query parameter correctly', function () {
         $mockService = Mockery::mock(DataCiteApiService::class);
         $mockService->shouldReceive('getMetadata')
@@ -458,6 +472,20 @@ describe('getAuthors', function () {
 
     it('returns 422 when doi query parameter is empty', function () {
         $response = $this->getJson('/api/datacite/authors?doi=');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('returns 422 when doi query parameter is whitespace only', function () {
+        $response = $this->getJson('/api/datacite/authors?doi=%20%20%20');
+
+        $response->assertStatus(422)
+            ->assertJson(['error' => 'Missing or invalid doi query parameter']);
+    });
+
+    it('returns 422 when doi query parameter has invalid format', function () {
+        $response = $this->getJson('/api/datacite/authors?doi=not-a-doi');
 
         $response->assertStatus(422)
             ->assertJson(['error' => 'Missing or invalid doi query parameter']);

--- a/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
+++ b/tests/pest/Feature/Http/Controllers/Api/DataCiteControllerTest.php
@@ -9,9 +9,9 @@ covers(DataCiteController::class);
 
 describe('getCitation', function () {
     it('returns citation for a valid DOI', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'author' => [
@@ -34,13 +34,13 @@ describe('getCitation', function () {
         $response->assertOk()
             ->assertJsonStructure(['citation', 'doi'])
             ->assertJson([
-                'doi' => '10.5880/GFZ.TEST.2024',
+                'doi' => '10.5880/gfz.test.2024',
                 'citation' => 'Smith, John (2024): Test Dataset. GFZ. https://doi.org/10.5880/GFZ.TEST.2024',
             ]);
     });
 
     it('returns 404 when DOI metadata not found', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
             ->with('10.5880/nonexistent')
             ->once()
@@ -83,9 +83,9 @@ describe('getCitation', function () {
     });
 
     it('normalizes DOI resolver URLs by stripping https://doi.org/ prefix', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'author' => [['family' => 'Smith', 'given' => 'John']],
@@ -104,11 +104,11 @@ describe('getCitation', function () {
         $response = $this->getJson('/api/datacite/citation?doi=' . urlencode('https://doi.org/10.5880/GFZ.TEST.2024'));
 
         $response->assertOk()
-            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
+            ->assertJsonPath('doi', '10.5880/gfz.test.2024');
     });
 
     it('normalizes DOI resolver URLs by stripping http://dx.doi.org/ prefix', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
             ->with('10.1111/bij.12893')
             ->once()
@@ -133,9 +133,9 @@ describe('getCitation', function () {
     });
 
     it('handles DOIs with encoded slashes in query parameter correctly', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'author' => [['family' => 'Smith', 'given' => 'John']],
@@ -151,19 +151,43 @@ describe('getCitation', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        // URL-encoded slash in query parameter (as browser sends it)
         $response = $this->getJson('/api/datacite/citation?doi=10.5880%2FGFZ.TEST.2024');
 
         $response->assertOk()
-            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
+            ->assertJsonPath('doi', '10.5880/gfz.test.2024');
+    });
+
+    it('returns DOIs in lowercase canonical form', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
+        $mockService->shouldReceive('getMetadata')
+            ->with('10.5880/gfz.mixed.case')
+            ->once()
+            ->andReturn([
+                'author' => [['family' => 'Smith', 'given' => 'John']],
+                'issued' => ['date-parts' => [[2024]]],
+                'title' => 'Test',
+                'publisher' => 'GFZ',
+                'DOI' => '10.5880/GFZ.MIXED.CASE',
+            ]);
+
+        $mockService->shouldReceive('buildCitationFromMetadata')
+            ->once()
+            ->andReturn('Smith, J. (2024)');
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        $response = $this->getJson('/api/datacite/citation?doi=10.5880/GFZ.MIXED.CASE');
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.5880/gfz.mixed.case');
     });
 });
 
 describe('getAuthors', function () {
     it('returns structured author data from DataCite REST API', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -201,7 +225,7 @@ describe('getAuthors', function () {
                 ],
             ])
             ->assertJson([
-                'doi' => '10.5880/GFZ.TEST.2024',
+                'doi' => '10.5880/gfz.test.2024',
                 'authors' => [
                     [
                         'given_name' => 'John',
@@ -228,13 +252,13 @@ describe('getAuthors', function () {
     });
 
     it('falls back to CSL JSON when DataCite REST API returns null', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturnNull();
         $mockService->shouldReceive('getMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'author' => [
@@ -251,7 +275,7 @@ describe('getAuthors', function () {
 
         $response->assertOk()
             ->assertJson([
-                'doi' => '10.5880/GFZ.TEST.2024',
+                'doi' => '10.5880/gfz.test.2024',
                 'authors' => [
                     [
                         'given_name' => 'John',
@@ -285,7 +309,7 @@ describe('getAuthors', function () {
     });
 
     it('returns 404 when both DataCite REST API and CSL JSON fail', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
             ->with('10.5880/nonexistent')
             ->once()
@@ -304,9 +328,9 @@ describe('getAuthors', function () {
     });
 
     it('returns empty authors array when DataCite metadata has no creators', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.NOAUTHORS')
+            ->with('10.5880/gfz.noauthors')
             ->once()
             ->andReturn([
                 'titles' => [['title' => 'Dataset Without Authors']],
@@ -318,15 +342,15 @@ describe('getAuthors', function () {
 
         $response->assertOk()
             ->assertJson([
-                'doi' => '10.5880/GFZ.NOAUTHORS',
+                'doi' => '10.5880/gfz.noauthors',
                 'authors' => [],
             ]);
     });
 
     it('extracts ORCID from DataCite nameIdentifiers', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.ORCID')
+            ->with('10.5880/gfz.orcid')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -365,9 +389,9 @@ describe('getAuthors', function () {
     });
 
     it('extracts ROR ID from organizational creators', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.ROR')
+            ->with('10.5880/gfz.ror')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -399,9 +423,9 @@ describe('getAuthors', function () {
     });
 
     it('extracts affiliations with ROR identifiers from personal creators', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.AFFIL')
+            ->with('10.5880/gfz.affil')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -444,9 +468,9 @@ describe('getAuthors', function () {
     });
 
     it('handles string-only affiliations from older DataCite records', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.OLDAFFIL')
+            ->with('10.5880/gfz.oldaffil')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -479,9 +503,9 @@ describe('getAuthors', function () {
     });
 
     it('handles bare ROR IDs without URL prefix', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.BAREROR')
+            ->with('10.5880/gfz.bareror')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -500,7 +524,6 @@ describe('getAuthors', function () {
 
         $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.BAREROR');
 
-        // Bare ROR ID is normalized to full URL
         $response->assertOk()
             ->assertJson([
                 'authors' => [
@@ -542,9 +565,9 @@ describe('getAuthors', function () {
     });
 
     it('normalizes DOI resolver URLs by stripping https://doi.org/ prefix', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -563,13 +586,13 @@ describe('getAuthors', function () {
         $response = $this->getJson('/api/datacite/authors?doi=' . urlencode('https://doi.org/10.5880/GFZ.TEST.2024'));
 
         $response->assertOk()
-            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
+            ->assertJsonPath('doi', '10.5880/gfz.test.2024');
     });
 
     it('handles DOIs with encoded slashes in query parameter correctly', function () {
-        $mockService = Mockery::mock(DataCiteApiService::class);
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
         $mockService->shouldReceive('getDataCiteMetadata')
-            ->with('10.5880/GFZ.TEST.2024')
+            ->with('10.5880/gfz.test.2024')
             ->once()
             ->andReturn([
                 'creators' => [
@@ -585,10 +608,34 @@ describe('getAuthors', function () {
 
         $this->app->instance(DataCiteApiService::class, $mockService);
 
-        // URL-encoded slash in query parameter (as browser sends it)
         $response = $this->getJson('/api/datacite/authors?doi=10.5880%2FGFZ.TEST.2024');
 
         $response->assertOk()
-            ->assertJsonPath('doi', '10.5880/GFZ.TEST.2024');
+            ->assertJsonPath('doi', '10.5880/gfz.test.2024');
+    });
+
+    it('returns DOIs in lowercase canonical form', function () {
+        $mockService = Mockery::mock(DataCiteApiService::class)->makePartial();
+        $mockService->shouldReceive('getDataCiteMetadata')
+            ->with('10.5880/gfz.mixed.case')
+            ->once()
+            ->andReturn([
+                'creators' => [
+                    [
+                        'nameType' => 'Personal',
+                        'givenName' => 'A',
+                        'familyName' => 'B',
+                        'nameIdentifiers' => [],
+                        'affiliation' => [],
+                    ],
+                ],
+            ]);
+
+        $this->app->instance(DataCiteApiService::class, $mockService);
+
+        $response = $this->getJson('/api/datacite/authors?doi=10.5880/GFZ.MIXED.CASE');
+
+        $response->assertOk()
+            ->assertJsonPath('doi', '10.5880/gfz.mixed.case');
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/ModelDescriptionSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ModelDescriptionSection.test.tsx
@@ -210,7 +210,7 @@ describe('ModelDescriptionSection', () => {
 
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledWith(
-                '/api/datacite/citation/10.5880%2Fspecial%2Fchars',
+                '/api/datacite/citation?doi=10.5880%2Fspecial%2Fchars',
                 expect.objectContaining({ signal: expect.any(AbortSignal) }),
             );
         });

--- a/tests/vitest/pages/LandingPages/__tests__/relation-browser/use-citation-labels.test.ts
+++ b/tests/vitest/pages/LandingPages/__tests__/relation-browser/use-citation-labels.test.ts
@@ -141,7 +141,7 @@ describe('useCitationLabels', () => {
 
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledWith(
-                '/api/datacite/citation/10.5880%2Ftest',
+                '/api/datacite/citation?doi=10.5880%2Ftest',
                 expect.any(Object),
             );
         });
@@ -193,7 +193,7 @@ describe('useCitationLabels', () => {
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledTimes(1);
             expect(global.fetch).toHaveBeenCalledWith(
-                '/api/datacite/citation/10.5880%2Fmissing',
+                '/api/datacite/citation?doi=10.5880%2Fmissing',
                 expect.any(Object),
             );
         });


### PR DESCRIPTION
This pull request refactors the DataCite API endpoints to accept DOIs as query parameters instead of URL path parameters. This change resolves issues with URL-encoded forward slashes in DOIs that caused 400 Bad Request errors on some web servers, and ensures robust DOI handling throughout the application. Additionally, the API documentation and frontend code are updated to reflect the new endpoint structure and improved error handling.

**API Endpoint Refactoring and DOI Handling**

* The `/api/datacite/citation` and `/api/datacite/authors` endpoints now accept the DOI as a required query parameter (`?doi=...`) instead of a path parameter. This avoids problems with encoded slashes in DOIs and improves compatibility with various web servers. [[1]](diffhunk://#diff-3e01b09822c75da54d93a3ad1804b6c72a99d0bebb7a070594c28763eaf5270dL24-R42) [[2]](diffhunk://#diff-3e01b09822c75da54d93a3ad1804b6c72a99d0bebb7a070594c28763eaf5270dL53-R78) [[3]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL93-R94)

* Both endpoints now include validation for the DOI query parameter, returning a 422 error for missing or invalid DOIs. A new private method `extractValidDoi` is added to normalize and validate DOIs consistently.

**Frontend Updates**

* All frontend code that calls the citation and author endpoints is updated to use the new query parameter format (`/api/datacite/citation?doi=...` and `/api/datacite/authors?doi=...`). This includes the Related Work section, Model Description section, and relation browser hooks. [[1]](diffhunk://#diff-ff87df6bafef688bb21a8215ed79b9955c77974488c850066e6a7f924f6a12faL41-R41) [[2]](diffhunk://#diff-4f36e227b308fb3b9c5468eeca49a68158d8d2ae6211dcb6e6137a970c30363eL115-R115) [[3]](diffhunk://#diff-a58882385bcfb492938bb91c61107393df05002b69f70fb9b2dd22c7976ffffcL100-R100) [[4]](diffhunk://#diff-80361a6d6254830da1012a7c51fac9463a4198103e653332adc76bcc023c7ae5L208-R208) [[5]](diffhunk://#diff-80361a6d6254830da1012a7c51fac9463a4198103e653332adc76bcc023c7ae5L257-R257)

**Documentation and Test Updates**

* The OpenAPI specification is updated to document the new query parameter structure, required/optional parameters, and error responses for the DataCite endpoints. [[1]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R37-R40) [[2]](diffhunk://#diff-b1a49189fc1db6832f842f9df4398327655dcc6b67938c47a008af750f0d4487R1054-R1257)

* The changelog is updated to describe the user-facing impact and the technical reason for the change.

* Tests are updated to use the new endpoint format and ensure correct behavior.