### PR TITLE
Fix: Import of old datsets not working beacuse sizes.numeric_value is too small

### DIFF
--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -406,7 +406,7 @@ entity "sizes" as sizes {
     * **id** : BIGINT <<PK>>
     --
     * resource_id : BIGINT <<FK>>
-    numeric_value : DECIMAL(12,4)
+    numeric_value : DECIMAL(20,4)
     unit : VARCHAR(50)
     type : VARCHAR(100)
     created_at : TIMESTAMP

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -364,7 +364,7 @@ erDiagram
     sizes {
         bigint id PK
         bigint resource_id FK
-        decimal numeric_value "12,4 nullable e.g. 3"
+        decimal numeric_value "20,4 nullable e.g. 3"
         varchar unit "50 nullable e.g. m"
         varchar type "100 nullable e.g. Drilled Length"
         timestamp created_at

--- a/database/migrations/0001_01_01_000003_create_ernie_schema.php
+++ b/database/migrations/0001_01_01_000003_create_ernie_schema.php
@@ -527,7 +527,8 @@ return new class extends Migration
                 ->constrained('resources')
                 ->cascadeOnDelete()
                 ->cascadeOnUpdate();
-            $table->decimal('numeric_value', 12, 4)->nullable(); // Numeric part, e.g., 3
+            // decimal(20, 4) accommodates byte-sized values from DataCite (e.g. multi-GB file sizes).
+            $table->decimal('numeric_value', 20, 4)->nullable(); // Numeric part, e.g., 3
             $table->string('unit', 50)->nullable();              // Unit, e.g., "m"
             $table->string('type', 100)->nullable();             // Type/label, e.g., "Drilled Length"
             $table->timestamps();

--- a/database/migrations/2026_04_22_000001_alter_sizes_numeric_value_precision.php
+++ b/database/migrations/2026_04_22_000001_alter_sizes_numeric_value_precision.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Widen sizes.numeric_value from decimal(12, 4) to decimal(20, 4).
+ *
+ * decimal(12, 4) caps at ~99,999,999.9999 which overflows on legitimate
+ * byte-sized values coming from the DataCite API (e.g. "2675059373 Bytes").
+ * decimal(20, 4) allows up to 16 digits before the decimal point and easily
+ * covers byte counts in the petabyte range while remaining compatible with
+ * the existing `decimal:4` Eloquent cast on App\Models\Size.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sizes', function (Blueprint $table): void {
+            $table->decimal('numeric_value', 20, 4)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        // Guard against data loss: refuse to narrow the column if any existing
+        // row holds a value that would overflow decimal(12, 4).
+        $maxFor12_4 = 99_999_999.9999;
+        $overflowExists = DB::table('sizes')
+            ->where('numeric_value', '>', $maxFor12_4)
+            ->exists();
+
+        if ($overflowExists) {
+            throw new RuntimeException(
+                'Cannot revert sizes.numeric_value to decimal(12, 4): '
+                .'existing rows contain values that would overflow the narrower precision.'
+            );
+        }
+
+        Schema::table('sizes', function (Blueprint $table): void {
+            $table->decimal('numeric_value', 12, 4)->nullable()->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_22_000001_alter_sizes_numeric_value_precision.php
+++ b/database/migrations/2026_04_22_000001_alter_sizes_numeric_value_precision.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -28,16 +29,30 @@ return new class extends Migration
     public function down(): void
     {
         // Guard against data loss: refuse to narrow the column if any existing
-        // row holds a value that would overflow decimal(12, 4).
-        $maxFor12_4 = 99_999_999.9999;
+        // row holds a value outside the signed decimal(12, 4) range
+        // [-99999999.9999, 99999999.9999].
+        //
+        // Use string bounds rather than PHP float literals: decimal(12, 4) can
+        // represent values that exceed PHP float precision (IEEE-754 double,
+        // ~15–17 significant digits), so a float-based comparison could
+        // misclassify boundary values after implicit float-to-string conversion.
+        // Query bindings are sent to the database as strings, which MySQL
+        // coerces using exact DECIMAL arithmetic.
+        $upperBound = '99999999.9999';
+        $lowerBound = '-99999999.9999';
+
         $overflowExists = DB::table('sizes')
-            ->where('numeric_value', '>', $maxFor12_4)
+            ->where(function (Builder $query) use ($upperBound, $lowerBound): void {
+                $query->where('numeric_value', '>', $upperBound)
+                    ->orWhere('numeric_value', '<', $lowerBound);
+            })
             ->exists();
 
         if ($overflowExists) {
             throw new RuntimeException(
                 'Cannot revert sizes.numeric_value to decimal(12, 4): '
-                .'existing rows contain values that would overflow the narrower precision.'
+                .'existing rows contain values outside the narrower precision '
+                ."range [{$lowerBound}, {$upperBound}]."
             );
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4601,9 +4601,9 @@
       }
     },
     "node_modules/@rolldown/debug": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/debug/-/debug-1.0.0-rc.16.tgz",
-      "integrity": "sha512-titF/ZuuhX4hg0eP04iuVNX/9+YV40k9laG68niMawfVssl12X2s5iVQLWP/vjrnPTDgFESzrJzNEw84IAj+Nw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/debug/-/debug-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ZPkkHYar4T6+nG0UII9nVCaAqjnKp2fVkk5JqHzS27mOpsf2fs0COeX4yDMLEPj2S60B7QoGEk1b4kGhCgb3A==",
       "dev": true,
       "license": "MIT"
     },
@@ -6493,15 +6493,15 @@
       }
     },
     "node_modules/@vitejs/devtools": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools/-/devtools-0.1.14.tgz",
-      "integrity": "sha512-WBpd8R5brzxSWKYsIfPtYxpjBxNhoCUgzk/OhCjPW2XC+MBLOzOXg4rHWY0OSXEw9w2XHtF3eTTgoc/Mcg+IHQ==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools/-/devtools-0.1.15.tgz",
+      "integrity": "sha512-LKE2HgsRMR25ordyXEjXCILO/IOrtHDzBc4Vzfg+ntvR8lF09I0XIX73GS7LQHO+Bzfpb0m3PrgnyThyaa2J0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitejs/devtools-kit": "0.1.14",
-        "@vitejs/devtools-rolldown": "0.1.14",
-        "@vitejs/devtools-rpc": "0.1.14",
+        "@vitejs/devtools-kit": "0.1.15",
+        "@vitejs/devtools-rolldown": "0.1.15",
+        "@vitejs/devtools-rpc": "0.1.15",
         "birpc": "^4.0.0",
         "cac": "^7.0.0",
         "h3": "^1.15.11",
@@ -6526,13 +6526,13 @@
       }
     },
     "node_modules/@vitejs/devtools-kit": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.1.14.tgz",
-      "integrity": "sha512-XvDzZaBigEO2c4EdT9hVRYKqEWU4zW37ao2DmD2W69/nrp+pwVdRNE/tu8fXKnvhCQtoqkI5g3H3Df1VYCUTfA==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-kit/-/devtools-kit-0.1.15.tgz",
+      "integrity": "sha512-6OCgoAW7HeJFMpxiNqIZLoBtG+jGTwXBwNgmxPi2KT77nCFUUvnDHrXSOZ8ErmQ7WdrDPLnUeBq/TWyi9xdAyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitejs/devtools-rpc": "0.1.14",
+        "@vitejs/devtools-rpc": "0.1.15",
         "birpc": "^4.0.0",
         "ohash": "^2.0.11"
       },
@@ -6541,17 +6541,17 @@
       }
     },
     "node_modules/@vitejs/devtools-rolldown": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rolldown/-/devtools-rolldown-0.1.14.tgz",
-      "integrity": "sha512-xhuLAhmDmzHCdbmYvn1rTlV1fe7hvaDHN3kp1CtKCiSM86QsDE8pBFCbcGpZeawqZgQ8MtkmUGJm09uCqaqCGg==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rolldown/-/devtools-rolldown-0.1.15.tgz",
+      "integrity": "sha512-PYojc9gQrd9bszNv+t20ocDG1zcrdryPA9XyxlZOO9EHbz+W50IW+22y+9+u8cat39cHsYuuChF6WqOYrM5hpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@pnpm/read-project-manifest": "^1001.2.6",
-        "@rolldown/debug": "^1.0.0-rc.15",
-        "@vitejs/devtools-kit": "0.1.14",
-        "@vitejs/devtools-rpc": "0.1.14",
+        "@rolldown/debug": "^1.0.0-rc.16",
+        "@vitejs/devtools-kit": "0.1.15",
+        "@vitejs/devtools-rpc": "0.1.15",
         "ansis": "^4.2.0",
         "birpc": "^4.0.0",
         "cac": "^7.0.0",
@@ -6577,9 +6577,9 @@
       }
     },
     "node_modules/@vitejs/devtools-rpc": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rpc/-/devtools-rpc-0.1.14.tgz",
-      "integrity": "sha512-xRxH/tmIXN/IegUebu53pkLb4rA87qwiBkgx7dtj2BmtzLXg88EiG/VtW5PThJh0AcvU6B8vCT/9+2QRQMKmzA==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@vitejs/devtools-rpc/-/devtools-rpc-0.1.15.tgz",
+      "integrity": "sha512-pHDz3bcK0dlpLzI2ve2Xwnnx6iSASRMuEFJDbe64LAZJPVCBW/Pb0IeEpodI58O9xVpB0EBZykZftz8/oTeVtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6785,14 +6785,14 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
+        "@vue/shared": "3.5.33",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -6819,31 +6819,31 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
       }
     },
@@ -6855,68 +6855,68 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.32"
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/runtime-core": "3.5.32",
-        "@vue/shared": "3.5.32",
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
-        "vue": "3.5.32"
+        "vue": "3.5.33"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7335,9 +7335,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7518,9 +7518,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
         {
@@ -8657,9 +8657,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.342",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.342.tgz",
-      "integrity": "sha512-GTuy59SdGxYgz+HN8KwOjFAVF2gfoKEmv0PFholcvVtbI9GPDND0m6ynGX3gAKOavcHRLrcfNy0QMbHbAemYdw==",
+      "version": "1.5.343",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
+      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
       "dev": true,
       "license": "ISC"
     },
@@ -8886,9 +8886,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -11727,9 +11727,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -15183,17 +15183,17 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-sfc": "3.5.32",
-        "@vue/runtime-dom": "3.5.32",
-        "@vue/server-renderer": "3.5.32",
-        "@vue/shared": "3.5.32"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0dev",
-        "date": "2026-04-21",
+        "date": "2026-04-22",
         "features": [
             {
                 "title": "Landing Page Template Management",
@@ -143,6 +143,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "DataCite import no longer aborts on large file sizes",
+                "description": "Widened the sizes.numeric_value column from decimal(12, 4) to decimal(20, 4). Previously, importing DOIs from the DataCite API could fail with 'SQLSTATE[22003]: Numeric value out of range' when a dataset reported a file size in bytes that exceeded ~99 million (approximately 100 MB), causing the entire import job to abort. Byte-sized values up to the petabyte range are now stored safely."
+            },
             {
                 "title": "Landing Page Template Clone Fails with 404",
                 "description": "Fixed a bug where cloning a new landing page template could fail with a 404 response when the immutable default template record was missing in the database. The clone endpoint now self-heals by restoring the default template automatically and proceeds with template creation. An idempotent database backfill migration was added to prevent this state in existing installations."

--- a/tests/pest/Feature/Database/AlterSizesNumericValuePrecisionMigrationTest.php
+++ b/tests/pest/Feature/Database/AlterSizesNumericValuePrecisionMigrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Resource;
+use App\Models\Size;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Coverage for the anonymous migration in
+ * `database/migrations/2026_04_22_000001_alter_sizes_numeric_value_precision.php`.
+ *
+ * RefreshDatabase already runs `up()` for us, so these tests focus on the
+ * `down()` path — specifically its data-loss guard, which is the part that
+ * would otherwise go untested.
+ */
+function loadAlterSizesPrecisionMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path(
+        'migrations/2026_04_22_000001_alter_sizes_numeric_value_precision.php'
+    );
+
+    return $migration;
+}
+
+it('reverts sizes.numeric_value back to decimal(12, 4) when no row would overflow', function (): void {
+    // Populate a row that comfortably fits both the new and old precision so
+    // the guard is satisfied and the actual Schema::table() path runs.
+    /** @var Resource $resource */
+    $resource = Resource::factory()->create();
+    Size::create([
+        'resource_id' => $resource->id,
+        'numeric_value' => '1.5',
+        'unit' => 'GB',
+    ]);
+
+    $migration = loadAlterSizesPrecisionMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    // Re-run up() so subsequent tests in the same process see the widened
+    // column again (RefreshDatabase would recreate it, but being explicit
+    // keeps this test self-contained).
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    // The row must still be present and readable after the round-trip.
+    /** @var Size $reloaded */
+    $reloaded = Size::query()->sole();
+    expect((float) $reloaded->numeric_value)->toBe(1.5)
+        ->and($reloaded->unit)->toBe('GB');
+});
+
+it('refuses to revert sizes.numeric_value when a row would overflow decimal(12, 4)', function (): void {
+    // Insert a value that only fits into decimal(20, 4). The guard must abort
+    // the rollback rather than silently truncating or corrupting data.
+    /** @var Resource $resource */
+    $resource = Resource::factory()->create();
+    DB::table('sizes')->insert([
+        'resource_id' => $resource->id,
+        'numeric_value' => '2675059373.0000',
+        'unit' => 'Bytes',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $migration = loadAlterSizesPrecisionMigration();
+
+    /** @phpstan-ignore method.notFound, argument.unresolvableType, function.unresolvableReturnType */
+    expect(fn () => $migration->down())
+        ->toThrow(RuntimeException::class, 'Cannot revert sizes.numeric_value to decimal(12, 4)');
+});
+
+it('can re-apply up() after it has already run without losing data', function (): void {
+    // Exercises the up() path explicitly (RefreshDatabase triggers it once,
+    // but Codecov attributes that run to the migration framework, not to the
+    // anonymous class). Calling it a second time on the already-widened
+    // column must remain a no-op from the caller's perspective.
+    $user = User::factory()->create();
+    /** @var Resource $resource */
+    $resource = Resource::factory()->create(['created_by_user_id' => $user->id]);
+    Size::create([
+        'resource_id' => $resource->id,
+        'numeric_value' => '2675059373',
+        'unit' => 'Bytes',
+    ]);
+
+    $migration = loadAlterSizesPrecisionMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    /** @var Size $reloaded */
+    $reloaded = Size::query()->sole();
+    expect((float) $reloaded->numeric_value)->toBe(2_675_059_373.0)
+        ->and($reloaded->unit)->toBe('Bytes');
+});

--- a/tests/pest/Feature/Database/AlterSizesNumericValuePrecisionMigrationTest.php
+++ b/tests/pest/Feature/Database/AlterSizesNumericValuePrecisionMigrationTest.php
@@ -75,6 +75,62 @@ it('refuses to revert sizes.numeric_value when a row would overflow decimal(12, 
         ->toThrow(RuntimeException::class, 'Cannot revert sizes.numeric_value to decimal(12, 4)');
 });
 
+it('refuses to revert sizes.numeric_value when a row underflows decimal(12, 4)', function (): void {
+    // decimal(12, 4) is signed, so the guard must also reject values below
+    // -99,999,999.9999. decimal(20, 4) can hold much larger negative values.
+    /** @var Resource $resource */
+    $resource = Resource::factory()->create();
+    DB::table('sizes')->insert([
+        'resource_id' => $resource->id,
+        'numeric_value' => '-2675059373.0000',
+        'unit' => 'Bytes',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $migration = loadAlterSizesPrecisionMigration();
+
+    /** @phpstan-ignore method.notFound, argument.unresolvableType, function.unresolvableReturnType */
+    expect(fn () => $migration->down())
+        ->toThrow(RuntimeException::class, 'Cannot revert sizes.numeric_value to decimal(12, 4)');
+});
+
+it('permits revert when values sit exactly on the decimal(12, 4) boundary', function (): void {
+    // Boundary values 99,999,999.9999 and -99,999,999.9999 must be accepted:
+    // they are the last legal values for decimal(12, 4), so the guard must
+    // reject only STRICTLY out-of-range values. This also catches float-based
+    // guards that round the bound and incorrectly reject exact boundary rows.
+    /** @var Resource $resource */
+    $resource = Resource::factory()->create();
+    DB::table('sizes')->insert([
+        [
+            'resource_id' => $resource->id,
+            'numeric_value' => '99999999.9999',
+            'unit' => 'max',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+        [
+            'resource_id' => $resource->id,
+            'numeric_value' => '-99999999.9999',
+            'unit' => 'min',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ],
+    ]);
+
+    $migration = loadAlterSizesPrecisionMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    // Restore widened precision for subsequent tests.
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Size::query()->count())->toBe(2);
+});
+
 it('can re-apply up() after it has already run without losing data', function (): void {
     // Exercises the up() path explicitly (RefreshDatabase triggers it once,
     // but Codecov attributes that run to the migration framework, not to the

--- a/tests/pest/Feature/Database/AlterSizesNumericValuePrecisionMigrationTest.php
+++ b/tests/pest/Feature/Database/AlterSizesNumericValuePrecisionMigrationTest.php
@@ -49,9 +49,12 @@ it('reverts sizes.numeric_value back to decimal(12, 4) when no row would overflo
     $migration->up();
 
     // The row must still be present and readable after the round-trip.
+    // Assert the exact string produced by the `decimal:4` cast so both the
+    // value and the 4-decimal scale are verified — a float cast would hide
+    // an accidental scale change.
     /** @var Size $reloaded */
     $reloaded = Size::query()->sole();
-    expect((float) $reloaded->numeric_value)->toBe(1.5)
+    expect($reloaded->numeric_value)->toBe('1.5000')
         ->and($reloaded->unit)->toBe('GB');
 });
 
@@ -152,6 +155,6 @@ it('can re-apply up() after it has already run without losing data', function ()
 
     /** @var Size $reloaded */
     $reloaded = Size::query()->sole();
-    expect((float) $reloaded->numeric_value)->toBe(2_675_059_373.0)
+    expect($reloaded->numeric_value)->toBe('2675059373.0000')
         ->and($reloaded->unit)->toBe('Bytes');
 });

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerSizesTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerSizesTest.php
@@ -58,6 +58,11 @@ describe('DataCiteToResourceTransformer::transformSizes()', function (): void {
         // aborted the DataCite import job when a DOI reported file sizes beyond
         // ~99 MB (the decimal(12, 4) ceiling). With decimal(20, 4) these values
         // must persist cleanly.
+        //
+        // We assert the exact string produced by Eloquent's `decimal:4` cast
+        // (rather than casting to float) so that BOTH the numeric value AND
+        // the 4-decimal scale are verified. A float-based comparison would not
+        // notice accidental scale regressions (e.g. a future `decimal:2` cast).
         $user = User::factory()->create();
         $transformer = new DataCiteToResourceTransformer;
 
@@ -68,7 +73,7 @@ describe('DataCiteToResourceTransformer::transformSizes()', function (): void {
 
         $size = Size::where('resource_id', $resource->id)->sole();
 
-        expect((float) $size->numeric_value)->toBe(2_675_059_373.0)
+        expect($size->numeric_value)->toBe('2675059373.0000')
             ->and($size->unit)->toBe('Bytes')
             ->and($size->type)->toBeNull();
     });
@@ -87,13 +92,14 @@ describe('DataCiteToResourceTransformer::transformSizes()', function (): void {
 
         $size = Size::where('resource_id', $resource->id)->sole();
 
-        expect((float) $size->numeric_value)->toBe(1_099_511_627_776.0)
+        expect($size->numeric_value)->toBe('1099511627776.0000')
             ->and($size->unit)->toBe('Bytes');
     });
 
     it('still parses small decimal size strings like "1.5 GB" correctly', function (): void {
         // Guards against accidental precision regressions that could change
-        // how fractional values are persisted.
+        // how fractional values are persisted. Asserting the full scaled
+        // string ("1.5000") also confirms the `decimal:4` cast is intact.
         $user = User::factory()->create();
         $transformer = new DataCiteToResourceTransformer;
 
@@ -104,7 +110,7 @@ describe('DataCiteToResourceTransformer::transformSizes()', function (): void {
 
         $size = Size::where('resource_id', $resource->id)->sole();
 
-        expect((float) $size->numeric_value)->toBe(1.5)
+        expect($size->numeric_value)->toBe('1.5000')
             ->and($size->unit)->toBe('GB');
     });
 
@@ -142,6 +148,6 @@ describe('sizes.numeric_value column precision', function (): void {
 
         $size->refresh();
 
-        expect((float) $size->numeric_value)->toBe(2_675_059_373.0);
+        expect($size->numeric_value)->toBe('2675059373.0000');
     });
 });

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerSizesTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerSizesTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Resource;
+use App\Models\Size;
+use App\Models\User;
+use App\Services\DataCiteToResourceTransformer;
+use Database\Seeders\ContributorTypeSeeder;
+use Database\Seeders\DescriptionTypeSeeder;
+use Database\Seeders\LanguageSeeder;
+use Database\Seeders\PublisherSeeder;
+use Database\Seeders\ResourceTypeSeeder;
+use Database\Seeders\TitleTypeSeeder;
+
+beforeEach(function (): void {
+    test()->seed(ResourceTypeSeeder::class);
+    test()->seed(TitleTypeSeeder::class);
+    test()->seed(DescriptionTypeSeeder::class);
+    test()->seed(ContributorTypeSeeder::class);
+    test()->seed(LanguageSeeder::class);
+    test()->seed(PublisherSeeder::class);
+});
+
+/**
+ * Build a minimal DataCite payload so we can exercise transformSizes() via the
+ * public transform() entry point without tripping over unrelated required data.
+ *
+ * @param  array<int, string>  $sizes
+ * @return array<string, mixed>
+ */
+function sizesDoiData(string $doi, array $sizes): array
+{
+    return [
+        'attributes' => [
+            'doi' => $doi,
+            'publicationYear' => 2024,
+            'titles' => [
+                ['title' => 'Sizes Regression Fixture'],
+            ],
+            'creators' => [
+                [
+                    'name' => 'Doe, John',
+                    'familyName' => 'Doe',
+                    'givenName' => 'John',
+                    'nameType' => 'Personal',
+                ],
+            ],
+            'sizes' => $sizes,
+        ],
+    ];
+}
+
+describe('DataCiteToResourceTransformer::transformSizes()', function (): void {
+
+    it('stores byte values exceeding the old decimal(12, 4) limit without overflow', function (): void {
+        // Regression guard for SQLSTATE[22003] "Numeric value out of range" that
+        // aborted the DataCite import job when a DOI reported file sizes beyond
+        // ~99 MB (the decimal(12, 4) ceiling). With decimal(20, 4) these values
+        // must persist cleanly.
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform(
+            sizesDoiData('10.5880/sizes.bigbytes.001', ['2675059373 Bytes']),
+            $user->id,
+        );
+
+        $size = Size::where('resource_id', $resource->id)->sole();
+
+        expect((float) $size->numeric_value)->toBe(2_675_059_373.0)
+            ->and($size->unit)->toBe('Bytes')
+            ->and($size->type)->toBeNull();
+    });
+
+    it('stores multi-terabyte byte values without overflow', function (): void {
+        // Push well past the decimal(12, 4) ceiling to make sure the widened
+        // precision holds for realistically large dataset payloads, not just
+        // the specific value from the original bug report.
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform(
+            sizesDoiData('10.5880/sizes.bigbytes.002', ['1099511627776 Bytes']), // 1 TiB
+            $user->id,
+        );
+
+        $size = Size::where('resource_id', $resource->id)->sole();
+
+        expect((float) $size->numeric_value)->toBe(1_099_511_627_776.0)
+            ->and($size->unit)->toBe('Bytes');
+    });
+
+    it('still parses small decimal size strings like "1.5 GB" correctly', function (): void {
+        // Guards against accidental precision regressions that could change
+        // how fractional values are persisted.
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform(
+            sizesDoiData('10.5880/sizes.small.001', ['1.5 GB']),
+            $user->id,
+        );
+
+        $size = Size::where('resource_id', $resource->id)->sole();
+
+        expect((float) $size->numeric_value)->toBe(1.5)
+            ->and($size->unit)->toBe('GB');
+    });
+
+    it('falls back to storing unparseable size strings in the unit column', function (): void {
+        // Preserves the existing transformer contract: values that do not match
+        // the "number unit" pattern must remain retrievable via export_string.
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform(
+            sizesDoiData('10.5880/sizes.freetext.001', ['several pages']),
+            $user->id,
+        );
+
+        $size = Size::where('resource_id', $resource->id)->sole();
+
+        expect($size->numeric_value)->toBeNull()
+            ->and($size->unit)->toBe('several pages');
+    });
+});
+
+describe('sizes.numeric_value column precision', function (): void {
+
+    it('allows values well beyond the legacy decimal(12, 4) ceiling', function (): void {
+        // Schema-level regression test. Writes directly through the Eloquent
+        // model (bypassing the transformer) so any future migration that
+        // narrows the column is caught here immediately.
+        $resource = Resource::factory()->create();
+
+        $size = Size::create([
+            'resource_id' => $resource->id,
+            'numeric_value' => '2675059373',
+            'unit' => 'Bytes',
+        ]);
+
+        $size->refresh();
+
+        expect((float) $size->numeric_value)->toBe(2_675_059_373.0);
+    });
+});


### PR DESCRIPTION
This pull request addresses an overflow issue with the `sizes.numeric_value` column that caused DataCite imports to fail when handling large byte-sized values. The precision of the `numeric_value` column has been widened from `decimal(12, 4)` to `decimal(20, 4)` throughout the schema, ER diagrams, and migrations. The migration includes a data-loss guard to prevent accidental truncation when reverting. Comprehensive tests have been added to ensure correct behavior and regression protection, and the changelog has been updated accordingly.

**Database schema and migration changes:**

* Widened the `sizes.numeric_value` column from `decimal(12, 4)` to `decimal(20, 4)` in the main migration, ER diagrams (`er-diagram.md`, `er-diagram-plantuml.md`), and a new migration (`2026_04_22_000001_alter_sizes_numeric_value_precision.php`). The new migration includes a guard to prevent data loss if reverting would truncate out-of-range values. [[1]](diffhunk://#diff-48233a84e89804556f6abb761a8926be6d5652676b58ea97a5b81f6f13178d02L530-R531) [[2]](diffhunk://#diff-e0196f1170dc7341f74a244f8ee5ad1128d2350be6c80928486fe029eb3867e3L367-R367) [[3]](diffhunk://#diff-a8d0111421d72b79d6b1e81ad37d41a69ce2f2f1b765ba6e5def7d7311d72814L409-R409) [[4]](diffhunk://#diff-9cdf2d85092f35578fd7442dd0ebf25cd7b3800bf4d57a2273a7a1e3af254550R1-R63)

**Testing improvements:**

* Added feature tests for the new migration, verifying both the up and down paths, including the data-loss guard and round-trip precision.
* Added regression and integration tests for the DataCite transformer and direct model usage, ensuring large and small values are handled as expected and that the transformer gracefully handles unparseable strings.

**Documentation and changelog:**

* Updated the changelog to document the fix, noting that DataCite imports no longer abort on large file sizes, and changed the release date. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR146-R149) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4)