### PR TITLE
Feature: Bulk resource register & export

### DIFF
--- a/app/Http/Controllers/BatchResourceExportController.php
+++ b/app/Http/Controllers/BatchResourceExportController.php
@@ -91,9 +91,9 @@ class BatchResourceExportController extends Controller
             abort(500, 'Unable to open temporary ZIP archive for writing.');
         }
 
-        $jsonExporter = new DataCiteJsonExporter;
-        $xmlExporter = new DataCiteXmlExporter;
-        $jsonLdExporter = new DataCiteLinkedDataExporter;
+        $jsonExporter = app(DataCiteJsonExporter::class);
+        $xmlExporter = app(DataCiteXmlExporter::class);
+        $jsonLdExporter = app(DataCiteLinkedDataExporter::class);
 
         $extension = match ($format) {
             self::FORMAT_XML => 'xml',

--- a/app/Http/Controllers/BatchResourceExportController.php
+++ b/app/Http/Controllers/BatchResourceExportController.php
@@ -93,6 +93,12 @@ class BatchResourceExportController extends Controller
                 };
 
                 if ($content === false) {
+                    Log::warning('Batch resource export: entry skipped (encoding failed)', [
+                        'resource_id' => $resource->id,
+                        'format' => $format,
+                        'json_error' => $format === self::FORMAT_XML ? null : json_last_error_msg(),
+                    ]);
+
                     continue;
                 }
 

--- a/app/Http/Controllers/BatchResourceExportController.php
+++ b/app/Http/Controllers/BatchResourceExportController.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Resource;
+use App\Services\DataCiteJsonExporter;
+use App\Services\DataCiteLinkedDataExporter;
+use App\Services\DataCiteXmlExporter;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use ZipArchive;
+
+/**
+ * Controller for exporting multiple resources as a ZIP archive.
+ *
+ * Supports three DataCite formats: JSON (4.7), XML (4.7) and JSON-LD.
+ * The archive streams back to the browser as a download.
+ */
+class BatchResourceExportController extends Controller
+{
+    /**
+     * Maximum number of resources that can be exported in a single batch.
+     */
+    private const MAX_BATCH_SIZE = 100;
+
+    private const FORMAT_JSON = 'datacite-json';
+
+    private const FORMAT_XML = 'datacite-xml';
+
+    private const FORMAT_JSONLD = 'jsonld';
+
+    /**
+     * Export the selected resources as a downloadable ZIP archive.
+     */
+    public function export(Request $request): BinaryFileResponse
+    {
+        $validated = $request->validate([
+            'ids' => ['required', 'array', 'min:1', 'max:' . self::MAX_BATCH_SIZE],
+            'ids.*' => ['required', 'integer', 'exists:resources,id'],
+            'format' => ['required', 'string', 'in:' . self::FORMAT_JSON . ',' . self::FORMAT_XML . ',' . self::FORMAT_JSONLD],
+        ]);
+
+        /** @var array<int> $ids */
+        $ids = array_values(array_unique($validated['ids']));
+
+        /** @var string $format */
+        $format = $validated['format'];
+
+        $resources = Resource::with([
+            'igsnMetadata',
+            'landingPage',
+            'resourceType',
+            'language',
+            'publisher',
+            'titles.titleType',
+            'creators.creatorable',
+            'creators.affiliations',
+            'contributors.contributorable',
+            'contributors.contributorTypes',
+            'contributors.affiliations',
+            'descriptions.descriptionType',
+            'dates.dateType',
+            'subjects',
+            'geoLocations',
+            'rights',
+            'relatedIdentifiers.identifierType',
+            'relatedIdentifiers.relationType',
+            'fundingReferences.funderIdentifierType',
+            'alternateIdentifiers',
+            'sizes',
+            'formats',
+        ])
+            ->whereIn('id', $ids)
+            ->get();
+
+        abort_if($resources->isEmpty(), 404, 'No resources found for the given ids.');
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'ernie-export-');
+
+        if ($tmpPath === false) {
+            abort(500, 'Unable to create temporary file for ZIP archive.');
+        }
+
+        $zip = new ZipArchive;
+
+        if ($zip->open($tmpPath, ZipArchive::OVERWRITE) !== true) {
+            @unlink($tmpPath);
+            abort(500, 'Unable to open temporary ZIP archive for writing.');
+        }
+
+        $jsonExporter = new DataCiteJsonExporter;
+        $xmlExporter = new DataCiteXmlExporter;
+        $jsonLdExporter = new DataCiteLinkedDataExporter;
+
+        $extension = match ($format) {
+            self::FORMAT_XML => 'xml',
+            self::FORMAT_JSONLD => 'jsonld',
+            default => 'json',
+        };
+
+        foreach ($resources as $resource) {
+            try {
+                $content = match ($format) {
+                    self::FORMAT_XML => $xmlExporter->export($resource),
+                    self::FORMAT_JSONLD => json_encode(
+                        $jsonLdExporter->export($resource),
+                        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                    ),
+                    default => json_encode(
+                        $jsonExporter->export($resource),
+                        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                    ),
+                };
+
+                if ($content === false) {
+                    continue;
+                }
+
+                $zip->addFromString(
+                    self::buildEntryName($resource, $extension),
+                    $content,
+                );
+            } catch (\Throwable $e) {
+                Log::error('Batch resource export: entry failed', [
+                    'resource_id' => $resource->id,
+                    'format' => $format,
+                    'error' => $e->getMessage(),
+                ]);
+                // Skip this entry but keep producing the archive.
+                continue;
+            }
+        }
+
+        $zip->close();
+
+        $timestamp = now()->format('Ymd-His');
+        $downloadName = "resources-export-{$format}-{$timestamp}.zip";
+
+        return response()
+            ->download($tmpPath, $downloadName, [
+                'Content-Type' => 'application/zip',
+            ])
+            ->deleteFileAfterSend(true);
+    }
+
+    /**
+     * Derive a safe, unique file name for an archive entry.
+     */
+    private static function buildEntryName(Resource $resource, string $extension): string
+    {
+        $idPart = (string) $resource->id;
+        $doi = $resource->doi;
+        $doiPart = $doi !== null && $doi !== ''
+            ? preg_replace('/[^A-Za-z0-9._-]+/', '-', $doi)
+            : '';
+
+        $base = $doiPart !== ''
+            ? "resource-{$idPart}-{$doiPart}"
+            : "resource-{$idPart}";
+
+        return "{$base}.{$extension}";
+    }
+}

--- a/app/Http/Controllers/BatchResourceExportController.php
+++ b/app/Http/Controllers/BatchResourceExportController.php
@@ -49,30 +49,7 @@ class BatchResourceExportController extends Controller
         /** @var string $format */
         $format = $validated['format'];
 
-        $resources = Resource::with([
-            'igsnMetadata',
-            'landingPage',
-            'resourceType',
-            'language',
-            'publisher',
-            'titles.titleType',
-            'creators.creatorable',
-            'creators.affiliations',
-            'contributors.contributorable',
-            'contributors.contributorTypes',
-            'contributors.affiliations',
-            'descriptions.descriptionType',
-            'dates.dateType',
-            'subjects',
-            'geoLocations',
-            'rights',
-            'relatedIdentifiers.identifierType',
-            'relatedIdentifiers.relationType',
-            'fundingReferences.funderIdentifierType',
-            'alternateIdentifiers',
-            'sizes',
-            'formats',
-        ])
+        $resources = Resource::with(Resource::DATACITE_EXPORT_RELATIONS)
             ->whereIn('id', $ids)
             ->get();
 

--- a/app/Http/Controllers/BatchResourceRegistrationController.php
+++ b/app/Http/Controllers/BatchResourceRegistrationController.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Resource;
+use App\Services\DataCiteRegistrationService;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Controller for batch registration of Resources (non-IGSN datasets) at DataCite.
+ *
+ * Processes each resource individually with error isolation – one failure
+ * does not stop the remaining registrations.
+ */
+class BatchResourceRegistrationController extends Controller
+{
+    /**
+     * Maximum number of resources that can be registered in a single batch.
+     *
+     * Kept intentionally low because each registration performs a synchronous
+     * HTTP request to the DataCite API, so large batches can exceed web-server
+     * request timeouts or tie up PHP workers.
+     */
+    private const MAX_BATCH_SIZE = 25;
+
+    /**
+     * Batch register or update resource DOIs at DataCite.
+     *
+     * Each resource is processed independently: failures are recorded but do not
+     * prevent other resources from being registered. Returns HTTP 200 if all
+     * succeed, or HTTP 207 (Multi-Status) if some fail.
+     *
+     * Resources already having a DOI are updated (metadata refresh). Resources
+     * without a DOI require the `prefix` request parameter for initial
+     * registration; otherwise those items are reported as failed.
+     *
+     * IGSN resources (resources carrying IGSN metadata) are rejected via the
+     * `failed` list – they must be registered via the IGSN batch endpoint.
+     */
+    public function register(Request $request): JsonResponse
+    {
+        // Authorization: only users who can register production DOIs may register resources
+        if (! $request->user()?->can('register-production-doi')) {
+            abort(403, 'You are not authorized to register resources.');
+        }
+
+        $validated = $request->validate([
+            'ids' => ['required', 'array', 'min:1', 'max:' . self::MAX_BATCH_SIZE],
+            'ids.*' => ['required', 'integer', 'exists:resources,id'],
+            'prefix' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        /** @var array<int> $ids */
+        $ids = array_values(array_unique($validated['ids']));
+
+        /** @var string|null $prefix */
+        $prefix = $validated['prefix'] ?? null;
+
+        /** @var array{success: list<array<string, mixed>>, failed: list<array<string, mixed>>} $results */
+        $results = ['success' => [], 'failed' => []];
+
+        /** @var DataCiteRegistrationService $service */
+        $service = app(DataCiteRegistrationService::class);
+
+        // Fetch all resources with ALL relations needed by DataCiteJsonExporter
+        // to avoid N+1 queries when export() is called inside the loop.
+        $resources = Resource::with([
+            'igsnMetadata',
+            'landingPage',
+            'resourceType',
+            'language',
+            'publisher',
+            'titles.titleType',
+            'creators.creatorable',
+            'creators.affiliations',
+            'contributors.contributorable',
+            'contributors.contributorTypes',
+            'contributors.affiliations',
+            'descriptions.descriptionType',
+            'dates.dateType',
+            'subjects',
+            'geoLocations',
+            'rights',
+            'relatedIdentifiers.identifierType',
+            'relatedIdentifiers.relationType',
+            'fundingReferences.funderIdentifierType',
+            'alternateIdentifiers',
+            'sizes',
+            'formats',
+        ])
+            ->whereIn('id', $ids)
+            ->get()
+            ->keyBy('id');
+
+        foreach ($ids as $resourceId) {
+            $resource = $resources->get($resourceId);
+
+            if (! $resource instanceof Resource) {
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => null,
+                    'reason' => 'Resource not found',
+                ];
+
+                continue;
+            }
+
+            // IGSN resources must use the dedicated IGSN batch endpoint.
+            if ($resource->igsnMetadata !== null) {
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'reason' => 'IGSN resources must be registered via /igsns/batch-register',
+                ];
+
+                continue;
+            }
+
+            if (! $resource->landingPage) {
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'reason' => 'No landing page configured',
+                ];
+
+                continue;
+            }
+
+            $wasAlreadyRegistered = $resource->doi !== null && $resource->doi !== '';
+
+            if (! $wasAlreadyRegistered && ($prefix === null || $prefix === '')) {
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => null,
+                    'reason' => 'Resource has no DOI. Provide a prefix to register a new DOI.',
+                ];
+
+                continue;
+            }
+
+            try {
+                if ($wasAlreadyRegistered) {
+                    $response = $service->updateMetadata($resource);
+                } else {
+                    /** @var string $prefix */
+                    $response = $service->registerDoi($resource, $prefix);
+                }
+
+                $doi = $response['data']['id'] ?? $resource->doi;
+
+                // Persist the freshly-minted DOI for new registrations.
+                if (! $wasAlreadyRegistered && $doi !== null && $doi !== $resource->doi) {
+                    $resource->doi = $doi;
+                    $resource->save();
+                }
+
+                $results['success'][] = [
+                    'id' => $resourceId,
+                    'doi' => $doi,
+                    'updated' => $wasAlreadyRegistered,
+                ];
+
+                Log::info('Batch resource registration: success', [
+                    'resource_id' => $resourceId,
+                    'doi' => $doi,
+                    'updated' => $wasAlreadyRegistered,
+                ]);
+            } catch (RequestException $e) {
+                // DataCite API error – extract user-friendly message
+                $apiResponse = $e->response;
+                /** @phpstan-ignore notIdentical.alwaysTrue */
+                $apiError = $apiResponse !== null ? $apiResponse->json() : null;
+
+                $errorMessage = 'Failed to communicate with DataCite API.';
+                if (isset($apiError['errors']) && is_array($apiError['errors']) && count($apiError['errors']) > 0) {
+                    $firstError = $apiError['errors'][0];
+                    $errorMessage = $firstError['title'] ?? $firstError['detail'] ?? $errorMessage;
+                }
+
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'reason' => $errorMessage,
+                ];
+
+                Log::error('Batch resource registration: DataCite API error', [
+                    'resource_id' => $resourceId,
+                    'error' => $e->getMessage(),
+                    'api_response' => $apiError,
+                ]);
+            } catch (\InvalidArgumentException|\RuntimeException $e) {
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'reason' => $e->getMessage(),
+                ];
+
+                Log::warning('Batch resource registration: validation error', [
+                    'resource_id' => $resourceId,
+                    'error' => $e->getMessage(),
+                ]);
+            } catch (\Throwable $e) {
+                $safeMessage = config('app.debug')
+                    ? $e->getMessage()
+                    : 'An unexpected error occurred during registration.';
+
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'reason' => $safeMessage,
+                ];
+
+                Log::error('Batch resource registration: unexpected error', [
+                    'resource_id' => $resourceId,
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+            }
+        }
+
+        // 200 if all succeed, 207 Multi-Status if some fail
+        $statusCode = $results['failed'] === [] ? 200 : 207;
+
+        return response()->json($results, $statusCode);
+    }
+}

--- a/app/Http/Controllers/BatchResourceRegistrationController.php
+++ b/app/Http/Controllers/BatchResourceRegistrationController.php
@@ -69,30 +69,7 @@ class BatchResourceRegistrationController extends Controller
 
         // Fetch all resources with ALL relations needed by DataCiteJsonExporter
         // to avoid N+1 queries when export() is called inside the loop.
-        $resources = Resource::with([
-            'igsnMetadata',
-            'landingPage',
-            'resourceType',
-            'language',
-            'publisher',
-            'titles.titleType',
-            'creators.creatorable',
-            'creators.affiliations',
-            'contributors.contributorable',
-            'contributors.contributorTypes',
-            'contributors.affiliations',
-            'descriptions.descriptionType',
-            'dates.dateType',
-            'subjects',
-            'geoLocations',
-            'rights',
-            'relatedIdentifiers.identifierType',
-            'relatedIdentifiers.relationType',
-            'fundingReferences.funderIdentifierType',
-            'alternateIdentifiers',
-            'sizes',
-            'formats',
-        ])
+        $resources = Resource::with(Resource::DATACITE_EXPORT_RELATIONS)
             ->whereIn('id', $ids)
             ->get()
             ->keyBy('id');
@@ -172,9 +149,7 @@ class BatchResourceRegistrationController extends Controller
                 ]);
             } catch (RequestException $e) {
                 // DataCite API error – extract user-friendly message
-                $apiResponse = $e->response;
-                /** @phpstan-ignore notIdentical.alwaysTrue */
-                $apiError = $apiResponse !== null ? $apiResponse->json() : null;
+                $apiError = $e->response->json();
 
                 $errorMessage = 'Failed to communicate with DataCite API.';
                 if (isset($apiError['errors']) && is_array($apiError['errors']) && count($apiError['errors']) > 0) {

--- a/app/Http/Controllers/BatchResourceRegistrationController.php
+++ b/app/Http/Controllers/BatchResourceRegistrationController.php
@@ -148,13 +148,23 @@ class BatchResourceRegistrationController extends Controller
                     'updated' => $wasAlreadyRegistered,
                 ]);
             } catch (RequestException $e) {
-                // DataCite API error – extract user-friendly message
-                $apiError = $e->response->json();
+                // DataCite API error – extract a user-friendly message.
+                // `response->json()` may legitimately return null for non-JSON
+                // upstream payloads (HTML error pages, empty bodies, etc.), so
+                // everything below must tolerate a non-array result.
+                $apiResponse = $e->response;
+                $apiError = $apiResponse->json();
 
                 $errorMessage = 'Failed to communicate with DataCite API.';
-                if (isset($apiError['errors']) && is_array($apiError['errors']) && count($apiError['errors']) > 0) {
+                if (is_array($apiError)
+                    && isset($apiError['errors'])
+                    && is_array($apiError['errors'])
+                    && count($apiError['errors']) > 0
+                ) {
                     $firstError = $apiError['errors'][0];
-                    $errorMessage = $firstError['title'] ?? $firstError['detail'] ?? $errorMessage;
+                    if (is_array($firstError)) {
+                        $errorMessage = $firstError['title'] ?? $firstError['detail'] ?? $errorMessage;
+                    }
                 }
 
                 $results['failed'][] = [
@@ -166,7 +176,8 @@ class BatchResourceRegistrationController extends Controller
                 Log::error('Batch resource registration: DataCite API error', [
                     'resource_id' => $resourceId,
                     'error' => $e->getMessage(),
-                    'api_response' => $apiError,
+                    'status' => $apiResponse->status(),
+                    'api_response' => is_array($apiError) ? $apiError : $apiResponse->body(),
                 ]);
             } catch (\InvalidArgumentException|\RuntimeException $e) {
                 $results['failed'][] = [

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -67,6 +67,40 @@ class Resource extends Model
         'publication_year' => 'integer',
     ];
 
+    /**
+     * Relations that must be eager-loaded for DataCite export/registration.
+     *
+     * Shared by BatchResourceExportController and BatchResourceRegistrationController
+     * so both endpoints preload the same graph and cannot drift apart when new
+     * relations are added to the exporters.
+     *
+     * @var list<string>
+     */
+    public const DATACITE_EXPORT_RELATIONS = [
+        'igsnMetadata',
+        'landingPage',
+        'resourceType',
+        'language',
+        'publisher',
+        'titles.titleType',
+        'creators.creatorable',
+        'creators.affiliations',
+        'contributors.contributorable',
+        'contributors.contributorTypes',
+        'contributors.affiliations',
+        'descriptions.descriptionType',
+        'dates.dateType',
+        'subjects',
+        'geoLocations',
+        'rights',
+        'relatedIdentifiers.identifierType',
+        'relatedIdentifiers.relationType',
+        'fundingReferences.funderIdentifierType',
+        'alternateIdentifiers',
+        'sizes',
+        'formats',
+    ];
+
     // =========================================================================
     // Lookup Table Relations
     // =========================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,9 +1216,9 @@
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
-      "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
+      "version": "0.41.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.5.tgz",
+      "integrity": "sha512-Fa2HztoLlZxRN6wVC2KB7q0SvRTKjfP0328NVnSit03+0nzm62syxyT46KGbgq3Vr1A/mmLeQwu3GprB0lNTjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8657,9 +8657,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.343",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
-      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -11530,9 +11530,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.4.tgz",
-      "integrity": "sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.5.tgz",
+      "integrity": "sha512-LuJem+CbqbywJtafv4zh5kcCQNmZnKwfJgJ/LcNYjeG3CU/xJLepJM1CNZcbp+oV8tXFGvUfswPGru34Mx7QGQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -66,18 +66,6 @@
         ],
         "improvements": [
             {
-                "title": "Bulk Register Prevents Prefix-less Minting",
-                "description": "The Register Selected button on the Resources page is now automatically disabled (with an explanatory tooltip) when the selection contains any resource without a DOI. The bulk flow does not prompt for a DataCite prefix, so mixed selections that would previously fail at the backend are now caught in the UI — users are directed to the editor's single-resource registration to mint new DOIs."
-            },
-            {
-                "title": "Shared DataCite Eager-Load Relations",
-                "description": "The list of Eloquent relations required by the DataCite exporters has been extracted into a single `Resource::DATACITE_EXPORT_RELATIONS` constant and is now reused by both the bulk registration and bulk export endpoints, preventing the two code paths from drifting as new relations are added."
-            },
-            {
-                "title": "Bulk Toolbar Uses Shared LoadingButton",
-                "description": "The Register Selected and Export Selected buttons on the Resources page now use the shared `LoadingButton` component for their loading and disabled states, matching the rest of the application and removing duplicated spinner markup."
-            },
-            {
                 "title": "Responsive Resources Page Layout",
                 "description": "The Resources page now mirrors the IGSN page layout for small screens. The Import-from-DataCite button moved out of the card header into a new toolbar row directly below the filters (next to the bulk actions). Less critical sub-rows (Resource Type, Curator) and the Created/Updated column hide progressively on small and medium viewports so the essential information (Title, Author/Year, Status, Actions) remains visible without horizontal scrolling."
             },

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -66,6 +66,18 @@
         ],
         "improvements": [
             {
+                "title": "Bulk Register Prevents Prefix-less Minting",
+                "description": "The Register Selected button on the Resources page is now automatically disabled (with an explanatory tooltip) when the selection contains any resource without a DOI. The bulk flow does not prompt for a DataCite prefix, so mixed selections that would previously fail at the backend are now caught in the UI — users are directed to the editor's single-resource registration to mint new DOIs."
+            },
+            {
+                "title": "Shared DataCite Eager-Load Relations",
+                "description": "The list of Eloquent relations required by the DataCite exporters has been extracted into a single `Resource::DATACITE_EXPORT_RELATIONS` constant and is now reused by both the bulk registration and bulk export endpoints, preventing the two code paths from drifting as new relations are added."
+            },
+            {
+                "title": "Bulk Toolbar Uses Shared LoadingButton",
+                "description": "The Register Selected and Export Selected buttons on the Resources page now use the shared `LoadingButton` component for their loading and disabled states, matching the rest of the application and removing duplicated spinner markup."
+            },
+            {
                 "title": "Responsive Resources Page Layout",
                 "description": "The Resources page now mirrors the IGSN page layout for small screens. The Import-from-DataCite button moved out of the card header into a new toolbar row directly below the filters (next to the bulk actions). Less critical sub-rows (Resource Type, Curator) and the Created/Updated column hide progressively on small and medium viewports so the essential information (Title, Author/Year, Status, Actions) remains visible without horizontal scrolling."
             },

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,8 +1,12 @@
 [
     {
         "version": "1.0.0dev",
-        "date": "2026-04-22",
+        "date": "2026-04-23",
         "features": [
+            {
+                "title": "Bulk Actions on Resources Page",
+                "description": "Curators can now select multiple resources via checkboxes and trigger bulk actions: register/update DOIs at DataCite (up to 25 at once) and export selected resources as a single ZIP archive in DataCite JSON, DataCite XML, or DataCite JSON-LD format (up to 100 at once). The bulk register button is hidden for users without DOI registration permission. Per-row actions remain available."
+            },
             {
                 "title": "Landing Page Template Management",
                 "description": "Admins and Group Leaders can now create custom landing page templates by cloning the immutable Default GFZ template. Custom templates allow renaming, replacing the header logo with a custom image, and reordering all content sections via drag-and-drop with a live preview. Templates created this way appear in the template dropdown when setting up a landing page for a resource. Templates that are currently in use by landing pages are protected from deletion."
@@ -61,6 +65,10 @@
             }
         ],
         "improvements": [
+            {
+                "title": "Responsive Resources Page Layout",
+                "description": "The Resources page now mirrors the IGSN page layout for small screens. The Import-from-DataCite button moved out of the card header into a new toolbar row directly below the filters (next to the bulk actions). Less critical sub-rows (Resource Type, Curator) and the Created/Updated column hide progressively on small and medium viewports so the essential information (Title, Author/Year, Status, Actions) remains visible without horizontal scrolling."
+            },
             {
                 "title": "TanStack Query Data Layer — Review Feedback Hardening",
                 "description": "Consolidated follow-up improvements from PR review rounds on the new TanStack Query data layer. CORS & headers: `apiClient` no longer injects `X-Requested-With` / CSRF headers on cross-origin requests by default and exposes an opt-out `skipCsrf` flag, avoiding needless preflights when calling third-party hosts; the MSL laboratories loader now fetches the external Utrecht vocabulary via a plain `fetch` with only simple headers to stay CORS-simple. Request handling: `apiRequest` recognises typed arrays and `DataView` via `ArrayBuffer.isView` so binary uploads reach the server untouched with the correct content type; the Vitest MSW server runs with `onUnhandledRequest: 'error'` and surfaces missing handlers as explicit test failures. DOI validation: `checkDoiBeforeSave` always hits the backend instead of reusing a cached 'available' response, coordinates with the debounced `validateDoi` through an `activeQueryKeyRef` so `isValidating` reports accurately across both paths, forwards TanStack Query's `signal` (combined with a local `AbortController`) into `apiRequest` so `queryClient.cancelQueries()` reliably aborts in-flight requests on unmount, falls back to the default/override error message on invalid format and resets `isValid` to `null` on errors; default error messages were translated to English. Caching & provider lifecycle: the 30-minute `staleTime` on ROR, MSL, and PID4INST vocabulary queries (and their editor prefetches) is now paired with a matching `gcTime` so cached data survives the full freshness window; `QueryProvider` lazily allocates a fallback `QueryClient` via a `useRef` only when no `client` prop is supplied (so `app.tsx` and the SSR entry point no longer pay for an unused internal instance per mount / request), and the Devtools import is additionally guarded by `typeof window !== 'undefined'` for safe SSR. Hook ergonomics: `useRorAffiliations` normalises the `unknown` error returned by TanStack Query to a real `Error` instance so its `Error | null` contract holds regardless of what the fetch layer throws. Tooling: query-key factory uses the Wayfinder `.url()` helper for consistency with the rest of the codebase; Vitest render helpers use a lazy `useState` initialiser so the test `QueryClient` is created once per mount; test cookie cleanup now iterates the jar and expires each entry instead of assigning an empty string (which is a no-op in jsdom). Coverage for the query layer increased substantially (DOI validation: 32% → 85%+, api-client: 86% → 92%)."

--- a/resources/js/components/resources/bulk-actions-toolbar.tsx
+++ b/resources/js/components/resources/bulk-actions-toolbar.tsx
@@ -1,13 +1,12 @@
 import { CloudUpload, Download } from 'lucide-react';
 
-import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Spinner } from '@/components/ui/spinner';
+import { LoadingButton } from '@/components/ui/loading-button';
 
 export type ResourcesBulkExportFormat = 'datacite-json' | 'datacite-xml' | 'jsonld';
 
@@ -18,6 +17,12 @@ export interface ResourcesBulkActionsToolbarProps {
     canRegister: boolean;
     isRegistering?: boolean;
     isExporting?: boolean;
+    /**
+     * Human-readable reason why the register button must stay disabled despite
+     * having a valid selection (e.g. selection contains DOI-less resources).
+     * Empty/undefined means the button is enabled when a selection exists.
+     */
+    registerDisabledReason?: string;
 }
 
 /**
@@ -34,8 +39,10 @@ export function ResourcesBulkActionsToolbar({
     canRegister,
     isRegistering = false,
     isExporting = false,
+    registerDisabledReason,
 }: ResourcesBulkActionsToolbarProps) {
     const hasSelection = selectedCount > 0;
+    const registerBlocked = Boolean(registerDisabledReason);
 
     return (
         <div
@@ -50,48 +57,33 @@ export function ResourcesBulkActionsToolbar({
 
             <div className="ml-auto flex items-center gap-2">
                 {canRegister && (
-                    <Button
+                    <LoadingButton
                         type="button"
                         size="default"
                         onClick={onRegister}
-                        disabled={!hasSelection || isRegistering || isExporting}
+                        disabled={!hasSelection || registerBlocked || isExporting}
+                        loading={isRegistering}
+                        title={registerBlocked ? registerDisabledReason : undefined}
                         data-testid="bulk-register-button"
                     >
-                        {isRegistering ? (
-                            <>
-                                <Spinner size="sm" className="mr-2" />
-                                Registering...
-                            </>
-                        ) : (
-                            <>
-                                <CloudUpload className="mr-2 size-4" aria-hidden="true" />
-                                Register Selected
-                            </>
-                        )}
-                    </Button>
+                        {!isRegistering && <CloudUpload className="size-4" aria-hidden="true" />}
+                        {isRegistering ? 'Registering...' : 'Register Selected'}
+                    </LoadingButton>
                 )}
 
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                        <Button
+                        <LoadingButton
                             type="button"
                             size="default"
                             variant="outline"
-                            disabled={!hasSelection || isExporting || isRegistering}
+                            disabled={!hasSelection || isRegistering}
+                            loading={isExporting}
                             data-testid="bulk-export-button"
                         >
-                            {isExporting ? (
-                                <>
-                                    <Spinner size="sm" className="mr-2" />
-                                    Exporting...
-                                </>
-                            ) : (
-                                <>
-                                    <Download className="mr-2 size-4" aria-hidden="true" />
-                                    Export Selected
-                                </>
-                            )}
-                        </Button>
+                            {!isExporting && <Download className="size-4" aria-hidden="true" />}
+                            {isExporting ? 'Exporting...' : 'Export Selected'}
+                        </LoadingButton>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                         <DropdownMenuItem onSelect={() => onExport('datacite-json')}>
@@ -109,3 +101,4 @@ export function ResourcesBulkActionsToolbar({
         </div>
     );
 }
+

--- a/resources/js/components/resources/bulk-actions-toolbar.tsx
+++ b/resources/js/components/resources/bulk-actions-toolbar.tsx
@@ -1,0 +1,111 @@
+import { CloudUpload, Download } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Spinner } from '@/components/ui/spinner';
+
+export type ResourcesBulkExportFormat = 'datacite-json' | 'datacite-xml' | 'jsonld';
+
+export interface ResourcesBulkActionsToolbarProps {
+    selectedCount: number;
+    onRegister: () => void;
+    onExport: (format: ResourcesBulkExportFormat) => void;
+    canRegister: boolean;
+    isRegistering?: boolean;
+    isExporting?: boolean;
+}
+
+/**
+ * Bulk actions toolbar for the Resources page.
+ *
+ * Always rendered (so the page layout stays stable). Buttons are disabled
+ * when no rows are selected. Heights match `size="default"` form inputs so
+ * the toolbar visually aligns with the filter row above it.
+ */
+export function ResourcesBulkActionsToolbar({
+    selectedCount,
+    onRegister,
+    onExport,
+    canRegister,
+    isRegistering = false,
+    isExporting = false,
+}: ResourcesBulkActionsToolbarProps) {
+    const hasSelection = selectedCount > 0;
+
+    return (
+        <div
+            data-testid="resources-bulk-actions-toolbar"
+            className="flex flex-wrap items-center gap-2"
+        >
+            <span className="text-sm text-muted-foreground" aria-live="polite">
+                {hasSelection
+                    ? `${selectedCount} ${selectedCount === 1 ? 'resource' : 'resources'} selected`
+                    : 'Select rows to enable bulk actions'}
+            </span>
+
+            <div className="ml-auto flex items-center gap-2">
+                {canRegister && (
+                    <Button
+                        type="button"
+                        size="default"
+                        onClick={onRegister}
+                        disabled={!hasSelection || isRegistering || isExporting}
+                        data-testid="bulk-register-button"
+                    >
+                        {isRegistering ? (
+                            <>
+                                <Spinner size="sm" className="mr-2" />
+                                Registering...
+                            </>
+                        ) : (
+                            <>
+                                <CloudUpload className="mr-2 size-4" aria-hidden="true" />
+                                Register Selected
+                            </>
+                        )}
+                    </Button>
+                )}
+
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button
+                            type="button"
+                            size="default"
+                            variant="outline"
+                            disabled={!hasSelection || isExporting || isRegistering}
+                            data-testid="bulk-export-button"
+                        >
+                            {isExporting ? (
+                                <>
+                                    <Spinner size="sm" className="mr-2" />
+                                    Exporting...
+                                </>
+                            ) : (
+                                <>
+                                    <Download className="mr-2 size-4" aria-hidden="true" />
+                                    Export Selected
+                                </>
+                            )}
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuItem onSelect={() => onExport('datacite-json')}>
+                            DataCite JSON
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onSelect={() => onExport('datacite-xml')}>
+                            DataCite XML
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onSelect={() => onExport('jsonld')}>
+                            DataCite JSON-LD
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/resources/bulk-actions-toolbar.tsx
+++ b/resources/js/components/resources/bulk-actions-toolbar.tsx
@@ -1,4 +1,4 @@
-import { CloudUpload, Download } from 'lucide-react';
+import { CloudUpload, Download, Info } from 'lucide-react';
 
 import {
     DropdownMenu,
@@ -7,6 +7,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { LoadingButton } from '@/components/ui/loading-button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 export type ResourcesBulkExportFormat = 'datacite-json' | 'datacite-xml' | 'jsonld';
 
@@ -45,60 +46,95 @@ export function ResourcesBulkActionsToolbar({
     const registerBlocked = Boolean(registerDisabledReason);
 
     return (
-        <div
-            data-testid="resources-bulk-actions-toolbar"
-            className="flex flex-wrap items-center gap-2"
-        >
-            <span className="text-sm text-muted-foreground" aria-live="polite">
-                {hasSelection
-                    ? `${selectedCount} ${selectedCount === 1 ? 'resource' : 'resources'} selected`
-                    : 'Select rows to enable bulk actions'}
-            </span>
+        <TooltipProvider>
+            <div
+                data-testid="resources-bulk-actions-toolbar"
+                className="flex flex-wrap items-center gap-x-2 gap-y-1"
+            >
+                <span className="text-sm text-muted-foreground" aria-live="polite">
+                    {hasSelection
+                        ? `${selectedCount} ${selectedCount === 1 ? 'resource' : 'resources'} selected`
+                        : 'Select rows to enable bulk actions'}
+                </span>
 
-            <div className="ml-auto flex items-center gap-2">
-                {canRegister && (
-                    <LoadingButton
-                        type="button"
-                        size="default"
-                        onClick={onRegister}
-                        disabled={!hasSelection || registerBlocked || isExporting}
-                        loading={isRegistering}
-                        title={registerBlocked ? registerDisabledReason : undefined}
-                        data-testid="bulk-register-button"
+                <div className="ml-auto flex items-center gap-2">
+                    {canRegister && (
+                        <Tooltip>
+                            {/*
+                             * Wrap the button in a span so Radix can still receive
+                             * pointer/focus events for the tooltip even when the button
+                             * itself is disabled. `tabIndex={0}` makes the trigger
+                             * keyboard-focusable so screen-reader users can discover
+                             * the reason as well.
+                             */}
+                            <TooltipTrigger asChild>
+                                <span
+                                    className="inline-flex"
+                                    tabIndex={registerBlocked ? 0 : -1}
+                                    aria-describedby={registerBlocked ? 'bulk-register-blocked-hint' : undefined}
+                                >
+                                    <LoadingButton
+                                        type="button"
+                                        size="default"
+                                        onClick={onRegister}
+                                        disabled={!hasSelection || registerBlocked || isExporting}
+                                        loading={isRegistering}
+                                        data-testid="bulk-register-button"
+                                    >
+                                        {!isRegistering && <CloudUpload className="size-4" aria-hidden="true" />}
+                                        {isRegistering ? 'Registering...' : 'Register Selected'}
+                                    </LoadingButton>
+                                </span>
+                            </TooltipTrigger>
+                            {registerBlocked && (
+                                <TooltipContent side="bottom" className="max-w-sm text-center">
+                                    {registerDisabledReason}
+                                </TooltipContent>
+                            )}
+                        </Tooltip>
+                    )}
+
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <LoadingButton
+                                type="button"
+                                size="default"
+                                variant="outline"
+                                disabled={!hasSelection || isRegistering}
+                                loading={isExporting}
+                                data-testid="bulk-export-button"
+                            >
+                                {!isExporting && <Download className="size-4" aria-hidden="true" />}
+                                {isExporting ? 'Exporting...' : 'Export Selected'}
+                            </LoadingButton>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem onSelect={() => onExport('datacite-json')}>
+                                DataCite JSON
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onSelect={() => onExport('datacite-xml')}>
+                                DataCite XML
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onSelect={() => onExport('jsonld')}>
+                                DataCite JSON-LD
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+
+                {registerBlocked && (
+                    <p
+                        id="bulk-register-blocked-hint"
+                        data-testid="bulk-register-blocked-hint"
+                        className="flex w-full items-start gap-1.5 text-xs text-muted-foreground"
+                        role="note"
                     >
-                        {!isRegistering && <CloudUpload className="size-4" aria-hidden="true" />}
-                        {isRegistering ? 'Registering...' : 'Register Selected'}
-                    </LoadingButton>
+                        <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                        <span>{registerDisabledReason}</span>
+                    </p>
                 )}
-
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <LoadingButton
-                            type="button"
-                            size="default"
-                            variant="outline"
-                            disabled={!hasSelection || isRegistering}
-                            loading={isExporting}
-                            data-testid="bulk-export-button"
-                        >
-                            {!isExporting && <Download className="size-4" aria-hidden="true" />}
-                            {isExporting ? 'Exporting...' : 'Export Selected'}
-                        </LoadingButton>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                        <DropdownMenuItem onSelect={() => onExport('datacite-json')}>
-                            DataCite JSON
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onSelect={() => onExport('datacite-xml')}>
-                            DataCite XML
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onSelect={() => onExport('jsonld')}>
-                            DataCite JSON-LD
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
             </div>
-        </div>
+        </TooltipProvider>
     );
 }
 

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1354,6 +1354,53 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                 ),
             },
             {
+                id: 'bulk-actions',
+                title: 'Bulk Actions on Resources',
+                icon: FileText,
+                minRole: 'beginner',
+                content: (
+                    <>
+                        <h3>Selecting and Acting on Multiple Resources</h3>
+                        <p>
+                            The <code>/resources</code> page supports multi-selection so you can act on several
+                            resources at once. Select rows individually with the checkbox in the leftmost column,
+                            or use the header checkbox to select all currently visible resources. The bulk
+                            actions toolbar sits directly below the filter row and shows how many resources are
+                            selected.
+                        </p>
+
+                        <h4>Bulk Export (all roles)</h4>
+                        <p>
+                            Click <strong>Export Selected</strong> to download a single ZIP archive containing
+                            the metadata of every selected resource in your chosen format:
+                        </p>
+                        <ul className="list-inside list-disc space-y-1">
+                            <li>DataCite JSON</li>
+                            <li>DataCite XML (validated against schema 4.6)</li>
+                            <li>DataCite JSON-LD (Linked Data)</li>
+                        </ul>
+                        <p className="text-sm text-muted-foreground">Limit: up to 100 resources per ZIP.</p>
+
+                        <h4>Bulk Register / Update DOI (Curator and above)</h4>
+                        <p>
+                            Click <strong>Register Selected</strong> to send every selected resource to DataCite
+                            in one batch. Resources that already have a DOI receive an updated metadata payload;
+                            resources without a DOI are minted using your default DOI prefix. Resources without a
+                            landing page or that are physical samples (IGSNs) are skipped and reported in the
+                            response toast.
+                        </p>
+                        <p className="text-sm text-muted-foreground">Limit: up to 25 resources per batch.</p>
+
+                        <h4>Responsive Layout</h4>
+                        <p>
+                            On smaller screens, less critical sub-rows (Resource Type, Curator) and the
+                            Created/Updated column are hidden so the essential columns (Title, Author/Year,
+                            Status, Actions) remain readable without horizontal scrolling.
+                        </p>
+                    </>
+                ),
+            },
+            {
                 id: 'json-export',
                 title: 'JSON Export',
                 icon: FileText,

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1376,18 +1376,24 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                         </p>
                         <ul className="list-inside list-disc space-y-1">
                             <li>DataCite JSON</li>
-                            <li>DataCite XML (validated against schema 4.6)</li>
+                            <li>DataCite XML</li>
                             <li>DataCite JSON-LD (Linked Data)</li>
                         </ul>
-                        <p className="text-sm text-muted-foreground">Limit: up to 100 resources per ZIP.</p>
+                        <p className="text-sm text-muted-foreground">
+                            Limit: up to 100 resources per ZIP. Bulk exports stream the generated payload
+                            directly to the browser without running the DataCite Schema 4.7 validator —
+                            use the single-resource export in the editor if you need schema-validated output.
+                        </p>
 
                         <h4>Bulk Register / Update DOI (Curator and above)</h4>
                         <p>
-                            Click <strong>Register Selected</strong> to send every selected resource to DataCite
-                            in one batch. Resources that already have a DOI receive an updated metadata payload;
-                            resources without a DOI are minted using your default DOI prefix. Resources without a
-                            landing page or that are physical samples (IGSNs) are skipped and reported in the
-                            response toast.
+                            Click <strong>Register Selected</strong> to push every selected resource to DataCite
+                            in one batch. The bulk flow <strong>only updates resources that already have a
+                            DOI</strong>; the button is disabled when the selection contains any DOI-less resource
+                            so you never accidentally mint a DOI without picking a prefix. To mint a new DOI,
+                            open the resource in the editor and use the single-resource register action there.
+                            Resources without a landing page or that are physical samples (IGSNs) are skipped
+                            and reported in the response toast.
                         </p>
                         <p className="text-sm text-muted-foreground">Limit: up to 25 resources per batch.</p>
 

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -8,6 +8,10 @@ import { toast } from 'sonner';
 import { DataCiteIcon } from '@/components/icons/datacite-icon';
 import { FileJsonIcon, FileXmlIcon } from '@/components/icons/file-icons';
 import SetupLandingPageModal from '@/components/landing-pages/modals/SetupLandingPageModal';
+import {
+    ResourcesBulkActionsToolbar,
+    type ResourcesBulkExportFormat,
+} from '@/components/resources/bulk-actions-toolbar';
 import ImportFromDataCiteModal from '@/components/resources/modals/ImportFromDataCiteModal';
 import RegisterDoiModal from '@/components/resources/modals/RegisterDoiModal';
 import { ResourcesFilters } from '@/components/resources-filters';
@@ -15,6 +19,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { type ValidationError, ValidationErrorModal } from '@/components/ui/validation-error-modal';
 import AppLayout from '@/layouts/app-layout';
@@ -300,6 +305,7 @@ function ResourcesPage({
 }: ResourcesProps) {
     const { auth } = usePage<{ auth: { user: AuthUser } }>().props;
     const canManageLandingPages = auth.user?.can_manage_landing_pages ?? false;
+    const canRegisterDoi = auth.user?.can_register_production_doi ?? false;
 
     const [resources, setResources] = useState<Resource[]>(initialResources);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -307,6 +313,9 @@ function ResourcesPage({
     const [loading, setLoading] = useState(false);
     const [loadingError, setLoadingError] = useState<string | null>(null);
     const [showImportModal, setShowImportModal] = useState(false);
+    const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+    const [isBulkRegistering, setIsBulkRegistering] = useState(false);
+    const [isBulkExporting, setIsBulkExporting] = useState(false);
     const [filters, setFilters] = useState<ResourceFilterState>(() => {
         // SSR-safe: Only access window.location on the client side
         if (typeof window === 'undefined') {
@@ -547,6 +556,141 @@ function ResourcesPage({
         // Refresh the resources list to show imported resources
         router.reload({ only: ['resources', 'pagination'] });
     }, []);
+
+    // Drop selections that no longer correspond to a loaded resource (e.g. after
+    // filter/sort changes that replace the list).
+    useEffect(() => {
+        setSelectedIds((prev) => {
+            if (prev.size === 0) {
+                return prev;
+            }
+            const validIds = new Set(resources.map((r) => r.id).filter((id): id is number => typeof id === 'number'));
+            let changed = false;
+            const next = new Set<number>();
+            prev.forEach((id) => {
+                if (validIds.has(id)) {
+                    next.add(id);
+                } else {
+                    changed = true;
+                }
+            });
+            return changed ? next : prev;
+        });
+    }, [resources]);
+
+    const visibleSelectableIds = useCallback((): number[] => {
+        return resources.map((r) => r.id).filter((id): id is number => typeof id === 'number');
+    }, [resources]);
+
+    const allVisibleSelected = resources.length > 0 && visibleSelectableIds().every((id) => selectedIds.has(id));
+    const someVisibleSelected = !allVisibleSelected && visibleSelectableIds().some((id) => selectedIds.has(id));
+
+    const handleSelectAll = useCallback(
+        (checked: boolean) => {
+            setSelectedIds(checked ? new Set(visibleSelectableIds()) : new Set());
+        },
+        [visibleSelectableIds],
+    );
+
+    const handleSelectOne = useCallback((id: number, checked: boolean) => {
+        setSelectedIds((prev) => {
+            const next = new Set(prev);
+            if (checked) {
+                next.add(id);
+            } else {
+                next.delete(id);
+            }
+            return next;
+        });
+    }, []);
+
+    const handleBulkRegister = useCallback(async () => {
+        if (selectedIds.size === 0) {
+            return;
+        }
+        setIsBulkRegistering(true);
+        try {
+            const response = await axios.post<{
+                success: Array<{ id: number; doi: string | null; updated: boolean }>;
+                failed: Array<{ id: number; doi: string | null; reason: string }>;
+            }>('/resources/batch-register', { ids: Array.from(selectedIds) });
+
+            const { success = [], failed = [] } = response.data ?? {};
+            if (success.length > 0) {
+                toast.success(`${success.length} ${success.length === 1 ? 'resource' : 'resources'} registered/updated`);
+            }
+            if (failed.length > 0) {
+                toast.error(`${failed.length} failed: ${failed[0].reason}`);
+            }
+            router.reload({ only: ['resources', 'pagination'] });
+            setSelectedIds(new Set());
+        } catch (error) {
+            // Axios returns 207 as an error in some configurations; handle gracefully.
+            if (isAxiosError(error) && error.response?.status === 207 && error.response.data) {
+                const { success = [], failed = [] } = error.response.data as {
+                    success?: Array<{ id: number; doi: string | null; updated: boolean }>;
+                    failed?: Array<{ id: number; doi: string | null; reason: string }>;
+                };
+                if (success.length > 0) {
+                    toast.success(`${success.length} ${success.length === 1 ? 'resource' : 'resources'} registered/updated`);
+                }
+                if (failed.length > 0) {
+                    toast.error(`${failed.length} failed: ${failed[0].reason}`);
+                }
+                router.reload({ only: ['resources', 'pagination'] });
+                setSelectedIds(new Set());
+                return;
+            }
+            console.error('Bulk register failed:', error);
+            toast.error('Bulk registration failed');
+        } finally {
+            setIsBulkRegistering(false);
+        }
+    }, [selectedIds]);
+
+    const handleBulkExport = useCallback(
+        async (format: ResourcesBulkExportFormat) => {
+            if (selectedIds.size === 0) {
+                return;
+            }
+            setIsBulkExporting(true);
+            try {
+                const response = await axios.post('/resources/batch-export', {
+                    ids: Array.from(selectedIds),
+                    format,
+                }, {
+                    responseType: 'blob',
+                });
+
+                const blob = new Blob([response.data as BlobPart], { type: 'application/zip' });
+                const contentDisposition = response.headers['content-disposition'] as string | undefined;
+                let filename = `resources-export-${format}.zip`;
+                if (contentDisposition) {
+                    const match = contentDisposition.match(/filename="?([^"]+)"?/);
+                    if (match) {
+                        filename = match[1];
+                    }
+                }
+
+                const url = window.URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                window.URL.revokeObjectURL(url);
+
+                toast.success(`Exported ${selectedIds.size} ${selectedIds.size === 1 ? 'resource' : 'resources'} as ${format.toUpperCase()}`);
+            } catch (error) {
+                console.error('Bulk export failed:', error);
+                toast.error('Bulk export failed');
+            } finally {
+                setIsBulkExporting(false);
+            }
+        },
+        [selectedIds],
+    );
 
     /**
      * Copy text to clipboard with toast notification
@@ -854,7 +998,7 @@ function ResourcesPage({
             label: (
                 <span className="flex flex-col leading-tight normal-case">
                     <span>Title</span>
-                    <span>Resource Type</span>
+                    <span className="hidden md:inline">Resource Type</span>
                 </span>
             ),
             widthClass: TITLE_COLUMN_WIDTH_CLASSES,
@@ -879,7 +1023,7 @@ function ResourcesPage({
                 return (
                     <div className="flex flex-col gap-1 text-left">
                         <span className="text-sm leading-relaxed font-normal wrap-break-word text-gray-900 dark:text-gray-100">{title}</span>
-                        <span className="text-sm whitespace-nowrap text-gray-600 dark:text-gray-300">{resourceType}</span>
+                        <span className="hidden text-sm whitespace-nowrap text-gray-600 md:inline dark:text-gray-300">{resourceType}</span>
                     </div>
                 );
             },
@@ -935,7 +1079,7 @@ function ResourcesPage({
             key: 'curator_status',
             label: (
                 <span className="flex flex-col leading-tight normal-case">
-                    <span>Curator</span>
+                    <span className="hidden lg:inline">Curator</span>
                     <span>Status</span>
                 </span>
             ),
@@ -988,7 +1132,7 @@ function ResourcesPage({
 
                 return (
                     <div className="flex flex-col gap-1 text-center text-gray-600 dark:text-gray-300">
-                        <span className="text-sm">{curator}</span>
+                        <span className="hidden text-sm lg:inline">{curator}</span>
                         <span
                             className={statusClasses}
                             onClick={isClickable ? () => handleStatusBadgeClick(resource, status) : undefined}
@@ -1016,8 +1160,8 @@ function ResourcesPage({
         {
             key: 'created_updated',
             label: DATE_COLUMN_HEADER_LABEL,
-            widthClass: 'min-w-[9rem]',
-            cellClassName: 'whitespace-normal align-middle',
+            widthClass: 'hidden min-w-[9rem] md:table-cell',
+            cellClassName: 'hidden whitespace-normal align-middle md:table-cell',
             sortOptions: [
                 {
                     key: 'created_at',
@@ -1056,6 +1200,9 @@ function ResourcesPage({
         <>
             {[...Array(5)].map((_, index) => (
                 <tr key={`skeleton-${index}`} className="animate-pulse">
+                    <td className="w-12 min-w-12 px-6 py-1.5 align-middle">
+                        <div className="size-4 rounded bg-gray-200 dark:bg-gray-700" />
+                    </td>
                     <td className={`px-6 py-1.5 align-middle ${ACTIONS_COLUMN_WIDTH_CLASSES}`}>
                         <div className="flex flex-col gap-0.5">
                             <div className="flex items-center gap-1">
@@ -1096,20 +1243,10 @@ function ResourcesPage({
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
                 <Card>
                     <CardHeader>
-                        <div className="flex items-start justify-between">
-                            <div>
-                                <CardTitle asChild>
-                                    <h1 className="text-2xl font-semibold tracking-tight">Resources</h1>
-                                </CardTitle>
-                                <CardDescription>Overview of curated resources in ERNIE</CardDescription>
-                            </div>
-                            {canImportFromDataCite && (
-                                <Button variant="outline" onClick={() => setShowImportModal(true)} className="flex items-center gap-2">
-                                    <DataCiteIcon className="size-4" aria-hidden="true" />
-                                    Import from DataCite
-                                </Button>
-                            )}
-                        </div>
+                        <CardTitle asChild>
+                            <h1 className="text-2xl font-semibold tracking-tight">Resources</h1>
+                        </CardTitle>
+                        <CardDescription>Overview of curated resources in ERNIE</CardDescription>
                     </CardHeader>
                     <CardContent>
                         {error ? (
@@ -1139,6 +1276,29 @@ function ResourcesPage({
                             isLoading={loading}
                         />
 
+                        {/* Bulk action toolbar + Import button (mirrors IGSN pattern) */}
+                        <div className="mt-4 flex flex-wrap items-center gap-2">
+                            <ResourcesBulkActionsToolbar
+                                selectedCount={selectedIds.size}
+                                onRegister={handleBulkRegister}
+                                onExport={handleBulkExport}
+                                canRegister={canRegisterDoi}
+                                isRegistering={isBulkRegistering}
+                                isExporting={isBulkExporting}
+                            />
+                            {canImportFromDataCite && (
+                                <Button
+                                    variant="outline"
+                                    size="default"
+                                    onClick={() => setShowImportModal(true)}
+                                    className="ml-auto flex items-center gap-2"
+                                >
+                                    <DataCiteIcon className="size-4" aria-hidden="true" />
+                                    Import from DataCite
+                                </Button>
+                            )}
+                        </div>
+
                         {sortedResources.length === 0 && !loading && !loadingError ? (
                             <div className="py-8 text-center text-muted-foreground">
                                 {error
@@ -1159,6 +1319,14 @@ function ResourcesPage({
                                         </caption>
                                         <TableHeader className="bg-gray-50 dark:bg-gray-800">
                                             <TableRow>
+                                                <TableHead className="w-12 min-w-12">
+                                                    <Checkbox
+                                                        checked={allVisibleSelected ? true : someVisibleSelected ? 'indeterminate' : false}
+                                                        onCheckedChange={(value) => handleSelectAll(value === true)}
+                                                        aria-label="Select all visible resources"
+                                                        data-testid="resources-select-all"
+                                                    />
+                                                </TableHead>
                                                 <TableHead
                                                     className={`text-xs tracking-wider text-gray-500 uppercase dark:text-gray-300 ${ACTIONS_COLUMN_WIDTH_CLASSES}`}
                                                 >
@@ -1233,7 +1401,18 @@ function ResourcesPage({
                                                         key={deriveResourceRowKey(resource)}
                                                         className="hover:bg-gray-50 dark:hover:bg-gray-800"
                                                         ref={isLast ? lastResourceElementRef : null}
+                                                        data-state={resource.id !== undefined && selectedIds.has(resource.id) ? 'selected' : undefined}
                                                     >
+                                                        <TableCell className="w-12 min-w-12 align-middle">
+                                                            {resource.id !== undefined && (
+                                                                <Checkbox
+                                                                    checked={selectedIds.has(resource.id)}
+                                                                    onCheckedChange={(value) => handleSelectOne(resource.id!, value === true)}
+                                                                    aria-label={`Select resource ${resourceLabel}`}
+                                                                    data-testid={`resources-row-checkbox-${resource.id}`}
+                                                                />
+                                                            )}
+                                                        </TableCell>
                                                         <TableCell
                                                             className={`align-middle text-sm text-gray-500 dark:text-gray-300 ${ACTIONS_COLUMN_WIDTH_CLASSES}`}
                                                         >

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -585,6 +585,24 @@ function ResourcesPage({
     const allVisibleSelected = resources.length > 0 && visibleSelectableIds().every((id) => selectedIds.has(id));
     const someVisibleSelected = !allVisibleSelected && visibleSelectableIds().some((id) => selectedIds.has(id));
 
+    /**
+     * Bulk register currently only updates existing DOIs — minting new ones requires
+     * a DataCite prefix which the bulk flow does not yet prompt for. Block the action
+     * (with an explanatory tooltip) whenever the selection contains DOI-less resources.
+     */
+    const registerDisabledReason = (() => {
+        if (selectedIds.size === 0) {
+            return undefined;
+        }
+        const selectedWithoutDoi = resources.filter(
+            (r) => typeof r.id === 'number' && selectedIds.has(r.id) && (r.doi === null || r.doi === ''),
+        );
+        if (selectedWithoutDoi.length === 0) {
+            return undefined;
+        }
+        return `Bulk register only updates existing DOIs. ${selectedWithoutDoi.length} ${selectedWithoutDoi.length === 1 ? 'resource has' : 'resources have'} no DOI yet — register them individually from the editor to mint a new DOI.`;
+    })();
+
     const handleSelectAll = useCallback(
         (checked: boolean) => {
             setSelectedIds(checked ? new Set(visibleSelectableIds()) : new Set());
@@ -1285,6 +1303,7 @@ function ResourcesPage({
                                 canRegister={canRegisterDoi}
                                 isRegistering={isBulkRegistering}
                                 isExporting={isBulkExporting}
+                                registerDisabledReason={registerDisabledReason}
                             />
                             {canImportFromDataCite && (
                                 <Button

--- a/routes/web.php
+++ b/routes/web.php
@@ -285,6 +285,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('resources/{resource}/register-doi', [ResourceController::class, 'registerDoi'])
         ->name('resources.register-doi');
 
+    Route::post('resources/batch-register', [\App\Http\Controllers\BatchResourceRegistrationController::class, 'register'])
+        ->name('resources.batch-register');
+
+    Route::post('resources/batch-export', [\App\Http\Controllers\BatchResourceExportController::class, 'export'])
+        ->name('resources.batch-export');
+
     // DataCite prefix configuration endpoint
     Route::get('api/datacite/prefixes', [ResourceController::class, 'getDataCitePrefixes'])
         ->name('api.datacite.prefixes');

--- a/tests/pest/Browser/ResourcesBulkActionsTest.php
+++ b/tests/pest/Browser/ResourcesBulkActionsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\Resource;
+use App\Models\User;
+use Tests\TestCase;
+
+/**
+ * Pest v4 Browser Tests for Resources page bulk actions.
+ *
+ * Validates that the multiselect UI introduced for issue #363 is wired up
+ * end-to-end and renders correctly for curators and beginners.
+ *
+ * @see Issue #363
+ */
+
+uses()->group('resources', 'bulk-actions', 'browser');
+
+describe('Resources page bulk actions (smoke)', function (): void {
+    it('renders the bulk actions toolbar with selection-aware state', function (): void {
+        /** @var TestCase $this */
+        $user = User::factory()->create([
+            'role' => UserRole::CURATOR,
+        ]);
+
+        Resource::factory()->count(3)->create();
+
+        $this->actingAs($user);
+
+        $page = visit('/resources')
+            ->assertNoSmoke()
+            ->assertSee('Select rows to enable bulk actions');
+
+        $page->click('[data-testid="resources-select-all"]')
+            ->assertSee('resources selected');
+    });
+
+    it('hides the bulk register button for beginners', function (): void {
+        /** @var TestCase $this */
+        $user = User::factory()->create([
+            'role' => UserRole::BEGINNER,
+        ]);
+
+        Resource::factory()->count(2)->create();
+
+        $this->actingAs($user);
+
+        visit('/resources')
+            ->assertNoSmoke()
+            ->assertDontSee('Register Selected');
+    });
+
+    it('shows the export dropdown trigger for any authenticated user', function (): void {
+        /** @var TestCase $this */
+        $user = User::factory()->create([
+            'role' => UserRole::BEGINNER,
+        ]);
+
+        Resource::factory()->count(2)->create();
+
+        $this->actingAs($user);
+
+        visit('/resources')
+            ->assertNoSmoke()
+            ->assertVisible('[data-testid="bulk-export-button"]');
+    });
+});

--- a/tests/pest/Feature/BatchResourceExportTest.php
+++ b/tests/pest/Feature/BatchResourceExportTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use App\Models\Resource;
 use App\Models\User;
+use App\Services\DataCiteJsonExporter;
+use App\Services\DataCiteLinkedDataExporter;
+use App\Services\DataCiteXmlExporter;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -169,5 +172,118 @@ describe('BatchResourceExportController@export', function () {
         @unlink($zipPath);
 
         expect($name)->toContain("resource-{$resource->id}-")->toContain('10.1234-abcd');
+    });
+
+    test('falls back to id-only entry name when resource has no DOI', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'datacite-json',
+            ]);
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath);
+        $name = $zip->getNameIndex(0);
+        $zip->close();
+        @unlink($zipPath);
+
+        expect($name)->toBe("resource-{$resource->id}.json");
+    });
+
+    test('skips entries that fail during export but still produces a zip', function () {
+        $good = Resource::factory()->create(['doi' => '10.1234/good']);
+        $bad = Resource::factory()->create(['doi' => '10.1234/bad']);
+
+        $exporter = Mockery::mock(DataCiteJsonExporter::class);
+        $exporter->shouldReceive('export')
+            ->andReturnUsing(function (Resource $resource) use ($bad) {
+                if ($resource->id === $bad->id) {
+                    throw new \RuntimeException('Synthetic export failure');
+                }
+
+                return ['id' => 'ok', 'attributes' => []];
+            });
+        app()->instance(DataCiteJsonExporter::class, $exporter);
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$good->id, $bad->id],
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertOk();
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath);
+        // Only the good resource ended up in the archive.
+        expect($zip->numFiles)->toBe(1);
+        expect($zip->getNameIndex(0))->toContain('10.1234-good');
+        $zip->close();
+        @unlink($zipPath);
+    });
+
+    test('uses the XML exporter for the datacite-xml format', function () {
+        $resource = Resource::factory()->create(['doi' => '10.1234/xml-call']);
+
+        $exporter = Mockery::mock(DataCiteXmlExporter::class);
+        $exporter->shouldReceive('export')
+            ->once()
+            ->andReturn('<?xml version="1.0"?><resource/>');
+        app()->instance(DataCiteXmlExporter::class, $exporter);
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'datacite-xml',
+            ]);
+
+        $response->assertOk();
+    });
+
+    test('uses the linked data exporter for the jsonld format', function () {
+        $resource = Resource::factory()->create(['doi' => '10.1234/ld-call']);
+
+        $exporter = Mockery::mock(DataCiteLinkedDataExporter::class);
+        $exporter->shouldReceive('export')
+            ->once()
+            ->andReturn(['@context' => 'https://schema.datacite.org/']);
+        app()->instance(DataCiteLinkedDataExporter::class, $exporter);
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'jsonld',
+            ]);
+
+        $response->assertOk();
+    });
+
+    test('deduplicates repeated ids in the export request', function () {
+        $resource = Resource::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id, $resource->id, $resource->id],
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertOk();
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath);
+        expect($zip->numFiles)->toBe(1);
+        $zip->close();
+        @unlink($zipPath);
     });
 });

--- a/tests/pest/Feature/BatchResourceExportTest.php
+++ b/tests/pest/Feature/BatchResourceExportTest.php
@@ -266,6 +266,44 @@ describe('BatchResourceExportController@export', function () {
         $response->assertOk();
     });
 
+    test('skips entries when json encoding produces invalid output', function () {
+        $good = Resource::factory()->create(['doi' => '10.1234/good']);
+        $bad = Resource::factory()->create(['doi' => '10.1234/uncodable']);
+
+        // INF cannot be represented in JSON — json_encode returns false for the bad entry,
+        // while the good entry is still added to the archive.
+        $exporter = Mockery::mock(DataCiteJsonExporter::class);
+        $exporter->shouldReceive('export')
+            ->andReturnUsing(function (Resource $resource) use ($bad) {
+                if ($resource->id === $bad->id) {
+                    return ['attributes' => ['number' => INF]];
+                }
+
+                return ['attributes' => ['titles' => [['title' => 'OK']]]];
+            });
+        app()->instance(DataCiteJsonExporter::class, $exporter);
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$good->id, $bad->id],
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertOk();
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath);
+        // Only the encodable resource was added; the INF entry was skipped via the
+        // `$content === false` branch.
+        expect($zip->numFiles)->toBe(1);
+        expect($zip->getNameIndex(0))->toContain('good');
+        $zip->close();
+        @unlink($zipPath);
+    });
+
     test('deduplicates repeated ids in the export request', function () {
         $resource = Resource::factory()->create();
 

--- a/tests/pest/Feature/BatchResourceExportTest.php
+++ b/tests/pest/Feature/BatchResourceExportTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Resource;
+use App\Models\User;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->curator()->create();
+});
+
+describe('BatchResourceExportController@export', function () {
+    test('requires authentication', function () {
+        $resource = Resource::factory()->create();
+
+        $response = $this->postJson('/resources/batch-export', [
+            'ids' => [$resource->id],
+            'format' => 'datacite-json',
+        ]);
+
+        expect($response->status())->toBeIn([302, 401, 403]);
+    });
+
+    test('validates that ids are required', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-export', [
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['ids']);
+    });
+
+    test('validates that format is required and one of allowed values', function () {
+        $resource = Resource::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-export', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['format']);
+
+        $response2 = $this->actingAs($this->user)
+            ->postJson('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'bogus',
+            ]);
+
+        $response2->assertStatus(422)->assertJsonValidationErrors(['format']);
+    });
+
+    test('rejects non-existent resource ids', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-export', [
+                'ids' => [999999],
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['ids.0']);
+    });
+
+    test('enforces maximum batch size of 100', function () {
+        $ids = range(1, 101);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-export', [
+                'ids' => $ids,
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertStatus(422);
+    });
+
+    test('returns a zip archive for the datacite-json format', function () {
+        $resources = Resource::factory()->count(2)->create();
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => $resources->pluck('id')->all(),
+                'format' => 'datacite-json',
+            ]);
+
+        $response->assertOk();
+        expect($response->headers->get('content-type'))->toContain('application/zip');
+        expect($response->headers->get('content-disposition'))->toContain('resources-export-datacite-json-');
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        expect($zip->open($zipPath))->toBeTrue();
+        expect($zip->numFiles)->toBe(2);
+
+        $names = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $names[] = $zip->getNameIndex($i);
+        }
+        foreach ($names as $name) {
+            expect($name)->toEndWith('.json');
+        }
+        $zip->close();
+        @unlink($zipPath);
+    });
+
+    test('returns a zip archive for the datacite-xml format', function () {
+        $resource = Resource::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'datacite-xml',
+            ]);
+
+        $response->assertOk();
+        expect($response->headers->get('content-disposition'))->toContain('resources-export-datacite-xml-');
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        expect($zip->open($zipPath))->toBeTrue();
+        expect($zip->numFiles)->toBe(1);
+        expect($zip->getNameIndex(0))->toEndWith('.xml');
+        $zip->close();
+        @unlink($zipPath);
+    });
+
+    test('returns a zip archive for the jsonld format', function () {
+        $resource = Resource::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'jsonld',
+            ]);
+
+        $response->assertOk();
+        expect($response->headers->get('content-disposition'))->toContain('resources-export-jsonld-');
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        expect($zip->open($zipPath))->toBeTrue();
+        expect($zip->numFiles)->toBe(1);
+        expect($zip->getNameIndex(0))->toEndWith('.jsonld');
+        $zip->close();
+        @unlink($zipPath);
+    });
+
+    test('includes DOI in archive entry name when available', function () {
+        $resource = Resource::factory()->create(['doi' => '10.1234/abcd']);
+
+        $response = $this->actingAs($this->user)
+            ->post('/resources/batch-export', [
+                'ids' => [$resource->id],
+                'format' => 'datacite-json',
+            ]);
+
+        $zipPath = tempnam(sys_get_temp_dir(), 'ernie-test-zip-');
+        file_put_contents($zipPath, $response->streamedContent() ?: $response->getContent());
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath);
+        $name = $zip->getNameIndex(0);
+        $zip->close();
+        @unlink($zipPath);
+
+        expect($name)->toContain("resource-{$resource->id}-")->toContain('10.1234-abcd');
+    });
+});

--- a/tests/pest/Feature/BatchResourceRegistrationTest.php
+++ b/tests/pest/Feature/BatchResourceRegistrationTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\IgsnMetadata;
+use App\Models\LandingPage;
+use App\Models\Resource;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    config([
+        'datacite.test_mode' => true,
+        'datacite.test.username' => 'TEST.USER',
+        'datacite.test.password' => 'test-password',
+        'datacite.test.endpoint' => 'https://api.test.datacite.org',
+        'datacite.test.prefixes' => ['10.83279', '10.83186', '10.83114'],
+        'datacite.production.username' => 'PROD.USER',
+        'datacite.production.password' => 'prod-password',
+        'datacite.production.endpoint' => 'https://api.datacite.org',
+        'datacite.production.prefixes' => ['10.5880', '10.26026', '10.14470'],
+    ]);
+
+    $this->user = User::factory()->curator()->create();
+});
+
+describe('BatchResourceRegistrationController@register', function () {
+    test('updates metadata for resources that already have a DOI', function () {
+        $resource1 = Resource::factory()->create(['doi' => '10.83279/BATCH-REG-001']);
+        $resource2 = Resource::factory()->create(['doi' => '10.83279/BATCH-REG-002']);
+        LandingPage::factory()->create(['resource_id' => $resource1->id]);
+        LandingPage::factory()->create(['resource_id' => $resource2->id]);
+
+        Http::fake([
+            '*datacite.org/*' => function (\Illuminate\Http\Client\Request $request) {
+                $payload = $request->data();
+                $doi = $payload['data']['attributes']['doi'] ?? 'unknown';
+
+                return Http::response([
+                    'data' => [
+                        'id' => $doi,
+                        'type' => 'dois',
+                        'attributes' => ['state' => 'findable'],
+                    ],
+                ], 200);
+            },
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource1->id, $resource2->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json();
+        expect($data['success'])->toHaveCount(2);
+        expect($data['failed'])->toHaveCount(0);
+        expect($data['success'][0]['updated'])->toBeTrue();
+    });
+
+    test('registers a new DOI when prefix is provided and resource lacks a DOI', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        Http::fake([
+            '*datacite.org/*' => function (\Illuminate\Http\Client\Request $request) {
+                $payload = $request->data();
+
+                return Http::response([
+                    'data' => [
+                        'id' => $payload['data']['attributes']['doi'] ?? '10.83279/NEW-001',
+                        'type' => 'dois',
+                        'attributes' => ['state' => 'findable'],
+                    ],
+                ], 201);
+            },
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+                'prefix' => '10.83279',
+            ]);
+
+        $response->assertOk();
+
+        $resource->refresh();
+        expect($resource->doi)->not->toBeNull()->toStartWith('10.83279/');
+        expect($response->json('success.0.updated'))->toBeFalse();
+    });
+
+    test('fails items without DOI when no prefix is provided', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))
+            ->toBe('Resource has no DOI. Provide a prefix to register a new DOI.');
+    });
+
+    test('rejects IGSN resources (must use IGSN batch endpoint)', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/IGSN-MIXED-001']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+        IgsnMetadata::create([
+            'resource_id' => $resource->id,
+            'upload_status' => IgsnMetadata::STATUS_UPLOADED,
+            'sample_type' => 'Rock',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))
+            ->toBe('IGSN resources must be registered via /igsns/batch-register');
+    });
+
+    test('reports failures for resources without landing pages', function () {
+        $resource1 = Resource::factory()->create(['doi' => '10.83279/LP-YES']);
+        $resource2 = Resource::factory()->create(['doi' => '10.83279/LP-NO']);
+        LandingPage::factory()->create(['resource_id' => $resource1->id]);
+        // resource2 has no landing page
+
+        Http::fake([
+            '*datacite.org/*' => Http::response([
+                'data' => [
+                    'id' => '10.83279/LP-YES',
+                    'type' => 'dois',
+                    'attributes' => ['state' => 'findable'],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource1->id, $resource2->id],
+            ]);
+
+        $response->assertStatus(207);
+        $data = $response->json();
+        expect($data['success'])->toHaveCount(1);
+        expect($data['failed'])->toHaveCount(1);
+        expect($data['failed'][0]['reason'])->toBe('No landing page configured');
+    });
+
+    test('isolates failures from successes', function () {
+        $ok = Resource::factory()->create(['doi' => '10.83279/OK-001']);
+        $bad = Resource::factory()->create(['doi' => null]);
+        LandingPage::factory()->create(['resource_id' => $ok->id]);
+        LandingPage::factory()->create(['resource_id' => $bad->id]);
+
+        Http::fake([
+            '*datacite.org/*' => Http::response([
+                'data' => [
+                    'id' => '10.83279/OK-001',
+                    'type' => 'dois',
+                    'attributes' => ['state' => 'findable'],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$ok->id, $bad->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('success'))->toHaveCount(1);
+        expect($response->json('failed'))->toHaveCount(1);
+    });
+
+    test('validates request requires ids', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', []);
+
+        $response->assertStatus(422);
+    });
+
+    test('rejects non-existent resource ids at validation', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [999999],
+            ]);
+
+        $response->assertStatus(422);
+    });
+
+    test('enforces maximum batch size of 25', function () {
+        $ids = range(1, 26);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => $ids,
+            ]);
+
+        $response->assertStatus(422);
+    });
+
+    test('rejects batch registration for beginners', function () {
+        $beginner = User::factory()->beginner()->create();
+        $resource = Resource::factory()->create(['doi' => '10.83279/BEG-001']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $response = $this->actingAs($beginner)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(403);
+    });
+
+    test('requires authentication', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/AUTH-001']);
+
+        $response = $this->postJson('/resources/batch-register', [
+            'ids' => [$resource->id],
+        ]);
+
+        // Authenticated middleware redirects or 401/302 depending on config.
+        expect($response->status())->toBeIn([302, 401, 403]);
+    });
+
+    test('handles DataCite API errors gracefully', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/FAIL-001']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        Http::fake([
+            '*datacite.org/*' => Http::response([
+                'errors' => [
+                    ['title' => 'Upstream error', 'detail' => 'Backend down'],
+                ],
+            ], 500),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))->toBe('Upstream error');
+    });
+});

--- a/tests/pest/Feature/BatchResourceRegistrationTest.php
+++ b/tests/pest/Feature/BatchResourceRegistrationTest.php
@@ -6,6 +6,7 @@ use App\Models\IgsnMetadata;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\User;
+use App\Services\DataCiteRegistrationService;
 use Illuminate\Support\Facades\Http;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
@@ -248,5 +249,193 @@ describe('BatchResourceRegistrationController@register', function () {
 
         $response->assertStatus(207);
         expect($response->json('failed.0.reason'))->toBe('Upstream error');
+    });
+
+    test('handles DataCite API error with detail-only error structure', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/DETAIL-ONLY']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        Http::fake([
+            '*datacite.org/*' => Http::response([
+                'errors' => [
+                    ['detail' => 'Detail-level error message'],
+                ],
+            ], 422),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))->toBe('Detail-level error message');
+    });
+
+    test('falls back to generic message when DataCite response has no errors body', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/NO-BODY']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        Http::fake([
+            '*datacite.org/*' => Http::response([], 503),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))
+            ->toBe('Failed to communicate with DataCite API.');
+    });
+
+    test('treats empty prefix string as missing prefix for new DOI registration', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+                'prefix' => '',
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))
+            ->toBe('Resource has no DOI. Provide a prefix to register a new DOI.');
+    });
+
+    test('reports InvalidArgumentException from the registration service as a failure', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/INVALID-001']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $mock = Mockery::mock(DataCiteRegistrationService::class);
+        $mock->shouldReceive('updateMetadata')
+            ->once()
+            ->andThrow(new \InvalidArgumentException('Bad payload'));
+        app()->instance(DataCiteRegistrationService::class, $mock);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))->toBe('Bad payload');
+    });
+
+    test('reports RuntimeException from the registration service as a failure', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $mock = Mockery::mock(DataCiteRegistrationService::class);
+        $mock->shouldReceive('registerDoi')
+            ->once()
+            ->andThrow(new \RuntimeException('Service offline'));
+        app()->instance(DataCiteRegistrationService::class, $mock);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+                'prefix' => '10.83279',
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))->toBe('Service offline');
+    });
+
+    test('hides unexpected errors from the user when app.debug is disabled', function () {
+        config(['app.debug' => false]);
+
+        $resource = Resource::factory()->create(['doi' => '10.83279/UNEXPECTED-001']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $mock = Mockery::mock(DataCiteRegistrationService::class);
+        $mock->shouldReceive('updateMetadata')
+            ->once()
+            ->andThrow(new \LogicException('Internal stack trace details'));
+        app()->instance(DataCiteRegistrationService::class, $mock);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))
+            ->toBe('An unexpected error occurred during registration.');
+    });
+
+    test('exposes unexpected errors when app.debug is enabled', function () {
+        config(['app.debug' => true]);
+
+        $resource = Resource::factory()->create(['doi' => '10.83279/UNEXPECTED-002']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $mock = Mockery::mock(DataCiteRegistrationService::class);
+        $mock->shouldReceive('updateMetadata')
+            ->once()
+            ->andThrow(new \LogicException('Detailed debug message'));
+        app()->instance(DataCiteRegistrationService::class, $mock);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))->toBe('Detailed debug message');
+    });
+
+    test('persists a freshly-minted DOI when DataCite returns a different identifier', function () {
+        $resource = Resource::factory()->create(['doi' => null]);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $mock = Mockery::mock(DataCiteRegistrationService::class);
+        $mock->shouldReceive('registerDoi')
+            ->once()
+            ->andReturn([
+                'data' => [
+                    'id' => '10.83279/SERVER-ASSIGNED-XYZ',
+                    'type' => 'dois',
+                    'attributes' => ['state' => 'findable'],
+                ],
+            ]);
+        app()->instance(DataCiteRegistrationService::class, $mock);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+                'prefix' => '10.83279',
+            ]);
+
+        $response->assertOk();
+        $resource->refresh();
+        expect($resource->doi)->toBe('10.83279/SERVER-ASSIGNED-XYZ');
+    });
+
+    test('deduplicates repeated ids in the request payload', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/DEDUPE-001']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $mock = Mockery::mock(DataCiteRegistrationService::class);
+        $mock->shouldReceive('updateMetadata')
+            ->once() // important: only once even though we send the id twice
+            ->andReturn([
+                'data' => [
+                    'id' => '10.83279/DEDUPE-001',
+                    'type' => 'dois',
+                    'attributes' => ['state' => 'findable'],
+                ],
+            ]);
+        app()->instance(DataCiteRegistrationService::class, $mock);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id, $resource->id],
+            ]);
+
+        $response->assertOk();
+        expect($response->json('success'))->toHaveCount(1);
     });
 });

--- a/tests/pest/Feature/BatchResourceRegistrationTest.php
+++ b/tests/pest/Feature/BatchResourceRegistrationTest.php
@@ -290,6 +290,30 @@ describe('BatchResourceRegistrationController@register', function () {
             ->toBe('Failed to communicate with DataCite API.');
     });
 
+    test('tolerates non-JSON DataCite error responses without raising a 500', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/NON-JSON']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        // Upstream returns an HTML error page, not JSON — `response()->json()` returns
+        // null. The handler must guard against that instead of dereferencing null.
+        Http::fake([
+            '*datacite.org/*' => Http::response(
+                '<html><body>Bad Gateway</body></html>',
+                502,
+                ['Content-Type' => 'text/html'],
+            ),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))
+            ->toBe('Failed to communicate with DataCite API.');
+    });
+
     test('treats empty prefix string as missing prefix for new DOI registration', function () {
         $resource = Resource::factory()->create(['doi' => null]);
         LandingPage::factory()->create(['resource_id' => $resource->id]);

--- a/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
+++ b/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
@@ -111,6 +111,40 @@ describe('ResourcesBulkActionsToolbar', () => {
             expect(onExport).toHaveBeenCalledWith('datacite-xml');
         });
 
+        it('invokes onExport with datacite-json when the JSON option is chosen', async () => {
+            const onExport = vi.fn();
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={1}
+                    onExport={onExport}
+                />,
+            );
+
+            await userEvent.click(screen.getByTestId('bulk-export-button'));
+            await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite JSON$/i }));
+
+            expect(onExport).toHaveBeenCalledTimes(1);
+            expect(onExport).toHaveBeenCalledWith('datacite-json');
+        });
+
+        it('invokes onExport with jsonld when the JSON-LD option is chosen', async () => {
+            const onExport = vi.fn();
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={1}
+                    onExport={onExport}
+                />,
+            );
+
+            await userEvent.click(screen.getByTestId('bulk-export-button'));
+            await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite JSON-LD/i }));
+
+            expect(onExport).toHaveBeenCalledTimes(1);
+            expect(onExport).toHaveBeenCalledWith('jsonld');
+        });
+
         it('exposes all three export formats', async () => {
             render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} />);
             await userEvent.click(screen.getByTestId('bulk-export-button'));

--- a/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
+++ b/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
@@ -1,0 +1,137 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ResourcesBulkActionsToolbar } from '@/components/resources/bulk-actions-toolbar';
+
+describe('ResourcesBulkActionsToolbar', () => {
+    const baseProps = {
+        selectedCount: 0,
+        onRegister: vi.fn(),
+        onExport: vi.fn(),
+        canRegister: true,
+        isRegistering: false,
+        isExporting: false,
+    };
+
+    beforeEach(() => {
+        baseProps.onRegister = vi.fn();
+        baseProps.onExport = vi.fn();
+    });
+
+    describe('rendering', () => {
+        it('renders an instructional message when no rows are selected', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} />);
+            expect(screen.getByText(/Select rows to enable bulk actions/i)).toBeInTheDocument();
+        });
+
+        it('renders singular "resource" for one selection', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} />);
+            expect(screen.getByText('1 resource selected')).toBeInTheDocument();
+        });
+
+        it('renders plural "resources" for multiple selections', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={4} />);
+            expect(screen.getByText('4 resources selected')).toBeInTheDocument();
+        });
+    });
+
+    describe('register button', () => {
+        it('is hidden when canRegister is false', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} canRegister={false} selectedCount={2} />);
+            expect(screen.queryByTestId('bulk-register-button')).not.toBeInTheDocument();
+        });
+
+        it('is disabled when nothing is selected', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} />);
+            expect(screen.getByTestId('bulk-register-button')).toBeDisabled();
+        });
+
+        it('is enabled when at least one row is selected', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={2} />);
+            expect(screen.getByTestId('bulk-register-button')).toBeEnabled();
+        });
+
+        it('invokes onRegister on click', async () => {
+            const onRegister = vi.fn();
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={2}
+                    onRegister={onRegister}
+                />,
+            );
+
+            await userEvent.click(screen.getByTestId('bulk-register-button'));
+            expect(onRegister).toHaveBeenCalledTimes(1);
+        });
+
+        it('shows a loading indicator while registering and disables both action buttons', () => {
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={2}
+                    isRegistering
+                />,
+            );
+
+            expect(screen.getByText(/Registering/i)).toBeInTheDocument();
+            expect(screen.getByTestId('bulk-register-button')).toBeDisabled();
+            expect(screen.getByTestId('bulk-export-button')).toBeDisabled();
+        });
+    });
+
+    describe('export dropdown', () => {
+        it('is disabled when nothing is selected', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} />);
+            expect(screen.getByTestId('bulk-export-button')).toBeDisabled();
+        });
+
+        it('is enabled when rows are selected', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} />);
+            expect(screen.getByTestId('bulk-export-button')).toBeEnabled();
+        });
+
+        it('invokes onExport with the chosen format', async () => {
+            const onExport = vi.fn();
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={2}
+                    onExport={onExport}
+                />,
+            );
+
+            await userEvent.click(screen.getByTestId('bulk-export-button'));
+            await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite XML/i }));
+
+            expect(onExport).toHaveBeenCalledTimes(1);
+            expect(onExport).toHaveBeenCalledWith('datacite-xml');
+        });
+
+        it('exposes all three export formats', async () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} />);
+            await userEvent.click(screen.getByTestId('bulk-export-button'));
+
+            expect(await screen.findByRole('menuitem', { name: /DataCite JSON$/i })).toBeInTheDocument();
+            expect(screen.getByRole('menuitem', { name: /DataCite XML/i })).toBeInTheDocument();
+            expect(screen.getByRole('menuitem', { name: /DataCite JSON-LD/i })).toBeInTheDocument();
+        });
+
+        it('shows a loading indicator while exporting and disables both action buttons', () => {
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={2}
+                    isExporting
+                />,
+            );
+
+            expect(screen.getByText(/Exporting/i)).toBeInTheDocument();
+            expect(screen.getByTestId('bulk-export-button')).toBeDisabled();
+            expect(screen.getByTestId('bulk-register-button')).toBeDisabled();
+        });
+    });
+});

--- a/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
+++ b/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
@@ -168,4 +168,41 @@ describe('ResourcesBulkActionsToolbar', () => {
             expect(screen.getByTestId('bulk-register-button')).toBeDisabled();
         });
     });
+
+    describe('register disabled reason', () => {
+        it('renders an inline hint and disables the register button when a reason is provided', () => {
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={3}
+                    registerDisabledReason="2 resources have no DOI yet."
+                />,
+            );
+
+            expect(screen.getByTestId('bulk-register-blocked-hint')).toHaveTextContent(
+                '2 resources have no DOI yet.',
+            );
+            expect(screen.getByTestId('bulk-register-button')).toBeDisabled();
+        });
+
+        it('wires aria-describedby so assistive tech can announce the reason', () => {
+            render(
+                <ResourcesBulkActionsToolbar
+                    {...baseProps}
+                    selectedCount={1}
+                    registerDisabledReason="Selection contains a DOI-less resource."
+                />,
+            );
+
+            const hint = screen.getByTestId('bulk-register-blocked-hint');
+            // The tooltip trigger wraps the button; aria-describedby must point to the hint id.
+            const wrapper = screen.getByTestId('bulk-register-button').parentElement;
+            expect(wrapper).toHaveAttribute('aria-describedby', hint.id);
+        });
+
+        it('does not render the hint when no reason is supplied', () => {
+            render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} />);
+            expect(screen.queryByTestId('bulk-register-blocked-hint')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -1,0 +1,201 @@
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ResourcesPage from '@/pages/resources';
+
+const routerMock = vi.hoisted(() => ({
+    get: vi.fn(),
+    delete: vi.fn(),
+    post: vi.fn(),
+    reload: vi.fn(),
+    visit: vi.fn(),
+}));
+
+const editorRouteMock = vi.hoisted(() =>
+    vi.fn(({ query }: { query?: Record<string, string> } = {}) => ({
+        url: query ? `/editor?${new URLSearchParams(query).toString()}` : '/editor',
+        method: 'get',
+    })),
+);
+
+const axiosPostMock = vi.hoisted(() => vi.fn());
+const axiosGetMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    router: routerMock,
+    usePage: () => ({
+        props: {
+            auth: {
+                user: {
+                    can_manage_landing_pages: true,
+                    can_register_production_doi: true,
+                },
+            },
+        },
+    }),
+}));
+
+vi.mock('@/routes', () => ({ editor: editorRouteMock }));
+
+vi.mock('@/lib/curation-query', () => ({
+    buildCurationQueryFromResource: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div data-testid="app-layout">{children}</div>,
+}));
+
+vi.mock('axios', async () => {
+    const actual = await vi.importActual<typeof import('axios')>('axios');
+    return {
+        ...actual,
+        default: {
+            ...actual.default,
+            post: axiosPostMock,
+            get: axiosGetMock,
+        },
+        post: axiosPostMock,
+        get: axiosGetMock,
+    };
+});
+
+const buildResource = (overrides: Partial<Record<string, unknown>>) => ({
+    id: 1,
+    doi: '10.9999/one',
+    year: 2024,
+    version: '1.0',
+    created_at: '2024-04-01T09:00:00Z',
+    updated_at: '2024-04-02T10:00:00Z',
+    resourcetypegeneral: 'Dataset',
+    title: 'First',
+    first_author: { givenName: 'A', familyName: 'B' },
+    curator: 'Curator',
+    publicstatus: 'curation',
+    ...overrides,
+});
+
+const buildProps = () => ({
+    resources: [
+        buildResource({ id: 1, doi: '10.9999/one', title: 'First' }),
+        buildResource({ id: 2, doi: '10.9999/two', title: 'Second' }),
+        buildResource({ id: 3, doi: null, title: 'Third' }),
+    ],
+    pagination: {
+        current_page: 1,
+        last_page: 1,
+        per_page: 50,
+        total: 3,
+        from: 1,
+        to: 3,
+        has_more: false,
+    },
+    sort: { key: 'id' as const, direction: 'asc' as const },
+});
+
+describe('ResourcesPage - bulk selection', () => {
+    beforeEach(() => {
+        routerMock.post.mockClear();
+        routerMock.reload.mockClear();
+        axiosPostMock.mockReset();
+        axiosGetMock.mockReset();
+    });
+
+    afterEach(() => {
+        document.head.innerHTML = '';
+    });
+
+    it('renders a select-all checkbox and per-row checkboxes', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        expect(screen.getByTestId('resources-select-all')).toBeInTheDocument();
+        expect(screen.getByTestId('resources-row-checkbox-1')).toBeInTheDocument();
+        expect(screen.getByTestId('resources-row-checkbox-2')).toBeInTheDocument();
+        expect(screen.getByTestId('resources-row-checkbox-3')).toBeInTheDocument();
+    });
+
+    it('shows the toolbar idle hint when no rows are selected', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        expect(screen.getByText(/select rows to enable bulk actions/i)).toBeInTheDocument();
+    });
+
+    it('updates selected count when toggling a row checkbox', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        const rowCheckbox = screen.getByTestId('resources-row-checkbox-2');
+        fireEvent.click(rowCheckbox);
+
+        expect(screen.getByText(/^1 resource selected$/i)).toBeInTheDocument();
+    });
+
+    it('selects every visible row when the header checkbox is clicked', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-select-all'));
+
+        expect(screen.getByText(/^3 resources selected$/i)).toBeInTheDocument();
+    });
+
+    it('posts selected ids to the batch-register endpoint', async () => {
+        axiosPostMock.mockResolvedValue({
+            data: { success: [{ id: 1, doi: '10.9999/one', updated: true }], failed: [] },
+        });
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        fireEvent.click(screen.getByTestId('bulk-register-button'));
+
+        // Wait for click handler to fire
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(axiosPostMock).toHaveBeenCalledWith('/resources/batch-register', { ids: [1] });
+    });
+
+    it('posts selected ids and chosen format to the batch-export endpoint', async () => {
+        axiosPostMock.mockResolvedValue({
+            data: new Blob(['zip'], { type: 'application/zip' }),
+            headers: { 'content-disposition': 'attachment; filename="resources-export-datacite-xml.zip"' },
+        });
+
+        // Mock URL.createObjectURL since jsdom doesn't provide it
+        const createUrl = vi.fn().mockReturnValue('blob:mock');
+        const revokeUrl = vi.fn();
+        Object.defineProperty(window.URL, 'createObjectURL', { value: createUrl, writable: true });
+        Object.defineProperty(window.URL, 'revokeObjectURL', { value: revokeUrl, writable: true });
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-2'));
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-3'));
+
+        // Open dropdown via userEvent (Radix relies on pointer events)
+        await userEvent.click(screen.getByTestId('bulk-export-button'));
+        await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite XML/i }));
+
+        expect(axiosPostMock).toHaveBeenCalledWith(
+            '/resources/batch-export',
+            { ids: expect.arrayContaining([2, 3]), format: 'datacite-xml' },
+            { responseType: 'blob' },
+        );
+    });
+
+    it('renders the import button alongside the bulk toolbar', () => {
+        const props = { ...buildProps(), canImportFromDataCite: true };
+        render(<ResourcesPage {...props} />);
+
+        expect(within(screen.getByTestId('app-layout')).getByRole('button', { name: /import from datacite/i })).toBeInTheDocument();
+    });
+
+    it('places the curator/created columns inside hidden responsive containers', () => {
+        render(<ResourcesPage {...buildProps()} />);
+        const created = screen.getByRole('columnheader', { name: /created/i });
+        // The header's TH carries the responsive hidden classes via cellClassName
+        expect(created.className).toMatch(/hidden/);
+    });
+});

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -102,6 +102,11 @@ const buildProps = () => ({
 });
 
 describe('ResourcesPage - bulk selection', () => {
+    let originalCreateObjectURL: typeof URL.createObjectURL | undefined;
+    let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined;
+    let createObjectUrlMock: ReturnType<typeof vi.fn>;
+    let revokeObjectUrlMock: ReturnType<typeof vi.fn>;
+
     beforeEach(() => {
         routerMock.post.mockClear();
         routerMock.reload.mockClear();
@@ -111,10 +116,51 @@ describe('ResourcesPage - bulk selection', () => {
         toastMock.success.mockClear();
         toastMock.error.mockClear();
         toastMock.warning.mockClear();
+
+        // jsdom does not implement URL.createObjectURL / revokeObjectURL.
+        // Save the original descriptors (if any) so afterEach can restore them,
+        // preventing test leakage into unrelated specs.
+        const createDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+        const revokeDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+        originalCreateObjectURL = createDescriptor ? (URL.createObjectURL as typeof URL.createObjectURL) : undefined;
+        originalRevokeObjectURL = revokeDescriptor ? (URL.revokeObjectURL as typeof URL.revokeObjectURL) : undefined;
+
+        createObjectUrlMock = vi.fn().mockReturnValue('blob:mock');
+        revokeObjectUrlMock = vi.fn();
+        Object.defineProperty(URL, 'createObjectURL', {
+            value: createObjectUrlMock,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(URL, 'revokeObjectURL', {
+            value: revokeObjectUrlMock,
+            configurable: true,
+            writable: true,
+        });
     });
 
     afterEach(() => {
         document.head.innerHTML = '';
+
+        // Restore the original URL methods so later specs see the pristine jsdom state.
+        if (originalCreateObjectURL === undefined) {
+            delete (URL as { createObjectURL?: typeof URL.createObjectURL }).createObjectURL;
+        } else {
+            Object.defineProperty(URL, 'createObjectURL', {
+                value: originalCreateObjectURL,
+                configurable: true,
+                writable: true,
+            });
+        }
+        if (originalRevokeObjectURL === undefined) {
+            delete (URL as { revokeObjectURL?: typeof URL.revokeObjectURL }).revokeObjectURL;
+        } else {
+            Object.defineProperty(URL, 'revokeObjectURL', {
+                value: originalRevokeObjectURL,
+                configurable: true,
+                writable: true,
+            });
+        }
     });
 
     it('renders a select-all checkbox and per-row checkboxes', () => {
@@ -172,12 +218,6 @@ describe('ResourcesPage - bulk selection', () => {
             headers: { 'content-disposition': 'attachment; filename="resources-export-datacite-xml.zip"' },
         });
 
-        // Mock URL.createObjectURL since jsdom doesn't provide it
-        const createUrl = vi.fn().mockReturnValue('blob:mock');
-        const revokeUrl = vi.fn();
-        Object.defineProperty(window.URL, 'createObjectURL', { value: createUrl, writable: true });
-        Object.defineProperty(window.URL, 'revokeObjectURL', { value: revokeUrl, writable: true });
-
         render(<ResourcesPage {...buildProps()} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-2'));
@@ -192,6 +232,7 @@ describe('ResourcesPage - bulk selection', () => {
             { ids: expect.arrayContaining([2, 3]), format: 'datacite-xml' },
             { responseType: 'blob' },
         );
+        expect(createObjectUrlMock).toHaveBeenCalled();
     });
 
     it('renders the import button alongside the bulk toolbar', () => {
@@ -291,18 +332,13 @@ describe('ResourcesPage - bulk selection', () => {
             headers: {},
         });
 
-        const createUrl = vi.fn().mockReturnValue('blob:mock');
-        const revokeUrl = vi.fn();
-        Object.defineProperty(window.URL, 'createObjectURL', { value: createUrl, writable: true });
-        Object.defineProperty(window.URL, 'revokeObjectURL', { value: revokeUrl, writable: true });
-
         render(<ResourcesPage {...buildProps()} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
         await userEvent.click(screen.getByTestId('bulk-export-button'));
         await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite JSON$/i }));
 
-        expect(createUrl).toHaveBeenCalled();
+        expect(createObjectUrlMock).toHaveBeenCalled();
         expect(toastMock.success).toHaveBeenCalledWith(expect.stringContaining('DATACITE-JSON'));
     });
 

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -23,6 +23,11 @@ const editorRouteMock = vi.hoisted(() =>
 
 const axiosPostMock = vi.hoisted(() => vi.fn());
 const axiosGetMock = vi.hoisted(() => vi.fn());
+const toastMock = vi.hoisted(() =>
+    Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), warning: vi.fn() }),
+);
+
+vi.mock('sonner', () => ({ toast: toastMock }));
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -102,6 +107,10 @@ describe('ResourcesPage - bulk selection', () => {
         routerMock.reload.mockClear();
         axiosPostMock.mockReset();
         axiosGetMock.mockReset();
+        toastMock.mockClear();
+        toastMock.success.mockClear();
+        toastMock.error.mockClear();
+        toastMock.warning.mockClear();
     });
 
     afterEach(() => {
@@ -197,5 +206,144 @@ describe('ResourcesPage - bulk selection', () => {
         const created = screen.getByRole('columnheader', { name: /created/i });
         // The header's TH carries the responsive hidden classes via cellClassName
         expect(created.className).toMatch(/hidden/);
+    });
+
+    it('clears selection and reloads after a successful bulk register', async () => {
+        axiosPostMock.mockResolvedValue({
+            data: {
+                success: [{ id: 1, doi: '10.9999/one', updated: true }],
+                failed: [],
+            },
+        });
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        fireEvent.click(screen.getByTestId('bulk-register-button'));
+
+        // flush microtasks for awaited axios + state updates
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(toastMock.success).toHaveBeenCalledWith(expect.stringMatching(/registered\/updated/i));
+        expect(routerMock.reload).toHaveBeenCalledWith({ only: ['resources', 'pagination'] });
+    });
+
+    it('reports failures from a 200 response with a `failed` array', async () => {
+        axiosPostMock.mockResolvedValue({
+            data: {
+                success: [],
+                failed: [{ id: 1, doi: '10.9999/one', reason: 'No landing page configured' }],
+            },
+        });
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        fireEvent.click(screen.getByTestId('bulk-register-button'));
+
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(toastMock.error).toHaveBeenCalledWith(expect.stringContaining('No landing page configured'));
+    });
+
+    it('handles a 207 partial-success error response from axios', async () => {
+        const error = Object.assign(new Error('Multi-Status'), {
+            isAxiosError: true,
+            response: {
+                status: 207,
+                data: {
+                    success: [{ id: 1, doi: '10.9999/one', updated: true }],
+                    failed: [{ id: 2, doi: '10.9999/two', reason: 'IGSN resources must use IGSN endpoint' }],
+                },
+            },
+        });
+        axiosPostMock.mockRejectedValue(error);
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-2'));
+        fireEvent.click(screen.getByTestId('bulk-register-button'));
+
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(toastMock.success).toHaveBeenCalledWith(expect.stringMatching(/registered\/updated/i));
+        expect(toastMock.error).toHaveBeenCalledWith(expect.stringContaining('IGSN'));
+        expect(routerMock.reload).toHaveBeenCalledWith({ only: ['resources', 'pagination'] });
+    });
+
+    it('shows a generic error toast when bulk register fails for an unexpected reason', async () => {
+        axiosPostMock.mockRejectedValue(new Error('boom'));
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        fireEvent.click(screen.getByTestId('bulk-register-button'));
+
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(toastMock.error).toHaveBeenCalledWith('Bulk registration failed');
+    });
+
+    it('falls back to a synthesized filename when content-disposition is missing', async () => {
+        axiosPostMock.mockResolvedValue({
+            data: new Blob(['zip'], { type: 'application/zip' }),
+            headers: {},
+        });
+
+        const createUrl = vi.fn().mockReturnValue('blob:mock');
+        const revokeUrl = vi.fn();
+        Object.defineProperty(window.URL, 'createObjectURL', { value: createUrl, writable: true });
+        Object.defineProperty(window.URL, 'revokeObjectURL', { value: revokeUrl, writable: true });
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        await userEvent.click(screen.getByTestId('bulk-export-button'));
+        await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite JSON$/i }));
+
+        expect(createUrl).toHaveBeenCalled();
+        expect(toastMock.success).toHaveBeenCalledWith(expect.stringContaining('DATACITE-JSON'));
+    });
+
+    it('shows an error toast when bulk export fails', async () => {
+        axiosPostMock.mockRejectedValue(new Error('network down'));
+
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        await userEvent.click(screen.getByTestId('bulk-export-button'));
+        await userEvent.click(await screen.findByRole('menuitem', { name: /DataCite JSON-LD/i }));
+
+        expect(toastMock.error).toHaveBeenCalledWith('Bulk export failed');
+    });
+
+    it('does not call the API when bulk register is invoked with no selection', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        // Button is disabled while no selection — clicking has no effect
+        fireEvent.click(screen.getByTestId('bulk-register-button'));
+
+        expect(axiosPostMock).not.toHaveBeenCalled();
+    });
+
+    it('toggles a row off when its checkbox is clicked twice', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        expect(screen.getByText(/^1 resource selected$/i)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        expect(screen.getByText(/select rows to enable bulk actions/i)).toBeInTheDocument();
+    });
+
+    it('clears the selection when the header checkbox is unchecked after a select-all', () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-select-all'));
+        expect(screen.getByText(/^3 resources selected$/i)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('resources-select-all'));
+        expect(screen.getByText(/select rows to enable bulk actions/i)).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
This pull request introduces major new bulk actions for the Resources page, allowing curators to register/update multiple DOIs at DataCite and export selected resources as a ZIP archive in various DataCite formats. It also improves the Resources page layout for responsiveness and updates the changelog accordingly. The backend adds two new controllers for batch export and batch registration, along with a shared constant for required eager-loading relations.

**Bulk Actions & Export Functionality:**

* Added `BatchResourceExportController` to export up to 100 selected resources as a ZIP archive in DataCite JSON, XML, or JSON-LD format, with robust error handling and per-resource logging.
* Added `BatchResourceRegistrationController` to register or update up to 25 resources' DOIs at DataCite in a single request, with per-resource error isolation and support for both new registrations and metadata updates.
* Introduced the `DATACITE_EXPORT_RELATIONS` constant in `Resource` to ensure both batch endpoints eager-load all required relations for export/registration, preventing N+1 query issues and future drift.

**User Interface & Experience:**

* Updated the changelog to announce bulk actions (register/update DOIs, export as ZIP) and clarify permission requirements for the bulk register button.
* Improved the Resources page layout for small screens, moving the import button and hiding less critical columns responsively to reduce horizontal scrolling.