### PR TITLE
Fix: Link custom landing page templates to resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1653,6 +1653,7 @@
       "version": "0.126.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
       "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -4341,9 +4342,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -4357,9 +4358,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -4373,9 +4374,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -4389,9 +4390,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -4405,9 +4406,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -4421,9 +4422,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -4440,9 +4441,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -4459,9 +4460,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -4478,9 +4479,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -4497,9 +4498,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -4516,9 +4517,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -4535,9 +4536,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -4551,27 +4552,48 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -4585,9 +4607,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -13337,13 +13359,13 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -13352,27 +13374,36 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT"
     },
     "node_modules/run-applescript": {
@@ -14980,15 +15011,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "rolldown": "1.0.0-rc.17",
         "tinyglobby": "^0.2.16"
       },
       "bin": {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -180,6 +180,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setExternalDomainId(String(config.external_domain_id ?? ''));
             setExternalPath(config.external_path ?? '');
             setLinks(config.links ?? []);
+            setLandingPageTemplateId(config.landing_page_template_id ?? null);
         } catch (error) {
             if (isAxiosError(error) && error.response?.status === 404) {
                 // No landing page exists yet, use defaults
@@ -191,6 +192,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 setExternalDomainId('');
                 setExternalPath('');
                 setLinks([]);
+                setLandingPageTemplateId(null);
             } else {
                 console.error('Failed to load landing page config:', error);
                 toast.error('Failed to load landing page configuration');

--- a/tests/pest/Browser/LandingPageManagementTest.php
+++ b/tests/pest/Browser/LandingPageManagementTest.php
@@ -88,12 +88,17 @@ describe('Landing Page Setup Modal (Smoke)', function (): void {
     });
 });
 
-describe('Landing Page Template Persistence (Regression)', function (): void {
-    // Regression coverage for the Setup Landing Page dialog losing its custom
-    // template selection on reopen. Before the fix, the select fell back to
-    // "Default GFZ Data Services" even when the resource had a custom
-    // landing_page_template_id persisted, because the loadLandingPageConfig()
-    // path did not hydrate the state.
+describe('Landing Page Template Persistence (Regression PR #674)', function (): void {
+    // Regression coverage (E2E) for PR #674: the Setup Landing Page dialog
+    // used to fall back to "Default GFZ Data Services" in the template select
+    // even when the resource had a custom landing_page_template_id persisted,
+    // because loadLandingPageConfig() did not hydrate that field into state.
+    //
+    // This test asserts the dropdown value reflects the persisted custom
+    // template on first open. The full close-and-reopen round-trip is covered
+    // exhaustively by the Vitest component test at
+    // tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+    // (see "retains custom template selection after closing and reopening").
 
     it('shows the previously assigned custom template in the Setup Landing Page dialog', function (): void {
         /** @var TestCase $this */

--- a/tests/pest/Browser/LandingPageManagementTest.php
+++ b/tests/pest/Browser/LandingPageManagementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\UserRole;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\User;
 use Tests\TestCase;
@@ -20,7 +21,6 @@ use Tests\TestCase;
  * @see Issue #375 - Enable subsequent modification of the landing page template
  * @see https://pestphp.com/docs/browser-testing
  */
-
 uses()->group('landing-pages', 'browser');
 
 describe('Landing Page Button Visibility (Smoke)', function (): void {
@@ -85,5 +85,48 @@ describe('Landing Page Setup Modal (Smoke)', function (): void {
 
         visit("/resources/{$resource->id}")
             ->assertNoSmoke();
+    });
+});
+
+describe('Landing Page Template Persistence (Regression)', function (): void {
+    // Regression coverage for the Setup Landing Page dialog losing its custom
+    // template selection on reopen. Before the fix, the select fell back to
+    // "Default GFZ Data Services" even when the resource had a custom
+    // landing_page_template_id persisted, because the loadLandingPageConfig()
+    // path did not hydrate the state.
+
+    it('shows the previously assigned custom template in the Setup Landing Page dialog', function (): void {
+        /** @var TestCase $this */
+        $user = User::factory()->create([
+            'role' => UserRole::CURATOR,
+        ]);
+
+        $customTemplate = LandingPageTemplate::factory()->create([
+            'name' => 'Regression Custom Template',
+            'slug' => 'regression-custom-template',
+            'is_default' => false,
+            'created_by' => $user->id,
+        ]);
+
+        $resource = Resource::factory()->create();
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $customTemplate->id,
+        ]);
+
+        $this->actingAs($user);
+
+        $page = visit('/resources')->assertNoSmoke();
+
+        // Open the Setup Landing Page dialog for this resource. The button is
+        // rendered with an aria-label containing "Setup landing page for
+        // resource" and a DOI/resource identifier.
+        $page->click('[aria-label^="Setup landing page for resource"]')
+            ->assertSee('Setup Landing Page')
+            // The Select trigger must display the custom template name, not
+            // the "Default GFZ Data Services" fallback value.
+            ->assertSee('Regression Custom Template')
+            ->assertDontSee('Default GFZ Data Services');
     });
 });

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\LandingPageController;
 use App\Models\LandingPage;
 use App\Models\LandingPageDomain;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\User;
 
@@ -415,7 +416,7 @@ describe('External Landing Page Update', function () {
 
 describe('Landing Page Template Assignment', function () {
     test('can create landing page with custom template', function () {
-        $template = \App\Models\LandingPageTemplate::factory()->create([
+        $template = LandingPageTemplate::factory()->create([
             'created_by' => $this->user->id,
         ]);
 
@@ -433,7 +434,7 @@ describe('Landing Page Template Assignment', function () {
     });
 
     test('can update landing page template assignment', function () {
-        $template = \App\Models\LandingPageTemplate::factory()->create([
+        $template = LandingPageTemplate::factory()->create([
             'created_by' => $this->user->id,
         ]);
 
@@ -456,7 +457,7 @@ describe('Landing Page Template Assignment', function () {
     });
 
     test('can clear template assignment by setting null', function () {
-        $template = \App\Models\LandingPageTemplate::factory()->create([
+        $template = LandingPageTemplate::factory()->create([
             'created_by' => $this->user->id,
         ]);
 
@@ -487,5 +488,46 @@ describe('Landing Page Template Assignment', function () {
         ]);
 
         $response->assertJsonValidationErrors(['landing_page_template_id']);
+    });
+});
+
+describe('Landing Page GET Endpoint', function () {
+    // Regression coverage for the Setup Landing Page dialog template-persistence
+    // bug: the GET endpoint must return landing_page_template_id so the frontend
+    // can hydrate the dropdown with the currently saved custom template.
+
+    test('returns landing_page_template_id when a custom template is assigned', function () {
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response = $this->getJson("/resources/{$this->resource->id}/landing-page");
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('landing_page.landing_page_template_id', $template->id)
+            ->assertJsonPath('landing_page.template', 'default_gfz')
+            ->assertJsonPath('landing_page.landing_page_template.id', $template->id)
+            ->assertJsonPath('landing_page.landing_page_template.name', $template->name);
+    });
+
+    test('returns null landing_page_template_id when no custom template is assigned', function () {
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => null,
+        ]);
+
+        $response = $this->getJson("/resources/{$this->resource->id}/landing-page");
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
     });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1161,4 +1161,233 @@ describe('SetupLandingPageModal', () => {
             expect(screen.queryByRole('button', { name: /Remove Preview/i })).not.toBeInTheDocument();
         });
     });
+
+    describe('Template Selection Persistence (Regression #<fix>)', () => {
+        // Regression tests for the bug where a custom landing page template was
+        // not retained when the Setup Landing Page dialog was reopened: the
+        // loadLandingPageConfig() path did not hydrate landing_page_template_id
+        // into state, so the dropdown fell back to "default_gfz" and a subsequent
+        // save overwrote the DB field with null.
+
+        const customTemplatesResponse = {
+            data: {
+                templates: [
+                    {
+                        id: 1,
+                        name: 'Default GFZ Data Services',
+                        slug: 'default_gfz',
+                        is_default: true,
+                        logo_url: null,
+                        right_column_order: [],
+                        left_column_order: [],
+                    },
+                    {
+                        id: 42,
+                        name: 'My Custom Template',
+                        slug: 'my-custom-template',
+                        is_default: false,
+                        logo_url: null,
+                        right_column_order: [],
+                        left_column_order: [],
+                    },
+                ],
+            },
+        };
+
+        it('restores custom template selection when loading config from server (no existingConfig prop)', async () => {
+            const serverConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                template: 'default_gfz',
+                landing_page_template_id: 42,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve(customTemplatesResponse);
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: serverConfig } });
+            });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            // The select trigger should display the custom template name, not
+            // the fallback "Default GFZ Data Services".
+            await waitFor(() => {
+                const trigger = screen.getByLabelText(/Landing Page Template/i);
+                expect(trigger).toHaveTextContent('My Custom Template');
+            });
+        });
+
+        it('sends the previously saved landing_page_template_id when saving without re-selection', async () => {
+            // This asserts the cascading symptom: if the custom template is NOT
+            // hydrated into state, a plain Save (no re-selection) sends null
+            // and silently resets the DB field. With the fix in place, the
+            // original template id must round-trip back on save.
+            const serverConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                template: 'default_gfz',
+                landing_page_template_id: 42,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve(customTemplatesResponse);
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: serverConfig } });
+            });
+            mockedAxiosPut.mockResolvedValue({ data: { landing_page: serverConfig } });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            // Wait for the custom template to be reflected in the trigger.
+            await waitFor(() => {
+                const trigger = screen.getByLabelText(/Landing Page Template/i);
+                expect(trigger).toHaveTextContent('My Custom Template');
+            });
+
+            const updateButton = screen.getByRole('button', { name: /Update/i });
+            await user.click(updateButton);
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz',
+                        landing_page_template_id: 42,
+                    }),
+                );
+            });
+        });
+
+        it('resets landing_page_template_id to null when server returns null (default template)', async () => {
+            // Regression guard: the defensive null-reset in the 404 branch and
+            // the successful-load branch must keep the null path stable.
+            const serverConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                template: 'default_gfz',
+                landing_page_template_id: null,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve(customTemplatesResponse);
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: serverConfig } });
+            });
+            mockedAxiosPut.mockResolvedValue({ data: { landing_page: serverConfig } });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                const trigger = screen.getByLabelText(/Landing Page Template/i);
+                expect(trigger).toHaveTextContent('Default GFZ Data Services');
+            });
+
+            const updateButton = screen.getByRole('button', { name: /Update/i });
+            await user.click(updateButton);
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz',
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+
+        it('resets landing_page_template_id to null on 404 (no landing page exists)', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve(customTemplatesResponse);
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({
+                    isAxiosError: true,
+                    response: { status: 404 },
+                });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: {
+                        ...mockExistingConfig,
+                        status: 'draft',
+                        landing_page_template_id: null,
+                    },
+                    preview_url: '/preview',
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            const saveButton = screen.getByRole('button', { name: /Create Preview/i });
+            await user.click(saveButton);
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+    });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1162,7 +1162,7 @@ describe('SetupLandingPageModal', () => {
         });
     });
 
-    describe('Template Selection Persistence (Regression #<fix>)', () => {
+    describe('Template Selection Persistence (Regression PR #674)', () => {
         // Regression tests for the bug where a custom landing page template was
         // not retained when the Setup Landing Page dialog was reopened: the
         // loadLandingPageConfig() path did not hydrate landing_page_template_id
@@ -1225,6 +1225,71 @@ describe('SetupLandingPageModal', () => {
             await waitFor(() => {
                 const trigger = screen.getByLabelText(/Landing Page Template/i);
                 expect(trigger).toHaveTextContent('My Custom Template');
+            });
+        });
+
+        it('retains custom template selection after closing and reopening the dialog', async () => {
+            // Reproduces the exact user-reported scenario: open dialog, close
+            // it, reopen it — the saved custom template must still be shown
+            // in the dropdown (not "Default GFZ Data Services"). Before the
+            // fix, reopening hydrated all fields except landing_page_template_id,
+            // so the select fell back to the built-in default value.
+            const serverConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                template: 'default_gfz',
+                landing_page_template_id: 42,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve(customTemplatesResponse);
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: serverConfig } });
+            });
+
+            const { rerender } = render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            // First open: custom template is shown.
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('My Custom Template');
+            });
+
+            // Close the dialog (state is reset in the component's useEffect
+            // cleanup branch when isOpen transitions to false).
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={false}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            });
+
+            // Reopen the dialog — this re-triggers loadLandingPageConfig().
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            // After reopen, the custom template must still be selected.
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('My Custom Template');
             });
         });
 


### PR DESCRIPTION
This pull request addresses a regression where the selected custom landing page template was not properly persisted and restored in the Setup Landing Page dialog. The main fix ensures that the `landing_page_template_id` is correctly hydrated into the component state when loading the landing page config, so the template selection is retained and round-trips reliably. The changes also add comprehensive regression tests at both the browser/E2E and component/unit level, and improve backend test coverage for the GET endpoint.

**Frontend bugfix and regression coverage:**

* Fixed the `SetupLandingPageModal` component to hydrate `landing_page_template_id` from the server response into state, ensuring the selected template is correctly shown and saved even after closing and reopening the dialog. [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R183) [[2]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R195)
* Added detailed Vitest component tests to verify template selection persistence, correct round-trip of the template ID on save, and proper fallback/reset to null when appropriate.

**Backend and E2E regression coverage:**

* Added a browser (Pest) test that verifies the Setup Landing Page dialog displays the correct custom template when a resource has a persisted `landing_page_template_id`, preventing fallback to the default template.
* Added feature tests to the GET endpoint to ensure it returns the correct `landing_page_template_id` (custom or null), so the frontend can hydrate the dropdown properly.

**Test code cleanup:**

* Standardized imports of `LandingPageTemplate` in backend tests for clarity and consistency. [[1]](diffhunk://#diff-a54c2e666893668f33679fa0ff181f45408ed244d7d136e218620e4456c71216R7) [[2]](diffhunk://#diff-d3c53f9471afe22a5a52786fa48f0189fab63804ab5257970dac905d28cd2913R8) [[3]](diffhunk://#diff-d3c53f9471afe22a5a52786fa48f0189fab63804ab5257970dac905d28cd2913L418-R419) [[4]](diffhunk://#diff-d3c53f9471afe22a5a52786fa48f0189fab63804ab5257970dac905d28cd2913L436-R437) [[5]](diffhunk://#diff-d3c53f9471afe22a5a52786fa48f0189fab63804ab5257970dac905d28cd2913L459-R460)