### PR TITLE
Fix: Landing page modal layout for long titles

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -152,6 +152,10 @@
         ],
         "fixes": [
             {
+                "title": "Landing Page setup modal layout for long titles",
+                "description": "The Setup Landing Page modal no longer overflows horizontally when a resource has a very long title. The header title is truncated to two lines with a tooltip exposing the full text on hover, the form body scrolls vertically, and the action buttons (Cancel, Preview, Save/Publish) stay visible in a sticky footer on all screen sizes. The same fix is applied to the IGSN landing page setup modal."
+            },
+            {
                 "title": "DataCite import no longer aborts on large file sizes",
                 "description": "Widened the sizes.numeric_value column from decimal(12, 4) to decimal(20, 4). Previously, importing DOIs from the DataCite API could fail with 'SQLSTATE[22003]: Numeric value out of range' when a dataset reported a file size in bytes that exceeded ~99 million (approximately 100 MB), causing the entire import job to abort. Byte-sized values up to the petabyte range are now stored safely."
             },

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -265,24 +265,41 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
     // Get IGSN-specific template options
     const templateOptions = getIgsnTemplateOptions();
 
+    const displayTitle = resource.title ?? `IGSN #${resource.id}`;
+
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
-                <DialogHeader>
+            <DialogContent
+                data-testid="setup-igsn-lp-modal-content"
+                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"
+            >
+                <DialogHeader className="shrink-0 border-b px-6 pt-6 pb-4">
                     <DialogTitle className="flex items-center gap-2">
                         <FlaskConical className="size-5" />
                         Setup IGSN Landing Page
                     </DialogTitle>
                     <DialogDescription>
-                        Configure the public landing page for physical sample{' '}
-                        <span className="font-medium">{resource.title ?? `IGSN #${resource.id}`}</span>
+                        Configure the public landing page for physical sample:
+                        <span
+                            data-testid="setup-igsn-lp-modal-resource-title"
+                            className="mt-1 block line-clamp-2 wrap-break-word font-medium text-foreground"
+                            title={displayTitle}
+                        >
+                            {displayTitle}
+                        </span>
                     </DialogDescription>
                 </DialogHeader>
 
                 {isLoading ? (
-                    <div className="py-8 text-center text-muted-foreground">Loading configuration...</div>
+                    <div
+                        data-testid="setup-igsn-lp-modal-scroll-area"
+                        className="flex-1 min-h-0 overflow-y-auto px-6 py-8 text-center text-muted-foreground"
+                    >
+                        Loading configuration...
+                    </div>
                 ) : (
-                    <div className="space-y-6 py-4">
+                    <div data-testid="setup-igsn-lp-modal-scroll-area" className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
+                        <div className="space-y-6">
                         {/* Template Selection */}
                         <div className="space-y-2">
                             <Label htmlFor="template">Landing Page Template</Label>
@@ -374,10 +391,14 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                                 <p className="text-xs text-green-700 dark:text-green-300">This landing page is publicly accessible</p>
                             </div>
                         )}
+                        </div>
                     </div>
                 )}
 
-                <DialogFooter className="gap-2">
+                <DialogFooter
+                    data-testid="setup-igsn-lp-modal-footer"
+                    className="shrink-0 flex-wrap gap-2 border-t px-6 py-4"
+                >
                     {/* Only show Remove Preview for draft landing pages */}
                     {currentConfig && currentConfig.status === 'draft' && (
                         <Button type="button" variant="destructive" onClick={handleRemovePreview} disabled={isSaving} className="mr-auto">

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -272,7 +272,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         <Dialog open={isOpen} onOpenChange={onClose}>
             <DialogContent
                 data-testid="setup-igsn-lp-modal-content"
-                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"
+                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0"
             >
                 <DialogHeader className="shrink-0 border-b px-6 pt-6 pb-4">
                     <DialogTitle className="flex items-center gap-2">
@@ -281,7 +281,11 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                     </DialogTitle>
                     <DialogDescription>
                         Configure the public landing page for physical sample:
-                        <TooltipProvider delayDuration={150}>
+                        {/* delayDuration aligned with the global TooltipProvider in
+                            app-sidebar-layout.tsx to keep tooltip timing consistent
+                            across the UI. The local provider is kept so the modal is
+                            self-contained when rendered in tests or outside the app shell. */}
+                        <TooltipProvider delayDuration={0}>
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <span

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig } from '@/types/landing-page';
 
 interface IgsnResource {
@@ -280,13 +281,26 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                     </DialogTitle>
                     <DialogDescription>
                         Configure the public landing page for physical sample:
-                        <span
-                            data-testid="setup-igsn-lp-modal-resource-title"
-                            className="mt-1 block line-clamp-2 wrap-break-word font-medium text-foreground"
-                            title={displayTitle}
-                        >
-                            {displayTitle}
-                        </span>
+                        <TooltipProvider delayDuration={150}>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <span
+                                        data-testid="setup-igsn-lp-modal-resource-title"
+                                        tabIndex={0}
+                                        className="mt-1 block line-clamp-2 wrap-break-word rounded-sm font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                                    >
+                                        {displayTitle}
+                                    </span>
+                                </TooltipTrigger>
+                                <TooltipContent
+                                    data-testid="setup-igsn-lp-modal-resource-title-tooltip"
+                                    side="bottom"
+                                    className="max-w-[min(32rem,calc(100vw-2rem))] wrap-break-word whitespace-normal text-left"
+                                >
+                                    {displayTitle}
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                     </DialogDescription>
                 </DialogHeader>
 

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -514,7 +514,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         <Dialog open={isOpen} onOpenChange={onClose}>
             <DialogContent
                 data-testid="setup-lp-modal-content"
-                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"
+                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0"
             >
                 <DialogHeader className="shrink-0 border-b px-6 pt-6 pb-4">
                     <DialogTitle className="flex items-center gap-2">
@@ -523,7 +523,11 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                     </DialogTitle>
                     <DialogDescription>
                         Configure the public landing page for:
-                        <TooltipProvider delayDuration={150}>
+                        {/* delayDuration aligned with the global TooltipProvider in
+                            app-sidebar-layout.tsx to keep tooltip timing consistent
+                            across the UI. The local provider is kept so the modal is
+                            self-contained when rendered in tests or outside the app shell. */}
+                        <TooltipProvider delayDuration={0}>
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <span

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -507,23 +507,41 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         setLinks((prev) => prev.map((link, i) => (i === index ? { ...link, [field]: value } : link)));
     }, []);
 
+    const displayTitle = resource.title ?? `Resource #${resource.id}`;
+
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
-                <DialogHeader>
+            <DialogContent
+                data-testid="setup-lp-modal-content"
+                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl"
+            >
+                <DialogHeader className="shrink-0 border-b px-6 pt-6 pb-4">
                     <DialogTitle className="flex items-center gap-2">
                         <Globe className="size-5" />
                         Setup Landing Page
                     </DialogTitle>
                     <DialogDescription>
-                        Configure the public landing page for <span className="font-medium">{resource.title ?? `Resource #${resource.id}`}</span>
+                        Configure the public landing page for:
+                        <span
+                            data-testid="setup-lp-modal-resource-title"
+                            className="mt-1 block line-clamp-2 wrap-break-word font-medium text-foreground"
+                            title={displayTitle}
+                        >
+                            {displayTitle}
+                        </span>
                     </DialogDescription>
                 </DialogHeader>
 
                 {isLoading ? (
-                    <div className="py-8 text-center text-muted-foreground">Loading configuration...</div>
+                    <div
+                        data-testid="setup-lp-modal-scroll-area"
+                        className="flex-1 min-h-0 overflow-y-auto px-6 py-8 text-center text-muted-foreground"
+                    >
+                        Loading configuration...
+                    </div>
                 ) : (
-                    <div className="space-y-6 py-4">
+                    <div data-testid="setup-lp-modal-scroll-area" className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
+                        <div className="space-y-6">
                         {/* Template Selection */}
                         <div className="space-y-2">
                             <Label htmlFor="template">Landing Page Template</Label>
@@ -788,10 +806,14 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                 <p className="text-xs text-green-700 dark:text-green-300">This landing page is publicly accessible</p>
                             </div>
                         )}
+                        </div>
                     </div>
                 )}
 
-                <DialogFooter className="gap-2">
+                <DialogFooter
+                    data-testid="setup-lp-modal-footer"
+                    className="shrink-0 flex-wrap gap-2 border-t px-6 py-4"
+                >
                     {/* Only show Remove Preview for draft landing pages.
                         Published landing pages cannot be removed because DOIs are persistent. */}
                     {currentConfig && currentConfig.status === 'draft' && (

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
 
 interface Resource {
@@ -522,13 +523,26 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                     </DialogTitle>
                     <DialogDescription>
                         Configure the public landing page for:
-                        <span
-                            data-testid="setup-lp-modal-resource-title"
-                            className="mt-1 block line-clamp-2 wrap-break-word font-medium text-foreground"
-                            title={displayTitle}
-                        >
-                            {displayTitle}
-                        </span>
+                        <TooltipProvider delayDuration={150}>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <span
+                                        data-testid="setup-lp-modal-resource-title"
+                                        tabIndex={0}
+                                        className="mt-1 block line-clamp-2 wrap-break-word rounded-sm font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                                    >
+                                        {displayTitle}
+                                    </span>
+                                </TooltipTrigger>
+                                <TooltipContent
+                                    data-testid="setup-lp-modal-resource-title-tooltip"
+                                    side="bottom"
+                                    className="max-w-[min(32rem,calc(100vw-2rem))] wrap-break-word whitespace-normal text-left"
+                                >
+                                    {displayTitle}
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                     </DialogDescription>
                 </DialogHeader>
 

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -105,7 +105,12 @@ describe('SetupIgsnLandingPageModal', () => {
             render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
-                expect(screen.getByText(/Rock Sample Core XYZ/i)).toBeInTheDocument();
+                // Scope the title match to the testid: Radix Tooltip adds a
+                // VisuallyHidden accessibility node that would otherwise
+                // cause `getByText` to match more than one element.
+                expect(screen.getByTestId('setup-igsn-lp-modal-resource-title')).toHaveTextContent(
+                    'Rock Sample Core XYZ',
+                );
                 expect(screen.getByText(/physical sample/i)).toBeInTheDocument();
             });
         });
@@ -413,22 +418,55 @@ describe('SetupIgsnLandingPageModal', () => {
     describe('Long Title Layout (Issue #670)', () => {
         // Regression tests for issue #670 applied to the IGSN modal variant.
         // Physical sample descriptions can also be long; the modal must not
-        // overflow horizontally, footer buttons must stay visible, and only
-        // the middle zone should scroll.
+        // overflow horizontally, footer buttons must stay visible, only the
+        // middle zone should scroll, and the full title must be exposed
+        // through an accessible shadcn Tooltip (keyboard + screen reader
+        // friendly) rather than the native `title` attribute.
 
         const longTitle = 'Rock sample core collected from borehole '.repeat(20).trim();
         const longTitleResource = { id: 888, doi: 'IEFGZ0999', title: longTitle };
 
         beforeEach(() => {
-            mockedAxiosGet.mockRejectedValue({ isAxiosError: true, response: { status: 404 } });
+            // URL-based mock: only the primary landing-page GET returns 404.
+            // The IGSN modal currently issues no other GETs, but this pattern
+            // future-proofs the test and avoids any stray console.error noise.
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes(`/resources/${longTitleResource.id}/landing-page`)) {
+                    return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
         });
 
-        it('renders the full long title inside the title attribute for tooltips', async () => {
+        it('renders the full long title inside the element text content (accessible to screen readers)', async () => {
             render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
-            expect(titleEl).toHaveAttribute('title', longTitle);
             expect(titleEl).toHaveTextContent(longTitle);
+        });
+
+        it('exposes the title via an accessible, focusable shadcn Tooltip trigger (not the native title attribute)', async () => {
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+
+            // Keyboard accessibility: focusable so keyboard users can trigger
+            // the tooltip (the native `title` attribute is not keyboard-
+            // accessible, which is the reason for this change).
+            expect(titleEl).toHaveAttribute('tabindex', '0');
+            expect(titleEl).toHaveAttribute('data-slot', 'tooltip-trigger');
+            expect(titleEl).not.toHaveAttribute('title');
+        });
+
+        it('shows the full long title in the shadcn tooltip content on hover', async () => {
+            const user = userEvent.setup();
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+            await user.hover(titleEl);
+
+            const tooltip = await screen.findByTestId('setup-igsn-lp-modal-resource-title-tooltip');
+            expect(tooltip).toHaveTextContent(longTitle);
         });
 
         it('applies line-clamp and word-wrap classes to the long title', async () => {
@@ -442,12 +480,13 @@ describe('SetupIgsnLandingPageModal', () => {
             expect(titleEl.className).toContain('wrap-break-word');
         });
 
-        it('falls back to "IGSN #<id>" when title is missing and still exposes it via title attribute', async () => {
+        it('falls back to "IGSN #<id>" when title is missing and still exposes it via the accessible tooltip', async () => {
             render(<SetupIgsnLandingPageModal resource={{ id: 555 }} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
-            expect(titleEl).toHaveAttribute('title', 'IGSN #555');
             expect(titleEl).toHaveTextContent('IGSN #555');
+            expect(titleEl).toHaveAttribute('data-slot', 'tooltip-trigger');
+            expect(titleEl).toHaveAttribute('tabindex', '0');
         });
 
         it('moves overflow-y-auto from the dialog content onto the scroll body', async () => {
@@ -502,7 +541,7 @@ describe('SetupIgsnLandingPageModal', () => {
             expect(screen.getByRole('button', { name: /^Cancel$/i })).toBeInTheDocument();
         });
 
-        it('still applies the layout classes when a short title is used', async () => {
+        it('applies the same accessible tooltip and layout classes for short titles', async () => {
             render(
                 <SetupIgsnLandingPageModal
                     resource={{ id: 1, title: 'Short sample' }}
@@ -512,8 +551,12 @@ describe('SetupIgsnLandingPageModal', () => {
             );
 
             const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
-            expect(titleEl).toHaveAttribute('title', 'Short sample');
+            expect(titleEl).toHaveTextContent('Short sample');
+            expect(titleEl).toHaveAttribute('data-slot', 'tooltip-trigger');
+            expect(titleEl).toHaveAttribute('tabindex', '0');
+            expect(titleEl).not.toHaveAttribute('title');
             expect(titleEl.className).toContain('line-clamp-2');
+            expect(titleEl.className).toContain('wrap-break-word');
         });
     });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -409,4 +409,108 @@ describe('SetupIgsnLandingPageModal', () => {
             });
         });
     });
+
+    describe('Long Title Layout (Issue #670)', () => {
+        // Regression tests for issue #670 applied to the IGSN modal variant.
+        // Physical sample descriptions can also be long; the modal must not
+        // overflow horizontally, footer buttons must stay visible, and only
+        // the middle zone should scroll.
+
+        const longTitle = 'Rock sample core collected from borehole '.repeat(20).trim();
+        const longTitleResource = { id: 888, doi: 'IEFGZ0999', title: longTitle };
+
+        beforeEach(() => {
+            mockedAxiosGet.mockRejectedValue({ isAxiosError: true, response: { status: 404 } });
+        });
+
+        it('renders the full long title inside the title attribute for tooltips', async () => {
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+            expect(titleEl).toHaveAttribute('title', longTitle);
+            expect(titleEl).toHaveTextContent(longTitle);
+        });
+
+        it('applies line-clamp and word-wrap classes to the long title', async () => {
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+            expect(titleEl.className).toContain('line-clamp-2');
+            expect(titleEl.className).toMatch(/wrap-break-word|break-words/);
+        });
+
+        it('falls back to "IGSN #<id>" when title is missing and still exposes it via title attribute', async () => {
+            render(<SetupIgsnLandingPageModal resource={{ id: 555 }} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+            expect(titleEl).toHaveAttribute('title', 'IGSN #555');
+            expect(titleEl).toHaveTextContent('IGSN #555');
+        });
+
+        it('moves overflow-y-auto from the dialog content onto the scroll body', async () => {
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const content = await screen.findByTestId('setup-igsn-lp-modal-content');
+            const scrollArea = await screen.findByTestId('setup-igsn-lp-modal-scroll-area');
+
+            expect(content.className).not.toContain('overflow-y-auto');
+            expect(content.className).toContain('overflow-hidden');
+            expect(content.className).toContain('flex');
+            expect(content.className).toContain('flex-col');
+
+            expect(scrollArea.className).toContain('overflow-y-auto');
+            expect(scrollArea.className).toContain('flex-1');
+            expect(scrollArea.className).toContain('min-h-0');
+        });
+
+        it('renders a sticky footer with wrap + border that never shrinks', async () => {
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const footer = await screen.findByTestId('setup-igsn-lp-modal-footer');
+            expect(footer.className).toContain('shrink-0');
+            expect(footer.className).toContain('flex-wrap');
+            expect(footer.className).toContain('border-t');
+        });
+
+        it('keeps all primary footer buttons visible even with an extremely long title', async () => {
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            const footer = screen.getByTestId('setup-igsn-lp-modal-footer');
+            expect(footer).toContainElement(screen.getByRole('button', { name: /^Preview$/i }));
+            expect(footer).toContainElement(screen.getByRole('button', { name: /^Cancel$/i }));
+            expect(footer).toContainElement(
+                screen.getByRole('button', { name: /^(Create Preview|Create & Publish|Update|Publish)$/i }),
+            );
+        });
+
+        it('shows the Loading state inside the scrollable zone (footer still rendered)', () => {
+            mockedAxiosGet.mockImplementation(() => new Promise(() => {}));
+
+            render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const scrollArea = screen.getByTestId('setup-igsn-lp-modal-scroll-area');
+            expect(scrollArea).toHaveTextContent(/Loading configuration/i);
+
+            expect(screen.getByTestId('setup-igsn-lp-modal-footer')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Cancel$/i })).toBeInTheDocument();
+        });
+
+        it('still applies the layout classes when a short title is used', async () => {
+            render(
+                <SetupIgsnLandingPageModal
+                    resource={{ id: 1, title: 'Short sample' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+            expect(titleEl).toHaveAttribute('title', 'Short sample');
+            expect(titleEl.className).toContain('line-clamp-2');
+        });
+    });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -435,8 +435,11 @@ describe('SetupIgsnLandingPageModal', () => {
             render(<SetupIgsnLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-igsn-lp-modal-resource-title');
+            // Tailwind v4 emits `.wrap-break-word { overflow-wrap: break-word }`
+            // (the v4 replacement for v3's `break-words`). Assert the exact
+            // utility so a broken/missing class cannot hide an overflow regression.
             expect(titleEl.className).toContain('line-clamp-2');
-            expect(titleEl.className).toMatch(/wrap-break-word|break-words/);
+            expect(titleEl.className).toContain('wrap-break-word');
         });
 
         it('falls back to "IGSN #<id>" when title is missing and still exposes it via title attribute', async () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1482,8 +1482,11 @@ describe('SetupLandingPageModal', () => {
             render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+            // Tailwind v4 emits `.wrap-break-word { overflow-wrap: break-word }`
+            // (the v4 replacement for v3's `break-words`). Assert the exact
+            // utility so a broken/missing class cannot hide an overflow regression.
             expect(titleEl.className).toContain('line-clamp-2');
-            expect(titleEl.className).toMatch(/wrap-break-word|break-words/);
+            expect(titleEl.className).toContain('wrap-break-word');
         });
 
         it('falls back to "Resource #<id>" when title is missing and still exposes it via title attribute', async () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1455,4 +1455,121 @@ describe('SetupLandingPageModal', () => {
             });
         });
     });
+
+    describe('Long Title Layout (Issue #670)', () => {
+        // Regression tests for issue #670: a very long resource title used to
+        // break the modal layout (horizontal overflow, footer buttons cut off).
+        // The fix introduces a three-zone flex layout (sticky header/footer,
+        // scrollable body) and truncates the title to two lines with a
+        // `title` attribute that exposes the full string on hover.
+
+        const longTitle = 'A'.repeat(500);
+        const longTitleResource = { id: 999, doi: '10.5880/GFZ.TEST.LONG', title: longTitle };
+
+        beforeEach(() => {
+            mockedAxiosGet.mockRejectedValue({ isAxiosError: true, response: { status: 404 } });
+        });
+
+        it('renders the full long title inside the title attribute for tooltips', async () => {
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+            expect(titleEl).toHaveAttribute('title', longTitle);
+            expect(titleEl).toHaveTextContent(longTitle);
+        });
+
+        it('applies line-clamp and word-wrap classes to the long title', async () => {
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+            expect(titleEl.className).toContain('line-clamp-2');
+            expect(titleEl.className).toMatch(/wrap-break-word|break-words/);
+        });
+
+        it('falls back to "Resource #<id>" when title is missing and still exposes it via title attribute', async () => {
+            render(
+                <SetupLandingPageModal
+                    resource={{ id: 777 }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+            expect(titleEl).toHaveAttribute('title', 'Resource #777');
+            expect(titleEl).toHaveTextContent('Resource #777');
+        });
+
+        it('moves overflow-y-auto from the dialog content onto the scroll body', async () => {
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const content = await screen.findByTestId('setup-lp-modal-content');
+            const scrollArea = await screen.findByTestId('setup-lp-modal-scroll-area');
+
+            // Scrolling happens inside the middle zone, not on the dialog itself.
+            expect(content.className).not.toContain('overflow-y-auto');
+            expect(content.className).toContain('overflow-hidden');
+            expect(content.className).toContain('flex');
+            expect(content.className).toContain('flex-col');
+
+            expect(scrollArea.className).toContain('overflow-y-auto');
+            expect(scrollArea.className).toContain('flex-1');
+            expect(scrollArea.className).toContain('min-h-0');
+        });
+
+        it('renders a sticky footer with wrap + border that never shrinks', async () => {
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const footer = await screen.findByTestId('setup-lp-modal-footer');
+            expect(footer.className).toContain('shrink-0');
+            expect(footer.className).toContain('flex-wrap');
+            expect(footer.className).toContain('border-t');
+        });
+
+        it('keeps all primary footer buttons visible even with an extremely long title', async () => {
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            const footer = screen.getByTestId('setup-lp-modal-footer');
+            // The footer must always contain at least Preview, Cancel and the
+            // primary save/publish button. Issue #670 reported these being
+            // pushed off-screen on narrow viewports.
+            expect(footer).toContainElement(screen.getByRole('button', { name: /^Preview$/i }));
+            expect(footer).toContainElement(screen.getByRole('button', { name: /^Cancel$/i }));
+            expect(footer).toContainElement(screen.getByRole('button', { name: /^(Create Preview|Create & Publish|Update|Publish)$/i }));
+        });
+
+        it('shows the Loading state inside the scrollable zone (footer still rendered)', () => {
+            // Keep the initial GET pending so the modal stays in its loading state.
+            mockedAxiosGet.mockImplementation(() => new Promise(() => {}));
+
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const scrollArea = screen.getByTestId('setup-lp-modal-scroll-area');
+            expect(scrollArea).toHaveTextContent(/Loading configuration/i);
+
+            // Footer (and its Cancel button) must stay reachable during loading.
+            expect(screen.getByTestId('setup-lp-modal-footer')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Cancel$/i })).toBeInTheDocument();
+        });
+
+        it('does not add a title attribute wrapper when title is short (still truncates via CSS only)', async () => {
+            render(
+                <SetupLandingPageModal
+                    resource={{ id: 1, title: 'Short title' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+            // Short titles still carry the `title` attribute for consistency -
+            // they just happen to be identical to the visible text.
+            expect(titleEl).toHaveAttribute('title', 'Short title');
+            expect(titleEl.className).toContain('line-clamp-2');
+        });
+    });
 });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -130,8 +130,13 @@ describe('SetupLandingPageModal', () => {
             );
 
             await waitFor(() => {
-                // Component shows title if available, otherwise "Resource #${id}"
-                expect(screen.getByText(/Test Resource Title/i)).toBeInTheDocument();
+                // Component shows title if available, otherwise "Resource #${id}".
+                // Scope to the title testid: Radix Tooltip adds a VisuallyHidden
+                // accessibility node that also contains the title text, so a
+                // plain `getByText` would match more than one element.
+                expect(screen.getByTestId('setup-lp-modal-resource-title')).toHaveTextContent(
+                    'Test Resource Title',
+                );
             });
         });
     });
@@ -1460,22 +1465,65 @@ describe('SetupLandingPageModal', () => {
         // Regression tests for issue #670: a very long resource title used to
         // break the modal layout (horizontal overflow, footer buttons cut off).
         // The fix introduces a three-zone flex layout (sticky header/footer,
-        // scrollable body) and truncates the title to two lines with a
-        // `title` attribute that exposes the full string on hover.
+        // scrollable body) and truncates the title to two lines. An accessible
+        // shadcn Tooltip (keyboard-focusable, visible on hover/focus) exposes
+        // the full string to sighted users; the full text is also present in
+        // the element's text content for screen readers.
 
         const longTitle = 'A'.repeat(500);
         const longTitleResource = { id: 999, doi: '10.5880/GFZ.TEST.LONG', title: longTitle };
 
         beforeEach(() => {
-            mockedAxiosGet.mockRejectedValue({ isAxiosError: true, response: { status: 404 } });
+            // URL-based mock so only the primary landing-page GET returns 404.
+            // Returning empty lists for domain / template endpoints prevents
+            // noisy console.error output and mirrors real production behavior
+            // when a resource has no landing page yet.
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
         });
 
-        it('renders the full long title inside the title attribute for tooltips', async () => {
+        it('renders the full long title inside the element text content (accessible to screen readers)', async () => {
             render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
-            expect(titleEl).toHaveAttribute('title', longTitle);
             expect(titleEl).toHaveTextContent(longTitle);
+        });
+
+        it('exposes the title via an accessible, focusable shadcn Tooltip trigger (not the native title attribute)', async () => {
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+
+            // Keyboard accessibility: the element must be focusable so keyboard
+            // users can trigger the tooltip (the native `title` attribute is
+            // not keyboard-accessible — that is the whole point of this fix).
+            expect(titleEl).toHaveAttribute('tabindex', '0');
+
+            // It must be wired up as a Radix/shadcn tooltip trigger …
+            expect(titleEl).toHaveAttribute('data-slot', 'tooltip-trigger');
+
+            // … and must NOT fall back to the inaccessible native tooltip.
+            expect(titleEl).not.toHaveAttribute('title');
+        });
+
+        it('shows the full long title in the shadcn tooltip content on hover', async () => {
+            const user = userEvent.setup();
+            render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
+
+            const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
+            await user.hover(titleEl);
+
+            // Tooltip content is rendered in a portal. Wait for the tooltip
+            // element to appear and verify it contains the full title.
+            const tooltip = await screen.findByTestId('setup-lp-modal-resource-title-tooltip');
+            expect(tooltip).toHaveTextContent(longTitle);
         });
 
         it('applies line-clamp and word-wrap classes to the long title', async () => {
@@ -1489,7 +1537,7 @@ describe('SetupLandingPageModal', () => {
             expect(titleEl.className).toContain('wrap-break-word');
         });
 
-        it('falls back to "Resource #<id>" when title is missing and still exposes it via title attribute', async () => {
+        it('falls back to "Resource #<id>" when title is missing and still exposes it via the accessible tooltip', async () => {
             render(
                 <SetupLandingPageModal
                     resource={{ id: 777 }}
@@ -1499,8 +1547,9 @@ describe('SetupLandingPageModal', () => {
             );
 
             const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
-            expect(titleEl).toHaveAttribute('title', 'Resource #777');
             expect(titleEl).toHaveTextContent('Resource #777');
+            expect(titleEl).toHaveAttribute('data-slot', 'tooltip-trigger');
+            expect(titleEl).toHaveAttribute('tabindex', '0');
         });
 
         it('moves overflow-y-auto from the dialog content onto the scroll body', async () => {
@@ -1547,7 +1596,15 @@ describe('SetupLandingPageModal', () => {
 
         it('shows the Loading state inside the scrollable zone (footer still rendered)', () => {
             // Keep the initial GET pending so the modal stays in its loading state.
-            mockedAxiosGet.mockImplementation(() => new Promise(() => {}));
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                return new Promise(() => {});
+            });
 
             render(<SetupLandingPageModal resource={longTitleResource} isOpen={true} onClose={mockOnClose} />);
 
@@ -1559,7 +1616,7 @@ describe('SetupLandingPageModal', () => {
             expect(screen.getByRole('button', { name: /^Cancel$/i })).toBeInTheDocument();
         });
 
-        it('does not add a title attribute wrapper when title is short (still truncates via CSS only)', async () => {
+        it('applies the same accessible tooltip and layout classes for short titles', async () => {
             render(
                 <SetupLandingPageModal
                     resource={{ id: 1, title: 'Short title' }}
@@ -1569,10 +1626,15 @@ describe('SetupLandingPageModal', () => {
             );
 
             const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
-            // Short titles still carry the `title` attribute for consistency -
-            // they just happen to be identical to the visible text.
-            expect(titleEl).toHaveAttribute('title', 'Short title');
+            // Short titles use the same accessible tooltip pattern for consistency.
+            // They are not visually clamped (only two lines are ever clamped),
+            // but the tooltip wiring and layout classes are applied uniformly.
+            expect(titleEl).toHaveTextContent('Short title');
+            expect(titleEl).toHaveAttribute('data-slot', 'tooltip-trigger');
+            expect(titleEl).toHaveAttribute('tabindex', '0');
+            expect(titleEl).not.toHaveAttribute('title');
             expect(titleEl.className).toContain('line-clamp-2');
+            expect(titleEl.className).toContain('wrap-break-word');
         });
     });
 });


### PR DESCRIPTION
This pull request improves the layout and accessibility of the Setup Landing Page and Setup IGSN Landing Page modals, especially for resources with very long titles. The modals now prevent horizontal overflow, ensure the header title is truncated to two lines with an accessible tooltip for the full text, and keep action buttons visible in a sticky footer. Extensive regression tests have been added to guarantee these behaviors.

**Landing Page Modal & IGSN Modal Layout and Accessibility Improvements:**

* The Setup Landing Page and Setup IGSN Landing Page modals now truncate long resource titles in the header to two lines with word wrapping. The full title is exposed via a keyboard- and screen reader-accessible tooltip, replacing the native `title` attribute for better accessibility. The form body scrolls vertically, and the footer with action buttons is sticky and always visible, preventing layout issues with long titles. [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R511-R562) [[2]](diffhunk://#diff-98d62451b07708a6fe223d90327a39c50f3a1730e9f2521f72a18166258298f7R269-R320)
* Updated modal component structure and class names to move vertical scrolling to the form body instead of the entire dialog, and made the footer sticky with proper wrapping and border styling. [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R828-R834) [[2]](diffhunk://#diff-98d62451b07708a6fe223d90327a39c50f3a1730e9f2521f72a18166258298f7R413-R419)
* Updated imports to include the new tooltip components. [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R16) [[2]](diffhunk://#diff-98d62451b07708a6fe223d90327a39c50f3a1730e9f2521f72a18166258298f7R12)

**Regression and Accessibility Testing:**

* Added comprehensive regression tests for the IGSN modal to verify long title handling, tooltip accessibility, layout, and sticky footer behavior. Tests ensure that both long and short titles are handled correctly and that all accessibility features are present.
* Updated existing tests for both modals to scope title assertions to the new test IDs, avoiding false positives from visually hidden accessibility nodes introduced by the tooltip. [[1]](diffhunk://#diff-dd0d95690dcbb2c4335f0c256dd77382e96edfe7598aa74d5d6b8e89202e04bbL108-R113) [[2]](diffhunk://#diff-4438f9654076ec984d84b2de52debd104bd4c14af90218b829fa882caece3636L133-R139)

**Changelog:**

* Added a changelog entry summarizing the improved layout and accessibility for long titles in both Setup Landing Page modals.