### PR TITLE
Feature: ORCID preflight for DOI registration

### DIFF
--- a/app/Http/Controllers/BatchResourceRegistrationController.php
+++ b/app/Http/Controllers/BatchResourceRegistrationController.php
@@ -68,6 +68,10 @@ class BatchResourceRegistrationController extends Controller
         /** @var DataCiteRegistrationService $service */
         $service = app(DataCiteRegistrationService::class);
 
+        // Resolve the ORCID preflight validator once and reuse it for every
+        // resource in the batch to avoid repeated container lookups.
+        $orcidPreflight = app(OrcidPreflightValidator::class);
+
         // Fetch all resources with ALL relations needed by DataCiteJsonExporter
         // to avoid N+1 queries when export() is called inside the loop.
         $resources = Resource::with(Resource::DATACITE_EXPORT_RELATIONS)
@@ -126,7 +130,7 @@ class BatchResourceRegistrationController extends Controller
             // transient warnings cause the resource to be skipped with a
             // human-readable reason. The curator can retry individually via
             // the Register DOI modal.
-            $preflight = app(OrcidPreflightValidator::class)->validate($resource, force: false);
+            $preflight = $orcidPreflight->validate($resource, force: false);
             if ($preflight->shouldBlock || $preflight->warnings !== []) {
                 $results['failed'][] = [
                     'id' => $resourceId,

--- a/app/Http/Controllers/BatchResourceRegistrationController.php
+++ b/app/Http/Controllers/BatchResourceRegistrationController.php
@@ -251,6 +251,6 @@ class BatchResourceRegistrationController extends Controller
             return "ORCID preflight failed: {$blocking} invalid ORCID identifier(s).";
         }
 
-        return "ORCID preflight skipped: {$warnings} identifier(s) could not be verified (orcid.org unreachable).";
+        return "ORCID preflight skipped: {$warnings} identifier(s) could not be verified (ORCID verification service unavailable).";
     }
 }

--- a/app/Http/Controllers/BatchResourceRegistrationController.php
+++ b/app/Http/Controllers/BatchResourceRegistrationController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Resource;
 use App\Services\DataCiteRegistrationService;
+use App\Services\Orcid\OrcidPreflightValidator;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -120,6 +121,22 @@ class BatchResourceRegistrationController extends Controller
                 continue;
             }
 
+            // Pre-flight ORCID validation (see issue #610). Batch mode has no
+            // interactive override, so both confirmed-invalid ORCIDs and
+            // transient warnings cause the resource to be skipped with a
+            // human-readable reason. The curator can retry individually via
+            // the Register DOI modal.
+            $preflight = app(OrcidPreflightValidator::class)->validate($resource, force: false);
+            if ($preflight->shouldBlock || $preflight->warnings !== []) {
+                $results['failed'][] = [
+                    'id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'reason' => $this->describeOrcidPreflightFailure($preflight),
+                ];
+
+                continue;
+            }
+
             try {
                 if ($wasAlreadyRegistered) {
                     $response = $service->updateMetadata($resource);
@@ -213,5 +230,27 @@ class BatchResourceRegistrationController extends Controller
         $statusCode = $results['failed'] === [] ? 200 : 207;
 
         return response()->json($results, $statusCode);
+    }
+
+    /**
+     * Build a human-readable reason string for an ORCID preflight failure.
+     *
+     * Kept private to the batch controller because the interactive Register
+     * DOI endpoint exposes the structured payload instead.
+     */
+    private function describeOrcidPreflightFailure(\App\Services\Orcid\OrcidPreflightResult $preflight): string
+    {
+        $blocking = count($preflight->invalid);
+        $warnings = count($preflight->warnings);
+
+        if ($blocking > 0 && $warnings > 0) {
+            return "ORCID preflight failed: {$blocking} invalid, {$warnings} unverifiable.";
+        }
+
+        if ($blocking > 0) {
+            return "ORCID preflight failed: {$blocking} invalid ORCID identifier(s).";
+        }
+
+        return "ORCID preflight skipped: {$warnings} identifier(s) could not be verified (orcid.org unreachable).";
     }
 }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -23,6 +23,7 @@ use App\Services\DataCiteSyncService;
 use App\Services\DataCiteXmlExporter;
 use App\Services\DataCiteXmlValidator;
 use App\Services\JsonSchemaValidator;
+use App\Services\Orcid\OrcidPreflightValidator;
 use App\Services\ResourceCacheService;
 use App\Services\ResourceStorageService;
 use Illuminate\Http\Client\RequestException;
@@ -1088,6 +1089,40 @@ class ResourceController extends Controller
 
             // Resolve service from container (allows testing with fake service)
             $service = app(DataCiteRegistrationService::class);
+
+            // Pre-flight ORCID validation (see issue #610). Confirmed-invalid
+            // ORCIDs block registration unconditionally; transient errors (e.g.
+            // orcid.org unreachable) require the curator to resubmit with
+            // `force=true`.
+            $force = $request->boolean('force');
+            $preflight = app(OrcidPreflightValidator::class)->validate($resource, $force);
+
+            if ($preflight->shouldBlock) {
+                Log::info('DOI registration blocked by ORCID preflight', [
+                    'resource_id' => $resource->id,
+                    'invalid_count' => count($preflight->invalid),
+                    'warning_count' => count($preflight->warnings),
+                ]);
+
+                return response()->json([
+                    'error' => 'orcid_validation_failed',
+                    'message' => 'One or more ORCID identifiers could not be verified. Please correct them before registering a DOI.',
+                    ...$preflight->toPayload(),
+                ], 422);
+            }
+
+            if ($preflight->needsConfirmation) {
+                Log::info('DOI registration paused for ORCID warning confirmation', [
+                    'resource_id' => $resource->id,
+                    'warning_count' => count($preflight->warnings),
+                ]);
+
+                return response()->json([
+                    'error' => 'orcid_validation_warning',
+                    'message' => 'ORCID verification service is temporarily unreachable for one or more authors. Review the warnings and confirm to continue.',
+                    ...$preflight->toPayload(),
+                ], 409);
+            }
 
             // Check if DOI already exists - if yes, update metadata instead of registering
             if ($resource->doi) {

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -1119,7 +1119,7 @@ class ResourceController extends Controller
 
                 return response()->json([
                     'error' => 'orcid_validation_warning',
-                    'message' => 'ORCID verification service is temporarily unreachable for one or more authors. Review the warnings and confirm to continue.',
+                    'message' => 'ORCID verification service is temporarily unreachable for one or more creators or contributors. Review the warnings and confirm to continue.',
                     ...$preflight->toPayload(),
                 ], 409);
             }

--- a/app/Http/Requests/RegisterDoiRequest.php
+++ b/app/Http/Requests/RegisterDoiRequest.php
@@ -42,6 +42,7 @@ class RegisterDoiRequest extends FormRequest
                 'string',
                 Rule::in($allowedPrefixes),
             ],
+            'force' => ['sometimes', 'boolean'],
         ];
     }
 

--- a/app/Http/Requests/RegisterDoiRequest.php
+++ b/app/Http/Requests/RegisterDoiRequest.php
@@ -26,6 +26,11 @@ class RegisterDoiRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
+     * The `prefix` field is only required when registering a *new* DOI.
+     * When the bound resource already has a DOI, the controller performs a
+     * metadata update and ignores the prefix entirely, so the modal is allowed
+     * to submit without a selection.
+     *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
@@ -36,9 +41,12 @@ class RegisterDoiRequest extends FormRequest
             ? Config::get('datacite.test.prefixes', [])
             : Config::get('datacite.production.prefixes', []);
 
+        $resource = $this->route('resource');
+        $hasExistingDoi = $resource instanceof \App\Models\Resource && $resource->doi !== null && $resource->doi !== '';
+
         return [
             'prefix' => [
-                'required',
+                $hasExistingDoi ? 'nullable' : 'required',
                 'string',
                 Rule::in($allowedPrefixes),
             ],
@@ -77,5 +85,17 @@ class RegisterDoiRequest extends FormRequest
         return [
             'prefix' => 'DOI prefix',
         ];
+    }
+
+    /**
+     * Normalize an empty-string prefix to null so the conditional `nullable`
+     * rule applied on metadata updates skips the `Rule::in(...)` check when
+     * the modal submits without a selection.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('prefix') && is_string($this->input('prefix')) && trim($this->input('prefix')) === '') {
+            $this->merge(['prefix' => null]);
+        }
     }
 }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $name_identifier
  * @property string|null $name_identifier_scheme
  * @property string|null $scheme_uri
+ * @property Carbon|null $orcid_verified_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Collection<int, ResourceCreator> $resourceCreators
@@ -38,6 +39,16 @@ class Person extends Model
 {
     /** @use HasFactory<Factory<static>> */
     use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'orcid_verified_at' => 'datetime',
+        ];
+    }
 
     /** @return MorphMany<ResourceCreator, static> */
     public function resourceCreators(): MorphMany

--- a/app/Services/Orcid/OrcidPreflightIssue.php
+++ b/app/Services/Orcid/OrcidPreflightIssue.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Orcid;
+
+/**
+ * Single ORCID issue discovered during {@see OrcidPreflightValidator::validate()}.
+ *
+ * Issues come in two flavors determined by {@see self::$severity}:
+ *  - "blocking"  – confirmed invalid/unknown ORCID (reason = not_found|checksum|format).
+ *  - "warning"   – transient error (reason = network|timeout|api_error|unknown).
+ *
+ * The curator-facing modal displays both lists separately.
+ */
+final readonly class OrcidPreflightIssue
+{
+    /**
+     * @param  'blocking'|'warning'  $severity
+     * @param  'not_found'|'checksum'|'format'|'network'|'timeout'|'api_error'|'unknown'  $reason
+     * @param  'creator'|'contributor'  $role
+     */
+    public function __construct(
+        public string $severity,
+        public string $reason,
+        public string $role,
+        public int $position,
+        public string $orcid,
+        public string $displayName,
+    ) {}
+
+    /**
+     * @return array{severity: string, reason: string, role: string, position: int, orcid: string, displayName: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'severity' => $this->severity,
+            'reason' => $this->reason,
+            'role' => $this->role,
+            'position' => $this->position,
+            'orcid' => $this->orcid,
+            'displayName' => $this->displayName,
+        ];
+    }
+}

--- a/app/Services/Orcid/OrcidPreflightResult.php
+++ b/app/Services/Orcid/OrcidPreflightResult.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Orcid;
+
+/**
+ * Result of an {@see OrcidPreflightValidator::validate()} run.
+ *
+ * Callers must inspect {@see self::$shouldBlock} first (hard stop on confirmed
+ * invalid ORCIDs) and then {@see self::$needsConfirmation} to decide whether
+ * the curator must explicitly override transient failures via `force=true`.
+ */
+final readonly class OrcidPreflightResult
+{
+    /**
+     * @param  list<OrcidPreflightIssue>  $invalid   Blocking issues (confirmed bad ORCIDs).
+     * @param  list<OrcidPreflightIssue>  $warnings  Transient issues (ORCID service unreachable).
+     */
+    public function __construct(
+        public array $invalid,
+        public array $warnings,
+        public bool $shouldBlock,
+        public bool $needsConfirmation,
+    ) {}
+
+    /**
+     * Build a pristine "all-clear" result.
+     */
+    public static function clean(): self
+    {
+        return new self([], [], false, false);
+    }
+
+    /**
+     * @return array{invalid: list<array<string, mixed>>, warnings: list<array<string, mixed>>}
+     */
+    public function toPayload(): array
+    {
+        return [
+            'invalid' => array_map(static fn (OrcidPreflightIssue $i): array => $i->toArray(), $this->invalid),
+            'warnings' => array_map(static fn (OrcidPreflightIssue $i): array => $i->toArray(), $this->warnings),
+        ];
+    }
+}

--- a/app/Services/Orcid/OrcidPreflightValidator.php
+++ b/app/Services/Orcid/OrcidPreflightValidator.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Orcid;
+
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
+use App\Services\OrcidService;
+use App\Support\OrcidNormalizer;
+use Illuminate\Support\Facades\Date;
+
+/**
+ * Validates every ORCID attached to a {@see Resource} against orcid.org
+ * immediately before DOI registration (see issue #610).
+ *
+ * This is intentionally the only server-side ORCID network validation path
+ * on the happy flow – loading a resource into the curation editor must NOT
+ * call orcid.org. Typing a new ORCID still triggers client-side auto-verify
+ * via the `useOrcidAutofill` hook.
+ *
+ * Failure handling mirrors the client-side reasons emitted by
+ * {@see OrcidService}: `not_found` / `checksum` / `format` are hard-blocking
+ * (`$result->shouldBlock === true`) while transient network errors
+ * (`timeout`, `api_error`, `network`, `unknown`) only require explicit
+ * curator confirmation via `force=true`.
+ */
+final readonly class OrcidPreflightValidator
+{
+    public function __construct(
+        private OrcidService $orcid,
+    ) {}
+
+    /**
+     * Validate every creator and contributor ORCID attached to $resource.
+     *
+     * @param  bool  $force  When true, transient warnings are suppressed (the
+     *                      curator has explicitly overridden them).
+     */
+    public function validate(Resource $resource, bool $force = false): OrcidPreflightResult
+    {
+        $invalid = [];
+        $warnings = [];
+
+        $resource->loadMissing(['creators', 'contributors']);
+
+        foreach ($resource->creators as $creator) {
+            /** @var ResourceCreator $creator */
+            $issue = $this->checkCreatorOrContributor($creator, 'creator');
+            if ($issue === null) {
+                continue;
+            }
+            if ($issue->severity === 'blocking') {
+                $invalid[] = $issue;
+            } else {
+                $warnings[] = $issue;
+            }
+        }
+
+        foreach ($resource->contributors as $contributor) {
+            /** @var ResourceContributor $contributor */
+            $issue = $this->checkCreatorOrContributor($contributor, 'contributor');
+            if ($issue === null) {
+                continue;
+            }
+            if ($issue->severity === 'blocking') {
+                $invalid[] = $issue;
+            } else {
+                $warnings[] = $issue;
+            }
+        }
+
+        $shouldBlock = $invalid !== [];
+        $needsConfirmation = ! $shouldBlock && $warnings !== [] && ! $force;
+
+        return new OrcidPreflightResult(
+            invalid: $invalid,
+            warnings: $warnings,
+            shouldBlock: $shouldBlock,
+            needsConfirmation: $needsConfirmation,
+        );
+    }
+
+    /**
+     * Validate a single creator/contributor row.
+     *
+     * Returns null for rows that don't need a check (no person, no identifier,
+     * non-ORCID scheme) and also for successful validations (the row is then
+     * marked verified via {@see self::markVerified()}).
+     *
+     * @param  ResourceCreator|ResourceContributor  $row
+     * @param  'creator'|'contributor'  $role
+     */
+    private function checkCreatorOrContributor(object $row, string $role): ?OrcidPreflightIssue
+    {
+        $person = $this->resolvePerson($row);
+        if ($person === null) {
+            return null;
+        }
+
+        $identifier = $person->name_identifier;
+        if ($identifier === null || trim($identifier) === '') {
+            return null;
+        }
+
+        // Only validate identifiers explicitly tagged as ORCID (or untagged legacy rows).
+        $scheme = $person->name_identifier_scheme;
+        if ($scheme !== null && strtoupper($scheme) !== 'ORCID') {
+            return null;
+        }
+
+        $bareId = OrcidNormalizer::extractBareId($identifier);
+        $position = (int) ($row->position ?? 0);
+        $displayName = $this->buildDisplayName($person);
+
+        // Offline gate – catch malformed IDs before hitting the network.
+        if (! OrcidNormalizer::isValidFormat($bareId)) {
+            return new OrcidPreflightIssue(
+                severity: 'blocking',
+                reason: 'format',
+                role: $role,
+                position: $position,
+                orcid: $bareId,
+                displayName: $displayName,
+            );
+        }
+
+        if (! OrcidNormalizer::isValidChecksum($bareId)) {
+            return new OrcidPreflightIssue(
+                severity: 'blocking',
+                reason: 'checksum',
+                role: $role,
+                position: $position,
+                orcid: $bareId,
+                displayName: $displayName,
+            );
+        }
+
+        $response = $this->orcid->validateOrcid($bareId);
+
+        // Successful confirmation → stamp verification timestamp and move on.
+        if (($response['exists'] ?? null) === true) {
+            $this->markVerified($person);
+
+            return null;
+        }
+
+        $reason = $response['errorType'] ?? 'unknown';
+
+        return match ($reason) {
+            'not_found', 'checksum', 'format' => new OrcidPreflightIssue(
+                severity: 'blocking',
+                reason: $reason,
+                role: $role,
+                position: $position,
+                orcid: $bareId,
+                displayName: $displayName,
+            ),
+            default => new OrcidPreflightIssue(
+                severity: 'warning',
+                reason: in_array($reason, ['timeout', 'api_error', 'network', 'unknown'], true) ? $reason : 'unknown',
+                role: $role,
+                position: $position,
+                orcid: $bareId,
+                displayName: $displayName,
+            ),
+        };
+    }
+
+    /**
+     * Resolve the Person model attached to a creator/contributor row.
+     *
+     * @param  ResourceCreator|ResourceContributor  $row
+     */
+    private function resolvePerson(object $row): ?Person
+    {
+        if ($row instanceof ResourceCreator) {
+            $related = $row->creatorable;
+        } else {
+            /** @var ResourceContributor $row */
+            $related = $row->contributorable;
+        }
+
+        return $related instanceof Person ? $related : null;
+    }
+
+    private function buildDisplayName(Person $person): string
+    {
+        $given = trim((string) $person->given_name);
+        $family = trim((string) $person->family_name);
+        $full = trim($given === '' ? $family : "{$given} {$family}");
+
+        return $full === '' ? 'Unnamed person' : $full;
+    }
+
+    private function markVerified(Person $person): void
+    {
+        $person->orcid_verified_at = Date::now();
+        $person->save();
+    }
+}

--- a/app/Services/Orcid/OrcidPreflightValidator.php
+++ b/app/Services/Orcid/OrcidPreflightValidator.php
@@ -53,9 +53,18 @@ final readonly class OrcidPreflightValidator
             'contributors.contributorable',
         ]);
 
+        // Cache network results per bare ORCID id within a single invocation.
+        // Each `OrcidService::validateOrcid()` call is globally throttled
+        // (~2.1s between calls), so deduplicating identifiers shared between
+        // creators/contributors keeps preflight time proportional to the
+        // number of *unique* ORCIDs rather than the number of rows.
+        //
+        // @var array<string, array<string, mixed>> $networkCache
+        $networkCache = [];
+
         foreach ($resource->creators as $creator) {
             /** @var ResourceCreator $creator */
-            $issue = $this->checkCreatorOrContributor($creator, 'creator');
+            $issue = $this->checkCreatorOrContributor($creator, 'creator', $force, $networkCache);
             if ($issue === null) {
                 continue;
             }
@@ -68,7 +77,7 @@ final readonly class OrcidPreflightValidator
 
         foreach ($resource->contributors as $contributor) {
             /** @var ResourceContributor $contributor */
-            $issue = $this->checkCreatorOrContributor($contributor, 'contributor');
+            $issue = $this->checkCreatorOrContributor($contributor, 'contributor', $force, $networkCache);
             if ($issue === null) {
                 continue;
             }
@@ -99,8 +108,12 @@ final readonly class OrcidPreflightValidator
      *
      * @param  ResourceCreator|ResourceContributor  $row
      * @param  'creator'|'contributor'  $role
+     * @param  array<string, array<string, mixed>>  $networkCache  Reference to
+     *         the per-invocation cache keyed by bare ORCID id. The entry is
+     *         populated on first network call and reused for subsequent rows
+     *         sharing the same identifier.
      */
-    private function checkCreatorOrContributor(object $row, string $role): ?OrcidPreflightIssue
+    private function checkCreatorOrContributor(object $row, string $role, bool $force, array &$networkCache): ?OrcidPreflightIssue
     {
         $person = $this->resolvePerson($row);
         if ($person === null) {
@@ -145,11 +158,21 @@ final readonly class OrcidPreflightValidator
             );
         }
 
-        $response = $this->orcid->validateOrcid(
-            $bareId,
-            maxAttempts: OrcidService::PREFLIGHT_MAX_ATTEMPTS,
-            timeoutSeconds: OrcidService::PREFLIGHT_VALIDATION_TIMEOUT,
-        );
+        // When the curator has already overridden warnings via `force=true`,
+        // skip the throttled network validation. The offline format+checksum
+        // gates above still catch truly malformed identifiers, and any
+        // `not_found` that was detected on the first pass would have returned
+        // a 422 (blocking) rather than the 409 that leads to the force retry.
+        if ($force) {
+            return null;
+        }
+
+        $response = $networkCache[$bareId]
+            ?? $networkCache[$bareId] = $this->orcid->validateOrcid(
+                $bareId,
+                maxAttempts: OrcidService::PREFLIGHT_MAX_ATTEMPTS,
+                timeoutSeconds: OrcidService::PREFLIGHT_VALIDATION_TIMEOUT,
+            );
 
         // Successful confirmation → stamp verification timestamp and move on.
         if (($response['exists'] ?? null) === true) {

--- a/app/Services/Orcid/OrcidPreflightValidator.php
+++ b/app/Services/Orcid/OrcidPreflightValidator.php
@@ -145,7 +145,11 @@ final readonly class OrcidPreflightValidator
             );
         }
 
-        $response = $this->orcid->validateOrcid($bareId);
+        $response = $this->orcid->validateOrcid(
+            $bareId,
+            maxAttempts: OrcidService::PREFLIGHT_MAX_ATTEMPTS,
+            timeoutSeconds: OrcidService::PREFLIGHT_VALIDATION_TIMEOUT,
+        );
 
         // Successful confirmation → stamp verification timestamp and move on.
         if (($response['exists'] ?? null) === true) {

--- a/app/Services/Orcid/OrcidPreflightValidator.php
+++ b/app/Services/Orcid/OrcidPreflightValidator.php
@@ -206,8 +206,20 @@ final readonly class OrcidPreflightValidator
         return $full === '' ? 'Unnamed person' : $full;
     }
 
+    /**
+     * Stamp the very first successful verification time for auditing.
+     *
+     * The timestamp is intentionally set only once: it represents *when this
+     * ORCID was first confirmed by orcid.org*, not the last check. Keeping it
+     * stable preserves the audit trail across repeated DOI updates and avoids
+     * unnecessary writes on every preflight pass.
+     */
     private function markVerified(Person $person): void
     {
+        if ($person->orcid_verified_at !== null) {
+            return;
+        }
+
         $person->orcid_verified_at = Date::now();
         $person->save();
     }

--- a/app/Services/Orcid/OrcidPreflightValidator.php
+++ b/app/Services/Orcid/OrcidPreflightValidator.php
@@ -44,7 +44,14 @@ final readonly class OrcidPreflightValidator
         $invalid = [];
         $warnings = [];
 
-        $resource->loadMissing(['creators', 'contributors']);
+        // Eager-load the morph targets to keep preflight O(1) queries regardless
+        // of author list size. Without `creators.creatorable` /
+        // `contributors.contributorable`, `resolvePerson()` would trigger one
+        // lazy-load query per row (classic N+1).
+        $resource->loadMissing([
+            'creators.creatorable',
+            'contributors.contributorable',
+        ]);
 
         foreach ($resource->creators as $creator) {
             /** @var ResourceCreator $creator */

--- a/app/Services/OrcidService.php
+++ b/app/Services/OrcidService.php
@@ -64,6 +64,14 @@ class OrcidService
     private const VALIDATION_TIMEOUT = 7;
 
     /**
+     * Shorter validation timeout (seconds) for latency-sensitive call sites
+     * such as the DOI registration preflight (see issue #610). Keeping the
+     * per-ORCID budget low is important because preflight checks every author
+     * sequentially before the DataCite call.
+     */
+    public const PREFLIGHT_VALIDATION_TIMEOUT = 4;
+
+    /**
      * Timeout for full record fetch requests (seconds)
      */
     private const FETCH_TIMEOUT = 12;
@@ -72,6 +80,13 @@ class OrcidService
      * Maximum number of attempts for API calls (1 initial + retries)
      */
     private const MAX_ATTEMPTS = 3;
+
+    /**
+     * Maximum attempts for latency-sensitive call sites (no retries/backoff).
+     * The DOI preflight uses this to cap total preflight time on large author
+     * lists (see issue #610).
+     */
+    public const PREFLIGHT_MAX_ATTEMPTS = 1;
 
     /**
      * Initial retry delay in seconds (doubles with each retry)
@@ -108,11 +123,22 @@ class OrcidService
      * Validate ORCID ID format and check if it exists
      *
      * @param  string  $orcid  The ORCID ID to validate
+     * @param  int|null  $maxAttempts  Override the default retry budget. Pass
+     *                                 {@see self::PREFLIGHT_MAX_ATTEMPTS} for
+     *                                 latency-sensitive call sites.
+     * @param  int|null  $timeoutSeconds  Override the per-request timeout.
      * @return array{valid: bool, exists: bool|null, message: string, errorType: string|null}
      */
     #[\NoDiscard('ORCID validation result must be checked')]
-    public function validateOrcid(string $orcid): array
+    public function validateOrcid(
+        string $orcid,
+        ?int $maxAttempts = null,
+        ?int $timeoutSeconds = null,
+    ): array
     {
+        $maxAttempts = $maxAttempts ?? self::MAX_ATTEMPTS;
+        $timeoutSeconds = $timeoutSeconds ?? self::VALIDATION_TIMEOUT;
+
         // Check format first
         if (! $this->validateOrcidFormat($orcid)) {
             return [
@@ -147,14 +173,15 @@ class OrcidService
             ];
         }
 
-        // Try API with retry logic for transient failures
+        // Try API with retry logic for transient failures. Preflight call sites
+        // may pass maxAttempts=1 to skip retries/backoff entirely (see issue #610).
         $retryDelay = self::RETRY_DELAY;
 
-        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
             try {
                 $this->respectRateLimit();
 
-                $response = Http::timeout(self::VALIDATION_TIMEOUT)
+                $response = Http::timeout($timeoutSeconds)
                     ->acceptJson()
                     ->get(self::API_BASE_URL.'/'.$orcid.'/person');
 
@@ -180,7 +207,7 @@ class OrcidService
                 }
 
                 // Server error (5xx) or rate limited (429) - retry if attempts remain
-                if (($response->status() >= 500 || $response->status() === 429) && $attempt < self::MAX_ATTEMPTS) {
+                if (($response->status() >= 500 || $response->status() === 429) && $attempt < $maxAttempts) {
                     Log::info('ORCID API error, retrying', [
                         'orcid' => $orcid,
                         'attempt' => $attempt,
@@ -205,7 +232,7 @@ class OrcidService
                     'error' => $e->getMessage(),
                 ]);
 
-                if ($attempt < self::MAX_ATTEMPTS) {
+                if ($attempt < $maxAttempts) {
                     sleep($retryDelay);
                     $retryDelay *= 2;
 
@@ -226,7 +253,7 @@ class OrcidService
                     'error' => $e->getMessage(),
                 ]);
 
-                if ($attempt < self::MAX_ATTEMPTS) {
+                if ($attempt < $maxAttempts) {
                     sleep($retryDelay);
                     $retryDelay *= 2;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5572,9 +5572,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
-      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.1.tgz",
+      "integrity": "sha512-awvQhOO/2TrSCHE5LKKsXcvvj6WSBncwEcMFCB/ez0Qs0b17iyyivoGArNV3HFfXryZwCpnb/olsaBBKrIbtSw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5582,9 +5582,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.2.tgz",
-      "integrity": "sha512-TEF1d+RYO9l8oeCwgzmOHIgKwAzXQmw2s/ny2bW8qeg2OMkkLjALfVEivgCMR3OL/jVdMmeTPX56WrV+uvYJFg==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.1.tgz",
+      "integrity": "sha512-jZLV2l7XjYxXCrXHj9pj15gZuY8Te+idoSPS2hIh3+SxOd20Gn0rfUoqEw9vc+us/b16hi0/DWqpzx9O1ZsyIQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5593,12 +5593,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
-      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.1.tgz",
+      "integrity": "sha512-UgWRLhQKprC37SsO6y1zRabOqDmM2gsdTNPbqTT35yl7kOOhwXU4nyfOiGHXPwoEFJV1IpSk85hjIFjNFWVpzw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.99.2"
+        "@tanstack/query-core": "5.100.1"
       },
       "funding": {
         "type": "github",
@@ -5609,20 +5609,20 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.99.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.2.tgz",
-      "integrity": "sha512-8txkK9A9XBNTB8RoxVgfp6W3qwBr25tNP10L4yu3KuyhAdEvccECfIRzesSwMVk/wpVVioAr+hbMtUkMMF+WVw==",
+      "version": "5.100.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.1.tgz",
+      "integrity": "sha512-JuLinBUl/BlZhm0WVX83fJgE2a3YSbuEdxf3fgP+THg92hX7YfwuH5DzT35a6sL/rifZsPr0yJ9itB6jDOcdRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.99.2"
+        "@tanstack/query-devtools": "5.100.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.99.2",
+        "@tanstack/react-query": "^5.100.1",
         "react": "^18 || ^19"
       }
     },
@@ -6981,9 +6981,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8692,13 +8692,13 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -12420,9 +12420,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.2.tgz",
-      "integrity": "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.3.tgz",
+      "integrity": "sha512-lckXaWWdo2ZVXoMoUO3WIBiz9hVY+YBEh1gYyMFfrWP9WZW/wpFXQKizHx7WrFQFMkcG0bGShdpp531X1n+qpg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -66,6 +66,10 @@
         ],
         "improvements": [
             {
+                "title": "ORCID Validation No Longer Runs on Load (Issue #610)",
+                "description": "Opening an existing resource in the curation editor no longer triggers a burst of ORCID API requests for every stored author. Client-side auto-verification is now gated behind explicit user interaction (editing the ORCID, first-name, or last-name field), eliminating the UI stutter when opening datasets with many authors. As a safety net, the server performs a single ORCID pre-flight validation immediately before DOI registration: confirmed-invalid ORCIDs (not_found / checksum / format) now hard-block DOI registration with a detailed error listing each offending author, while transient failures (network / timeout / API error) show a warning that the curator can override via a new 'Register anyway' button. Successful pre-flight validation stamps an `orcid_verified_at` timestamp on the person record."
+            },
+            {
                 "title": "Responsive Resources Page Layout",
                 "description": "The Resources page now mirrors the IGSN page layout for small screens. The Import-from-DataCite button moved out of the card header into a new toolbar row directly below the filters (next to the bulk actions). Less critical sub-rows (Resource Type, Curator) and the Created/Updated column hide progressively on small and medium viewports so the essential information (Title, Author/Year, Status, Actions) remains visible without horizontal scrolling."
             },

--- a/resources/js/components/curation/fields/author/author-item.tsx
+++ b/resources/js/components/curation/fields/author/author-item.tsx
@@ -72,13 +72,15 @@ export default function AuthorItem({
     };
     const contactLabelTextId = `${author.id}-contact-label-text`;
 
-    // Track user interactions with name fields to prevent auto-suggest on initial load
+    // Track user interactions to prevent auto-suggest / auto-verify on initial load
+    // (see issue #610 – avoids ORCID network traffic when merely opening an existing resource)
     const [hasUserInteracted, setHasUserInteracted] = useState(false);
 
-    // Wrapper for onPersonFieldChange that marks user interaction for name fields only
-    // Only firstName/lastName changes should enable ORCID auto-suggest, not email/website/orcid
+    // Wrapper for onPersonFieldChange that marks user interaction for the fields
+    // that should trigger ORCID lookups (orcid for auto-verify, firstName/lastName
+    // for suggestion search). Email/website do NOT flip the flag.
     const handlePersonFieldChange = (field: 'orcid' | 'firstName' | 'lastName' | 'email' | 'website', value: string) => {
-        if (field === 'firstName' || field === 'lastName') {
+        if (field === 'orcid' || field === 'firstName' || field === 'lastName') {
             setHasUserInteracted(true);
         }
         onPersonFieldChange(field, value);

--- a/resources/js/components/curation/fields/contributor/contributor-item.tsx
+++ b/resources/js/components/curation/fields/contributor/contributor-item.tsx
@@ -75,13 +75,15 @@ export default function ContributorItem({
         opacity: isDragging ? 0.5 : 1,
     };
 
-    // Track user interactions to prevent auto-suggest on initial load
+    // Track user interactions to prevent auto-suggest / auto-verify on initial load
+    // (see issue #610 – avoids ORCID network traffic when merely opening an existing resource)
     const [hasUserInteracted, setHasUserInteracted] = useState(false);
 
-    // Wrapper for onPersonFieldChange that marks user interaction for name fields only
-    // Only firstName/lastName changes should enable ORCID auto-suggest, not orcid field itself
+    // Wrapper for onPersonFieldChange that marks user interaction for the fields
+    // that should trigger ORCID lookups (orcid for auto-verify, firstName/lastName
+    // for suggestion search). Email/website do NOT flip the flag.
     const handlePersonFieldChange = (field: 'orcid' | 'firstName' | 'lastName' | 'email' | 'website', value: string) => {
-        if (field === 'firstName' || field === 'lastName') {
+        if (field === 'orcid' || field === 'firstName' || field === 'lastName') {
             setHasUserInteracted(true);
         }
         onPersonFieldChange(field, value);

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -87,8 +87,24 @@ function isOrcidPreflightPayload(data: unknown): data is OrcidPreflightPayload {
     if (!data || typeof data !== 'object') {
         return false;
     }
-    const error = (data as { error?: unknown }).error;
-    return error === 'orcid_validation_failed' || error === 'orcid_validation_warning';
+    const { error, invalid, warnings } = data as {
+        error?: unknown;
+        invalid?: unknown;
+        warnings?: unknown;
+    };
+    if (error !== 'orcid_validation_failed' && error !== 'orcid_validation_warning') {
+        return false;
+    }
+    // Both fields are always emitted by the backend, but some proxies strip
+    // empty arrays. Accept missing fields, but reject anything that is present
+    // and not an array to avoid storing non-iterable values in state.
+    if (invalid !== undefined && !Array.isArray(invalid)) {
+        return false;
+    }
+    if (warnings !== undefined && !Array.isArray(warnings)) {
+        return false;
+    }
+    return true;
 }
 
 export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess }: RegisterDoiModalProps) {
@@ -219,8 +235,8 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
             // require explicit curator confirmation.
             if (isAxiosError(err) && err.response && isOrcidPreflightPayload(err.response.data)) {
                 const payload = err.response.data;
-                setOrcidBlockers(payload.invalid ?? []);
-                setOrcidWarnings(payload.warnings ?? []);
+                setOrcidBlockers(Array.isArray(payload.invalid) ? payload.invalid : []);
+                setOrcidWarnings(Array.isArray(payload.warnings) ? payload.warnings : []);
                 setError(null);
                 setIsSubmitting(false);
                 setSubmittingAction(null);

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -1,6 +1,6 @@
 import { usePage } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
-import { AlertCircle, CheckCircle2, GraduationCap } from 'lucide-react';
+import { AlertCircle, AlertTriangle, CheckCircle2, GraduationCap } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -42,10 +42,53 @@ interface DoiRegistrationResponse {
     details?: unknown;
 }
 
+/**
+ * Reason codes emitted by {@see \App\Services\Orcid\OrcidPreflightValidator}.
+ *
+ * `blocking` reasons (not_found / checksum / format) prevent registration.
+ * Warning reasons (network / timeout / api_error / unknown) can be overridden
+ * by the curator via "Register anyway", which re-posts with `force: true`.
+ */
+type OrcidPreflightReason = 'not_found' | 'checksum' | 'format' | 'network' | 'timeout' | 'api_error' | 'unknown';
+
+interface OrcidPreflightIssue {
+    severity: 'blocking' | 'warning';
+    reason: OrcidPreflightReason;
+    role: 'creator' | 'contributor';
+    position: number;
+    orcid: string;
+    displayName: string;
+}
+
+interface OrcidPreflightPayload {
+    error: 'orcid_validation_failed' | 'orcid_validation_warning';
+    message?: string;
+    invalid: OrcidPreflightIssue[];
+    warnings: OrcidPreflightIssue[];
+}
+
 interface PrefixConfig {
     test: string[];
     production: string[];
     test_mode: boolean;
+}
+
+const ORCID_REASON_LABELS: Record<OrcidPreflightReason, string> = {
+    not_found: 'not found in ORCID registry',
+    checksum: 'invalid ORCID checksum',
+    format: 'malformed ORCID identifier',
+    network: 'ORCID service unreachable',
+    timeout: 'ORCID service timed out',
+    api_error: 'ORCID service reported an error',
+    unknown: 'ORCID verification failed for an unknown reason',
+};
+
+function isOrcidPreflightPayload(data: unknown): data is OrcidPreflightPayload {
+    if (!data || typeof data !== 'object') {
+        return false;
+    }
+    const error = (data as { error?: unknown }).error;
+    return error === 'orcid_validation_failed' || error === 'orcid_validation_warning';
 }
 
 export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess }: RegisterDoiModalProps) {
@@ -56,6 +99,11 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
     const [availablePrefixes, setAvailablePrefixes] = useState<string[]>([]);
     const [isTestMode, setIsTestMode] = useState<boolean>(true);
     const [isLoadingConfig, setIsLoadingConfig] = useState(true);
+    // ORCID preflight state (see issue #610). `orcidBlockers` are hard blockers
+    // surfaced by the backend; `orcidWarnings` are transient failures the
+    // curator may override via the "Register anyway" button.
+    const [orcidBlockers, setOrcidBlockers] = useState<OrcidPreflightIssue[]>([]);
+    const [orcidWarnings, setOrcidWarnings] = useState<OrcidPreflightIssue[]>([]);
 
     const hasExistingDoi = Boolean(resource.doi);
     const hasLandingPage = Boolean(resource.landingPage);
@@ -70,6 +118,8 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
             setSelectedPrefix('');
             setError(null);
             setIsSubmitting(false);
+            setOrcidBlockers([]);
+            setOrcidWarnings([]);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen]);
@@ -104,7 +154,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
         }
     };
 
-    const handleSubmit = async () => {
+    const handleSubmit = async (force = false) => {
         setError(null);
 
         // Validation
@@ -123,6 +173,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
         try {
             const response = await axios.post<DoiRegistrationResponse>(`/resources/${resource.id}/register-doi`, {
                 prefix: selectedPrefix,
+                force,
             });
 
             const { doi, updated, mode } = response.data;
@@ -134,6 +185,10 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                 description: `${modeLabel} DOI: ${doi}`,
                 duration: 5000,
             });
+
+            // Clear ORCID preflight state on success
+            setOrcidBlockers([]);
+            setOrcidWarnings([]);
 
             // Close modal first to ensure UI is updated
             onClose();
@@ -153,6 +208,18 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                 }
             }
         } catch (err) {
+            // ORCID preflight (see issue #610): the backend returns 422 for
+            // confirmed-invalid ORCIDs and 409 for transient failures that
+            // require explicit curator confirmation.
+            if (isAxiosError(err) && err.response && isOrcidPreflightPayload(err.response.data)) {
+                const payload = err.response.data;
+                setOrcidBlockers(payload.invalid ?? []);
+                setOrcidWarnings(payload.warnings ?? []);
+                setError(null);
+                setIsSubmitting(false);
+                return;
+            }
+
             console.error('DOI registration failed:', err);
 
             let errorMessage = 'Failed to register DOI. Please try again.';
@@ -283,6 +350,60 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                         </div>
                     )}
 
+                    {/* ORCID Preflight Blockers (see issue #610) */}
+                    {orcidBlockers.length > 0 && (
+                        <Alert variant="destructive" data-testid="orcid-preflight-blockers">
+                            <AlertCircle className="size-4" />
+                            <AlertTitle>
+                                ORCID validation failed ({orcidBlockers.length}{' '}
+                                {orcidBlockers.length === 1 ? 'author' : 'authors'})
+                            </AlertTitle>
+                            <AlertDescription>
+                                <p className="mb-2">
+                                    The following ORCID identifiers could not be verified. Please correct them in the editor before registering
+                                    the DOI.
+                                </p>
+                                <ul className="list-disc space-y-1 pl-5">
+                                    {orcidBlockers.map((issue) => (
+                                        <li key={`${issue.role}-${issue.position}-${issue.orcid}`}>
+                                            <strong>{issue.displayName}</strong>{' '}
+                                            <span className="text-xs text-muted-foreground">({issue.role})</span>
+                                            <br />
+                                            <code className="text-xs">{issue.orcid}</code> – {ORCID_REASON_LABELS[issue.reason]}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </AlertDescription>
+                        </Alert>
+                    )}
+
+                    {/* ORCID Preflight Warnings (transient failures, curator may override) */}
+                    {orcidBlockers.length === 0 && orcidWarnings.length > 0 && (
+                        <Alert data-testid="orcid-preflight-warnings">
+                            <AlertTriangle className="size-4" />
+                            <AlertTitle>
+                                ORCID verification unavailable ({orcidWarnings.length}{' '}
+                                {orcidWarnings.length === 1 ? 'author' : 'authors'})
+                            </AlertTitle>
+                            <AlertDescription>
+                                <p className="mb-2">
+                                    The ORCID service is temporarily unreachable for the following identifiers. You can retry or register anyway
+                                    if you are confident the ORCIDs are correct.
+                                </p>
+                                <ul className="list-disc space-y-1 pl-5">
+                                    {orcidWarnings.map((issue) => (
+                                        <li key={`${issue.role}-${issue.position}-${issue.orcid}`}>
+                                            <strong>{issue.displayName}</strong>{' '}
+                                            <span className="text-xs text-muted-foreground">({issue.role})</span>
+                                            <br />
+                                            <code className="text-xs">{issue.orcid}</code> – {ORCID_REASON_LABELS[issue.reason]}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </AlertDescription>
+                        </Alert>
+                    )}
+
                     {/* Error Display */}
                     {error && (
                         <Alert variant="destructive">
@@ -297,23 +418,48 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                     <Button variant="outline" onClick={handleClose} disabled={isSubmitting}>
                         Cancel
                     </Button>
-                    <Button
-                        onClick={handleSubmit}
-                        disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
-                    >
-                        {isSubmitting ? (
-                            <>
-                                <span className="mr-2" aria-live="polite">
-                                    Processing...
-                                </span>
-                                <Spinner size="sm" aria-label="Loading" />
-                            </>
-                        ) : hasExistingDoi ? (
-                            'Update Metadata'
-                        ) : (
-                            'Register DOI'
-                        )}
-                    </Button>
+                    {orcidBlockers.length === 0 && orcidWarnings.length > 0 ? (
+                        <Button
+                            onClick={() => handleSubmit(true)}
+                            disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
+                            data-testid="orcid-preflight-override"
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <span className="mr-2" aria-live="polite">
+                                        Processing...
+                                    </span>
+                                    <Spinner size="sm" aria-label="Loading" />
+                                </>
+                            ) : (
+                                'Register anyway'
+                            )}
+                        </Button>
+                    ) : (
+                        <Button
+                            onClick={() => handleSubmit()}
+                            disabled={
+                                isSubmitting ||
+                                !hasLandingPage ||
+                                (!hasExistingDoi && !selectedPrefix) ||
+                                isLoadingConfig ||
+                                orcidBlockers.length > 0
+                            }
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <span className="mr-2" aria-live="polite">
+                                        Processing...
+                                    </span>
+                                    <Spinner size="sm" aria-label="Loading" />
+                                </>
+                            ) : hasExistingDoi ? (
+                                'Update Metadata'
+                            ) : (
+                                'Register DOI'
+                            )}
+                        </Button>
+                    )}
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -63,8 +63,10 @@ interface OrcidPreflightIssue {
 interface OrcidPreflightPayload {
     error: 'orcid_validation_failed' | 'orcid_validation_warning';
     message?: string;
-    invalid: OrcidPreflightIssue[];
-    warnings: OrcidPreflightIssue[];
+    // Kept optional because some proxies strip empty arrays from JSON error
+    // responses. The guard and consumers must treat missing values as `[]`.
+    invalid?: OrcidPreflightIssue[];
+    warnings?: OrcidPreflightIssue[];
 }
 
 interface PrefixConfig {
@@ -82,6 +84,15 @@ const ORCID_REASON_LABELS: Record<OrcidPreflightReason, string> = {
     api_error: 'ORCID service reported an error',
     unknown: 'ORCID verification failed for an unknown reason',
 };
+
+const KNOWN_ORCID_REASONS: ReadonlySet<string> = new Set(Object.keys(ORCID_REASON_LABELS));
+
+function describeOrcidReason(reason: string | undefined): string {
+    if (reason !== undefined && KNOWN_ORCID_REASONS.has(reason)) {
+        return ORCID_REASON_LABELS[reason as OrcidPreflightReason];
+    }
+    return ORCID_REASON_LABELS.unknown;
+}
 
 function isOrcidPreflightPayload(data: unknown): data is OrcidPreflightPayload {
     if (!data || typeof data !== 'object') {
@@ -393,7 +404,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                             <strong>{issue.displayName}</strong>{' '}
                                             <span className="text-xs text-muted-foreground">({issue.role})</span>
                                             <br />
-                                            <code className="text-xs">{issue.orcid}</code> – {ORCID_REASON_LABELS[issue.reason]}
+                                            <code className="text-xs">{issue.orcid}</code> – {describeOrcidReason(issue.reason)}
                                         </li>
                                     ))}
                                 </ul>
@@ -420,7 +431,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                             <strong>{issue.displayName}</strong>{' '}
                                             <span className="text-xs text-muted-foreground">({issue.role})</span>
                                             <br />
-                                            <code className="text-xs">{issue.orcid}</code> – {ORCID_REASON_LABELS[issue.reason]}
+                                            <code className="text-xs">{issue.orcid}</code> – {describeOrcidReason(issue.reason)}
                                         </li>
                                     ))}
                                 </ul>

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -9,8 +9,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
+import { LoadingButton } from '@/components/ui/loading-button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Spinner } from '@/components/ui/spinner';
 import { type User as AuthUser } from '@/types';
 
 interface Resource {
@@ -95,6 +95,10 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
     const { auth } = usePage<{ auth: { user: AuthUser } }>().props;
     const [selectedPrefix, setSelectedPrefix] = useState<string>('');
     const [isSubmitting, setIsSubmitting] = useState(false);
+    // Tracks which action is currently in flight so only the clicked button
+    // renders its loading indicator. The Cancel button and form inputs remain
+    // gated by the broader `isSubmitting` flag.
+    const [submittingAction, setSubmittingAction] = useState<'submit' | 'retry' | 'override' | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [availablePrefixes, setAvailablePrefixes] = useState<string[]>([]);
     const [isTestMode, setIsTestMode] = useState<boolean>(true);
@@ -118,6 +122,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
             setSelectedPrefix('');
             setError(null);
             setIsSubmitting(false);
+            setSubmittingAction(null);
             setOrcidBlockers([]);
             setOrcidWarnings([]);
         }
@@ -154,7 +159,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
         }
     };
 
-    const handleSubmit = async (force = false) => {
+    const handleSubmit = async (force = false, action: 'submit' | 'retry' | 'override' = 'submit') => {
         setError(null);
 
         // Validation
@@ -169,6 +174,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
         }
 
         setIsSubmitting(true);
+        setSubmittingAction(action);
 
         try {
             const response = await axios.post<DoiRegistrationResponse>(`/resources/${resource.id}/register-doi`, {
@@ -217,6 +223,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                 setOrcidWarnings(payload.warnings ?? []);
                 setError(null);
                 setIsSubmitting(false);
+                setSubmittingAction(null);
                 return;
             }
 
@@ -237,6 +244,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
             setError(errorMessage);
         } finally {
             setIsSubmitting(false);
+            setSubmittingAction(null);
         }
     };
 
@@ -420,49 +428,34 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                     </Button>
                     {orcidBlockers.length === 0 && orcidWarnings.length > 0 ? (
                         <>
-                            <Button
+                            <LoadingButton
                                 variant="secondary"
+                                loading={submittingAction === 'retry'}
                                 onClick={() => {
                                     // Retry re-runs the preflight without force=true.
                                     // If orcid.org is reachable now, the warnings clear
                                     // automatically and the regular primary button reappears.
                                     setOrcidWarnings([]);
                                     setOrcidBlockers([]);
-                                    handleSubmit(false);
+                                    handleSubmit(false, 'retry');
                                 }}
                                 disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
                                 data-testid="orcid-preflight-retry"
                             >
-                                {isSubmitting ? (
-                                    <>
-                                        <span className="mr-2" aria-live="polite">
-                                            Processing...
-                                        </span>
-                                        <Spinner size="sm" aria-label="Loading" />
-                                    </>
-                                ) : (
-                                    'Retry verification'
-                                )}
-                            </Button>
-                            <Button
-                                onClick={() => handleSubmit(true)}
+                                Retry verification
+                            </LoadingButton>
+                            <LoadingButton
+                                loading={submittingAction === 'override'}
+                                onClick={() => handleSubmit(true, 'override')}
                                 disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
                                 data-testid="orcid-preflight-override"
                             >
-                                {isSubmitting ? (
-                                    <>
-                                        <span className="mr-2" aria-live="polite">
-                                            Processing...
-                                        </span>
-                                        <Spinner size="sm" aria-label="Loading" />
-                                    </>
-                                ) : (
-                                    'Register anyway'
-                                )}
-                            </Button>
+                                Register anyway
+                            </LoadingButton>
                         </>
                     ) : (
-                        <Button
+                        <LoadingButton
+                            loading={submittingAction === 'submit'}
                             onClick={() => handleSubmit()}
                             disabled={
                                 isSubmitting ||
@@ -472,19 +465,8 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                 orcidBlockers.length > 0
                             }
                         >
-                            {isSubmitting ? (
-                                <>
-                                    <span className="mr-2" aria-live="polite">
-                                        Processing...
-                                    </span>
-                                    <Spinner size="sm" aria-label="Loading" />
-                                </>
-                            ) : hasExistingDoi ? (
-                                'Update Metadata'
-                            ) : (
-                                'Register DOI'
-                            )}
-                        </Button>
+                            {hasExistingDoi ? 'Update Metadata' : 'Register DOI'}
+                        </LoadingButton>
                     )}
                 </DialogFooter>
             </DialogContent>

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -476,7 +476,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                 disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
                                 data-testid="orcid-preflight-override"
                             >
-                                Register anyway
+                                {hasExistingDoi ? 'Update anyway' : 'Register anyway'}
                             </LoadingButton>
                         </>
                     ) : (

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -364,7 +364,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                             <AlertCircle className="size-4" />
                             <AlertTitle>
                                 ORCID validation failed ({orcidBlockers.length}{' '}
-                                {orcidBlockers.length === 1 ? 'author' : 'authors'})
+                                {orcidBlockers.length === 1 ? 'identifier' : 'identifiers'})
                             </AlertTitle>
                             <AlertDescription>
                                 <p className="mb-2">
@@ -391,7 +391,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                             <AlertTriangle className="size-4" />
                             <AlertTitle>
                                 ORCID verification unavailable ({orcidWarnings.length}{' '}
-                                {orcidWarnings.length === 1 ? 'author' : 'authors'})
+                                {orcidWarnings.length === 1 ? 'identifier' : 'identifiers'})
                             </AlertTitle>
                             <AlertDescription>
                                 <p className="mb-2">

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -419,22 +419,48 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                         Cancel
                     </Button>
                     {orcidBlockers.length === 0 && orcidWarnings.length > 0 ? (
-                        <Button
-                            onClick={() => handleSubmit(true)}
-                            disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
-                            data-testid="orcid-preflight-override"
-                        >
-                            {isSubmitting ? (
-                                <>
-                                    <span className="mr-2" aria-live="polite">
-                                        Processing...
-                                    </span>
-                                    <Spinner size="sm" aria-label="Loading" />
-                                </>
-                            ) : (
-                                'Register anyway'
-                            )}
-                        </Button>
+                        <>
+                            <Button
+                                variant="secondary"
+                                onClick={() => {
+                                    // Retry re-runs the preflight without force=true.
+                                    // If orcid.org is reachable now, the warnings clear
+                                    // automatically and the regular primary button reappears.
+                                    setOrcidWarnings([]);
+                                    setOrcidBlockers([]);
+                                    handleSubmit(false);
+                                }}
+                                disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
+                                data-testid="orcid-preflight-retry"
+                            >
+                                {isSubmitting ? (
+                                    <>
+                                        <span className="mr-2" aria-live="polite">
+                                            Processing...
+                                        </span>
+                                        <Spinner size="sm" aria-label="Loading" />
+                                    </>
+                                ) : (
+                                    'Retry verification'
+                                )}
+                            </Button>
+                            <Button
+                                onClick={() => handleSubmit(true)}
+                                disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
+                                data-testid="orcid-preflight-override"
+                            >
+                                {isSubmitting ? (
+                                    <>
+                                        <span className="mr-2" aria-live="polite">
+                                            Processing...
+                                        </span>
+                                        <Spinner size="sm" aria-label="Loading" />
+                                    </>
+                                ) : (
+                                    'Register anyway'
+                                )}
+                            </Button>
+                        </>
                     ) : (
                         <Button
                             onClick={() => handleSubmit()}

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -432,11 +432,10 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                 variant="secondary"
                                 loading={submittingAction === 'retry'}
                                 onClick={() => {
-                                    // Retry re-runs the preflight without force=true.
-                                    // If orcid.org is reachable now, the warnings clear
-                                    // automatically and the regular primary button reappears.
-                                    setOrcidWarnings([]);
-                                    setOrcidBlockers([]);
+                                    // Keep the warning state visible while the retry is in flight so
+                                    // this button stays mounted and its loading indicator is shown.
+                                    // On success, handleSubmit clears the warnings before closing the
+                                    // modal; on another failure, the catch branch repopulates them.
                                     handleSubmit(false, 'retry');
                                 }}
                                 disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -186,8 +186,8 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
 
             // Show success toast
             const modeLabel = mode === 'test' ? 'Test' : 'Production';
-            const action = updated ? 'updated' : 'registered';
-            toast.success(`DOI ${action} successfully`, {
+            const actionLabel = updated ? 'updated' : 'registered';
+            toast.success(`DOI ${actionLabel} successfully`, {
                 description: `${modeLabel} DOI: ${doi}`,
                 duration: 5000,
             });

--- a/resources/js/hooks/use-orcid-autofill.ts
+++ b/resources/js/hooks/use-orcid-autofill.ts
@@ -420,14 +420,29 @@ export function useOrcidAutofill<T extends BaseEntry>({
     const prevOrcidRef = useRef(orcidValue);
     const entryRef = useRef(entry);
     const onEntryChangeRef = useRef(onEntryChange);
+    // Mirror isVerifying so the auto-verify effect can check it without
+    // having to list it as a dependency (which would re-trigger the effect
+    // on every true/false toggle and cause repeated ORCID traffic on
+    // transient failures, see issue #676 review).
+    const isVerifyingRef = useRef(false);
+    // Signature of the last ORCID value we attempted to verify. Combined
+    // with `retryTrigger`, this guarantees auto-verify runs at most once
+    // per (ORCID value, manual retry) pair – transient failures don't
+    // re-fire just because unrelated entry fields change.
+    const lastAttemptedSignatureRef = useRef<string | null>(null);
     entryRef.current = entry;
     onEntryChangeRef.current = onEntryChange;
+    isVerifyingRef.current = isVerifying;
     useEffect(() => {
         setPendingOrcidData(null);
         // Reset verified state when the ORCID value actually changes so the new value can be re-verified
         const currentEntry = entryRef.current;
         if (prevOrcidRef.current !== orcidValue && isPersonEntry(currentEntry) && currentEntry.orcidVerified) {
             onEntryChangeRef.current({ ...currentEntry, orcidVerified: false, orcidVerifiedAt: undefined } as T);
+        }
+        if (prevOrcidRef.current !== orcidValue) {
+            // A fresh ORCID value always deserves a new verification attempt.
+            lastAttemptedSignatureRef.current = null;
         }
         prevOrcidRef.current = orcidValue;
     }, [orcidValue, entryType]);
@@ -616,6 +631,13 @@ export function useOrcidAutofill<T extends BaseEntry>({
      * don't trigger network validation of pre-filled, unverified ORCIDs
      * (see issue #610). A manual retry via `retryVerification()` bypasses the
      * gate by bumping `retryTrigger`.
+     *
+     * The effect is intentionally NOT dependent on `isVerifying`: listing it
+     * would cause the effect to re-fire on every true/false toggle, and
+     * transient failures (timeout / api_error / network) would then re-issue
+     * an ORCID request every debounce interval. Instead we read the current
+     * value through `isVerifyingRef` and use `lastAttemptedSignatureRef` to
+     * guarantee each (ORCID value, retryTrigger) pair is only verified once.
      */
     useEffect(() => {
         const autoVerifyOrcid = async () => {
@@ -635,10 +657,24 @@ export function useOrcidAutofill<T extends BaseEntry>({
             // Only auto-verify if:
             // 1. ORCID has valid format
             // 2. Not already verified
-            // 3. Not currently verifying
-            if (!personEntry.orcid?.trim() || !OrcidService.isValidFormat(personEntry.orcid) || personEntry.orcidVerified || isVerifying) {
+            // 3. Not currently verifying (read via ref – see effect header)
+            if (
+                !personEntry.orcid?.trim()
+                || !OrcidService.isValidFormat(personEntry.orcid)
+                || personEntry.orcidVerified
+                || isVerifyingRef.current
+            ) {
                 return;
             }
+
+            // Skip if we already attempted this exact (ORCID, retryTrigger) pair.
+            // The signature is refreshed when the curator bumps retryTrigger or
+            // edits the ORCID itself, so intentional retries still work.
+            const signature = `${personEntry.orcid}|${retryTrigger}`;
+            if (lastAttemptedSignatureRef.current === signature) {
+                return;
+            }
+            lastAttemptedSignatureRef.current = signature;
 
             // Early checksum validation (offline) - provides instant feedback without network round-trip.
             // Backend also validates for security, but frontend validation improves UX.
@@ -730,7 +766,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
         const timeoutId = setTimeout(autoVerifyOrcid, 500);
 
         return () => clearTimeout(timeoutId);
-    }, [entry, isVerifying, onEntryChange, includeEmail, retryTrigger, hasUserInteracted]);
+    }, [entry, onEntryChange, includeEmail, retryTrigger, hasUserInteracted]);
 
     return {
         isVerifying,

--- a/resources/js/hooks/use-orcid-autofill.ts
+++ b/resources/js/hooks/use-orcid-autofill.ts
@@ -611,11 +611,22 @@ export function useOrcidAutofill<T extends BaseEntry>({
 
     /**
      * Auto-verify when a valid ORCID is entered
+     *
+     * Gated by `hasUserInteracted` so existing resources loaded into the editor
+     * don't trigger network validation of pre-filled, unverified ORCIDs
+     * (see issue #610). A manual retry via `retryVerification()` bypasses the
+     * gate by bumping `retryTrigger`.
      */
     useEffect(() => {
         const autoVerifyOrcid = async () => {
             // Only auto-verify if person type
             if (!isPersonEntry(entry)) {
+                return;
+            }
+
+            // Skip on initial load – only verify after the curator has actively
+            // touched the field. Manual retries bypass this via retryTrigger.
+            if (!hasUserInteracted && retryTrigger === 0) {
                 return;
             }
 
@@ -719,7 +730,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
         const timeoutId = setTimeout(autoVerifyOrcid, 500);
 
         return () => clearTimeout(timeoutId);
-    }, [entry, isVerifying, onEntryChange, includeEmail, retryTrigger]);
+    }, [entry, isVerifying, onEntryChange, includeEmail, retryTrigger, hasUserInteracted]);
 
     return {
         isVerifying,

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1294,6 +1294,36 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             <li>Save is blocked until the DOI conflict is resolved</li>
                         </ul>
 
+                        <h4>ORCID Pre-flight Validation</h4>
+                        <p>
+                            Immediately before a DOI is registered, ERNIE performs a final ORCID pre-flight
+                            check for every author and contributor attached to the resource:
+                        </p>
+                        <ul className="list-inside list-disc space-y-1">
+                            <li>
+                                <strong>Hard block</strong> – If an ORCID is malformed, has an invalid checksum,
+                                or is reported as "not found" by orcid.org, registration is refused with a
+                                422 response listing each offending author. You must correct the identifier in
+                                the editor before retrying.
+                            </li>
+                            <li>
+                                <strong>Warning (override possible)</strong> – If the ORCID service is
+                                temporarily unreachable (network error, timeout, API error), the registration
+                                modal shows a warning. You can click <strong>"Register anyway"</strong> to
+                                resubmit with an override flag and continue without verification.
+                            </li>
+                            <li>
+                                <strong>Success</strong> – Confirmed ORCIDs are stamped with an internal
+                                <code>orcid_verified_at</code> timestamp so that subsequent saves and imports
+                                reuse the verified status.
+                            </li>
+                        </ul>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                            Note: Opening an existing resource in the editor no longer triggers ORCID
+                            validation for stored authors. The network check only runs when you actively edit
+                            an ORCID / name field or when you press <strong>Register DOI</strong>.
+                        </p>
+
                         <h4>Test vs Production</h4>
                         <div className="mt-2 space-y-2">
                             <div className="rounded-lg border bg-card p-4">

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1314,8 +1314,10 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             </li>
                             <li>
                                 <strong>Success</strong> – Confirmed ORCIDs are stamped with an internal
-                                <code>orcid_verified_at</code> timestamp so that subsequent saves and imports
-                                reuse the verified status.
+                                <code>orcid_verified_at</code> timestamp on the person record for auditing
+                                purposes. The editor itself still marks identifiers as verified via an
+                                offline format + checksum check when a resource is loaded; the stored
+                                timestamp is not yet consumed to skip future preflight checks.
                             </li>
                         </ul>
                         <p className="mt-2 text-sm text-muted-foreground">

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1318,11 +1318,14 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 never overridden this way.
                             </li>
                             <li>
-                                <strong>Success</strong> – Confirmed ORCIDs are stamped with an internal
-                                <code>orcid_verified_at</code> timestamp on the person record for auditing
-                                purposes. The editor itself still marks identifiers as verified via an
-                                offline format + checksum check when a resource is loaded; the stored
-                                timestamp is not yet consumed to skip future preflight checks.
+                                <strong>Success</strong> – On the first successful pre-flight, the person
+                                record is stamped with an internal <code>orcid_verified_at</code> timestamp
+                                for auditing purposes. The timestamp records the *first* confirmation by
+                                orcid.org and is intentionally not refreshed on subsequent registrations,
+                                so the audit trail of the original verification is preserved. The editor
+                                itself still marks identifiers as verified via an offline format + checksum
+                                check when a resource is loaded; the stored timestamp is not yet consumed
+                                to skip future preflight checks.
                             </li>
                         </ul>
                         <p className="mt-2 text-sm text-muted-foreground">

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1312,7 +1312,10 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 modal shows a warning with two options: <strong>"Retry verification"</strong>{' '}
                                 re-runs the pre-flight against orcid.org (use this when the service may have
                                 recovered), and <strong>"Register anyway"</strong> submits with an override
-                                flag and continues without online verification.
+                                flag. The pre-flight still contacts orcid.org on the next attempt, but any
+                                transient warnings are ignored and registration proceeds regardless of the
+                                verification outcome. Hard blockers (malformed / checksum / not found) are
+                                never overridden this way.
                             </li>
                             <li>
                                 <strong>Success</strong> – Confirmed ORCIDs are stamped with an internal

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1320,8 +1320,8 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             <li>
                                 <strong>Success</strong> – On the first successful pre-flight, the person
                                 record is stamped with an internal <code>orcid_verified_at</code> timestamp
-                                for auditing purposes. The timestamp records the *first* confirmation by
-                                orcid.org and is intentionally not refreshed on subsequent registrations,
+                                for auditing purposes. The timestamp records the <em>first</em> confirmation
+                                by orcid.org and is intentionally not refreshed on subsequent registrations,
                                 so the audit trail of the original verification is preserved. The editor
                                 itself still marks identifiers as verified via an offline format + checksum
                                 check when a resource is loaded; the stored timestamp is not yet consumed

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1312,11 +1312,13 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 temporarily unreachable (network error, timeout, API error), the registration
                                 modal shows a warning with two options: <strong>"Retry verification"</strong>{' '}
                                 re-runs the pre-flight against orcid.org (use this when the service may have
-                                recovered), and <strong>"Register anyway"</strong> submits with an override
-                                flag. The pre-flight still contacts orcid.org on the next attempt, but any
-                                transient warnings are ignored and registration proceeds regardless of the
-                                verification outcome. Hard blockers (malformed / checksum / not found) are
-                                never overridden this way.
+                                recovered), and <strong>"Register anyway"</strong> (labeled{' '}
+                                <strong>"Update anyway"</strong> when updating an existing DOI) submits with
+                                an override flag. On the override attempt the throttled orcid.org call is
+                                skipped entirely – only the offline format + checksum gates still run, and
+                                registration (or metadata update) proceeds regardless of the earlier transient
+                                warning. Hard blockers (malformed / checksum / not found) are never overridden
+                                this way.
                             </li>
                             <li>
                                 <strong>Success</strong> – On the first successful pre-flight, the person
@@ -1332,7 +1334,8 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                         <p className="mt-2 text-sm text-muted-foreground">
                             Note: Opening an existing resource in the editor no longer triggers ORCID
                             validation for stored authors. The network check only runs when you actively edit
-                            an ORCID / name field or when you press <strong>Register DOI</strong>.
+                            an ORCID / name field or when you press <strong>Register DOI</strong> or{' '}
+                            <strong>Update Metadata</strong>.
                         </p>
 
                         <h4>Test vs Production</h4>

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1309,8 +1309,10 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             <li>
                                 <strong>Warning (override possible)</strong> – If the ORCID service is
                                 temporarily unreachable (network error, timeout, API error), the registration
-                                modal shows a warning. You can click <strong>"Register anyway"</strong> to
-                                resubmit with an override flag and continue without verification.
+                                modal shows a warning with two options: <strong>"Retry verification"</strong>{' '}
+                                re-runs the pre-flight against orcid.org (use this when the service may have
+                                recovered), and <strong>"Register anyway"</strong> submits with an override
+                                flag and continues without online verification.
                             </li>
                             <li>
                                 <strong>Success</strong> – Confirmed ORCIDs are stamped with an internal

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1296,15 +1296,16 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <h4>ORCID Pre-flight Validation</h4>
                         <p>
-                            Immediately before a DOI is registered, ERNIE performs a final ORCID pre-flight
-                            check for every author and contributor attached to the resource:
+                            Both when registering a new DOI <em>and</em> when updating metadata for an
+                            existing DOI, ERNIE performs a final ORCID pre-flight check for every creator
+                            and contributor attached to the resource before any request is sent to DataCite:
                         </p>
                         <ul className="list-inside list-disc space-y-1">
                             <li>
                                 <strong>Hard block</strong> – If an ORCID is malformed, has an invalid checksum,
-                                or is reported as "not found" by orcid.org, registration is refused with a
-                                422 response listing each offending author. You must correct the identifier in
-                                the editor before retrying.
+                                or is reported as "not found" by orcid.org, registration <em>and</em> metadata
+                                updates are refused with a 422 response listing each offending person. You must
+                                correct the identifier in the editor before retrying.
                             </li>
                             <li>
                                 <strong>Warning (override possible)</strong> – If the ORCID service is

--- a/tests/pest/Arch/ArchTest.php
+++ b/tests/pest/Arch/ArchTest.php
@@ -72,6 +72,9 @@ describe('Services', function () {
             'App\Services\Assistance\AbstractAssistant',
             'App\Services\Assistance\GenericTableAssistant',
             'App\Services\Assistance\AssistantRegistrar',
+            'App\Services\Orcid\OrcidPreflightIssue',
+            'App\Services\Orcid\OrcidPreflightResult',
+            'App\Services\Orcid\OrcidPreflightValidator',
         ]);
 
     arch('services are not extending controllers')

--- a/tests/pest/Feature/BatchResourceRegistrationTest.php
+++ b/tests/pest/Feature/BatchResourceRegistrationTest.php
@@ -462,4 +462,135 @@ describe('BatchResourceRegistrationController@register', function () {
         $response->assertOk();
         expect($response->json('success'))->toHaveCount(1);
     });
+
+    // --- Issue #610: ORCID preflight ---
+    test('ORCID preflight skips resources with confirmed-invalid ORCIDs', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/ORCID-BAD']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $person = \App\Models\Person::factory()->create([
+            'given_name' => 'Bad',
+            'family_name' => 'Author',
+            'name_identifier' => '0000-0002-1825-0097',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+        \App\Models\ResourceCreator::factory()
+            ->forPerson($person)
+            ->position(0)
+            ->create(['resource_id' => $resource->id]);
+
+        $this->mock(\App\Services\OrcidService::class, function (\Mockery\MockInterface $mock) {
+            $mock->shouldReceive('validateOrcid')
+                ->andReturn([
+                    'valid' => false,
+                    'exists' => false,
+                    'message' => 'Not found',
+                    'errorType' => 'not_found',
+                ]);
+        });
+
+        // DataCite must never be called when preflight blocks.
+        $dataCite = Mockery::mock(DataCiteRegistrationService::class);
+        $dataCite->shouldNotReceive('updateMetadata');
+        $dataCite->shouldNotReceive('registerDoi');
+        app()->instance(DataCiteRegistrationService::class, $dataCite);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed'))->toHaveCount(1);
+        expect($response->json('failed.0.reason'))->toContain('ORCID preflight failed');
+        expect($response->json('failed.0.reason'))->toContain('invalid ORCID');
+    });
+
+    test('ORCID preflight skips resources when ORCID service is unreachable (warnings)', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/ORCID-WARN']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $person = \App\Models\Person::factory()->create([
+            'given_name' => 'Flaky',
+            'family_name' => 'Network',
+            'name_identifier' => '0000-0002-1825-0097',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+        \App\Models\ResourceCreator::factory()
+            ->forPerson($person)
+            ->position(0)
+            ->create(['resource_id' => $resource->id]);
+
+        $this->mock(\App\Services\OrcidService::class, function (\Mockery\MockInterface $mock) {
+            $mock->shouldReceive('validateOrcid')
+                ->andReturn([
+                    'valid' => false,
+                    'exists' => null,
+                    'message' => 'Timeout',
+                    'errorType' => 'timeout',
+                ]);
+        });
+
+        $dataCite = Mockery::mock(DataCiteRegistrationService::class);
+        $dataCite->shouldNotReceive('updateMetadata');
+        app()->instance(DataCiteRegistrationService::class, $dataCite);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        expect($response->json('failed.0.reason'))->toContain('ORCID preflight skipped');
+    });
+
+    test('ORCID preflight reports combined invalid + warning counts', function () {
+        $resource = Resource::factory()->create(['doi' => '10.83279/ORCID-MIX']);
+        LandingPage::factory()->create(['resource_id' => $resource->id]);
+
+        $badPerson = \App\Models\Person::factory()->create([
+            'given_name' => 'Bad',
+            'family_name' => 'One',
+            'name_identifier' => '0000-0002-1825-0097',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+        $flakyPerson = \App\Models\Person::factory()->create([
+            'given_name' => 'Flaky',
+            'family_name' => 'Two',
+            'name_identifier' => '0000-0001-5109-3700',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+        \App\Models\ResourceCreator::factory()->forPerson($badPerson)->position(0)
+            ->create(['resource_id' => $resource->id]);
+        \App\Models\ResourceCreator::factory()->forPerson($flakyPerson)->position(1)
+            ->create(['resource_id' => $resource->id]);
+
+        $this->mock(\App\Services\OrcidService::class, function (\Mockery\MockInterface $mock) {
+            $mock->shouldReceive('validateOrcid')
+                ->with('0000-0002-1825-0097')
+                ->andReturn([
+                    'valid' => false, 'exists' => false,
+                    'message' => 'Not found', 'errorType' => 'not_found',
+                ]);
+            $mock->shouldReceive('validateOrcid')
+                ->with('0000-0001-5109-3700')
+                ->andReturn([
+                    'valid' => false, 'exists' => null,
+                    'message' => 'Timeout', 'errorType' => 'timeout',
+                ]);
+        });
+
+        $dataCite = Mockery::mock(DataCiteRegistrationService::class);
+        app()->instance(DataCiteRegistrationService::class, $dataCite);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/resources/batch-register', [
+                'ids' => [$resource->id],
+            ]);
+
+        $response->assertStatus(207);
+        $reason = $response->json('failed.0.reason');
+        expect($reason)->toContain('1 invalid');
+        expect($reason)->toContain('1 unverifiable');
+    });
 });

--- a/tests/pest/Feature/BatchResourceRegistrationTest.php
+++ b/tests/pest/Feature/BatchResourceRegistrationTest.php
@@ -567,13 +567,13 @@ describe('BatchResourceRegistrationController@register', function () {
 
         $this->mock(\App\Services\OrcidService::class, function (\Mockery\MockInterface $mock) {
             $mock->shouldReceive('validateOrcid')
-                ->with('0000-0002-1825-0097')
+                ->with('0000-0002-1825-0097', Mockery::any(), Mockery::any())
                 ->andReturn([
                     'valid' => false, 'exists' => false,
                     'message' => 'Not found', 'errorType' => 'not_found',
                 ]);
             $mock->shouldReceive('validateOrcid')
-                ->with('0000-0001-5109-3700')
+                ->with('0000-0001-5109-3700', Mockery::any(), Mockery::any())
                 ->andReturn([
                     'valid' => false, 'exists' => null,
                     'message' => 'Timeout', 'errorType' => 'timeout',

--- a/tests/pest/Feature/DoiRegistration/DoiRegistrationTest.php
+++ b/tests/pest/Feature/DoiRegistration/DoiRegistrationTest.php
@@ -161,6 +161,41 @@ test('doi registration updates metadata for existing doi', function () {
     expect($response->json('message'))->toContain('metadata updated');
 });
 
+test('doi registration allows metadata update without a prefix', function () {
+    actingAs($this->user);
+
+    $this->resource->update(['doi' => '10.83279/existing-doi']);
+
+    LandingPage::factory()->create([
+        'resource_id' => $this->resource->id,
+        'is_published' => true,
+    ]);
+
+    Http::fake([
+        '*datacite.org/*' => Http::response([
+            'data' => [
+                'id' => '10.83279/existing-doi',
+                'type' => 'dois',
+                'attributes' => [
+                    'doi' => '10.83279/existing-doi',
+                    'state' => 'findable',
+                ],
+            ],
+        ], 200),
+    ]);
+
+    // Modal submits prefix='' when a DOI already exists – validation must accept it.
+    $response = $this->post(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '',
+    ]);
+
+    $response->assertOk();
+    $response->assertJson([
+        'success' => true,
+        'updated' => true,
+    ]);
+});
+
 test('doi registration handles datacite api errors gracefully', function () {
     actingAs($this->user);
 

--- a/tests/pest/Feature/DoiRegistration/OrcidPreflightTest.php
+++ b/tests/pest/Feature/DoiRegistration/OrcidPreflightTest.php
@@ -103,13 +103,13 @@ test('registerDoi returns 409 warning for transient ORCID failures and succeeds 
     actingAs($this->user);
     attachCreatorWithOrcid($this->resource, '0000-0002-1825-0097');
 
-    // Mock called twice: first without force (warning), then with force (no
-    // revalidation is performed because force bypasses the warning path, but
-    // preflight still re-runs the API call – the fake just keeps returning
-    // the transient error).
+    // The service is called exactly once: on the first (force=false) pass.
+    // When the curator overrides via force=true, the preflight short-circuits
+    // the throttled network call for identifiers that already passed the
+    // offline format+checksum gates, so no second API request is issued.
     $this->mock(OrcidService::class, function (MockInterface $mock) {
         $mock->shouldReceive('validateOrcid')
-            ->twice()
+            ->once()
             ->andReturn([
                 'valid' => false,
                 'exists' => null,

--- a/tests/pest/Feature/DoiRegistration/OrcidPreflightTest.php
+++ b/tests/pest/Feature/DoiRegistration/OrcidPreflightTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\User;
+use App\Services\DataCiteRegistrationService;
+use App\Services\DataCiteServiceInterface;
+use App\Services\FakeDataCiteRegistrationService;
+use App\Services\OrcidService;
+use Mockery\MockInterface;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\withoutVite;
+
+/**
+ * Feature tests for the DOI registration ORCID preflight (issue #610).
+ *
+ * These tests exercise the full controller path (policy → request → service →
+ * OrcidPreflightValidator → DataCite) and verify the three documented
+ * outcomes: happy path (200), hard block (422), and warning override (409).
+ */
+beforeEach(function () {
+    withoutVite();
+
+    config([
+        'datacite.test_mode' => true,
+        'datacite.test.username' => 'TEST.USER',
+        'datacite.test.password' => 'test-password',
+        'datacite.test.endpoint' => 'https://api.test.datacite.org',
+        'datacite.test.prefixes' => ['10.83279'],
+        'datacite.production.prefixes' => ['10.5880'],
+    ]);
+
+    $this->user = User::factory()->create();
+    $this->resource = Resource::factory()->create([
+        'doi' => null,
+        'created_by_user_id' => $this->user->id,
+        'updated_by_user_id' => $this->user->id,
+    ]);
+    LandingPage::factory()->create([
+        'resource_id' => $this->resource->id,
+        'is_published' => false,
+    ]);
+
+    // Ensure DataCite calls go through the fake implementation so we never
+    // touch the real API during preflight tests.
+    app()->bind(DataCiteRegistrationService::class, fn () => new FakeDataCiteRegistrationService);
+    app()->bind(DataCiteServiceInterface::class, fn () => new FakeDataCiteRegistrationService);
+});
+
+/** Attaches one creator with the given ORCID + scheme to the resource. */
+function attachCreatorWithOrcid(Resource $resource, string $orcid, ?string $scheme = 'ORCID'): Person
+{
+    $person = Person::factory()->create([
+        'given_name' => 'Jane',
+        'family_name' => 'Doe',
+        'name_identifier' => $orcid,
+        'name_identifier_scheme' => $scheme,
+        'orcid_verified_at' => null,
+    ]);
+    ResourceCreator::factory()
+        ->forPerson($person)
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+
+    return $person;
+}
+
+test('registerDoi blocks with 422 when a creator ORCID is not found', function () {
+    actingAs($this->user);
+    $person = attachCreatorWithOrcid($this->resource, '0000-0002-1825-0097');
+
+    $this->mock(OrcidService::class, function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->once()
+            ->andReturn([
+                'valid' => false,
+                'exists' => false,
+                'message' => 'Not found',
+                'errorType' => 'not_found',
+            ]);
+    });
+
+    $response = $this->postJson(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '10.83279',
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJson([
+        'error' => 'orcid_validation_failed',
+    ]);
+    expect($response->json('invalid'))->toHaveCount(1);
+    expect($response->json('invalid.0.reason'))->toBe('not_found');
+    expect($this->resource->fresh()->doi)->toBeNull();
+    expect($person->fresh()->orcid_verified_at)->toBeNull();
+});
+
+test('registerDoi returns 409 warning for transient ORCID failures and succeeds when replayed with force=true', function () {
+    actingAs($this->user);
+    attachCreatorWithOrcid($this->resource, '0000-0002-1825-0097');
+
+    // Mock called twice: first without force (warning), then with force (no
+    // revalidation is performed because force bypasses the warning path, but
+    // preflight still re-runs the API call – the fake just keeps returning
+    // the transient error).
+    $this->mock(OrcidService::class, function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->twice()
+            ->andReturn([
+                'valid' => false,
+                'exists' => null,
+                'message' => 'Timeout',
+                'errorType' => 'timeout',
+            ]);
+    });
+
+    // 1st call – without force → 409.
+    $warning = $this->postJson(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '10.83279',
+    ]);
+    $warning->assertStatus(409);
+    $warning->assertJson(['error' => 'orcid_validation_warning']);
+    expect($warning->json('warnings'))->toHaveCount(1);
+
+    // 2nd call – with force=true → proceeds to DataCite and succeeds.
+    $ok = $this->postJson(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '10.83279',
+        'force' => true,
+    ]);
+    $ok->assertStatus(200);
+    $ok->assertJson(['success' => true]);
+    expect($this->resource->fresh()->doi)->not->toBeNull();
+});
+
+test('registerDoi stamps orcid_verified_at and proceeds when preflight confirms the ORCID', function () {
+    actingAs($this->user);
+    $person = attachCreatorWithOrcid($this->resource, '0000-0002-1825-0097');
+
+    $this->mock(OrcidService::class, function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->once()
+            ->andReturn([
+                'valid' => true,
+                'exists' => true,
+                'message' => 'Valid',
+                'errorType' => null,
+            ]);
+    });
+
+    $response = $this->postJson(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '10.83279',
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertJson(['success' => true]);
+    expect($person->fresh()->orcid_verified_at)->not->toBeNull();
+    expect($this->resource->fresh()->doi)->not->toBeNull();
+});
+
+test('registerDoi does not call ORCID API when resource has no ORCIDs', function () {
+    actingAs($this->user);
+
+    $this->mock(OrcidService::class, function (MockInterface $mock) {
+        $mock->shouldNotReceive('validateOrcid');
+    });
+
+    $response = $this->postJson(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '10.83279',
+    ]);
+
+    $response->assertStatus(200);
+});
+
+test('registerDoi accepts the `force` boolean in the validated request', function () {
+    actingAs($this->user);
+
+    $this->mock(OrcidService::class, function (MockInterface $mock) {
+        $mock->shouldNotReceive('validateOrcid');
+    });
+
+    $response = $this->postJson(route('resources.register-doi', ['resource' => $this->resource->id]), [
+        'prefix' => '10.83279',
+        'force' => 'not-a-boolean',
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['force']);
+});

--- a/tests/pest/Feature/Http/Requests/FormRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/FormRequestTest.php
@@ -95,6 +95,44 @@ describe('RegisterDoiRequest', function () {
 
         expect($request->authorize())->toBeTrue();
     });
+
+    it('makes prefix nullable when the bound resource already has a DOI', function () {
+        Config::set('datacite.test_mode', true);
+        Config::set('datacite.test.prefixes', ['10.5880']);
+
+        $resource = \App\Models\Resource::factory()->create(['doi' => '10.5880/existing']);
+
+        $route = new \Illuminate\Routing\Route('POST', '/resources/{resource}/register-doi', []);
+        $route->bind(\Illuminate\Http\Request::create('/resources/'.$resource->id.'/register-doi', 'POST'));
+        $route->setParameter('resource', $resource);
+
+        $request = RegisterDoiRequest::create('/resources/'.$resource->id.'/register-doi', 'POST');
+        $request->setRouteResolver(fn () => $route);
+
+        $rules = $request->rules();
+
+        expect($rules['prefix'])->toContain('nullable')
+            ->and($rules['prefix'])->not->toContain('required');
+    });
+
+    it('requires prefix when the bound resource has no DOI yet', function () {
+        Config::set('datacite.test_mode', true);
+        Config::set('datacite.test.prefixes', ['10.5880']);
+
+        $resource = \App\Models\Resource::factory()->create(['doi' => null]);
+
+        $route = new \Illuminate\Routing\Route('POST', '/resources/{resource}/register-doi', []);
+        $route->bind(\Illuminate\Http\Request::create('/resources/'.$resource->id.'/register-doi', 'POST'));
+        $route->setParameter('resource', $resource);
+
+        $request = RegisterDoiRequest::create('/resources/'.$resource->id.'/register-doi', 'POST');
+        $request->setRouteResolver(fn () => $route);
+
+        $rules = $request->rules();
+
+        expect($rules['prefix'])->toContain('required')
+            ->and($rules['prefix'])->not->toContain('nullable');
+    });
 });
 
 /*

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -117,7 +117,7 @@ it('stamps orcid_verified_at and returns clean result when the API confirms the 
     $orcid = mockOrcidService(function (MockInterface $mock) {
         $mock->shouldReceive('validateOrcid')
             ->once()
-            ->with(VALID_ORCID)
+            ->with(VALID_ORCID, Mockery::any(), Mockery::any())
             ->andReturn([
                 'valid' => true,
                 'exists' => true,

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -135,6 +135,30 @@ it('stamps orcid_verified_at and returns clean result when the API confirms the 
         ->and($person->fresh()->orcid_verified_at)->not->toBeNull();
 });
 
+it('preserves the original orcid_verified_at on subsequent successful preflights', function () {
+    [$resource, $person] = makeResourceWithCreatorOrcid(VALID_ORCID);
+
+    $original = now()->subDays(7)->startOfSecond();
+    $person->forceFill(['orcid_verified_at' => $original])->save();
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->once()
+            ->with(VALID_ORCID, Mockery::any(), Mockery::any())
+            ->andReturn([
+                'valid' => true,
+                'exists' => true,
+                'message' => 'Valid',
+                'errorType' => null,
+            ]);
+    });
+
+    (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    // The audit timestamp must reflect the *first* verification, not the latest.
+    expect($person->fresh()->orcid_verified_at?->equalTo($original))->toBeTrue();
+});
+
 it('hard-blocks on not_found responses', function () {
     [$resource, $person] = makeResourceWithCreatorOrcid(VALID_ORCID);
 

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -242,3 +242,91 @@ it('produces a serializable payload shape', function () {
             'severity', 'reason', 'role', 'position', 'orcid', 'displayName',
         ]);
 });
+
+it('skips creators with null name_identifier', function () {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'name_identifier' => null,
+        'name_identifier_scheme' => null,
+    ]);
+    ResourceCreator::factory()
+        ->forPerson($person)
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource->fresh());
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->warnings)->toBe([]);
+});
+
+it('skips institution creators (non-Person morph target)', function () {
+    $resource = Resource::factory()->create();
+    \App\Models\ResourceCreator::factory()
+        ->forInstitution()
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource->fresh());
+
+    expect($result->shouldBlock)->toBeFalse();
+});
+
+it('falls back to "Unnamed person" when display name cannot be built', function () {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'given_name' => '',
+        'family_name' => '',
+        'name_identifier' => 'not-an-orcid',
+        'name_identifier_scheme' => 'ORCID',
+    ]);
+    ResourceCreator::factory()
+        ->forPerson($person)
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource->fresh());
+
+    expect($result->invalid[0]->displayName)->toBe('Unnamed person');
+});
+
+it('normalizes unexpected API error types to "unknown" warning', function () {
+    [$resource] = makeResourceWithCreatorOrcid(VALID_ORCID);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->andReturn([
+                'valid' => false,
+                'exists' => false,
+                'message' => 'Weird',
+                'errorType' => 'something_we_never_saw_before',
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->warnings)->toHaveCount(1)
+        ->and($result->warnings[0]->reason)->toBe('unknown');
+});
+
+it('OrcidPreflightResult::clean() produces a result with no issues', function () {
+    $result = \App\Services\Orcid\OrcidPreflightResult::clean();
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->needsConfirmation)->toBeFalse()
+        ->and($result->invalid)->toBe([])
+        ->and($result->warnings)->toBe([])
+        ->and($result->toPayload())->toBe(['invalid' => [], 'warnings' => []]);
+});

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -387,11 +387,16 @@ it('eager-loads morph targets to avoid N+1 queries', function () {
     $freshResource = Resource::query()->findOrFail($resource->id);
 
     $queryCount = 0;
-    \DB::listen(static function () use (&$queryCount): void {
-        $queryCount++;
-    });
+    \DB::flushQueryLog();
+    \DB::enableQueryLog();
 
-    (new OrcidPreflightValidator($orcid))->validate($freshResource);
+    try {
+        (new OrcidPreflightValidator($orcid))->validate($freshResource);
+        $queryCount = count(\DB::getQueryLog());
+    } finally {
+        \DB::disableQueryLog();
+        \DB::flushQueryLog();
+    }
 
     // Expected queries:
     //   1. creators

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -202,24 +202,38 @@ it('emits a warning (not a block) on timeout and requires confirmation', functio
         ->and($result->warnings[0]->reason)->toBe('timeout');
 });
 
-it('suppresses needsConfirmation when force=true even with warnings', function () {
+it('skips the throttled network validation entirely when force=true', function () {
     [$resource] = makeResourceWithCreatorOrcid(VALID_ORCID);
 
     $orcid = mockOrcidService(function (MockInterface $mock) {
-        $mock->shouldReceive('validateOrcid')
-            ->andReturn([
-                'valid' => false,
-                'exists' => null,
-                'message' => 'API error',
-                'errorType' => 'api_error',
-            ]);
+        // force=true is the override path – we must NOT issue another
+        // throttled network call for identifiers that already passed the
+        // offline format+checksum gates on the first pass.
+        $mock->shouldNotReceive('validateOrcid');
     });
 
     $result = (new OrcidPreflightValidator($orcid))->validate($resource, force: true);
 
     expect($result->shouldBlock)->toBeFalse()
         ->and($result->needsConfirmation)->toBeFalse()
-        ->and($result->warnings)->toHaveCount(1);
+        ->and($result->warnings)->toBe([])
+        ->and($result->invalid)->toBe([]);
+});
+
+it('still reports blocking offline issues (format/checksum) when force=true', function () {
+    // An ORCID with an invalid checksum must still block even on the override
+    // path, because the offline gate runs before the network short-circuit.
+    [$resource] = makeResourceWithCreatorOrcid('0000-0002-1825-0000');
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldNotReceive('validateOrcid');
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource, force: true);
+
+    expect($result->shouldBlock)->toBeTrue()
+        ->and($result->invalid)->toHaveCount(1)
+        ->and($result->invalid[0]->reason)->toBe('checksum');
 });
 
 it('validates contributors in addition to creators', function () {
@@ -250,6 +264,42 @@ it('validates contributors in addition to creators', function () {
 
     expect($result->shouldBlock)->toBeTrue()
         ->and($result->invalid[0]->role)->toBe('contributor');
+});
+
+it('deduplicates the throttled network call when the same ORCID is shared across rows', function () {
+    // Same identifier used both as creator and as contributor – the throttled
+    // network call must only be issued once per bare ORCID id per invocation.
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'given_name' => 'Dup',
+        'family_name' => 'Licate',
+        'name_identifier' => VALID_ORCID,
+        'name_identifier_scheme' => 'ORCID',
+        'orcid_verified_at' => null,
+    ]);
+    ResourceCreator::factory()
+        ->forPerson($person)
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+    ResourceContributor::factory()
+        ->forPerson($person)
+        ->atPosition(0)
+        ->create(['resource_id' => $resource->id]);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->once()
+            ->andReturn([
+                'valid' => true,
+                'exists' => true,
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource->fresh());
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->invalid)->toBe([])
+        ->and($result->warnings)->toBe([]);
 });
 
 it('produces a serializable payload shape', function () {

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
+use App\Services\Orcid\OrcidPreflightValidator;
+use App\Services\OrcidService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery\MockInterface;
+
+uses(RefreshDatabase::class);
+
+/**
+ * A valid ORCID iD with a correct checksum (issue #610).
+ *
+ * Using a well-known example from Chen et al. that passes ISO 7064
+ * mod 11-2 so format/checksum offline gates always succeed.
+ */
+const VALID_ORCID = '0000-0002-1825-0097';
+
+/**
+ * Well-formed but checksum-invalid ORCID.
+ */
+const INVALID_CHECKSUM_ORCID = '0000-0002-1825-0099';
+
+function makeResourceWithCreatorOrcid(string $orcid, string $scheme = 'ORCID'): array
+{
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'given_name' => 'Jane',
+        'family_name' => 'Doe',
+        'name_identifier' => $orcid,
+        'name_identifier_scheme' => $scheme,
+        'orcid_verified_at' => null,
+    ]);
+    ResourceCreator::factory()
+        ->forPerson($person)
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+
+    return [$resource->fresh(), $person];
+}
+
+function mockOrcidService(callable $setup): OrcidService
+{
+    return tap(Mockery::mock(OrcidService::class), $setup);
+}
+
+it('returns a clean result when no creators carry an ORCID', function () {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create();
+    ResourceCreator::factory()
+        ->forPerson($person)
+        ->position(0)
+        ->create(['resource_id' => $resource->id]);
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource->fresh());
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->needsConfirmation)->toBeFalse()
+        ->and($result->invalid)->toBe([])
+        ->and($result->warnings)->toBe([]);
+});
+
+it('skips identifiers that are explicitly tagged with a non-ORCID scheme', function () {
+    [$resource, $person] = makeResourceWithCreatorOrcid('0000-0001-5109-3700', 'ISNI');
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($person->fresh()->orcid_verified_at)->toBeNull();
+});
+
+it('hard-blocks on malformed ORCID format without hitting the network', function () {
+    [$resource] = makeResourceWithCreatorOrcid('not-an-orcid');
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeTrue()
+        ->and($result->invalid)->toHaveCount(1)
+        ->and($result->invalid[0]->reason)->toBe('format')
+        ->and($result->invalid[0]->severity)->toBe('blocking')
+        ->and($result->invalid[0]->role)->toBe('creator');
+});
+
+it('hard-blocks on checksum-invalid ORCID without hitting the network', function () {
+    [$resource] = makeResourceWithCreatorOrcid(INVALID_CHECKSUM_ORCID);
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeTrue()
+        ->and($result->invalid[0]->reason)->toBe('checksum');
+});
+
+it('stamps orcid_verified_at and returns clean result when the API confirms the ORCID', function () {
+    [$resource, $person] = makeResourceWithCreatorOrcid(VALID_ORCID);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->once()
+            ->with(VALID_ORCID)
+            ->andReturn([
+                'valid' => true,
+                'exists' => true,
+                'message' => 'Valid',
+                'errorType' => null,
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->needsConfirmation)->toBeFalse()
+        ->and($result->invalid)->toBe([])
+        ->and($result->warnings)->toBe([])
+        ->and($person->fresh()->orcid_verified_at)->not->toBeNull();
+});
+
+it('hard-blocks on not_found responses', function () {
+    [$resource, $person] = makeResourceWithCreatorOrcid(VALID_ORCID);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->andReturn([
+                'valid' => false,
+                'exists' => false,
+                'message' => 'Not found',
+                'errorType' => 'not_found',
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeTrue()
+        ->and($result->invalid)->toHaveCount(1)
+        ->and($result->invalid[0]->reason)->toBe('not_found')
+        ->and($person->fresh()->orcid_verified_at)->toBeNull();
+});
+
+it('emits a warning (not a block) on timeout and requires confirmation', function () {
+    [$resource] = makeResourceWithCreatorOrcid(VALID_ORCID);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->andReturn([
+                'valid' => false,
+                'exists' => null,
+                'message' => 'Timeout',
+                'errorType' => 'timeout',
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource);
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->needsConfirmation)->toBeTrue()
+        ->and($result->warnings)->toHaveCount(1)
+        ->and($result->warnings[0]->severity)->toBe('warning')
+        ->and($result->warnings[0]->reason)->toBe('timeout');
+});
+
+it('suppresses needsConfirmation when force=true even with warnings', function () {
+    [$resource] = makeResourceWithCreatorOrcid(VALID_ORCID);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->andReturn([
+                'valid' => false,
+                'exists' => null,
+                'message' => 'API error',
+                'errorType' => 'api_error',
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource, force: true);
+
+    expect($result->shouldBlock)->toBeFalse()
+        ->and($result->needsConfirmation)->toBeFalse()
+        ->and($result->warnings)->toHaveCount(1);
+});
+
+it('validates contributors in addition to creators', function () {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'given_name' => 'Chris',
+        'family_name' => 'Contributor',
+        'name_identifier' => VALID_ORCID,
+        'name_identifier_scheme' => 'ORCID',
+    ]);
+    ResourceContributor::factory()
+        ->forPerson($person)
+        ->atPosition(0)
+        ->create(['resource_id' => $resource->id]);
+
+    $orcid = mockOrcidService(function (MockInterface $mock) {
+        $mock->shouldReceive('validateOrcid')
+            ->once()
+            ->andReturn([
+                'valid' => false,
+                'exists' => false,
+                'message' => 'Not found',
+                'errorType' => 'not_found',
+            ]);
+    });
+
+    $result = (new OrcidPreflightValidator($orcid))->validate($resource->fresh());
+
+    expect($result->shouldBlock)->toBeTrue()
+        ->and($result->invalid[0]->role)->toBe('contributor');
+});
+
+it('produces a serializable payload shape', function () {
+    [$resource] = makeResourceWithCreatorOrcid('not-an-orcid');
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+
+    $payload = (new OrcidPreflightValidator($orcid))->validate($resource)->toPayload();
+
+    expect($payload)->toHaveKeys(['invalid', 'warnings'])
+        ->and($payload['invalid'])->toBeArray()
+        ->and($payload['invalid'][0])->toHaveKeys([
+            'severity', 'reason', 'role', 'position', 'orcid', 'displayName',
+        ]);
+});

--- a/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
+++ b/tests/pest/Unit/Services/Orcid/OrcidPreflightValidatorTest.php
@@ -330,3 +330,51 @@ it('OrcidPreflightResult::clean() produces a result with no issues', function ()
         ->and($result->warnings)->toBe([])
         ->and($result->toPayload())->toBe(['invalid' => [], 'warnings' => []]);
 });
+
+it('eager-loads morph targets to avoid N+1 queries', function () {
+    $resource = Resource::factory()->create();
+    for ($i = 0; $i < 5; $i++) {
+        $person = Person::factory()->create([
+            'name_identifier' => null,
+            'name_identifier_scheme' => null,
+        ]);
+        ResourceCreator::factory()
+            ->forPerson($person)
+            ->position($i)
+            ->create(['resource_id' => $resource->id]);
+    }
+    for ($i = 0; $i < 5; $i++) {
+        $person = Person::factory()->create([
+            'name_identifier' => null,
+            'name_identifier_scheme' => null,
+        ]);
+        ResourceContributor::factory()
+            ->forPerson($person)
+            ->atPosition($i)
+            ->create(['resource_id' => $resource->id]);
+    }
+
+    /** @var OrcidService&MockInterface $orcid */
+    $orcid = Mockery::mock(OrcidService::class);
+    $orcid->shouldNotReceive('validateOrcid');
+
+    // Simulate the controller path: fetch the resource without pre-loading
+    // anything, then let the validator handle eager loading.
+    $freshResource = Resource::query()->findOrFail($resource->id);
+
+    $queryCount = 0;
+    \DB::listen(static function () use (&$queryCount): void {
+        $queryCount++;
+    });
+
+    (new OrcidPreflightValidator($orcid))->validate($freshResource);
+
+    // Expected queries:
+    //   1. creators
+    //   2. creatorable morph (persons + institutions, grouped)
+    //   3. contributors
+    //   4. contributorable morph
+    // Plus at most a couple of extra framework queries. Anything proportional
+    // to the number of creators/contributors indicates an N+1 regression.
+    expect($queryCount)->toBeLessThanOrEqual(8);
+});

--- a/tests/pest/Unit/Services/OrcidServiceTest.php
+++ b/tests/pest/Unit/Services/OrcidServiceTest.php
@@ -421,6 +421,42 @@ describe('Retries', function () {
         // Verify all 3 attempts were made (2 retries + final success)
         Http::assertSentCount(3);
     });
+
+    it('honors maxAttempts=1 for preflight to avoid retry/backoff budget', function () {
+        Http::fake([
+            'pub.orcid.org/v3.0/0000-0002-1825-0097/person' => Http::sequence()
+                ->push(null, 500)
+                ->push(null, 500)
+                ->push(['name' => []], 200),
+        ]);
+
+        $result = $this->service->validateOrcid(
+            '0000-0002-1825-0097',
+            maxAttempts: \App\Services\OrcidService::PREFLIGHT_MAX_ATTEMPTS,
+            timeoutSeconds: \App\Services\OrcidService::PREFLIGHT_VALIDATION_TIMEOUT,
+        );
+
+        // No retry → first 500 immediately surfaces as api_error.
+        expect($result['errorType'])->toBe('api_error');
+        Http::assertSentCount(1);
+    });
+
+    it('honors maxAttempts=1 for preflight on connection failures', function () {
+        $attempts = 0;
+        Http::fake(function () use (&$attempts) {
+            $attempts++;
+            throw new ConnectionException('timed out');
+        });
+
+        $result = $this->service->validateOrcid(
+            '0000-0002-1825-0097',
+            maxAttempts: \App\Services\OrcidService::PREFLIGHT_MAX_ATTEMPTS,
+            timeoutSeconds: \App\Services\OrcidService::PREFLIGHT_VALIDATION_TIMEOUT,
+        );
+
+        expect($result['errorType'])->toBe('timeout');
+        expect($attempts)->toBe(1);
+    });
 });
 
 describe('ROR ID extraction from affiliations', function () {

--- a/tests/vitest/components/curation/fields/contributor/contributor-item.test.tsx
+++ b/tests/vitest/components/curation/fields/contributor/contributor-item.test.tsx
@@ -200,4 +200,36 @@ describe('ContributorItem Component', () => {
         expect(screen.getByDisplayValue('slug@example.org')).toBeInTheDocument();
         expect(screen.getByDisplayValue('https://slug.example.org')).toBeInTheDocument();
     });
+
+    it('forwards orcid, firstName, lastName, email and website changes via onPersonFieldChange', async () => {
+        const user = userEvent.setup();
+        const contactPerson: ContributorEntry = {
+            ...mockPersonContributor,
+            firstName: '',
+            lastName: '',
+            orcid: '',
+            roles: [{ value: 'ContactPerson' }],
+            rolesInput: 'ContactPerson',
+            email: '',
+            website: '',
+        };
+        render(<ContributorItem contributor={contactPerson} {...mockProps} />);
+
+        // First name / last name / ORCID flip the interaction gate (true branch).
+        await user.type(screen.getByLabelText(/^first name/i), 'A');
+        await user.type(screen.getByLabelText(/^last name/i), 'B');
+        await user.type(screen.getByLabelText(/^orcid/i), '0');
+
+        // Email + website hit the false branch of the `field === 'orcid' || ...` gate.
+        await user.type(screen.getByLabelText(/^email/i), 'x');
+        await user.type(screen.getByLabelText(/^website/i), 'y');
+
+        // The callback fires for every keystroke; assert each field produced at least one call.
+        const calls = mockProps.onPersonFieldChange.mock.calls.map((c: unknown[]) => c[0]);
+        expect(calls).toContain('firstName');
+        expect(calls).toContain('lastName');
+        expect(calls).toContain('orcid');
+        expect(calls).toContain('email');
+        expect(calls).toContain('website');
+    });
 });

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -381,8 +381,12 @@ describe('RegisterDoiModal', () => {
         const submitButton = screen.getByRole('button', { name: /register doi/i });
         await user.click(submitButton);
 
-        // Buttons should be disabled while submitting
-        expect(screen.getByRole('button', { name: /processing/i })).toBeDisabled();
+        // Buttons should be disabled while submitting. With <LoadingButton> the
+        // accessible name stays "Register DOI" – only the spinner + aria-busy
+        // indicate progress. The Cancel button is gated by the same isSubmitting flag.
+        const loadingButton = screen.getByRole('button', { name: /register doi/i });
+        expect(loadingButton).toBeDisabled();
+        expect(loadingButton).toHaveAttribute('aria-busy', 'true');
         expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
     });
 
@@ -665,6 +669,51 @@ describe('RegisterDoiModal', () => {
 
             // Warning state cleared after successful retry.
             expect(screen.queryByTestId('orcid-preflight-warnings')).not.toBeInTheDocument();
+        });
+
+        it('only shows the loading indicator on the clicked preflight action button', async () => {
+            const user = userEvent.setup();
+
+            const warningResponse = makeAxiosError(409, {
+                error: 'orcid_validation_warning',
+                message: 'ORCID service unavailable',
+                invalid: [],
+                warnings: [
+                    {
+                        severity: 'warning',
+                        reason: 'timeout',
+                        role: 'creator',
+                        position: 0,
+                        orcid: '0000-0002-1825-0097',
+                        displayName: 'Jane Doe',
+                    },
+                ],
+            });
+
+            // First call: warning. Second (override): pending forever so we can
+            // observe the loading state while the request is in flight.
+            mockPost
+                .mockRejectedValueOnce(warningResponse)
+                .mockImplementationOnce(() => new Promise(() => {}));
+
+            render(<RegisterDoiModal {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const overrideButton = await screen.findByTestId('orcid-preflight-override');
+            const retryButton = screen.getByTestId('orcid-preflight-retry');
+
+            await user.click(overrideButton);
+
+            // Only the override button is busy; retry is merely disabled.
+            await waitFor(() => {
+                expect(overrideButton).toHaveAttribute('aria-busy', 'true');
+            });
+            expect(retryButton).toBeDisabled();
+            expect(retryButton).not.toHaveAttribute('aria-busy', 'true');
         });
     });
 });

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -715,5 +715,49 @@ describe('RegisterDoiModal', () => {
             expect(retryButton).toBeDisabled();
             expect(retryButton).not.toHaveAttribute('aria-busy', 'true');
         });
+
+        it('keeps the Retry button mounted with a loading indicator while the retry request is in flight', async () => {
+            const user = userEvent.setup();
+
+            const warningResponse = makeAxiosError(409, {
+                error: 'orcid_validation_warning',
+                message: 'ORCID service unavailable',
+                invalid: [],
+                warnings: [
+                    {
+                        severity: 'warning',
+                        reason: 'timeout',
+                        role: 'creator',
+                        position: 0,
+                        orcid: '0000-0002-1825-0097',
+                        displayName: 'Jane Doe',
+                    },
+                ],
+            });
+
+            // First call: warning. Second (retry): pending forever so we can
+            // observe the retry button's loading state while the request is in flight.
+            mockPost
+                .mockRejectedValueOnce(warningResponse)
+                .mockImplementationOnce(() => new Promise(() => {}));
+
+            render(<RegisterDoiModal {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const retryButton = await screen.findByTestId('orcid-preflight-retry');
+            await user.click(retryButton);
+
+            // The retry button must remain mounted AND show its loading indicator
+            // while the request is in flight. The warning alert stays visible so
+            // the user has continuous feedback that their retry is being processed.
+            await waitFor(() => {
+                expect(screen.getByTestId('orcid-preflight-retry')).toHaveAttribute('aria-busy', 'true');
+            });
+            expect(screen.getByTestId('orcid-preflight-warnings')).toBeInTheDocument();
+        });
     });
 });

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -509,6 +509,40 @@ describe('RegisterDoiModal', () => {
             });
         });
 
+        it('labels the override button "Update anyway" when the resource already has a DOI', async () => {
+            const user = userEvent.setup();
+
+            mockPost.mockRejectedValueOnce(
+                makeAxiosError(409, {
+                    error: 'orcid_validation_warning',
+                    message: 'ORCID service unavailable',
+                    invalid: [],
+                    warnings: [
+                        {
+                            severity: 'warning',
+                            reason: 'timeout',
+                            role: 'creator',
+                            position: 0,
+                            orcid: '0000-0002-3333-4444',
+                            displayName: 'Alex Creator',
+                        },
+                    ],
+                }),
+            );
+
+            render(<RegisterDoiModal {...defaultProps} resource={mockResourceWithDoi} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /update metadata/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /update metadata/i }));
+
+            const overrideButton = await screen.findByTestId('orcid-preflight-override');
+            expect(overrideButton).toHaveTextContent(/update anyway/i);
+            expect(overrideButton).not.toHaveTextContent(/register anyway/i);
+        });
+
         it('renders plural identifier count when multiple ORCIDs are invalid', async () => {
             const user = userEvent.setup();
 

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -605,5 +605,66 @@ describe('RegisterDoiModal', () => {
             expect(screen.queryByTestId('orcid-preflight-blockers')).not.toBeInTheDocument();
             expect(screen.queryByTestId('orcid-preflight-warnings')).not.toBeInTheDocument();
         });
+
+        it('offers a "Retry verification" button that re-runs preflight with force=false', async () => {
+            const user = userEvent.setup();
+
+            const warningResponse = makeAxiosError(409, {
+                error: 'orcid_validation_warning',
+                message: 'ORCID service unavailable',
+                invalid: [],
+                warnings: [
+                    {
+                        severity: 'warning',
+                        reason: 'timeout',
+                        role: 'creator',
+                        position: 0,
+                        orcid: '0000-0002-1825-0097',
+                        displayName: 'Jane Doe',
+                    },
+                ],
+            });
+
+            // First: warning. Second (retry): success.
+            mockPost
+                .mockRejectedValueOnce(warningResponse)
+                .mockResolvedValueOnce({
+                    data: {
+                        success: true,
+                        message: 'DOI registered successfully',
+                        doi: '10.83279/retried-doi',
+                        mode: 'test',
+                        updated: false,
+                    },
+                });
+
+            const onSuccess = vi.fn();
+            render(<RegisterDoiModal {...defaultProps} onSuccess={onSuccess} />);
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const retryButton = await screen.findByTestId('orcid-preflight-retry');
+            expect(retryButton).toHaveTextContent(/retry verification/i);
+
+            await user.click(retryButton);
+
+            // Second call must use force=false (not an override).
+            await waitFor(() => {
+                expect(mockPost).toHaveBeenLastCalledWith('/resources/1/register-doi', {
+                    prefix: '10.83279',
+                    force: false,
+                });
+            });
+
+            await waitFor(() => {
+                expect(onSuccess).toHaveBeenCalledWith('10.83279/retried-doi');
+            });
+
+            // Warning state cleared after successful retry.
+            expect(screen.queryByTestId('orcid-preflight-warnings')).not.toBeInTheDocument();
+        });
     });
 });

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -509,7 +509,7 @@ describe('RegisterDoiModal', () => {
             });
         });
 
-        it('renders plural author count when multiple ORCIDs are invalid', async () => {
+        it('renders plural identifier count when multiple ORCIDs are invalid', async () => {
             const user = userEvent.setup();
 
             mockPost.mockRejectedValueOnce(
@@ -545,7 +545,7 @@ describe('RegisterDoiModal', () => {
             await user.click(screen.getByRole('button', { name: /register doi/i }));
 
             const alert = await screen.findByTestId('orcid-preflight-blockers');
-            expect(alert).toHaveTextContent(/2 authors/i);
+            expect(alert).toHaveTextContent(/2 identifiers/i);
             expect(alert).toHaveTextContent('Jane Doe');
             expect(alert).toHaveTextContent('Bob Smith');
         });

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -504,5 +504,106 @@ describe('RegisterDoiModal', () => {
                 expect(onSuccess).toHaveBeenCalledWith('10.83279/forced-doi');
             });
         });
+
+        it('renders plural author count when multiple ORCIDs are invalid', async () => {
+            const user = userEvent.setup();
+
+            mockPost.mockRejectedValueOnce(
+                makeAxiosError(422, {
+                    error: 'orcid_validation_failed',
+                    message: 'ORCID validation failed',
+                    invalid: [
+                        {
+                            severity: 'blocking',
+                            reason: 'not_found',
+                            role: 'creator',
+                            position: 0,
+                            orcid: '0000-0001-2345-6789',
+                            displayName: 'Jane Doe',
+                        },
+                        {
+                            severity: 'blocking',
+                            reason: 'checksum',
+                            role: 'creator',
+                            position: 1,
+                            orcid: '0000-0002-1111-1111',
+                            displayName: 'Bob Smith',
+                        },
+                    ],
+                    warnings: [],
+                }),
+            );
+
+            render(<RegisterDoiModal {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const alert = await screen.findByTestId('orcid-preflight-blockers');
+            expect(alert).toHaveTextContent(/2 authors/i);
+            expect(alert).toHaveTextContent('Jane Doe');
+            expect(alert).toHaveTextContent('Bob Smith');
+        });
+
+        it('swallows errors thrown by onSuccess callback without breaking the modal', async () => {
+            const user = userEvent.setup();
+
+            mockPost.mockResolvedValueOnce({
+                data: {
+                    success: true,
+                    message: 'DOI registered successfully',
+                    doi: '10.83279/new-doi',
+                    mode: 'test',
+                    updated: false,
+                },
+            });
+
+            // onSuccess throws synchronously – modal must NOT re-throw.
+            const onSuccess = vi.fn(() => {
+                throw new Error('callback boom');
+            });
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            render(<RegisterDoiModal {...defaultProps} onSuccess={onSuccess} />);
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            await waitFor(() => {
+                expect(onSuccess).toHaveBeenCalledWith('10.83279/new-doi');
+            });
+            expect(consoleSpy).toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
+        });
+
+        it('re-displays generic error message when 500 response has no ORCID payload', async () => {
+            const user = userEvent.setup();
+
+            mockPost.mockRejectedValueOnce({
+                isAxiosError: true,
+                response: {
+                    status: 500,
+                    data: { success: false, message: 'Internal server error', doi: '', mode: 'test', updated: false },
+                },
+            });
+
+            render(<RegisterDoiModal {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            await waitFor(() => {
+                expect(screen.getByText(/internal server error/i)).toBeInTheDocument();
+            });
+            // No preflight alerts.
+            expect(screen.queryByTestId('orcid-preflight-blockers')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('orcid-preflight-warnings')).not.toBeInTheDocument();
+        });
     });
 });

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -208,6 +208,7 @@ describe('RegisterDoiModal', () => {
         await waitFor(() => {
             expect(mockPost).toHaveBeenCalledWith('/resources/1/register-doi', {
                 prefix: '10.83279',
+                force: false,
             });
         });
     });
@@ -383,5 +384,125 @@ describe('RegisterDoiModal', () => {
         // Buttons should be disabled while submitting
         expect(screen.getByRole('button', { name: /processing/i })).toBeDisabled();
         expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+    });
+
+    // --- Issue #610: ORCID preflight ---
+    describe('ORCID preflight', () => {
+        const makeAxiosError = (status: number, data: unknown) => ({
+            isAxiosError: true,
+            response: { status, data },
+        });
+
+        it('renders blocking alert and disables submit when backend returns 422', async () => {
+            const user = userEvent.setup();
+
+            mockPost.mockRejectedValueOnce(
+                makeAxiosError(422, {
+                    error: 'orcid_validation_failed',
+                    message: 'ORCID validation failed',
+                    invalid: [
+                        {
+                            severity: 'blocking',
+                            reason: 'not_found',
+                            role: 'creator',
+                            position: 0,
+                            orcid: '0000-0001-2345-6789',
+                            displayName: 'Jane Doe',
+                        },
+                    ],
+                    warnings: [],
+                }),
+            );
+
+            render(<RegisterDoiModal {...defaultProps} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const alert = await screen.findByTestId('orcid-preflight-blockers');
+            expect(alert).toBeInTheDocument();
+            expect(alert).toHaveTextContent('Jane Doe');
+            expect(alert).toHaveTextContent('0000-0001-2345-6789');
+            expect(alert).toHaveTextContent(/not found in orcid registry/i);
+
+            // No warnings alert rendered alongside blockers.
+            expect(screen.queryByTestId('orcid-preflight-warnings')).not.toBeInTheDocument();
+
+            // Primary submit stays disabled due to blockers.
+            expect(screen.getByRole('button', { name: /register doi/i })).toBeDisabled();
+
+            // No override button is offered when hard blockers exist.
+            expect(screen.queryByTestId('orcid-preflight-override')).not.toBeInTheDocument();
+        });
+
+        it('renders warning alert and offers "Register anyway" override on 409', async () => {
+            const user = userEvent.setup();
+
+            // First call: 409 warning, second call (forced): success.
+            mockPost
+                .mockRejectedValueOnce(
+                    makeAxiosError(409, {
+                        error: 'orcid_validation_warning',
+                        message: 'ORCID service unavailable',
+                        invalid: [],
+                        warnings: [
+                            {
+                                severity: 'warning',
+                                reason: 'timeout',
+                                role: 'contributor',
+                                position: 2,
+                                orcid: '0000-0002-3333-4444',
+                                displayName: 'Alex Contributor',
+                            },
+                        ],
+                    }),
+                )
+                .mockResolvedValueOnce({
+                    data: {
+                        success: true,
+                        message: 'DOI registered successfully',
+                        doi: '10.83279/forced-doi',
+                        mode: 'test',
+                        updated: false,
+                    },
+                });
+
+            const onSuccess = vi.fn();
+
+            render(<RegisterDoiModal {...defaultProps} onSuccess={onSuccess} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const warningAlert = await screen.findByTestId('orcid-preflight-warnings');
+            expect(warningAlert).toHaveTextContent('Alex Contributor');
+            expect(warningAlert).toHaveTextContent(/orcid service timed out/i);
+
+            // Blockers alert not rendered alongside warnings.
+            expect(screen.queryByTestId('orcid-preflight-blockers')).not.toBeInTheDocument();
+
+            // Override button replaces the regular submit button.
+            const overrideButton = await screen.findByTestId('orcid-preflight-override');
+            expect(overrideButton).toHaveTextContent(/register anyway/i);
+
+            await user.click(overrideButton);
+
+            await waitFor(() => {
+                expect(mockPost).toHaveBeenLastCalledWith('/resources/1/register-doi', {
+                    prefix: '10.83279',
+                    force: true,
+                });
+            });
+
+            await waitFor(() => {
+                expect(onSuccess).toHaveBeenCalledWith('10.83279/forced-doi');
+            });
+        });
     });
 });

--- a/tests/vitest/hooks/__tests__/use-orcid-autofill.test.ts
+++ b/tests/vitest/hooks/__tests__/use-orcid-autofill.test.ts
@@ -451,6 +451,30 @@ describe('useOrcidAutofill', () => {
             vi.useRealTimers();
         });
 
+        // Issue #610: auto-verify must stay silent until the curator has
+        // actively touched the field – otherwise opening an existing resource
+        // triggers ORCID traffic for every pre-filled author.
+        it('does not auto-verify on initial load (hasUserInteracted=false)', async () => {
+            vi.mocked(OrcidService.isValidFormat).mockReturnValue(true);
+            vi.mocked(OrcidService.validateChecksum).mockReturnValue(true);
+
+            const entry = createPersonEntry({ orcid: '0000-0001-2345-6789' });
+            const onEntryChange = vi.fn();
+
+            renderHook(() =>
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+            );
+
+            await act(async () => {
+                vi.advanceTimersByTime(1200);
+                await vi.runAllTimersAsync();
+            });
+
+            expect(OrcidService.validateOrcid).not.toHaveBeenCalled();
+            expect(OrcidService.fetchOrcidRecord).not.toHaveBeenCalled();
+            expect(onEntryChange).not.toHaveBeenCalled();
+        });
+
         it('auto-verifies a valid ORCID after debounce', async () => {
             vi.mocked(OrcidService.isValidFormat).mockReturnValue(true);
             vi.mocked(OrcidService.validateChecksum).mockReturnValue(true);
@@ -475,7 +499,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             // Advance past debounce (500ms)
@@ -503,7 +527,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             const { result } = renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -528,7 +552,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             const { result } = renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -553,7 +577,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             const { result } = renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -578,7 +602,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             const { result } = renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -599,7 +623,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -617,7 +641,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -644,7 +668,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             const { result } = renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -669,7 +693,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             const { result } = renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true }),
             );
 
             await act(async () => {
@@ -705,7 +729,7 @@ describe('useOrcidAutofill', () => {
             const onEntryChange = vi.fn();
 
             renderHook(() =>
-                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false, includeEmail: true }),
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: true, includeEmail: true }),
             );
 
             await act(async () => {
@@ -719,6 +743,55 @@ describe('useOrcidAutofill', () => {
                     orcidVerified: true,
                 }),
             );
+        });
+
+        // Issue #610: the manual retry button must still work even when the
+        // curator hasn't edited the field yet. This covers the "I re-opened
+        // the modal and want to check again" case.
+        it('retryVerification bypasses hasUserInteracted gate', async () => {
+            vi.mocked(OrcidService.isValidFormat).mockReturnValue(true);
+            vi.mocked(OrcidService.validateChecksum).mockReturnValue(true);
+            vi.mocked(OrcidService.validateOrcid).mockResolvedValue({
+                success: true,
+                data: { valid: true, exists: true, message: 'Valid', errorType: null },
+            });
+            vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
+                success: true,
+                data: {
+                    orcid: '0000-0001-2345-6789',
+                    firstName: 'Jane',
+                    lastName: 'Smith',
+                    creditName: null,
+                    emails: [],
+                    affiliations: [],
+                    verifiedAt: new Date().toISOString(),
+                },
+            });
+
+            const entry = createPersonEntry({ orcid: '0000-0001-2345-6789' });
+            const onEntryChange = vi.fn();
+
+            const { result } = renderHook(() =>
+                useOrcidAutofill({ entry, onEntryChange, hasUserInteracted: false }),
+            );
+
+            // Without interaction, nothing happens even after debounce.
+            await act(async () => {
+                vi.advanceTimersByTime(600);
+                await vi.runAllTimersAsync();
+            });
+            expect(OrcidService.validateOrcid).not.toHaveBeenCalled();
+
+            // Manual retry should force an auto-verify run.
+            act(() => {
+                result.current.retryVerification();
+            });
+            await act(async () => {
+                vi.advanceTimersByTime(600);
+                await vi.runAllTimersAsync();
+            });
+
+            expect(OrcidService.validateOrcid).toHaveBeenCalledWith('0000-0001-2345-6789');
         });
     });
 


### PR DESCRIPTION
This pull request introduces comprehensive server-side ORCID validation before DOI registration, addressing issue #610. It adds a new `OrcidPreflightValidator` service that checks all ORCID identifiers for creators and contributors, blocking registration on confirmed invalid entries and requiring explicit curator confirmation for transient errors. The changes also refine the DOI registration flow and request validation to support this new logic, and update the `Person` model to track ORCID verification timestamps.

**ORCID Preflight Validation and Integration:**

* Added `OrcidPreflightValidator`, `OrcidPreflightResult`, and `OrcidPreflightIssue` classes to encapsulate ORCID validation logic, result reporting, and issue details. These classes handle both blocking (invalid ORCIDs) and warning (transient errors) conditions, and provide structured payloads for UI feedback. [[1]](diffhunk://#diff-f969626d01ebaf2b9cbfca2d873ba6f4e6af8288d372045d535456d061930794R1-R249) [[2]](diffhunk://#diff-98482873bf2a2bbcecfee75f371e9a15b6eebebfaf6d16b4afd6992b774e7998R1-R45) [[3]](diffhunk://#diff-3fdbdb820cb9dafcbc07c83f4081dedd0d1188c2beeff0b77fddd68bd1907a44R1-R46)
* Integrated ORCID preflight validation into both batch and individual DOI registration endpoints. Batch registration skips resources with any invalid or warning ORCIDs, while individual registration blocks on invalid ORCIDs and allows curators to override warnings via a `force` flag. Human-readable error messages and structured payloads are returned as appropriate. [[1]](diffhunk://#diff-5c62bca30a93734e24dffd092626929af54e682b56bf450002ba783347f4a239R71-R74) [[2]](diffhunk://#diff-5c62bca30a93734e24dffd092626929af54e682b56bf450002ba783347f4a239R128-R143) [[3]](diffhunk://#diff-5c62bca30a93734e24dffd092626929af54e682b56bf450002ba783347f4a239R238-R259) [[4]](diffhunk://#diff-97a05ae65121d8a5b4e27bb2c957110d07b6017912d9937264782930e7625295R1093-R1126)

**DOI Registration Request and Validation Improvements:**

* Updated `RegisterDoiRequest` rules to make the `prefix` field conditionally required only for new DOI registrations, and to accept a `force` boolean for overriding transient ORCID errors. Added normalization of empty-string prefixes to null for proper validation. [[1]](diffhunk://#diff-7ccf8656a3e3fce419ba09ee6dbf2b80e6605f7f92222fd3c76a704f2b9ad265R29-R33) [[2]](diffhunk://#diff-7ccf8656a3e3fce419ba09ee6dbf2b80e6605f7f92222fd3c76a704f2b9ad265R44-R53) [[3]](diffhunk://#diff-7ccf8656a3e3fce419ba09ee6dbf2b80e6605f7f92222fd3c76a704f2b9ad265R89-R100)

**Model Enhancements:**

* Added an `orcid_verified_at` timestamp to the `Person` model, with appropriate casting, to record when an ORCID was first successfully verified. [[1]](diffhunk://#diff-117ca03fc11c334ca17f453c605ed81090c6c7c0076e0264d84b294c42ef2864R28) [[2]](diffhunk://#diff-117ca03fc11c334ca17f453c605ed81090c6c7c0076e0264d84b294c42ef2864R43-R52)

**ORCID Service Configuration:**

* Introduced new constants in `OrcidService` to define shorter timeouts and reduced retry attempts for latency-sensitive preflight validation, ensuring efficient batch processing. [[1]](diffhunk://#diff-407862d1a88457c9de4e4c8a8405b69027ba556176c68dbe88594b81d9bb53fcR66-R73) [[2]](diffhunk://#diff-407862d1a88457c9de4e4c8a8405b69027ba556176c68dbe88594b81d9bb53fcR84-R90)