### PR TITLE
Feature: Password visibility toggles on password reset page

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,8 +1,12 @@
 [
     {
         "version": "1.0.0dev",
-        "date": "2026-04-23",
+        "date": "2026-04-24",
         "features": [
+            {
+                "title": "Password Visibility Toggle on Reset Password Page",
+                "description": "The 'Reset password' page now shows an eye icon inside both the password and confirm-password fields. Clicking the icon toggles the entered value between hidden and plain text, helping users verify their new password before submission and avoid typos. The icon clearly indicates the current state (eye = hidden, eye-with-slash = visible), is fully keyboard accessible, and carries distinct screen-reader labels for the two fields. Toggling visibility does not affect how the password is transmitted or stored."
+            },
             {
                 "title": "Bulk Actions on Resources Page",
                 "description": "Curators can now select multiple resources via checkboxes and trigger bulk actions: register/update DOIs at DataCite (up to 25 at once) and export selected resources as a single ZIP archive in DataCite JSON, DataCite XML, or DataCite JSON-LD format (up to 100 at once). The bulk register button is hidden for users without DOI registration permission. Per-row actions remain available."

--- a/resources/js/pages/auth/reset-password.tsx
+++ b/resources/js/pages/auth/reset-password.tsx
@@ -7,6 +7,7 @@ import NewPasswordController from '@/actions/App/Http/Controllers/Auth/NewPasswo
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { LoadingButton } from '@/components/ui/loading-button';
+import { PasswordInput } from '@/components/ui/password-input';
 import AuthLayout from '@/layouts/auth-layout';
 import { type ResetPasswordInput, resetPasswordSchema } from '@/lib/validations/user';
 
@@ -65,7 +66,15 @@ export default function ResetPassword({ token, email }: ResetPasswordProps) {
                             <FormItem className="grid gap-2">
                                 <FormLabel>Password</FormLabel>
                                 <FormControl>
-                                    <Input {...field} type="password" autoComplete="new-password" className="mt-1 block w-full" autoFocus placeholder="Password" />
+                                    <PasswordInput
+                                        {...field}
+                                        autoComplete="new-password"
+                                        className="mt-1 block w-full"
+                                        autoFocus
+                                        placeholder="Password"
+                                        showPasswordLabel="Show password"
+                                        hidePasswordLabel="Hide password"
+                                    />
                                 </FormControl>
                                 <FormMessage />
                             </FormItem>
@@ -79,7 +88,14 @@ export default function ResetPassword({ token, email }: ResetPasswordProps) {
                             <FormItem className="grid gap-2">
                                 <FormLabel>Confirm password</FormLabel>
                                 <FormControl>
-                                    <Input {...field} type="password" autoComplete="new-password" className="mt-1 block w-full" placeholder="Confirm password" />
+                                    <PasswordInput
+                                        {...field}
+                                        autoComplete="new-password"
+                                        className="mt-1 block w-full"
+                                        placeholder="Confirm password"
+                                        showPasswordLabel="Show password confirmation"
+                                        hidePasswordLabel="Hide password confirmation"
+                                    />
                                 </FormControl>
                                 <FormMessage />
                             </FormItem>

--- a/tests/vitest/pages/auth/__tests__/reset-password.integration.test.tsx
+++ b/tests/vitest/pages/auth/__tests__/reset-password.integration.test.tsx
@@ -86,4 +86,34 @@ describe('ResetPassword integration', () => {
             expect(screen.getByRole('button', { name: /reset password/i })).not.toBeDisabled();
         });
     });
+
+    it('transmits the plain password regardless of visibility toggle state (AC #4)', async () => {
+        routerMock.post.mockImplementation((_url: string, _data: unknown, options?: { onFinish?: () => void }) => {
+            options?.onFinish?.();
+        });
+        render(<ResetPassword token={token} email={email} />);
+        const user = userEvent.setup();
+
+        await user.type(screen.getByLabelText('Password'), 'newpassword');
+        await user.type(screen.getByLabelText(/confirm password/i), 'newpassword');
+
+        // Toggle both fields to visible before submission
+        await user.click(screen.getByRole('button', { name: 'Show password' }));
+        await user.click(screen.getByRole('button', { name: 'Show password confirmation' }));
+
+        await user.click(screen.getByRole('button', { name: /reset password/i }));
+
+        await waitFor(() => {
+            expect(routerMock.post).toHaveBeenCalledWith(
+                '/reset-password',
+                expect.objectContaining({
+                    email,
+                    password: 'newpassword',
+                    password_confirmation: 'newpassword',
+                    token,
+                }),
+                expect.any(Object),
+            );
+        });
+    });
 });

--- a/tests/vitest/pages/auth/__tests__/reset-password.test.tsx
+++ b/tests/vitest/pages/auth/__tests__/reset-password.test.tsx
@@ -66,4 +66,98 @@ describe('ResetPassword page', () => {
             expect(screen.getByRole('button', { name: /reset password/i })).toBeDisabled();
         });
     });
+
+    describe('password visibility toggle (issue #380)', () => {
+        it('renders both password inputs with type="password" by default', () => {
+            render(<ResetPassword token={token} email={email} />);
+            expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password');
+            expect(screen.getByLabelText(/confirm password/i)).toHaveAttribute('type', 'password');
+        });
+
+        it('renders a distinct show-toggle button for each password field', () => {
+            render(<ResetPassword token={token} email={email} />);
+            expect(screen.getByRole('button', { name: 'Show password' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Show password confirmation' })).toBeInTheDocument();
+        });
+
+        it('toggles only the password field when its icon is clicked', async () => {
+            render(<ResetPassword token={token} email={email} />);
+            const user = userEvent.setup();
+
+            await user.click(screen.getByRole('button', { name: 'Show password' }));
+
+            expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text');
+            expect(screen.getByLabelText(/confirm password/i)).toHaveAttribute('type', 'password');
+            expect(screen.getByRole('button', { name: 'Hide password' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Show password confirmation' })).toBeInTheDocument();
+        });
+
+        it('toggles only the confirm-password field when its icon is clicked', async () => {
+            render(<ResetPassword token={token} email={email} />);
+            const user = userEvent.setup();
+
+            await user.click(screen.getByRole('button', { name: 'Show password confirmation' }));
+
+            expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password');
+            expect(screen.getByLabelText(/confirm password/i)).toHaveAttribute('type', 'text');
+            expect(screen.getByRole('button', { name: 'Show password' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Hide password confirmation' })).toBeInTheDocument();
+        });
+
+        it('hides the password again when the toggle is clicked twice', async () => {
+            render(<ResetPassword token={token} email={email} />);
+            const user = userEvent.setup();
+
+            const toggle = screen.getByRole('button', { name: 'Show password' });
+            await user.click(toggle);
+            await user.click(screen.getByRole('button', { name: 'Hide password' }));
+
+            expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password');
+            expect(screen.getByRole('button', { name: 'Show password' })).toBeInTheDocument();
+        });
+
+        it('does not submit the form when a toggle is activated', async () => {
+            render(<ResetPassword token={token} email={email} />);
+            const user = userEvent.setup();
+
+            await user.click(screen.getByRole('button', { name: 'Show password' }));
+            await user.click(screen.getByRole('button', { name: 'Show password confirmation' }));
+
+            expect(routerMock.post).not.toHaveBeenCalled();
+        });
+
+        it('preserves the typed value across visibility toggles', async () => {
+            render(<ResetPassword token={token} email={email} />);
+            const user = userEvent.setup();
+
+            const input = screen.getByLabelText('Password') as HTMLInputElement;
+            await user.type(input, 'MySecret#1');
+            expect(input).toHaveValue('MySecret#1');
+
+            await user.click(screen.getByRole('button', { name: 'Show password' }));
+            expect(screen.getByLabelText('Password')).toHaveValue('MySecret#1');
+
+            await user.click(screen.getByRole('button', { name: 'Hide password' }));
+            expect(screen.getByLabelText('Password')).toHaveValue('MySecret#1');
+        });
+
+        it('is keyboard accessible (toggle reachable via Tab and activatable via Space)', async () => {
+            render(<ResetPassword token={token} email={email} />);
+            const user = userEvent.setup();
+
+            screen.getByLabelText('Password').focus();
+            await user.tab();
+            const toggle = screen.getByRole('button', { name: 'Show password' });
+            expect(toggle).toHaveFocus();
+
+            await user.keyboard(' ');
+            expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'text');
+        });
+
+        it('renders toggle buttons with type="button" so they do not submit the form', () => {
+            render(<ResetPassword token={token} email={email} />);
+            expect(screen.getByRole('button', { name: 'Show password' })).toHaveAttribute('type', 'button');
+            expect(screen.getByRole('button', { name: 'Show password confirmation' })).toHaveAttribute('type', 'button');
+        });
+    });
 });


### PR DESCRIPTION
This pull request adds a password visibility toggle feature to the "Reset password" page, improving usability and accessibility. It introduces a new `PasswordInput` component for both password fields, updates the changelog, and adds comprehensive tests to ensure correct behavior and accessibility.

**Password visibility toggle feature:**

* Added a new `PasswordInput` component to both the password and confirm-password fields in `reset-password.tsx`, allowing users to toggle visibility with an eye icon. The icon reflects the current state, is keyboard accessible, and has distinct screen-reader labels for each field. [[1]](diffhunk://#diff-80332ff9457179dcf0bcf35e6add074641b403be3456f42c0ef9f9ddfb616446R10) [[2]](diffhunk://#diff-80332ff9457179dcf0bcf35e6add074641b403be3456f42c0ef9f9ddfb616446L68-R77) [[3]](diffhunk://#diff-80332ff9457179dcf0bcf35e6add074641b403be3456f42c0ef9f9ddfb616446L82-R98)
* Updated the changelog (`changelog.json`) to document the new password visibility toggle feature for the reset password page.

**Testing and accessibility:**

* Added integration and unit tests to verify that the password visibility toggle works as expected, including default states, toggling behavior, keyboard accessibility, form submission, and value preservation. [[1]](diffhunk://#diff-92d2dd107a853d620d6fb5d20456d6453271977859f6c33c420b64740dd0035dR69-R162) [[2]](diffhunk://#diff-5ad9635462087ef08d72b23918625c00e2abed7b24f07f4a7cc0b305d495fdc3R89-R118)