### PR TITLE
Feature: Split descriptions into individual metadata modules

### DIFF
--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -75,5 +75,19 @@ class UpdateLandingPageTemplateRequest extends FormRequest
         if ($this->has('name') && is_string($this->input('name'))) {
             $this->merge(['name' => trim($this->input('name'))]);
         }
+
+        if ($this->has('right_column_order')) {
+            $rightOrder = $this->input('right_column_order');
+
+            if (is_array($rightOrder)) {
+                $stringKeys = array_values(array_filter($rightOrder, 'is_string'));
+
+                if (count($stringKeys) === count($rightOrder)) {
+                    $this->merge([
+                        'right_column_order' => LandingPageTemplate::normalizeRightColumnOrder($stringKeys),
+                    ]);
+                }
+            }
+        }
     }
 }

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -73,12 +73,26 @@ class LandingPageTemplate extends Model
     ];
 
     /**
+     * Description-type section keys rendered inside the shared metadata card.
+     *
+     * @var list<string>
+     */
+    public const DESCRIPTION_COLUMN_SECTIONS = [
+        'abstract',
+        'methods',
+        'technical_info',
+        'series_information',
+        'table_of_contents',
+        'other',
+    ];
+
+    /**
      * Valid section keys for the right column.
      *
      * @var list<string>
      */
     public const RIGHT_COLUMN_SECTIONS = [
-        'descriptions',
+        ...self::DESCRIPTION_COLUMN_SECTIONS,
         'creators',
         'contributors',
         'funders',
@@ -226,6 +240,40 @@ class LandingPageTemplate extends Model
         sort($validSorted);
 
         return $sorted === $validSorted;
+    }
+
+    /**
+     * Keep `location` as a standalone card before or after the shared metadata card.
+     *
+     * When the editor submits `location` in the middle of the right-column list,
+     * we normalize it to the end. Users can still place it first explicitly.
+     * Duplicate or missing `location` keys are left untouched so validation can
+     * reject the malformed order instead of silently hiding an error.
+     *
+     * @param  array<int, string>  $order
+     * @return array<int, string>
+     */
+    public static function normalizeRightColumnOrder(array $order): array
+    {
+        $locationOccurrences = array_keys($order, 'location', true);
+
+        if (count($locationOccurrences) !== 1) {
+            return $order;
+        }
+
+        $locationIndex = $locationOccurrences[0];
+        if ($locationIndex === 0 || $locationIndex === array_key_last($order)) {
+            return $order;
+        }
+
+        $withoutLocation = array_values(array_filter(
+            $order,
+            static fn (string $key): bool => $key !== 'location',
+        ));
+
+        $withoutLocation[] = 'location';
+
+        return $withoutLocation;
     }
 
     /**

--- a/database/factories/LandingPageTemplateFactory.php
+++ b/database/factories/LandingPageTemplateFactory.php
@@ -46,8 +46,8 @@ class LandingPageTemplateFactory extends Factory
     public function default(): static
     {
         return $this->state(fn (array $attributes) => [
-            'name' => 'Default GFZ Data Services',
-            'slug' => 'default_gfz',
+            'name' => LandingPageTemplate::DEFAULT_TEMPLATE_NAME,
+            'slug' => LandingPageTemplate::DEFAULT_TEMPLATE_SLUG,
             'is_default' => true,
             'template_type' => LandingPageTemplate::TEMPLATE_TYPE_RESOURCE,
             'created_by' => null,

--- a/database/migrations/2026_05_01_000001_expand_landing_page_template_description_sections.php
+++ b/database/migrations/2026_05_01_000001_expand_landing_page_template_description_sections.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Expand the legacy `descriptions` section key into individual description-type
+ * modules for landing page templates.
+ *
+ * Existing right-column orders stored a single `descriptions` slot which
+ * rendered Abstract and optionally Methods inside one shared card. The new
+ * landing-page renderer supports independent template ordering for every
+ * supported DataCite description type, so historic orders must be rewritten.
+ *
+ * Migration strategy:
+ * - keep the relative ordering intent of all existing non-description keys
+ * - replace `descriptions` in-place with the new description-type keys
+ * - append any missing keys from the new canonical set
+ * - keep `location` as a standalone card before or after the shared metadata
+ *   card, never in the middle of the expanded metadata-module list
+ *
+ * Canonical keys are intentionally inlined here so the migration remains a
+ * stable historical artifact independent of future model changes.
+ */
+return new class extends Migration
+{
+    /** @var list<string> */
+    private const DESCRIPTION_SECTIONS = [
+        'abstract',
+        'methods',
+        'technical_info',
+        'series_information',
+        'table_of_contents',
+        'other',
+    ];
+
+    /** @var list<string> */
+    private const RIGHT_METADATA_CANONICAL = [
+        ...self::DESCRIPTION_SECTIONS,
+        'creators',
+        'contributors',
+        'funders',
+        'keywords',
+        'metadata_download',
+    ];
+
+    public function up(): void
+    {
+        DB::table('landing_page_templates')
+            ->select(['id', 'right_column_order'])
+            ->orderBy('id')
+            ->each(function (object $row): void {
+                $right = $this->normalizeRightOrder($this->decodeOrder($row->right_column_order));
+
+                DB::table('landing_page_templates')
+                    ->where('id', $row->id)
+                    ->update([
+                        'right_column_order' => json_encode($right, JSON_THROW_ON_ERROR),
+                        'updated_at' => now(),
+                    ]);
+            });
+    }
+
+    public function down(): void
+    {
+        // No-op. Reconstructing the historic single `descriptions` slot would
+        // destroy ordering information introduced by the new expanded modules.
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function decodeOrder(mixed $value): array
+    {
+        if (is_array($value)) {
+            return array_values(array_filter($value, 'is_string'));
+        }
+
+        if (! is_string($value) || $value === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_filter($decoded, 'is_string'));
+    }
+
+    /**
+     * @param  list<string>  $stored
+     * @return list<string>
+     */
+    private function normalizeRightOrder(array $stored): array
+    {
+        $locationBeforeMetadata = $this->locationAppearsBeforeMetadata($stored);
+        $cleanedMetadata = [];
+
+        foreach ($stored as $key) {
+            if ($key === 'location') {
+                continue;
+            }
+
+            if ($key === 'descriptions') {
+                foreach (self::DESCRIPTION_SECTIONS as $descriptionKey) {
+                    if (! in_array($descriptionKey, $cleanedMetadata, true)) {
+                        $cleanedMetadata[] = $descriptionKey;
+                    }
+                }
+
+                continue;
+            }
+
+            if (! in_array($key, self::RIGHT_METADATA_CANONICAL, true)) {
+                continue;
+            }
+
+            if (! in_array($key, $cleanedMetadata, true)) {
+                $cleanedMetadata[] = $key;
+            }
+        }
+
+        foreach (self::RIGHT_METADATA_CANONICAL as $canonicalKey) {
+            if (! in_array($canonicalKey, $cleanedMetadata, true)) {
+                $cleanedMetadata[] = $canonicalKey;
+            }
+        }
+
+        if ($locationBeforeMetadata) {
+            return ['location', ...$cleanedMetadata];
+        }
+
+        return [...$cleanedMetadata, 'location'];
+    }
+
+    /**
+     * @param  list<string>  $stored
+     */
+    private function locationAppearsBeforeMetadata(array $stored): bool
+    {
+        foreach ($stored as $key) {
+            if ($key === 'location') {
+                return true;
+            }
+
+            if ($key === 'descriptions' || in_array($key, self::RIGHT_METADATA_CANONICAL, true)) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+};

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-05-01",
         "features": [
             {
+                "title": "Separate Description-Type Modules on Default Landing Pages",
+                "description": "Default GFZ landing pages for both regular resources and IGSNs now render every supported DataCite description type as its own module inside the shared metadata card. Abstract, Methods, Technical Information, Series Information, Table of Contents, and Other are displayed independently when present, including multiple entries of the same type in their original order. In Landing Page Template Management, these description modules can now be reordered individually instead of being grouped under a single 'Abstract & Descriptions' block, while the Location / Map card remains a separate module before or after the shared metadata card."
+            },
+            {
                 "title": "IGSN Landing Page: General & Acquisition Modules",
                 "description": "The default IGSN landing page now displays sample-specific metadata in two new modules in the left column. 'General' shows Project (from funding award titles), Campaign (cruise/field program), Type, IGSN, Parent IGSN (rendered as a link to the parent's landing page when published), Purpose, and Release Date (from the Available date). 'Acquisition' shows Material, Rock Classification (joined IGSN classifications), Collection Method (with optional method description), Funding Agency (deduplicated funder names), Comments (from descriptions of type 'Other'), Chief Scientist (contributors with role 'Data Collector'), and Start/End Date (from the Collected date range). Empty fields and empty modules are hidden automatically. Both new sections are configurable in landing page templates and can be reordered alongside Contact, Model Description, and Related Work."
             },

--- a/resources/js/pages/LandingPages/components/AbstractSection.tsx
+++ b/resources/js/pages/LandingPages/components/AbstractSection.tsx
@@ -6,6 +6,7 @@ import type {
     LandingPageSubject,
 } from '@/types/landing-page';
 
+import { expandMetadataOrder, isDescriptionSectionKey, type MetadataSectionKey } from '../lib/metadata-sections';
 import { ContributorsSection } from './ContributorsSection';
 import { CreatorsSection } from './CreatorsSection';
 import { DescriptionSection } from './DescriptionSection';
@@ -23,13 +24,14 @@ interface AbstractSectionProps {
     resourceId: number;
     /** Public JSON-LD export URL for landing pages (avoids auth-protected routes) */
     jsonLdExportUrl?: string;
+    sectionOrder?: MetadataSectionKey[];
 }
 
 /**
- * Abstract Section — composition root.
+ * Metadata card composition root for the landing page right column.
  *
- * Wraps Description, Creators, Contributors, Funders, Keywords, and
- * Download Metadata sub-components inside a single LandingPageCard.
+ * Wraps description modules, Creators, Contributors, Funders, Keywords,
+ * and Download Metadata inside a single shared LandingPageCard.
  */
 export function AbstractSection({
     descriptions,
@@ -39,21 +41,42 @@ export function AbstractSection({
     subjects,
     resourceId,
     jsonLdExportUrl,
+    sectionOrder = ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
 }: AbstractSectionProps) {
-    const hasAbstract = descriptions.some((desc) => desc.description_type?.toLowerCase() === 'abstract');
+    const expandedSectionOrder = expandMetadataOrder(sectionOrder);
 
-    if (!hasAbstract) {
+    const renderedSections = expandedSectionOrder
+        .map((sectionKey) => {
+            if (isDescriptionSectionKey(sectionKey)) {
+                return <DescriptionSection key={sectionKey} descriptions={descriptions} sectionKey={sectionKey} />;
+            }
+
+            switch (sectionKey) {
+                case 'creators':
+                    return <CreatorsSection key="creators" creators={creators} />;
+                case 'contributors':
+                    return <ContributorsSection key="contributors" contributors={contributors} />;
+                case 'funders':
+                    return <FundersSection key="funders" fundingReferences={fundingReferences} />;
+                case 'keywords':
+                    return <KeywordsSection key="keywords" subjects={subjects} />;
+                case 'metadata_download':
+                    return <DownloadMetadataSection key="metadata_download" resourceId={resourceId} jsonLdExportUrl={jsonLdExportUrl} />;
+                default:
+                    return null;
+            }
+        })
+        .filter(Boolean);
+
+    if (renderedSections.length === 0) {
         return null;
     }
 
     return (
-        <LandingPageCard aria-labelledby="heading-abstract" data-testid="abstract-section">
-            <DescriptionSection descriptions={descriptions} />
-            <CreatorsSection creators={creators} />
-            <ContributorsSection contributors={contributors} />
-            <FundersSection fundingReferences={fundingReferences} />
-            <KeywordsSection subjects={subjects} />
-            <DownloadMetadataSection resourceId={resourceId} jsonLdExportUrl={jsonLdExportUrl} />
+        <LandingPageCard data-testid="metadata-section">
+            <div className="[&>*:first-child]:mt-0">
+                {renderedSections}
+            </div>
         </LandingPageCard>
     );
 }

--- a/resources/js/pages/LandingPages/components/DescriptionSection.tsx
+++ b/resources/js/pages/LandingPages/components/DescriptionSection.tsx
@@ -1,42 +1,43 @@
 import type { LandingPageDescription } from '@/types/landing-page';
 
+import { DESCRIPTION_SECTION_CONFIG, type DescriptionSectionKey,filterDescriptionsBySection } from '../lib/metadata-sections';
+
 interface DescriptionSectionProps {
     descriptions: LandingPageDescription[];
+    sectionKey: DescriptionSectionKey;
 }
 
 /**
- * Renders the Abstract text and optional Methods subsection.
- * Returns null if no abstract is found.
+ * Renders all descriptions belonging to a single DataCite description type.
  */
-export function DescriptionSection({ descriptions }: DescriptionSectionProps) {
-    const abstract = descriptions.find((desc) => desc.description_type?.toLowerCase() === 'abstract');
-    const methods = descriptions.find((desc) => desc.description_type?.toLowerCase() === 'methods');
+export function DescriptionSection({ descriptions, sectionKey }: DescriptionSectionProps) {
+    const { heading } = DESCRIPTION_SECTION_CONFIG[sectionKey];
+    const matchingDescriptions = filterDescriptionsBySection(descriptions, sectionKey);
 
-    if (!abstract) {
+    if (matchingDescriptions.length === 0) {
         return null;
     }
 
     return (
-        <>
-            <h2 id="heading-abstract" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                Abstract
-            </h2>
-            <div className="prose prose-sm dark:prose-invert max-w-none text-gray-700 dark:text-gray-300">
-                <p className="mt-0 whitespace-pre-wrap" data-testid="abstract-text">
-                    {abstract.value}
-                </p>
+        <section
+            className="mt-6"
+            data-testid={`${sectionKey}-section`}
+            aria-labelledby={`heading-${sectionKey.replaceAll('_', '-')}`}
+        >
+            <h3 id={`heading-${sectionKey.replaceAll('_', '-')}`} className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                {heading}
+            </h3>
+            <div className="prose prose-sm max-w-none space-y-4 text-gray-700 dark:prose-invert dark:text-gray-300">
+                {matchingDescriptions.map((description, index) => (
+                    <p
+                        key={description.id}
+                        className="mt-0 whitespace-pre-wrap"
+                        data-testid={index === 0 ? `${sectionKey}-text` : `${sectionKey}-text-${index + 1}`}
+                    >
+                        {description.value}
+                    </p>
+                ))}
             </div>
-
-            {methods && (
-                <section className="mt-6" data-testid="methods-section" aria-labelledby="heading-methods">
-                    <h3 id="heading-methods" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Methods</h3>
-                    <div className="prose prose-sm dark:prose-invert max-w-none text-gray-700 dark:text-gray-300">
-                        <p className="mt-0 whitespace-pre-wrap" data-testid="methods-text">
-                            {methods.value}
-                        </p>
-                    </div>
-                </section>
-            )}
-        </>
+        </section>
     );
 }

--- a/resources/js/pages/LandingPages/default_gfz.tsx
+++ b/resources/js/pages/LandingPages/default_gfz.tsx
@@ -15,6 +15,7 @@ import { RelatedWorkSection } from './components/RelatedWorkSection';
 import { ResourceHero } from './components/ResourceHero';
 import { useSystemDarkMode } from './hooks/useSystemDarkMode';
 import { buildCitation } from './lib/buildCitation';
+import { type MetadataSectionKey } from './lib/metadata-sections';
 
 /**
  * Props passed to landing page templates via Inertia
@@ -37,7 +38,20 @@ interface DefaultGfzTemplatePageProps {
 }
 
 /** Default section orders matching the original layout */
-const DEFAULT_RIGHT_ORDER: RightColumnSection[] = ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'];
+const DEFAULT_RIGHT_ORDER: RightColumnSection[] = [
+    'abstract',
+    'methods',
+    'technical_info',
+    'series_information',
+    'table_of_contents',
+    'other',
+    'creators',
+    'contributors',
+    'funders',
+    'keywords',
+    'metadata_download',
+    'location',
+];
 const DEFAULT_LEFT_ORDER: LeftColumnSection[] = ['files', 'contact', 'model_description', 'related_work'];
 
 export default function DefaultGfzTemplate() {
@@ -54,17 +68,21 @@ export default function DefaultGfzTemplate() {
     // Resolve section orders (custom template overrides or defaults)
     const rightOrder = sectionOrder?.rightColumn ?? DEFAULT_RIGHT_ORDER;
     const leftOrder = sectionOrder?.leftColumn ?? DEFAULT_LEFT_ORDER;
+    const metadataOrder = rightOrder.filter((key): key is MetadataSectionKey => key !== 'location');
+    const firstMetadataIndex = rightOrder.findIndex((key) => key !== 'location');
+    const locationIndex = rightOrder.indexOf('location');
+    const renderLocationBeforeMetadata = locationIndex !== -1 && (firstMetadataIndex === -1 || locationIndex < firstMetadataIndex);
 
     // Logo: custom template logo or default GFZ logo
     const logoSrc = customLogoUrl ?? '/images/gfz-ds-logo.png';
 
     // Section registry: map section keys to React elements
-    const rightSectionRegistry = useMemo((): Record<RightColumnSection, ReactNode> => {
+    const rightSectionRegistry = useMemo((): { metadata: ReactNode; location: ReactNode } => {
         const jsonLdExportUrl = landingPage?.public_url ? `${landingPage.public_url}/jsonld` : undefined;
         return {
-            descriptions: (
+            metadata: (
                 <AbstractSection
-                    key="descriptions"
+                    key="metadata"
                     descriptions={resource.descriptions || []}
                     creators={resource.creators || []}
                     contributors={resource.contributors || []}
@@ -72,16 +90,12 @@ export default function DefaultGfzTemplate() {
                     subjects={resource.subjects || []}
                     resourceId={resource.id}
                     jsonLdExportUrl={jsonLdExportUrl}
+                    sectionOrder={metadataOrder}
                 />
             ),
-            creators: null, // Rendered inside AbstractSection
-            contributors: null, // Rendered inside AbstractSection
-            funders: null, // Rendered inside AbstractSection
-            keywords: null, // Rendered inside AbstractSection
-            metadata_download: null, // Rendered inside AbstractSection
             location: <LocationSection key="location" geoLocations={resource.geo_locations || []} isDark={isDark} />,
         };
-    }, [resource, landingPage, isDark]);
+    }, [resource, landingPage, isDark, metadataOrder]);
 
     const leftSectionRegistry = useMemo((): Record<LeftColumnSection, ReactNode> => {
         return {
@@ -161,7 +175,9 @@ export default function DefaultGfzTemplate() {
                         <div className="mx-8 mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
                             {/* Right Column (Abstract, Location) — show first on mobile */}
                             <div className="order-1 space-y-6 lg:order-2 lg:col-span-2">
-                                {rightOrder.map((key) => rightSectionRegistry[key]).filter(Boolean)}
+                                {renderLocationBeforeMetadata && rightSectionRegistry.location}
+                                {rightSectionRegistry.metadata}
+                                {!renderLocationBeforeMetadata && rightSectionRegistry.location}
                             </div>
 
                             {/* Left Column (Files, Contact, Related) — show second on mobile */}

--- a/resources/js/pages/LandingPages/default_gfz_igsn.tsx
+++ b/resources/js/pages/LandingPages/default_gfz_igsn.tsx
@@ -16,6 +16,7 @@ import { RelatedWorkSection } from './components/RelatedWorkSection';
 import { ResourceHero } from './components/ResourceHero';
 import { useSystemDarkMode } from './hooks/useSystemDarkMode';
 import { buildCitation } from './lib/buildCitation';
+import { type MetadataSectionKey } from './lib/metadata-sections';
 
 /**
  * Props passed to IGSN landing page template via Inertia
@@ -34,7 +35,20 @@ interface DefaultGfzIgsnTemplatePageProps {
 }
 
 /** Default section orders for the IGSN template (no `files`; `general`/`acquisition` first). */
-const DEFAULT_RIGHT_ORDER: RightColumnSection[] = ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'];
+const DEFAULT_RIGHT_ORDER: RightColumnSection[] = [
+    'abstract',
+    'methods',
+    'technical_info',
+    'series_information',
+    'table_of_contents',
+    'other',
+    'creators',
+    'contributors',
+    'funders',
+    'keywords',
+    'metadata_download',
+    'location',
+];
 const DEFAULT_LEFT_ORDER: LeftColumnSection[] = ['general', 'acquisition', 'contact', 'model_description', 'related_work'];
 
 /**
@@ -56,15 +70,19 @@ export default function DefaultGfzIgsnTemplate() {
 
     const rightOrder = sectionOrder?.rightColumn ?? DEFAULT_RIGHT_ORDER;
     const leftOrder = sectionOrder?.leftColumn ?? DEFAULT_LEFT_ORDER;
+    const metadataOrder = rightOrder.filter((key): key is MetadataSectionKey => key !== 'location');
+    const firstMetadataIndex = rightOrder.findIndex((key) => key !== 'location');
+    const locationIndex = rightOrder.indexOf('location');
+    const renderLocationBeforeMetadata = locationIndex !== -1 && (firstMetadataIndex === -1 || locationIndex < firstMetadataIndex);
 
     const logoSrc = customLogoUrl ?? '/images/gfz-ds-logo.png';
 
-    const rightSectionRegistry = useMemo((): Record<RightColumnSection, ReactNode> => {
+    const rightSectionRegistry = useMemo((): { metadata: ReactNode; location: ReactNode } => {
         const jsonLdExportUrl = landingPage?.public_url ? `${landingPage.public_url}/jsonld` : undefined;
         return {
-            descriptions: (
+            metadata: (
                 <AbstractSection
-                    key="descriptions"
+                    key="metadata"
                     descriptions={resource.descriptions || []}
                     creators={resource.creators || []}
                     contributors={resource.contributors || []}
@@ -72,16 +90,12 @@ export default function DefaultGfzIgsnTemplate() {
                     subjects={resource.subjects || []}
                     resourceId={resource.id}
                     jsonLdExportUrl={jsonLdExportUrl}
+                    sectionOrder={metadataOrder}
                 />
             ),
-            creators: null, // Rendered inside AbstractSection
-            contributors: null, // Rendered inside AbstractSection
-            funders: null, // Rendered inside AbstractSection
-            keywords: null, // Rendered inside AbstractSection
-            metadata_download: null, // Rendered inside AbstractSection
             location: <LocationSection key="location" geoLocations={resource.geo_locations || []} isDark={isDark} />,
         };
-    }, [resource, landingPage, isDark]);
+    }, [resource, landingPage, isDark, metadataOrder]);
 
     const leftSectionRegistry = useMemo((): Record<LeftColumnSection, ReactNode> => {
         return {
@@ -182,7 +196,9 @@ export default function DefaultGfzIgsnTemplate() {
                         <div className="mx-8 mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
                             {/* Right column (Abstract, Location) — first on mobile */}
                             <div className="order-1 space-y-6 lg:order-2 lg:col-span-2">
-                                {rightOrder.map((key) => rightSectionRegistry[key]).filter(Boolean)}
+                                {renderLocationBeforeMetadata && rightSectionRegistry.location}
+                                {rightSectionRegistry.metadata}
+                                {!renderLocationBeforeMetadata && rightSectionRegistry.location}
                             </div>
 
                             {/* Left column (General, Acquisition, Contact, Related) — second on mobile */}

--- a/resources/js/pages/LandingPages/lib/metadata-sections.ts
+++ b/resources/js/pages/LandingPages/lib/metadata-sections.ts
@@ -1,0 +1,66 @@
+import type { LandingPageDescription, RightColumnSection } from '@/types/landing-page';
+
+export const LEGACY_DESCRIPTIONS_SECTION_KEY = 'descriptions' as const;
+
+export const DESCRIPTION_SECTION_KEYS = [
+    'abstract',
+    'methods',
+    'technical_info',
+    'series_information',
+    'table_of_contents',
+    'other',
+] as const;
+
+export type DescriptionSectionKey = (typeof DESCRIPTION_SECTION_KEYS)[number];
+
+export type MetadataSectionKey = Exclude<RightColumnSection, 'location'>;
+
+export type ExpandedMetadataSectionKey = Exclude<MetadataSectionKey, typeof LEGACY_DESCRIPTIONS_SECTION_KEY>;
+
+export const DESCRIPTION_SECTION_CONFIG: Record<DescriptionSectionKey, { heading: string; matches: string[] }> = {
+    abstract: { heading: 'Abstract', matches: ['abstract'] },
+    methods: { heading: 'Methods', matches: ['methods'] },
+    technical_info: { heading: 'Technical Information', matches: ['technicalinfo', 'technicalinformation'] },
+    series_information: { heading: 'Series Information', matches: ['seriesinformation'] },
+    table_of_contents: { heading: 'Table of Contents', matches: ['tableofcontents'] },
+    other: { heading: 'Other', matches: ['other'] },
+};
+
+export function normalizeDescriptionType(value: string | null | undefined): string {
+    return (value ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+export function filterDescriptionsBySection(
+    descriptions: LandingPageDescription[],
+    sectionKey: DescriptionSectionKey,
+): LandingPageDescription[] {
+    const { matches } = DESCRIPTION_SECTION_CONFIG[sectionKey];
+
+    return descriptions.filter((description) => matches.includes(normalizeDescriptionType(description.description_type)));
+}
+
+export function isDescriptionSectionKey(key: MetadataSectionKey | ExpandedMetadataSectionKey): key is DescriptionSectionKey {
+    return DESCRIPTION_SECTION_KEYS.includes(key as DescriptionSectionKey);
+}
+
+export function expandMetadataOrder(sectionOrder: readonly MetadataSectionKey[]): ExpandedMetadataSectionKey[] {
+    const expanded: ExpandedMetadataSectionKey[] = [];
+    const seen = new Set<ExpandedMetadataSectionKey>();
+
+    for (const key of sectionOrder) {
+        const keysToInsert = key === LEGACY_DESCRIPTIONS_SECTION_KEY
+            ? [...DESCRIPTION_SECTION_KEYS]
+            : [key as ExpandedMetadataSectionKey];
+
+        for (const expandedKey of keysToInsert) {
+            if (seen.has(expandedKey)) {
+                continue;
+            }
+
+            seen.add(expandedKey);
+            expanded.push(expandedKey);
+        }
+    }
+
+    return expanded;
+}

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1331,12 +1331,18 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             <WorkflowSteps.Step number={3} title="Reorder Sections">
                                 <p>
                                     Click the edit icon on a template card. Use <strong>drag &amp; drop</strong> to rearrange the
-                                    right column sections (e.g., Descriptions, Creators, Location) and left column sections (e.g.,
-                                    Files, Contact, Model Description, Related Work) independently. For IGSN landing pages, the
-                                    left column also includes <strong>General</strong> (Project, Campaign, Type, IGSN, Parent IGSN,
-                                    Purpose, Release Date) and <strong>Acquisition</strong> (Material, Rock Classification,
-                                    Collection Method, Funding Agency, Comments, Chief Scientist, Start/End Date) modules. Empty
-                                    fields and empty modules are hidden automatically on the rendered page.
+                                    right column sections and left column sections independently. The right column now exposes
+                                    separate description modules for <strong>Abstract</strong>, <strong>Methods</strong>,
+                                    <strong>Technical Information</strong>, <strong>Series Information</strong>,
+                                    <strong>Table of Contents</strong>, and <strong>Other</strong>, followed by Creators,
+                                    Contributors, Funding References, Keywords, Metadata Download, and Location / Map. Description
+                                    modules are reordered individually, but they still render together inside one shared metadata
+                                    card on the public landing page. The <strong>Location / Map</strong> section stays as a separate
+                                    card above or below that metadata card. For IGSN landing pages, the left column also includes
+                                    <strong>General</strong> (Project, Campaign, Type, IGSN, Parent IGSN, Purpose, Release Date)
+                                    and <strong>Acquisition</strong> (Material, Rock Classification, Collection Method, Funding
+                                    Agency, Comments, Chief Scientist, Start/End Date) modules. Empty fields and empty modules are
+                                    hidden automatically on the rendered page.
                                 </p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={4} title="Upload Custom Logo (Optional)">

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -19,6 +19,7 @@ import { LoadingButton } from '@/components/ui/loading-button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import AppLayout from '@/layouts/app-layout';
+import { DESCRIPTION_SECTION_KEYS, LEGACY_DESCRIPTIONS_SECTION_KEY } from '@/pages/LandingPages/lib/metadata-sections';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import type { LandingPageTemplateConfig, LeftColumnSection, RightColumnSection } from '@/types/landing-page';
 
@@ -27,6 +28,12 @@ const breadcrumbs: BreadcrumbItem[] = [{ title: 'Landing Pages', href: '/landing
 /** Display labels for right column sections */
 const RIGHT_SECTION_LABELS: Record<RightColumnSection, string> = {
     descriptions: 'Abstract & Descriptions',
+    abstract: 'Abstract',
+    methods: 'Methods',
+    technical_info: 'Technical Information',
+    series_information: 'Series Information',
+    table_of_contents: 'Table of Contents',
+    other: 'Other',
     creators: 'Creators / Authors',
     contributors: 'Contributors',
     funders: 'Funding References',
@@ -47,7 +54,7 @@ const LEFT_SECTION_LABELS: Record<LeftColumnSection, string> = {
 
 /** Canonical section orders – mirror of `LandingPageTemplate::*_COLUMN_SECTIONS`. */
 const CANONICAL_RIGHT_ORDER: RightColumnSection[] = [
-    'descriptions',
+    ...DESCRIPTION_SECTION_KEYS,
     'creators',
     'contributors',
     'funders',
@@ -95,6 +102,51 @@ function normalizeOrder<T extends string>(stored: readonly T[], canonical: reado
     return result;
 }
 
+function normalizeRightColumnOrder(stored: readonly RightColumnSection[]): RightColumnSection[] {
+    const locationBeforeMetadata = stored.find((key) => {
+        if (key === 'location') return true;
+        if (key === LEGACY_DESCRIPTIONS_SECTION_KEY) return true;
+
+        return CANONICAL_RIGHT_ORDER.includes(key);
+    }) === 'location';
+
+    const metadataItems: RightColumnSection[] = [];
+    const seen = new Set<RightColumnSection>();
+
+    for (const key of stored) {
+        if (key === 'location') {
+            continue;
+        }
+
+        if (key === LEGACY_DESCRIPTIONS_SECTION_KEY) {
+            for (const descriptionKey of DESCRIPTION_SECTION_KEYS) {
+                if (seen.has(descriptionKey)) continue;
+                seen.add(descriptionKey);
+                metadataItems.push(descriptionKey);
+            }
+            continue;
+        }
+
+        if (!CANONICAL_RIGHT_ORDER.includes(key) || seen.has(key)) {
+            continue;
+        }
+
+        seen.add(key);
+        metadataItems.push(key);
+    }
+
+    for (const key of CANONICAL_RIGHT_ORDER) {
+        if (key === 'location' || seen.has(key)) {
+            continue;
+        }
+
+        seen.add(key);
+        metadataItems.push(key);
+    }
+
+    return locationBeforeMetadata ? ['location', ...metadataItems] : [...metadataItems, 'location'];
+}
+
 interface PageProps extends SharedData {
     templates: LandingPageTemplateConfig[];
     [key: string]: unknown;
@@ -138,11 +190,13 @@ function SectionOrderEditor({
     items,
     labels,
     onReorder,
+    description,
 }: {
     title: string;
     items: string[];
     labels: Record<string, string>;
     onReorder: (items: string[]) => void;
+    description?: string;
 }) {
     const sensors = useSensors(
         useSensor(PointerSensor),
@@ -164,6 +218,7 @@ function SectionOrderEditor({
     return (
         <div className="space-y-2">
             <Label className="text-sm font-medium">{title}</Label>
+            {description && <p className="text-xs text-muted-foreground">{description}</p>}
             <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
                 <SortableContext items={items} strategy={verticalListSortingStrategy}>
                     <div className="space-y-1.5">
@@ -235,7 +290,7 @@ export default function LandingPageTemplatesPage() {
     const openEdit = (tmpl: LandingPageTemplateConfig) => {
         setEditTemplate(tmpl);
         setEditName(tmpl.name);
-        setEditRightOrder(normalizeOrder<RightColumnSection>(tmpl.right_column_order, CANONICAL_RIGHT_ORDER));
+        setEditRightOrder(normalizeRightColumnOrder(tmpl.right_column_order));
         setEditLeftOrder(normalizeOrder<LeftColumnSection>(tmpl.left_column_order, CANONICAL_LEFT_ORDER));
         setEditOpen(true);
     };
@@ -246,7 +301,7 @@ export default function LandingPageTemplatesPage() {
         try {
             await axios.put(`/landing-pages/${editTemplate.id}`, {
                 name: editName.trim(),
-                right_column_order: editRightOrder,
+                right_column_order: normalizeRightColumnOrder(editRightOrder),
                 left_column_order: editLeftOrder,
             });
             toast.success('Template updated successfully');
@@ -420,7 +475,7 @@ export default function LandingPageTemplatesPage() {
                                     <div>
                                         <span className="font-medium text-foreground">Right Column:</span>
                                         <ol className="mt-0.5 list-inside list-decimal space-y-0.5">
-                                            {tmpl.right_column_order.map((key) => (
+                                            {normalizeRightColumnOrder(tmpl.right_column_order).map((key) => (
                                                 <li key={key}>{RIGHT_SECTION_LABELS[key] ?? key}</li>
                                             ))}
                                         </ol>
@@ -560,7 +615,8 @@ export default function LandingPageTemplatesPage() {
                                 title="Right Column (main content)"
                                 items={editRightOrder}
                                 labels={RIGHT_SECTION_LABELS}
-                                onReorder={(items) => setEditRightOrder(items as RightColumnSection[])}
+                                description="Description modules render inside one shared metadata card. Location / Map stays outside that card and snaps to the top or bottom position."
+                                onReorder={(items) => setEditRightOrder(normalizeRightColumnOrder(items as RightColumnSection[]))}
                             />
                             <SectionOrderEditor
                                 title="Left Column (sidebar)"

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -1,7 +1,20 @@
 /**
  * Right column section identifiers for landing page templates.
  */
-export type RightColumnSection = 'descriptions' | 'creators' | 'contributors' | 'funders' | 'keywords' | 'metadata_download' | 'location';
+export type RightColumnSection =
+    | 'descriptions'
+    | 'abstract'
+    | 'methods'
+    | 'technical_info'
+    | 'series_information'
+    | 'table_of_contents'
+    | 'other'
+    | 'creators'
+    | 'contributors'
+    | 'funders'
+    | 'keywords'
+    | 'metadata_download'
+    | 'location';
 
 /**
  * Left column section identifiers for landing page templates.

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -457,7 +457,7 @@ describe('Landing Page with Custom Template', function () {
     test('renders landing page with custom template section order and logo', function () {
         $template = \App\Models\LandingPageTemplate::factory()->create([
             'created_by' => \App\Models\User::factory()->admin()->create()->id,
-            'right_column_order' => ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
             'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
             'logo_path' => 'landing-page-logos/test/custom-logo.png',
         ]);

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -41,6 +41,17 @@ beforeEach(function (): void {
     $this->igsnDefaultTemplate = $systemTemplates[LandingPageTemplate::TEMPLATE_TYPE_IGSN];
 });
 
+function locationFirstRightColumnOrder(): array
+{
+    return [
+        'location',
+        ...array_values(array_filter(
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+            static fn (string $key): bool => $key !== 'location',
+        )),
+    ];
+}
+
 // ─── Authorization ───────────────────────────────────────────────────────────
 
 describe('Authorization', function (): void {
@@ -279,7 +290,7 @@ describe('Update', function (): void {
     it('updates template name and section order', function (): void {
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
 
-        $newRightOrder = ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'];
+        $newRightOrder = locationFirstRightColumnOrder();
         $newLeftOrder = ['contact', 'files', 'general', 'acquisition', 'model_description', 'related_work'];
 
         $response = $this->actingAs($this->admin)
@@ -298,6 +309,33 @@ describe('Update', function (): void {
             ->and($template->left_column_order)->toBe($newLeftOrder);
     });
 
+    it('normalizes location to the end when it is submitted in the middle of the right column order', function (): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $submittedRightOrder = [
+            'abstract',
+            'location',
+            'methods',
+            'technical_info',
+            'series_information',
+            'table_of_contents',
+            'other',
+            'creators',
+            'contributors',
+            'funders',
+            'keywords',
+            'metadata_download',
+        ];
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'right_column_order' => $submittedRightOrder,
+            ])
+            ->assertOk();
+
+        expect($template->fresh()->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS);
+    });
+
     it('prevents updating the default template', function (): void {
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$this->defaultTemplate->id}", ['name' => 'Hacked'])
@@ -310,7 +348,7 @@ describe('Update', function (): void {
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", [
                 'name' => 'Valid Name',
-                'right_column_order' => ['descriptions', 'invalid_section'],
+                'right_column_order' => ['abstract', 'invalid_section'],
             ])
             ->assertJsonValidationErrors(['right_column_order']);
     });
@@ -322,7 +360,7 @@ describe('Update', function (): void {
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", [
                 'name' => 'Valid Name',
-                'right_column_order' => ['descriptions', 'creators'],
+                'right_column_order' => ['abstract', 'creators'],
             ])
             ->assertJsonValidationErrors(['right_column_order']);
     });
@@ -621,7 +659,7 @@ describe('Model', function (): void {
 
     it('validates section order with valid input', function (): void {
         $valid = LandingPageTemplate::isValidSectionOrder(
-            ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
             LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
         );
 
@@ -630,7 +668,7 @@ describe('Model', function (): void {
 
     it('validates section order with reordered input', function (): void {
         $valid = LandingPageTemplate::isValidSectionOrder(
-            ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            locationFirstRightColumnOrder(),
             LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
         );
 
@@ -639,7 +677,7 @@ describe('Model', function (): void {
 
     it('rejects section order with wrong count', function (): void {
         $valid = LandingPageTemplate::isValidSectionOrder(
-            ['descriptions', 'creators'],
+            ['abstract', 'creators'],
             LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
         );
 
@@ -648,7 +686,7 @@ describe('Model', function (): void {
 
     it('rejects section order with invalid keys', function (): void {
         $valid = LandingPageTemplate::isValidSectionOrder(
-            ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'invalid_key'],
+            ['abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'invalid_key'],
             LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
         );
 
@@ -657,7 +695,7 @@ describe('Model', function (): void {
 
     it('rejects section order with duplicate keys', function (): void {
         $valid = LandingPageTemplate::isValidSectionOrder(
-            ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'descriptions'],
+            ['abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'abstract'],
             LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
         );
 
@@ -729,7 +767,7 @@ describe('Factory', function (): void {
     });
 
     it('creates a template with custom section order', function (): void {
-        $rightOrder = ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'];
+        $rightOrder = locationFirstRightColumnOrder();
         $leftOrder = ['contact', 'files', 'model_description', 'related_work'];
 
         $template = LandingPageTemplate::factory()
@@ -816,7 +854,7 @@ describe('Update Edge Cases', function (): void {
         $originalName = $template->name;
         $originalLeftOrder = $template->left_column_order;
 
-        $newRightOrder = ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'];
+        $newRightOrder = locationFirstRightColumnOrder();
 
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", ['right_column_order' => $newRightOrder])

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateDescriptionSectionsMigrationTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateDescriptionSectionsMigrationTest.php
@@ -28,6 +28,19 @@ function runDescriptionSectionsMigration(): void
     $migration->up();
 }
 
+function newDescriptionSectionsMigration(): object
+{
+    return require database_path('migrations/2026_05_01_000001_expand_landing_page_template_description_sections.php');
+}
+
+function invokeMigrationHelper(object $migration, string $method, mixed ...$arguments): mixed
+{
+    $reflection = new ReflectionMethod($migration, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invokeArgs($migration, $arguments);
+}
+
 it('expands the legacy descriptions slot while preserving trailing location placement', function (): void {
     $template = LandingPageTemplate::factory()->create([
         'right_column_order' => ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
@@ -46,4 +59,47 @@ it('expands the legacy descriptions slot while preserving leading location place
     runDescriptionSectionsMigration();
 
     expect($template->fresh()->right_column_order)->toBe(expandedLocationFirstRightColumnOrder());
+});
+
+it('decodes stored orders defensively', function (): void {
+    $migration = newDescriptionSectionsMigration();
+
+    expect(invokeMigrationHelper($migration, 'decodeOrder', ['location', 123, 'descriptions']))
+        ->toBe(['location', 'descriptions'])
+        ->and(invokeMigrationHelper($migration, 'decodeOrder', ''))
+        ->toBe([])
+        ->and(invokeMigrationHelper($migration, 'decodeOrder', 'not-json'))
+        ->toBe([])
+        ->and(invokeMigrationHelper($migration, 'decodeOrder', '["abstract",1,"location"]'))
+        ->toBe(['abstract', 'location']);
+});
+
+it('normalizes malformed legacy orders by dropping unknown keys and appending missing modules', function (): void {
+    $migration = newDescriptionSectionsMigration();
+
+    $normalized = invokeMigrationHelper($migration, 'normalizeRightOrder', ['unknown', 'descriptions', 'keywords', 'keywords', 'location']);
+
+    expect($normalized)->toBe([
+        'abstract',
+        'methods',
+        'technical_info',
+        'series_information',
+        'table_of_contents',
+        'other',
+        'keywords',
+        'creators',
+        'contributors',
+        'funders',
+        'metadata_download',
+        'location',
+    ]);
+});
+
+it('falls back to the canonical trailing-location order for malformed payloads', function (): void {
+    $migration = newDescriptionSectionsMigration();
+
+    $decoded = invokeMigrationHelper($migration, 'decodeOrder', '{"unexpected":true}');
+    $normalized = invokeMigrationHelper($migration, 'normalizeRightOrder', $decoded);
+
+    expect($normalized)->toBe(expandedRightColumnOrder());
 });

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateDescriptionSectionsMigrationTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateDescriptionSectionsMigrationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPageTemplate;
+
+uses()->group('landing-page-templates');
+
+function expandedRightColumnOrder(): array
+{
+    return LandingPageTemplate::RIGHT_COLUMN_SECTIONS;
+}
+
+function expandedLocationFirstRightColumnOrder(): array
+{
+    return [
+        'location',
+        ...array_values(array_filter(
+            LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
+            static fn (string $key): bool => $key !== 'location',
+        )),
+    ];
+}
+
+function runDescriptionSectionsMigration(): void
+{
+    $migration = require database_path('migrations/2026_05_01_000001_expand_landing_page_template_description_sections.php');
+    $migration->up();
+}
+
+it('expands the legacy descriptions slot while preserving trailing location placement', function (): void {
+    $template = LandingPageTemplate::factory()->create([
+        'right_column_order' => ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+    ]);
+
+    runDescriptionSectionsMigration();
+
+    expect($template->fresh()->right_column_order)->toBe(expandedRightColumnOrder());
+});
+
+it('expands the legacy descriptions slot while preserving leading location placement', function (): void {
+    $template = LandingPageTemplate::factory()->create([
+        'right_column_order' => ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+    ]);
+
+    runDescriptionSectionsMigration();
+
+    expect($template->fresh()->right_column_order)->toBe(expandedLocationFirstRightColumnOrder());
+});

--- a/tests/vitest/pages/LandingPages/__tests__/AbstractSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/AbstractSection.test.tsx
@@ -100,41 +100,31 @@ const defaultProps = {
 
 describe('AbstractSection', () => {
     describe('rendering conditions', () => {
-        it('renders when abstract description exists', () => {
+        it('renders metadata card when abstract description exists', () => {
             render(<AbstractSection {...defaultProps} />);
             
-            expect(screen.getByTestId('abstract-section')).toBeInTheDocument();
+            expect(screen.getByTestId('metadata-section')).toBeInTheDocument();
             expect(screen.getByText('Abstract')).toBeInTheDocument();
         });
 
-        it('returns null when no abstract description exists', () => {
-            const { container } = render(
+        it('renders methods without requiring abstract', () => {
+            render(
                 <AbstractSection
                     {...defaultProps}
                     descriptions={[createDescription({ description_type: 'Methods' })]}
                 />
             );
             
-            expect(container).toBeEmptyDOMElement();
+            expect(screen.getByTestId('metadata-section')).toBeInTheDocument();
+            expect(screen.getByText('Methods')).toBeInTheDocument();
         });
 
-        it('returns null when descriptions array is empty', () => {
-            const { container } = render(
+        it('still renders metadata download when descriptions array is empty', () => {
+            render(
                 <AbstractSection {...defaultProps} descriptions={[]} />
             );
             
-            expect(container).toBeEmptyDOMElement();
-        });
-
-        it('finds abstract case-insensitively', () => {
-            render(
-                <AbstractSection
-                    {...defaultProps}
-                    descriptions={[createDescription({ description_type: 'ABSTRACT' })]}
-                />
-            );
-            
-            expect(screen.getByTestId('abstract-section')).toBeInTheDocument();
+            expect(screen.getByText('Download Metadata')).toBeInTheDocument();
         });
 
         it('displays the abstract text', () => {
@@ -181,6 +171,25 @@ describe('AbstractSection', () => {
             );
 
             expect(screen.getByTestId('methods-section')).toBeInTheDocument();
+        });
+
+        it('renders technical information with multiple values in order', () => {
+            render(
+                <AbstractSection
+                    {...defaultProps}
+                    descriptions={[
+                        createDescription({ id: 1, value: 'Technical block A', description_type: 'TechnicalInfo' }),
+                        createDescription({ id: 2, value: 'Technical block B', description_type: 'Technical Info' }),
+                    ]}
+                    sectionOrder={['technical_info', 'metadata_download']}
+                />
+            );
+
+            expect(screen.getByText('Technical Information')).toBeInTheDocument();
+            const paragraphs = screen.getAllByText(/Technical block/i);
+            expect(paragraphs).toHaveLength(2);
+            expect(paragraphs[0]).toHaveTextContent('Technical block A');
+            expect(paragraphs[1]).toHaveTextContent('Technical block B');
         });
     });
 

--- a/tests/vitest/pages/LandingPages/__tests__/AbstractSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/AbstractSection.test.tsx
@@ -127,6 +127,22 @@ describe('AbstractSection', () => {
             expect(screen.getByText('Download Metadata')).toBeInTheDocument();
         });
 
+        it('returns null when no metadata modules are requested', () => {
+            const { container } = render(
+                <AbstractSection
+                    {...defaultProps}
+                    descriptions={[]}
+                    creators={[]}
+                    contributors={[]}
+                    fundingReferences={[]}
+                    subjects={[]}
+                    sectionOrder={[]}
+                />
+            );
+
+            expect(container).toBeEmptyDOMElement();
+        });
+
         it('displays the abstract text', () => {
             render(<AbstractSection {...defaultProps} />);
             

--- a/tests/vitest/pages/LandingPages/__tests__/DescriptionSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/DescriptionSection.test.tsx
@@ -9,13 +9,13 @@ import { DescriptionSection } from '@/pages/LandingPages/components/DescriptionS
 describe('DescriptionSection', () => {
     it('renders abstract text', () => {
         const descriptions = [{ id: 1, value: 'This is the abstract text.', description_type: 'Abstract' }];
-        render(<DescriptionSection descriptions={descriptions} />);
+        render(<DescriptionSection descriptions={descriptions} sectionKey="abstract" />);
         expect(screen.getByTestId('abstract-text')).toHaveTextContent('This is the abstract text.');
     });
 
-    it('returns null when no abstract exists', () => {
+    it('returns null when no matching description type exists', () => {
         const descriptions = [{ id: 1, value: 'Some methods.', description_type: 'Methods' }];
-        const { container } = render(<DescriptionSection descriptions={descriptions} />);
+        const { container } = render(<DescriptionSection descriptions={descriptions} sectionKey="abstract" />);
         expect(container.innerHTML).toBe('');
     });
 
@@ -24,19 +24,27 @@ describe('DescriptionSection', () => {
             { id: 1, value: 'Abstract text.', description_type: 'Abstract' },
             { id: 2, value: 'Methods description.', description_type: 'Methods' },
         ];
-        render(<DescriptionSection descriptions={descriptions} />);
+        render(<DescriptionSection descriptions={descriptions} sectionKey="methods" />);
         expect(screen.getByTestId('methods-text')).toHaveTextContent('Methods description.');
     });
 
-    it('does not render methods when not present', () => {
-        const descriptions = [{ id: 1, value: 'Abstract text.', description_type: 'Abstract' }];
-        render(<DescriptionSection descriptions={descriptions} />);
-        expect(screen.queryByTestId('methods-section')).not.toBeInTheDocument();
+    it('renders multiple descriptions of the same type in data order', () => {
+        const descriptions = [
+            { id: 1, value: 'First technical block.', description_type: 'TechnicalInfo' },
+            { id: 2, value: 'Second technical block.', description_type: 'Technical Info' },
+        ];
+
+        render(<DescriptionSection descriptions={descriptions} sectionKey="technical_info" />);
+
+        const paragraphs = screen.getAllByText(/technical block\./i);
+        expect(paragraphs).toHaveLength(2);
+        expect(paragraphs[0]).toHaveTextContent('First technical block.');
+        expect(paragraphs[1]).toHaveTextContent('Second technical block.');
     });
 
     it('matches abstract case-insensitively', () => {
         const descriptions = [{ id: 1, value: 'Lowercase abstract.', description_type: 'abstract' }];
-        render(<DescriptionSection descriptions={descriptions} />);
+        render(<DescriptionSection descriptions={descriptions} sectionKey="abstract" />);
         expect(screen.getByTestId('abstract-text')).toBeInTheDocument();
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/default_gfz.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/default_gfz.test.tsx
@@ -21,7 +21,7 @@ describe('DefaultGfzTemplate', () => {
             { id: 1, title: 'Test Dataset Title', title_type: 'MainTitle' },
             { id: 2, title: 'Test Subtitle', title_type: 'Subtitle' },
         ],
-        descriptions: [{ id: 1, description: 'Test abstract', description_type: 'Abstract' }],
+        descriptions: [{ id: 1, value: 'Test abstract', description_type: 'Abstract' }],
         creators: [],
         funding_references: [],
         subjects: [],
@@ -483,6 +483,65 @@ describe('DefaultGfzTemplate', () => {
             // Render should succeed with jsonLdExportUrl derived from public_url
             render(<DefaultGfzTemplate />);
             expect(screen.getByText('Test Dataset Title')).toBeInTheDocument();
+        });
+
+        it('renders separate description modules in the configured order', () => {
+            mockUsePage.mockReturnValue({
+                props: {
+                    resource: {
+                        ...mockResource,
+                        descriptions: [
+                            { id: 1, value: 'Abstract block', description_type: 'Abstract' },
+                            { id: 2, value: 'Methods block', description_type: 'Methods' },
+                            { id: 3, value: 'Technical block', description_type: 'TechnicalInfo' },
+                        ],
+                    },
+                    landingPage: mockLandingPage,
+                    isPreview: false,
+                    sectionOrder: {
+                        rightColumn: [
+                            'methods',
+                            'abstract',
+                            'technical_info',
+                            'creators',
+                            'contributors',
+                            'funders',
+                            'keywords',
+                            'metadata_download',
+                            'location',
+                        ],
+                        leftColumn: ['files', 'contact', 'model_description', 'related_work'],
+                    },
+                },
+            } as unknown as ReturnType<typeof usePage>);
+
+            render(<DefaultGfzTemplate />);
+
+            const methodsHeading = screen.getByText('Methods');
+            const abstractHeading = screen.getByText('Abstract');
+            const technicalHeading = screen.getByText('Technical Information');
+
+            expect(methodsHeading.compareDocumentPosition(abstractHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+            expect(abstractHeading.compareDocumentPosition(technicalHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+            expect(screen.getByText('Technical block')).toBeInTheDocument();
+        });
+
+        it('renders non-abstract descriptions when no abstract exists', () => {
+            mockUsePage.mockReturnValue({
+                props: {
+                    resource: {
+                        ...mockResource,
+                        descriptions: [{ id: 1, value: 'Only methods', description_type: 'Methods' }],
+                    },
+                    landingPage: mockLandingPage,
+                    isPreview: false,
+                },
+            } as unknown as ReturnType<typeof usePage>);
+
+            render(<DefaultGfzTemplate />);
+
+            expect(screen.getByText('Methods')).toBeInTheDocument();
+            expect(screen.getByText('Only methods')).toBeInTheDocument();
         });
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/default_gfz.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/default_gfz.test.tsx
@@ -485,6 +485,43 @@ describe('DefaultGfzTemplate', () => {
             expect(screen.getByText('Test Dataset Title')).toBeInTheDocument();
         });
 
+        it('uses customLogoUrl when provided', () => {
+            mockUsePage.mockReturnValue({
+                props: {
+                    resource: mockResource,
+                    landingPage: mockLandingPage,
+                    isPreview: false,
+                    customLogoUrl: 'https://cdn.example/custom-logo.png',
+                },
+            } as unknown as ReturnType<typeof usePage>);
+
+            render(<DefaultGfzTemplate />);
+
+            expect(screen.getByAltText('GFZ Data Services')).toHaveAttribute('src', 'https://cdn.example/custom-logo.png');
+        });
+
+        it('handles a right column order that only contains location', () => {
+            mockUsePage.mockReturnValue({
+                props: {
+                    resource: {
+                        ...mockResource,
+                        descriptions: [],
+                    },
+                    landingPage: mockLandingPage,
+                    isPreview: false,
+                    sectionOrder: {
+                        rightColumn: ['location'],
+                        leftColumn: ['files', 'contact', 'model_description', 'related_work'],
+                    },
+                },
+            } as unknown as ReturnType<typeof usePage>);
+
+            render(<DefaultGfzTemplate />);
+
+            expect(screen.getByText('Test Dataset Title')).toBeInTheDocument();
+            expect(screen.queryByText('Abstract')).not.toBeInTheDocument();
+        });
+
         it('renders separate description modules in the configured order', () => {
             mockUsePage.mockReturnValue({
                 props: {

--- a/tests/vitest/pages/LandingPages/__tests__/default_gfz_igsn.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/default_gfz_igsn.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -397,16 +397,23 @@ describe('DefaultGfzIgsnTemplate', () => {
 
             render(<DefaultGfzIgsnTemplate />);
 
-            expect(screen.getByText('Acquisition')).toBeInTheDocument();
-            expect(screen.getByText('Basalt')).toBeInTheDocument();
-            expect(screen.getByText('Igneous, Volcanic')).toBeInTheDocument();
-            expect(screen.getByText('Hand sampling')).toBeInTheDocument();
-            expect(screen.getByText('Surface outcrop')).toBeInTheDocument();
-            expect(screen.getByText('NSF')).toBeInTheDocument();
-            expect(screen.getByText('Field comments here')).toBeInTheDocument();
-            expect(screen.getByText('Jane Smith')).toBeInTheDocument();
-            expect(screen.getByText('2023-06-01')).toBeInTheDocument();
-            expect(screen.getByText('2023-06-30')).toBeInTheDocument();
+            const acquisitionHeading = screen.getByText('Acquisition');
+            const acquisitionCard = acquisitionHeading.closest('[data-slot="landing-page-card"]');
+
+            expect(acquisitionCard).not.toBeNull();
+
+            const acquisition = within(acquisitionCard as HTMLElement);
+
+            expect(acquisitionHeading).toBeInTheDocument();
+            expect(acquisition.getByText('Basalt')).toBeInTheDocument();
+            expect(acquisition.getByText('Igneous, Volcanic')).toBeInTheDocument();
+            expect(acquisition.getByText('Hand sampling')).toBeInTheDocument();
+            expect(acquisition.getByText('Surface outcrop')).toBeInTheDocument();
+            expect(acquisition.getByText('NSF')).toBeInTheDocument();
+            expect(acquisition.getByText('Field comments here')).toBeInTheDocument();
+            expect(acquisition.getByText('Jane Smith')).toBeInTheDocument();
+            expect(acquisition.getByText('2023-06-01')).toBeInTheDocument();
+            expect(acquisition.getByText('2023-06-30')).toBeInTheDocument();
         });
 
         it('hides General and Acquisition modules when no IGSN data is provided', () => {
@@ -499,7 +506,7 @@ describe('DefaultGfzIgsnTemplate', () => {
                     isPreview: false,
                     sectionOrder: {
                         leftColumn: ['files', 'acquisition', 'general', 'contact', 'model_description', 'related_work'],
-                        rightColumn: ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+                        rightColumn: ['abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
                     },
                 },
             } as unknown as ReturnType<typeof usePage>);
@@ -542,6 +549,33 @@ describe('DefaultGfzIgsnTemplate', () => {
 
             // Should still render the page with main title; status defaulted internally
             expect(screen.getByText('Rock Sample Core XYZ')).toBeInTheDocument();
+        });
+
+        it('renders methods before abstract when the right column order requests it', () => {
+            mockUsePage.mockReturnValue({
+                props: {
+                    resource: {
+                        ...mockResource,
+                        descriptions: [
+                            { id: 1, value: 'IGSN abstract', description_type: 'Abstract' },
+                            { id: 2, value: 'IGSN methods', description_type: 'Methods' },
+                        ],
+                    },
+                    landingPage: mockLandingPage,
+                    isPreview: false,
+                    sectionOrder: {
+                        leftColumn: ['general', 'acquisition', 'contact', 'model_description', 'related_work'],
+                        rightColumn: ['methods', 'abstract', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+                    },
+                },
+            } as unknown as ReturnType<typeof usePage>);
+
+            render(<DefaultGfzIgsnTemplate />);
+
+            const methodsHeading = screen.getByText('Methods');
+            const abstractHeading = screen.getByText('Abstract');
+            expect(methodsHeading.compareDocumentPosition(abstractHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+            expect(screen.getByText('IGSN methods')).toBeInTheDocument();
         });
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/default_gfz_igsn.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/default_gfz_igsn.test.tsx
@@ -551,6 +551,28 @@ describe('DefaultGfzIgsnTemplate', () => {
             expect(screen.getByText('Rock Sample Core XYZ')).toBeInTheDocument();
         });
 
+        it('handles a right column order that only contains location', () => {
+            mockUsePage.mockReturnValue({
+                props: {
+                    resource: {
+                        ...mockResource,
+                        descriptions: [],
+                    },
+                    landingPage: mockLandingPage,
+                    isPreview: false,
+                    sectionOrder: {
+                        leftColumn: ['general', 'acquisition', 'contact', 'model_description', 'related_work'],
+                        rightColumn: ['location'],
+                    },
+                },
+            } as unknown as ReturnType<typeof usePage>);
+
+            render(<DefaultGfzIgsnTemplate />);
+
+            expect(screen.getByText('Rock Sample Core XYZ')).toBeInTheDocument();
+            expect(screen.queryByText('Abstract')).not.toBeInTheDocument();
+        });
+
         it('renders methods before abstract when the right column order requests it', () => {
             mockUsePage.mockReturnValue({
                 props: {

--- a/tests/vitest/pages/LandingPages/__tests__/metadata-sections.test.ts
+++ b/tests/vitest/pages/LandingPages/__tests__/metadata-sections.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DESCRIPTION_SECTION_KEYS,
+    expandMetadataOrder,
+    filterDescriptionsBySection,
+    isDescriptionSectionKey,
+    normalizeDescriptionType,
+} from '@/pages/LandingPages/lib/metadata-sections';
+
+describe('metadata-sections helpers', () => {
+    it('normalizes description types defensively', () => {
+        expect(normalizeDescriptionType('Technical Information')).toBe('technicalinformation');
+        expect(normalizeDescriptionType('Table of Contents')).toBe('tableofcontents');
+        expect(normalizeDescriptionType(undefined)).toBe('');
+        expect(normalizeDescriptionType(null)).toBe('');
+    });
+
+    it('filters descriptions by normalized section aliases', () => {
+        const descriptions = [
+            { id: 1, value: 'Tech A', description_type: 'TechnicalInfo' },
+            { id: 2, value: 'Tech B', description_type: 'Technical Information' },
+            { id: 3, value: 'Ignored', description_type: null },
+        ];
+
+        expect(filterDescriptionsBySection(descriptions, 'technical_info')).toEqual([
+            descriptions[0],
+            descriptions[1],
+        ]);
+        expect(filterDescriptionsBySection(descriptions, 'methods')).toEqual([]);
+    });
+
+    it('identifies description section keys correctly', () => {
+        expect(isDescriptionSectionKey('abstract')).toBe(true);
+        expect(isDescriptionSectionKey('other')).toBe(true);
+        expect(isDescriptionSectionKey('creators')).toBe(false);
+        expect(isDescriptionSectionKey('descriptions')).toBe(false);
+    });
+
+    it('expands legacy descriptions and deduplicates repeated modules', () => {
+        expect(expandMetadataOrder(['descriptions', 'methods', 'creators', 'descriptions', 'keywords'])).toEqual([
+            ...DESCRIPTION_SECTION_KEYS,
+            'creators',
+            'keywords',
+        ]);
+    });
+});

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -38,6 +38,40 @@ const locationFirstRightOrder: LandingPageTemplateConfig['right_column_order'] =
     'metadata_download',
 ];
 
+const legacyLocationFirstRightOrder = [
+    'location',
+    'descriptions',
+    'keywords',
+] as unknown as LandingPageTemplateConfig['right_column_order'];
+
+const middleLocationRightOrder = [
+    'abstract',
+    'location',
+    'methods',
+] as unknown as LandingPageTemplateConfig['right_column_order'];
+
+const dirtyRightOrder = [
+    'unknown',
+    'abstract',
+    'abstract',
+    'location',
+] as unknown as LandingPageTemplateConfig['right_column_order'];
+
+const expandedLegacyLocationFirstOrder = [
+    'location',
+    'abstract',
+    'methods',
+    'technical_info',
+    'series_information',
+    'table_of_contents',
+    'other',
+    'keywords',
+    'creators',
+    'contributors',
+    'funders',
+    'metadata_download',
+];
+
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 const routerMock = vi.hoisted(() => ({ reload: vi.fn() }));
@@ -163,6 +197,14 @@ const customTemplateNoLogo: LandingPageTemplateConfig = {
     landing_pages_count: 0,
     created_at: '2025-04-01T00:00:00Z',
     updated_at: '2025-04-01T00:00:00Z',
+};
+
+const defaultIgsnTemplate: LandingPageTemplateConfig = {
+    ...defaultTemplate,
+    id: 4,
+    name: 'Default GFZ IGSN',
+    slug: 'default_gfz_igsn',
+    template_type: 'igsn',
 };
 
 let mockTemplates: LandingPageTemplateConfig[] = [];
@@ -370,6 +412,21 @@ describe('LandingPageTemplatesPage', () => {
                 expect(screen.queryByText('Clone Default Template')).not.toBeInTheDocument();
             });
         });
+
+        it('clones from the default IGSN template with igsn template type', async () => {
+            mockedAxiosPost.mockResolvedValue({ data: { message: 'Created', template: {} } });
+            mockTemplates = [defaultIgsnTemplate];
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Clone this template/i }));
+            await user.type(screen.getByLabelText('Template Name'), 'IGSN Clone');
+            await user.click(screen.getByRole('button', { name: /Clone Template/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith('/landing-pages', { name: 'IGSN Clone', template_type: 'igsn' });
+            });
+        });
     });
 
     // ─── Edit Dialog ─────────────────────────────────────────────────────
@@ -451,6 +508,79 @@ describe('LandingPageTemplatesPage', () => {
 
             expect(screen.getByText('Right Column (main content)')).toBeInTheDocument();
             expect(screen.getByText('Left Column (sidebar)')).toBeInTheDocument();
+            expect(screen.getByText(/Description modules render inside one shared metadata card/i)).toBeInTheDocument();
+        });
+
+        it('normalizes middle location to the end before saving', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            mockTemplates = [
+                {
+                    ...customTemplateNoLogo,
+                    right_column_order: middleLocationRightOrder,
+                },
+            ];
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Edit/i }));
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    `/landing-pages/${customTemplateNoLogo.id}`,
+                    expect.objectContaining({
+                        right_column_order: defaultRightOrder,
+                    }),
+                );
+            });
+        });
+
+        it('expands legacy descriptions while preserving leading location before saving', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            mockTemplates = [
+                {
+                    ...customTemplateNoLogo,
+                    right_column_order: legacyLocationFirstRightOrder,
+                },
+            ];
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Edit/i }));
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    `/landing-pages/${customTemplateNoLogo.id}`,
+                    expect.objectContaining({
+                        right_column_order: expandedLegacyLocationFirstOrder,
+                    }),
+                );
+            });
+        });
+
+        it('drops unknown and duplicate right column keys before saving', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            mockTemplates = [
+                {
+                    ...customTemplateNoLogo,
+                    right_column_order: dirtyRightOrder,
+                },
+            ];
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Edit/i }));
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    `/landing-pages/${customTemplateNoLogo.id}`,
+                    expect.objectContaining({
+                        right_column_order: defaultRightOrder,
+                    }),
+                );
+            });
         });
 
         it('closes edit dialog via Cancel', async () => {
@@ -558,6 +688,27 @@ describe('LandingPageTemplatesPage', () => {
 
             await waitFor(() => {
                 expect(toast.error).toHaveBeenCalledWith('Failed to delete template');
+            });
+        });
+
+        it('shows backend delete error message when provided', async () => {
+            const { toast } = await import('sonner');
+            mockedAxiosDelete.mockRejectedValue({
+                isAxiosError: true,
+                response: { data: { message: 'Template is currently in use.' } },
+            });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const deleteButtons = screen.getAllByRole('button', { name: /Delete/i });
+            await user.click(deleteButtons[1]);
+
+            const confirmButtons = screen.getAllByRole('button', { name: /Delete/i });
+            const alertDialogDelete = confirmButtons.find((btn) => btn.closest('[role="alertdialog"]'));
+            if (alertDialogDelete) await user.click(alertDialogDelete);
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Template is currently in use.');
             });
         });
     });

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -8,6 +8,36 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LandingPageTemplateConfig } from '@/types/landing-page';
 
+const defaultRightOrder: LandingPageTemplateConfig['right_column_order'] = [
+    'abstract',
+    'methods',
+    'technical_info',
+    'series_information',
+    'table_of_contents',
+    'other',
+    'creators',
+    'contributors',
+    'funders',
+    'keywords',
+    'metadata_download',
+    'location',
+];
+
+const locationFirstRightOrder: LandingPageTemplateConfig['right_column_order'] = [
+    'location',
+    'abstract',
+    'methods',
+    'technical_info',
+    'series_information',
+    'table_of_contents',
+    'other',
+    'creators',
+    'contributors',
+    'funders',
+    'keywords',
+    'metadata_download',
+];
+
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 const routerMock = vi.hoisted(() => ({ reload: vi.fn() }));
@@ -90,7 +120,7 @@ const defaultTemplate: LandingPageTemplateConfig = {
     logo_path: null,
     logo_filename: null,
     logo_url: null,
-    right_column_order: ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+    right_column_order: defaultRightOrder,
     left_column_order: ['files', 'contact', 'model_description', 'related_work'],
     created_by: null,
     creator: null,
@@ -108,7 +138,7 @@ const customTemplate: LandingPageTemplateConfig = {
     logo_path: 'landing-page-logos/geophysics/logo.png',
     logo_filename: 'logo.png',
     logo_url: 'http://localhost/storage/landing-page-logos/geophysics/logo.png',
-    right_column_order: ['location', 'descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+    right_column_order: locationFirstRightOrder,
     left_column_order: ['contact', 'files', 'model_description', 'related_work'],
     created_by: 1,
     creator: { id: 1, name: 'Admin User' },
@@ -126,7 +156,7 @@ const customTemplateNoLogo: LandingPageTemplateConfig = {
     logo_path: null,
     logo_filename: null,
     logo_url: null,
-    right_column_order: ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download', 'location'],
+    right_column_order: defaultRightOrder,
     left_column_order: ['files', 'contact', 'model_description', 'related_work'],
     created_by: 1,
     creator: { id: 1, name: 'Admin User' },
@@ -200,7 +230,8 @@ describe('LandingPageTemplatesPage', () => {
         it('shows section order lists', () => {
             render(<LandingPageTemplatesPage />);
             // Check section labels are rendered
-            expect(screen.getAllByText('Abstract & Descriptions').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Abstract').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Methods').length).toBeGreaterThanOrEqual(1);
             expect(screen.getAllByText('Creators / Authors').length).toBeGreaterThanOrEqual(1);
         });
 
@@ -637,7 +668,12 @@ describe('LandingPageTemplatesPage', () => {
     describe('Section Labels', () => {
         it('renders right column section labels', () => {
             render(<LandingPageTemplatesPage />);
-            expect(screen.getAllByText('Abstract & Descriptions').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Abstract').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Methods').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Technical Information').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Series Information').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Table of Contents').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Other').length).toBeGreaterThanOrEqual(1);
             expect(screen.getAllByText('Creators / Authors').length).toBeGreaterThanOrEqual(1);
             expect(screen.getAllByText('Contributors').length).toBeGreaterThanOrEqual(1);
             expect(screen.getAllByText('Funding References').length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
This pull request introduces a major update to how landing page templates handle and render DataCite description types. Instead of grouping all descriptions under a single "Abstract & Descriptions" block, each supported description type (e.g., Abstract, Methods, Technical Info) is now displayed as its own module within the shared metadata card. This change affects both the backend (template configuration, normalization, and migration) and the frontend (React component structure and rendering). The update ensures more granular control and flexibility in template management and improves the clarity of displayed metadata.

**Backend: Template Structure, Normalization, and Migration**
- **Granular Description Modules:** The `LandingPageTemplate` model now defines a list of individual description-type section keys (`DESCRIPTION_COLUMN_SECTIONS`) and expands the valid right-column sections to include each description type separately, instead of a single `descriptions` key.
- **Section Order Normalization:** A new `normalizeRightColumnOrder` method ensures the `location` section always appears before or after the metadata card, never in the middle, and normalizes user-provided orders. [[1]](diffhunk://#diff-89db60696bf448c0e760b389a3c263334d50c9025088f7bad8dd21dbb26cfb09R245-R278) [[2]](diffhunk://#diff-e976cd81325a09aaa0975eac5721055d597f7efb169781c61512f41f5b7a1df2R78-R91)
- **Database Migration:** A new migration rewrites existing landing page template configurations, replacing the legacy `descriptions` key with the expanded set of description-type keys, while preserving the order of other sections and the special handling of `location`.

**Frontend: Rendering and Component Updates**
- **Modular Metadata Rendering:** The `AbstractSection` React component now renders each description type as a separate sub-section within the shared metadata card, using the new `DescriptionSection` component for each type. The section order is dynamically determined and customizable. [[1]](diffhunk://#diff-1ce06da91960e3bb6a5e6359cb2a9d1e6e257da1ee27ca5d814d98698cac3a0eR9) [[2]](diffhunk://#diff-1ce06da91960e3bb6a5e6359cb2a9d1e6e257da1ee27ca5d814d98698cac3a0eR27-R34) [[3]](diffhunk://#diff-1ce06da91960e3bb6a5e6359cb2a9d1e6e257da1ee27ca5d814d98698cac3a0eR44-R79) [[4]](diffhunk://#diff-dcb22f99dd376d71e261e6889468f944afcb04a7d1e80df9a59c5607e0c6cb51R3-L40)
- **Template Layout Adjustments:** The default landing page templates (`default_gfz.tsx` and `default_gfz_igsn.tsx`) are updated to use the new section order, separating description modules and ensuring correct placement of the location card. [[1]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450R18) [[2]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450L40-R54) [[3]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450R71-R98) [[4]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450L164-R180) [[5]](diffhunk://#diff-81f5f358a21e82d0ae7182bcdaa9b62706ef8a39361ea0bca45a9d2db73ead4aR19)

**Other Improvements**
- **Changelog Entry:** The changelog is updated to document the new feature, highlighting the improved rendering and configurability of description-type modules on landing pages.

**Most important changes:**

**Backend: Template and Data Migration**
* Added `DESCRIPTION_COLUMN_SECTIONS` to `LandingPageTemplate`, expanded `RIGHT_COLUMN_SECTIONS` to include individual description types, and implemented `normalizeRightColumnOrder` for correct section ordering. [[1]](diffhunk://#diff-89db60696bf448c0e760b389a3c263334d50c9025088f7bad8dd21dbb26cfb09R75-R95) [[2]](diffhunk://#diff-89db60696bf448c0e760b389a3c263334d50c9025088f7bad8dd21dbb26cfb09R245-R278)
* Introduced a migration to convert legacy `descriptions` keys in template configurations to individual description-type keys, ensuring backward compatibility and correct data structure.
* Updated request validation to normalize and process the new right column order format.

**Frontend: Component and Layout Refactor**
* Refactored `AbstractSection` and `DescriptionSection` components to render each description type as a separate module, using dynamic section order and improved composability. [[1]](diffhunk://#diff-1ce06da91960e3bb6a5e6359cb2a9d1e6e257da1ee27ca5d814d98698cac3a0eR9) [[2]](diffhunk://#diff-1ce06da91960e3bb6a5e6359cb2a9d1e6e257da1ee27ca5d814d98698cac3a0eR27-R34) [[3]](diffhunk://#diff-1ce06da91960e3bb6a5e6359cb2a9d1e6e257da1ee27ca5d814d98698cac3a0eR44-R79) [[4]](diffhunk://#diff-dcb22f99dd376d71e261e6889468f944afcb04a7d1e80df9a59c5607e0c6cb51R3-L40)
* Updated default landing page templates to use the new section order and rendering logic, ensuring location and metadata cards are placed correctly. [[1]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450R18) [[2]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450L40-R54) [[3]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450R71-R98) [[4]](diffhunk://#diff-441be98c1971d864b2d72792a7044c552c63b3c0f9f8052222279480c75a7450L164-R180) [[5]](diffhunk://#diff-81f5f358a21e82d0ae7182bcdaa9b62706ef8a39361ea0bca45a9d2db73ead4aR19)

**Documentation**
* Added a changelog entry describing the new feature and its impact on landing page rendering and configuration.