### PR TITLE
Fix: Setup landing page template modal allows wrong template

### DIFF
--- a/app/Console/Commands/GenerateWayfinderDefinitions.php
+++ b/app/Console/Commands/GenerateWayfinderDefinitions.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+use function Illuminate\Filesystem\join_paths;
+
+#[Description('Generate Wayfinder definitions and normalize query parameter ordering')]
+#[Signature('ernie:wayfinder-generate {--path=} {--skip-actions} {--skip-routes} {--with-form}')]
+class GenerateWayfinderDefinitions extends Command
+{
+    public function __construct(
+        private readonly Filesystem $files,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $exitCode = $this->call('wayfinder:generate', [
+            '--path' => $this->option('path'),
+            '--skip-actions' => (bool) $this->option('skip-actions'),
+            '--skip-routes' => (bool) $this->option('skip-routes'),
+            '--with-form' => (bool) $this->option('with-form'),
+        ]);
+
+        if ($exitCode !== self::SUCCESS) {
+            return $exitCode;
+        }
+
+        return $this->normalizeWayfinderHelper()
+            ? self::SUCCESS
+            : self::FAILURE;
+    }
+
+    private function normalizeWayfinderHelper(): bool
+    {
+        $basePath = $this->option('path') ?? join_paths(resource_path(), 'js');
+        $wayfinderPath = join_paths($basePath, 'wayfinder', 'index.ts');
+
+        if (! $this->files->exists($wayfinderPath)) {
+            $this->error("Generated Wayfinder helper not found at {$wayfinderPath}.");
+
+            return false;
+        }
+
+        $contents = $this->files->get($wayfinderPath);
+
+        if (str_contains($contents, 'Array.from(params.entries()).sort((')) {
+            return true;
+        }
+
+        $updatedContents = str_replace(
+            '    const str = params.toString();',
+            <<<'TS'
+    const str = includeExisting
+        ? new URLSearchParams(
+            Array.from(params.entries()).sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
+        ).toString()
+        : params.toString();
+TS,
+            $contents,
+            $count,
+        );
+
+        if ($count !== 1) {
+            $this->error('Unable to normalize generated Wayfinder helper output.');
+
+            return false;
+        }
+
+        $this->files->put($wayfinderPath, $updatedContents);
+
+        return true;
+    }
+}

--- a/app/Http/Controllers/IgsnController.php
+++ b/app/Http/Controllers/IgsnController.php
@@ -702,9 +702,11 @@ class IgsnController extends Controller
      */
     private function applySorting(\Illuminate\Database\Eloquent\Builder $query, string $sortKey, string $sortDirection): void
     {
+        $direction = $sortDirection === 'asc' ? 'asc' : 'desc';
+
         switch ($sortKey) {
             case 'igsn':
-                $query->orderBy('doi', $sortDirection);
+                $query->orderBy('doi', $direction);
                 break;
 
             case 'title':
@@ -716,7 +718,7 @@ class IgsnController extends Controller
                         ->whereColumn('titles.resource_id', 'resources.id')
                         ->orderBy('title_type_id')
                         ->limit(1);
-                }, $sortDirection);
+                }, $direction);
                 break;
 
             case 'sample_type':
@@ -727,7 +729,7 @@ class IgsnController extends Controller
                         ->from('igsn_metadata')
                         ->whereColumn('igsn_metadata.resource_id', 'resources.id')
                         ->limit(1);
-                }, $sortDirection);
+                }, $direction);
                 break;
 
             case 'collection_date':
@@ -740,11 +742,11 @@ class IgsnController extends Controller
                         ->whereColumn('dates.resource_id', 'resources.id')
                         ->where('date_types.slug', 'Collected')
                         ->limit(1);
-                }, $sortDirection);
+                }, $direction);
                 break;
 
             default:
-                $query->orderBy($sortKey, $sortDirection);
+                $query->orderBy($sortKey, $direction);
                 break;
         }
     }

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -28,6 +28,11 @@ class LandingPageController extends Controller
     use AuthorizesRequests;
     use ChecksCacheTagging;
 
+    private static function templateSupportsCustomTemplateId(string $template): bool
+    {
+        return $template === LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
+    }
+
     public function __construct(
         private readonly KeywordSuggestionService $keywordService,
     ) {}
@@ -130,7 +135,8 @@ class LandingPageController extends Controller
             ], 422);
         }
 
-        if ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'] ?? null, $resource->resourceType?->slug)) {
+        if (self::templateSupportsCustomTemplateId($validated['template'])
+            && ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'] ?? null, $resource->resourceType?->slug))) {
             return response()->json([
                 'message' => $customTemplateError,
                 'error' => 'invalid_template_for_resource_type',
@@ -358,7 +364,10 @@ class LandingPageController extends Controller
             }
         }
 
-        if (array_key_exists('landing_page_template_id', $validated)) {
+        $effectiveTemplate = $validated['template'] ?? $landingPage->template;
+
+        if (array_key_exists('landing_page_template_id', $validated)
+            && self::templateSupportsCustomTemplateId($effectiveTemplate)) {
             $resource->loadMissing('resourceType');
 
             if ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'], $resource->resourceType?->slug)) {
@@ -393,8 +402,6 @@ class LandingPageController extends Controller
 
         // Wrap all mutations in a transaction for atomicity.
         // This ensures the landing page + links are updated together.
-        $effectiveTemplate = $validated['template'] ?? $landingPage->template;
-
         DB::transaction(function () use ($landingPage, $validated, $effectiveTemplate): void {
             // Update template and ftp_url if provided
             // Note: contact_url is a computed accessor (public_url + '/contact'), not a database field

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -605,7 +605,7 @@ class LandingPageController extends Controller
      *
      * @return array<string, mixed>
      */
-    private function serializeLandingPagePayload(Resource $resource, LandingPage $landingPage): array
+    public static function serializeLandingPagePayload(Resource $resource, LandingPage $landingPage): array
     {
         $resource->loadMissing('resourceType');
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -130,6 +130,13 @@ class LandingPageController extends Controller
             ], 422);
         }
 
+        if ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'] ?? null, $resource->resourceType?->slug)) {
+            return response()->json([
+                'message' => $customTemplateError,
+                'error' => 'invalid_template_for_resource_type',
+            ], 422);
+        }
+
         // Detect conflicting status/is_published values.
         // If both are provided with conflicting values, this may indicate a client bug.
         if (isset($validated['status']) && isset($validated['is_published'])) {
@@ -346,6 +353,17 @@ class LandingPageController extends Controller
             if ($templateError = LandingPageTemplate::builtInTemplateScopeError($validated['template'], $resource->resourceType?->slug)) {
                 return response()->json([
                     'message' => $templateError,
+                    'error' => 'invalid_template_for_resource_type',
+                ], 422);
+            }
+        }
+
+        if (array_key_exists('landing_page_template_id', $validated)) {
+            $resource->loadMissing('resourceType');
+
+            if ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'], $resource->resourceType?->slug)) {
+                return response()->json([
+                    'message' => $customTemplateError,
                     'error' => 'invalid_template_for_resource_type',
                 ], 422);
             }

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -363,9 +363,9 @@ class LandingPageController extends Controller
 
         $validated = $request->validated();
 
-        if (isset($validated['template'])) {
-            $resource->loadMissing('resourceType');
+        $resource->loadMissing('resourceType');
 
+        if (isset($validated['template'])) {
             if ($templateError = LandingPageTemplate::builtInTemplateScopeError($validated['template'], $resource->resourceType?->slug)) {
                 return response()->json([
                     'message' => $templateError,
@@ -374,19 +374,27 @@ class LandingPageController extends Controller
             }
         }
 
-        $effectiveTemplate = $validated['template'] ?? $landingPage->template;
-        $templateChanged = array_key_exists('template', $validated)
-            && $validated['template'] !== $landingPage->template;
+        $effectiveTemplate = array_key_exists('template', $validated)
+            ? $validated['template']
+            : LandingPageTemplate::normalizeBuiltInTemplateForResource($landingPage->template, $resource->resourceType?->slug);
+        $templateChanged = $effectiveTemplate !== $landingPage->template;
 
-        if (array_key_exists('landing_page_template_id', $validated)
-            && self::templateSupportsCustomTemplateId($effectiveTemplate)) {
-            $resource->loadMissing('resourceType');
+        $effectiveLandingPageTemplateId = null;
 
-            if ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'], $resource->resourceType?->slug)) {
-                return response()->json([
-                    'message' => $customTemplateError,
-                    'error' => 'invalid_template_for_resource_type',
-                ], 422);
+        if (self::templateSupportsCustomTemplateId($effectiveTemplate)) {
+            $effectiveLandingPageTemplateId = array_key_exists('landing_page_template_id', $validated)
+                ? $validated['landing_page_template_id']
+                : $landingPage->landing_page_template_id;
+
+            if ($customTemplateError = LandingPageTemplate::customTemplateScopeError($effectiveLandingPageTemplateId, $resource->resourceType?->slug)) {
+                if (array_key_exists('landing_page_template_id', $validated)) {
+                    return response()->json([
+                        'message' => $customTemplateError,
+                        'error' => 'invalid_template_for_resource_type',
+                    ], 422);
+                }
+
+                $effectiveLandingPageTemplateId = null;
             }
         }
 
@@ -414,17 +422,16 @@ class LandingPageController extends Controller
 
         // Wrap all mutations in a transaction for atomicity.
         // This ensures the landing page + links are updated together.
-        DB::transaction(function () use ($landingPage, $validated, $effectiveTemplate, $templateChanged): void {
+        DB::transaction(function () use ($landingPage, $validated, $effectiveLandingPageTemplateId, $effectiveTemplate, $templateChanged): void {
             // Update template and ftp_url if provided
             // Note: contact_url is a computed accessor (public_url + '/contact'), not a database field
-            if (isset($validated['template'])) {
-                $landingPage->template = $validated['template'];
+            if ($templateChanged) {
+                $landingPage->template = $effectiveTemplate;
             }
-            if (array_key_exists('landing_page_template_id', $validated)) {
-                $landingPage->landing_page_template_id = self::templateSupportsCustomTemplateId($effectiveTemplate)
-                    ? $validated['landing_page_template_id']
-                    : null;
-            } elseif ($templateChanged) {
+
+            if (self::templateSupportsCustomTemplateId($effectiveTemplate)) {
+                $landingPage->landing_page_template_id = $effectiveLandingPageTemplateId;
+            } elseif ($templateChanged || array_key_exists('landing_page_template_id', $validated)) {
                 $landingPage->landing_page_template_id = null;
             }
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -41,6 +41,17 @@ class LandingPageController extends Controller
         return $template === LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
     }
 
+    private static function templateSupportsLinks(string $template): bool
+    {
+        return $template !== 'external'
+            && ! in_array($template, self::IGSN_ONLY_TEMPLATES, true);
+    }
+
+    private static function templateSupportsExternalFields(string $template): bool
+    {
+        return $template === 'external';
+    }
+
     public function __construct(
         private readonly KeywordSuggestionService $keywordService,
     ) {}
@@ -388,12 +399,21 @@ class LandingPageController extends Controller
                 ];
             }
 
-            $supportsLinks = $effectiveTemplate !== 'external'
-                && ! in_array($effectiveTemplate, self::IGSN_ONLY_TEMPLATES, true);
-
-            if (array_key_exists('links', $validated) && ! $supportsLinks) {
+            if (array_key_exists('links', $validated) && ! self::templateSupportsLinks($effectiveTemplate)) {
                 $unsupportedFields['links'] = [
                     'The links field is not supported when this landing page is normalized to the IGSN template.',
+                ];
+            }
+
+            if (array_key_exists('external_domain_id', $validated) && ! self::templateSupportsExternalFields($effectiveTemplate)) {
+                $unsupportedFields['external_domain_id'] = [
+                    'The external_domain_id field is not supported when this landing page is normalized to the IGSN template.',
+                ];
+            }
+
+            if (array_key_exists('external_path', $validated) && ! self::templateSupportsExternalFields($effectiveTemplate)) {
+                $unsupportedFields['external_path'] = [
+                    'The external_path field is not supported when this landing page is normalized to the IGSN template.',
                 ];
             }
 
@@ -468,7 +488,7 @@ class LandingPageController extends Controller
             }
 
             // Update external landing page fields
-            if ($effectiveTemplate === 'external') {
+            if (self::templateSupportsExternalFields($effectiveTemplate)) {
                 if (array_key_exists('external_domain_id', $validated)) {
                     $landingPage->external_domain_id = $validated['external_domain_id'];
                 }
@@ -486,10 +506,7 @@ class LandingPageController extends Controller
             $landingPage->save();
 
             // Sync additional links: determine once whether this template supports links
-            $isLinksTemplate = $effectiveTemplate !== 'external'
-                && ! in_array($effectiveTemplate, self::IGSN_ONLY_TEMPLATES, true);
-
-            if (! $isLinksTemplate) {
+            if (! self::templateSupportsLinks($effectiveTemplate)) {
                 // Template does not support links – clear any existing ones
                 $landingPage->links()->delete();
             } elseif (array_key_exists('links', $validated)) {
@@ -573,8 +590,55 @@ class LandingPageController extends Controller
         $landingPage->load(['externalDomain', 'files', 'links', 'landingPageTemplate']);
 
         return response()->json([
-            'landing_page' => $landingPage,
+            'landing_page' => $this->serializeLandingPagePayload($resource, $landingPage),
         ]);
+    }
+
+    /**
+     * Return the normalized landing page contract exposed to API consumers.
+     *
+     * Legacy Physical Object pages may still be stored with the old default
+     * resource renderer and stale field combinations. The GET endpoint exposes
+     * the same effective contract that update()/preview/public rendering use,
+     * so clients can safely round-trip the payload without reimplementing the
+     * normalization logic on their side.
+     *
+     * @return array<string, mixed>
+     */
+    private function serializeLandingPagePayload(Resource $resource, LandingPage $landingPage): array
+    {
+        $resource->loadMissing('resourceType');
+
+        $resourceTypeSlug = $resource->resourceType?->slug;
+        $effectiveTemplate = LandingPageTemplate::normalizeBuiltInTemplateForResource($landingPage->template, $resourceTypeSlug);
+        $effectiveLandingPageTemplate = self::templateSupportsCustomTemplateId($effectiveTemplate)
+            ? LandingPageTemplate::resolveCustomTemplate($landingPage->landingPageTemplate, $resourceTypeSlug)
+            : null;
+
+        $payload = $landingPage->toArray();
+        $payload['template'] = $effectiveTemplate;
+        $payload['landing_page_template_id'] = $effectiveLandingPageTemplate?->id;
+        $payload['landing_page_template'] = $effectiveLandingPageTemplate?->toArray();
+        $payload['ftp_url'] = self::templateSupportsFtpUrl($effectiveTemplate)
+            ? $landingPage->ftp_url
+            : null;
+        $payload['links'] = self::templateSupportsLinks($effectiveTemplate)
+            ? $landingPage->links->values()->toArray()
+            : [];
+
+        if (self::templateSupportsExternalFields($effectiveTemplate)) {
+            $payload['external_domain_id'] = $landingPage->external_domain_id;
+            $payload['external_path'] = $landingPage->external_path;
+            $payload['external_domain'] = $landingPage->externalDomain?->toArray();
+            $payload['external_url'] = $landingPage->external_url;
+        } else {
+            $payload['external_domain_id'] = null;
+            $payload['external_path'] = null;
+            $payload['external_domain'] = null;
+            $payload['external_url'] = null;
+        }
+
+        return $payload;
     }
 
     /**

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -9,6 +9,7 @@ use App\Exceptions\ResourceAlreadyExistsException;
 use App\Http\Requests\LandingPage\StoreLandingPageRequest;
 use App\Http\Requests\LandingPage\UpdateLandingPageRequest;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Services\KeywordSuggestionService;
 use App\Support\Traits\ChecksCacheTagging;
@@ -42,14 +43,25 @@ class LandingPageController extends Controller
      *
      * @var list<string>
      */
-    public const ALLOWED_TEMPLATES = ['default_gfz', 'default_gfz_igsn', 'external'];
+    public const ALLOWED_TEMPLATES = [
+        LandingPageTemplate::DEFAULT_TEMPLATE_SLUG,
+        LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_SLUG,
+        'external',
+    ];
 
     /**
      * Templates restricted to PhysicalObject resources (IGSNs).
      *
      * @var list<string>
      */
-    public const IGSN_ONLY_TEMPLATES = ['default_gfz_igsn'];
+    public const IGSN_ONLY_TEMPLATES = [LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_SLUG];
+
+    /**
+     * Templates restricted to non-PhysicalObject resources.
+     *
+     * @var list<string>
+     */
+    public const RESOURCE_ONLY_TEMPLATES = [LandingPageTemplate::DEFAULT_TEMPLATE_SLUG];
 
     /**
      * Display the public landing page.
@@ -109,15 +121,13 @@ class LandingPageController extends Controller
 
         $validated = $request->validated();
 
-        // Validate that IGSN-only templates can only be used with PhysicalObject resources
-        if (in_array($validated['template'], self::IGSN_ONLY_TEMPLATES, true)) {
-            $resource->loadMissing('resourceType');
-            if ($resource->resourceType?->slug !== 'physical-object') {
-                return response()->json([
-                    'message' => 'The IGSN template can only be used with Physical Object resources.',
-                    'error' => 'invalid_template_for_resource_type',
-                ], 422);
-            }
+        $resource->loadMissing('resourceType');
+
+        if ($templateError = LandingPageTemplate::builtInTemplateScopeError($validated['template'], $resource->resourceType?->slug)) {
+            return response()->json([
+                'message' => $templateError,
+                'error' => 'invalid_template_for_resource_type',
+            ], 422);
         }
 
         // Detect conflicting status/is_published values.
@@ -330,12 +340,12 @@ class LandingPageController extends Controller
 
         $validated = $request->validated();
 
-        // Validate that IGSN-only templates can only be used with PhysicalObject resources
-        if (isset($validated['template']) && in_array($validated['template'], self::IGSN_ONLY_TEMPLATES, true)) {
+        if (isset($validated['template'])) {
             $resource->loadMissing('resourceType');
-            if ($resource->resourceType?->slug !== 'physical-object') {
+
+            if ($templateError = LandingPageTemplate::builtInTemplateScopeError($validated['template'], $resource->resourceType?->slug)) {
                 return response()->json([
-                    'message' => 'The IGSN template can only be used with Physical Object resources.',
+                    'message' => $templateError,
                     'error' => 'invalid_template_for_resource_type',
                 ], 422);
             }

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -52,6 +52,41 @@ class LandingPageController extends Controller
         return $template === 'external';
     }
 
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, list<string>>
+     */
+    private static function unsupportedFieldErrorsForTemplate(array $validated, string $template): array
+    {
+        $unsupportedFields = [];
+
+        if (array_key_exists('ftp_url', $validated) && ! self::templateSupportsFtpUrl($template)) {
+            $unsupportedFields['ftp_url'] = [
+                'The ftp_url field is not supported for this landing page template.',
+            ];
+        }
+
+        if (array_key_exists('links', $validated) && ! self::templateSupportsLinks($template)) {
+            $unsupportedFields['links'] = [
+                'The links field is not supported for this landing page template.',
+            ];
+        }
+
+        if (array_key_exists('external_domain_id', $validated) && ! self::templateSupportsExternalFields($template)) {
+            $unsupportedFields['external_domain_id'] = [
+                'The external_domain_id field is not supported for this landing page template.',
+            ];
+        }
+
+        if (array_key_exists('external_path', $validated) && ! self::templateSupportsExternalFields($template)) {
+            $unsupportedFields['external_path'] = [
+                'The external_path field is not supported for this landing page template.',
+            ];
+        }
+
+        return $unsupportedFields;
+    }
+
     public function __construct(
         private readonly KeywordSuggestionService $keywordService,
     ) {}
@@ -324,36 +359,16 @@ class LandingPageController extends Controller
         // handle all exception cases by returning early, so we never reach
         // refresh() after a failed transaction.
         $landingPage->refresh();
-        $landingPage->load(['externalDomain', 'links', 'landingPageTemplate']);
+        $landingPage->load(['externalDomain', 'files', 'links', 'landingPageTemplate']);
 
         // Invalidate keyword suggestions cache if landing page was created as published
         if ($landingPage->is_published) {
             $this->keywordService->invalidateCache();
         }
 
-        // Determine status string for API response
-        $status = $landingPage->is_published ? 'published' : 'draft';
-
         return response()->json([
             'message' => 'Landing page created successfully',
-            'landing_page' => [
-                'id' => $landingPage->id,
-                'resource_id' => $landingPage->resource_id,
-                'doi_prefix' => $landingPage->doi_prefix,
-                'slug' => $landingPage->slug,
-                'template' => $landingPage->template,
-                'landing_page_template_id' => $landingPage->landing_page_template_id,
-                'ftp_url' => $landingPage->ftp_url,
-                'external_domain_id' => $landingPage->external_domain_id,
-                'external_path' => $landingPage->external_path,
-                'external_url' => $landingPage->external_url,
-                'external_domain' => $landingPage->externalDomain,
-                'links' => $landingPage->links,
-                'status' => $status,
-                'preview_token' => $landingPage->preview_token,
-                'preview_url' => $landingPage->preview_url,
-                'public_url' => $landingPage->public_url,
-            ],
+            'landing_page' => self::serializeLandingPagePayload($resource, $landingPage),
         ], 201);
     }
 
@@ -390,39 +405,13 @@ class LandingPageController extends Controller
             : LandingPageTemplate::normalizeBuiltInTemplateForResource($landingPage->template, $resource->resourceType?->slug);
         $templateChanged = $effectiveTemplate !== $landingPage->template;
 
-        if (! array_key_exists('template', $validated) && $templateChanged) {
-            $unsupportedFields = [];
+        $unsupportedFields = self::unsupportedFieldErrorsForTemplate($validated, $effectiveTemplate);
 
-            if (array_key_exists('ftp_url', $validated) && ! self::templateSupportsFtpUrl($effectiveTemplate)) {
-                $unsupportedFields['ftp_url'] = [
-                    'The ftp_url field is not supported when this landing page is normalized to the IGSN template.',
-                ];
-            }
-
-            if (array_key_exists('links', $validated) && ! self::templateSupportsLinks($effectiveTemplate)) {
-                $unsupportedFields['links'] = [
-                    'The links field is not supported when this landing page is normalized to the IGSN template.',
-                ];
-            }
-
-            if (array_key_exists('external_domain_id', $validated) && ! self::templateSupportsExternalFields($effectiveTemplate)) {
-                $unsupportedFields['external_domain_id'] = [
-                    'The external_domain_id field is not supported when this landing page is normalized to the IGSN template.',
-                ];
-            }
-
-            if (array_key_exists('external_path', $validated) && ! self::templateSupportsExternalFields($effectiveTemplate)) {
-                $unsupportedFields['external_path'] = [
-                    'The external_path field is not supported when this landing page is normalized to the IGSN template.',
-                ];
-            }
-
-            if ($unsupportedFields !== []) {
-                return response()->json([
-                    'message' => 'The request includes fields that are not supported for the normalized landing page template.',
-                    'errors' => $unsupportedFields,
-                ], 422);
-            }
+        if ($unsupportedFields !== []) {
+            return response()->json([
+                'message' => 'The request includes fields that are not supported for this landing page template.',
+                'errors' => $unsupportedFields,
+            ], 422);
         }
 
         $effectiveLandingPageTemplateId = null;

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -405,13 +405,15 @@ class LandingPageController extends Controller
             : LandingPageTemplate::normalizeBuiltInTemplateForResource($landingPage->template, $resource->resourceType?->slug);
         $templateChanged = $effectiveTemplate !== $landingPage->template;
 
-        $unsupportedFields = self::unsupportedFieldErrorsForTemplate($validated, $effectiveTemplate);
+        if (array_key_exists('template', $validated) || $templateChanged) {
+            $unsupportedFields = self::unsupportedFieldErrorsForTemplate($validated, $effectiveTemplate);
 
-        if ($unsupportedFields !== []) {
-            return response()->json([
-                'message' => 'The request includes fields that are not supported for this landing page template.',
-                'errors' => $unsupportedFields,
-            ], 422);
+            if ($unsupportedFields !== []) {
+                return response()->json([
+                    'message' => 'The request includes fields that are not supported for this landing page template.',
+                    'errors' => $unsupportedFields,
+                ], 422);
+            }
         }
 
         $effectiveLandingPageTemplateId = null;

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -477,7 +477,7 @@ class LandingPageController extends Controller
 
             if (self::templateSupportsCustomTemplateId($effectiveTemplate)) {
                 $landingPage->landing_page_template_id = $effectiveLandingPageTemplateId;
-            } elseif ($templateChanged || array_key_exists('landing_page_template_id', $validated)) {
+            } else {
                 $landingPage->landing_page_template_id = null;
             }
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -379,6 +379,32 @@ class LandingPageController extends Controller
             : LandingPageTemplate::normalizeBuiltInTemplateForResource($landingPage->template, $resource->resourceType?->slug);
         $templateChanged = $effectiveTemplate !== $landingPage->template;
 
+        if (! array_key_exists('template', $validated) && $templateChanged) {
+            $unsupportedFields = [];
+
+            if (array_key_exists('ftp_url', $validated) && ! self::templateSupportsFtpUrl($effectiveTemplate)) {
+                $unsupportedFields['ftp_url'] = [
+                    'The ftp_url field is not supported when this landing page is normalized to the IGSN template.',
+                ];
+            }
+
+            $supportsLinks = $effectiveTemplate !== 'external'
+                && ! in_array($effectiveTemplate, self::IGSN_ONLY_TEMPLATES, true);
+
+            if (array_key_exists('links', $validated) && ! $supportsLinks) {
+                $unsupportedFields['links'] = [
+                    'The links field is not supported when this landing page is normalized to the IGSN template.',
+                ];
+            }
+
+            if ($unsupportedFields !== []) {
+                return response()->json([
+                    'message' => 'The request includes fields that are not supported for the normalized landing page template.',
+                    'errors' => $unsupportedFields,
+                ], 422);
+            }
+        }
+
         $effectiveLandingPageTemplateId = null;
 
         if (self::templateSupportsCustomTemplateId($effectiveTemplate)) {

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -590,7 +590,7 @@ class LandingPageController extends Controller
         $landingPage->load(['externalDomain', 'files', 'links', 'landingPageTemplate']);
 
         return response()->json([
-            'landing_page' => $this->serializeLandingPagePayload($resource, $landingPage),
+            'landing_page' => self::serializeLandingPagePayload($resource, $landingPage),
         ]);
     }
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -519,12 +519,13 @@ class LandingPageController extends Controller
         // Invalidate cache
         $this->invalidateCache($resource->id);
 
-        $freshLandingPage = $landingPage->fresh();
-        $freshLandingPage?->load(['externalDomain', 'files', 'links', 'landingPageTemplate']);
+        $freshLandingPage = LandingPage::query()
+            ->with(['externalDomain', 'files', 'links', 'landingPageTemplate'])
+            ->findOrFail($landingPage->id);
 
         return response()->json([
             'message' => 'Landing page updated successfully',
-            'landing_page' => $freshLandingPage,
+            'landing_page' => self::serializeLandingPagePayload($resource, $freshLandingPage),
         ]);
     }
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -28,7 +28,15 @@ class LandingPageController extends Controller
     use AuthorizesRequests;
     use ChecksCacheTagging;
 
-    private static function templateSupportsCustomTemplateId(string $template): bool
+    public static function templateSupportsCustomTemplateId(string $template): bool
+    {
+        return in_array($template, [
+            LandingPageTemplate::DEFAULT_TEMPLATE_SLUG,
+            LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_SLUG,
+        ], true);
+    }
+
+    public static function templateSupportsFtpUrl(string $template): bool
     {
         return $template === LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
     }
@@ -197,10 +205,12 @@ class LandingPageController extends Controller
                 // We don't set them here to avoid redundancy and ensure single source of truth.
                 $createData = [
                     'template' => $validated['template'],
-                    'landing_page_template_id' => $validated['template'] === 'default_gfz'
+                    'landing_page_template_id' => self::templateSupportsCustomTemplateId($validated['template'])
                         ? ($validated['landing_page_template_id'] ?? null)
                         : null,
-                    'ftp_url' => $validated['ftp_url'] ?? null,
+                    'ftp_url' => self::templateSupportsFtpUrl($validated['template'])
+                        ? ($validated['ftp_url'] ?? null)
+                        : null,
                     'is_published' => $isPublished,
                     'published_at' => $isPublished ? now() : null,
                 ];
@@ -365,6 +375,8 @@ class LandingPageController extends Controller
         }
 
         $effectiveTemplate = $validated['template'] ?? $landingPage->template;
+        $templateChanged = array_key_exists('template', $validated)
+            && $validated['template'] !== $landingPage->template;
 
         if (array_key_exists('landing_page_template_id', $validated)
             && self::templateSupportsCustomTemplateId($effectiveTemplate)) {
@@ -402,19 +414,24 @@ class LandingPageController extends Controller
 
         // Wrap all mutations in a transaction for atomicity.
         // This ensures the landing page + links are updated together.
-        DB::transaction(function () use ($landingPage, $validated, $effectiveTemplate): void {
+        DB::transaction(function () use ($landingPage, $validated, $effectiveTemplate, $templateChanged): void {
             // Update template and ftp_url if provided
             // Note: contact_url is a computed accessor (public_url + '/contact'), not a database field
             if (isset($validated['template'])) {
                 $landingPage->template = $validated['template'];
             }
             if (array_key_exists('landing_page_template_id', $validated)) {
-                $landingPage->landing_page_template_id = $effectiveTemplate === 'default_gfz'
+                $landingPage->landing_page_template_id = self::templateSupportsCustomTemplateId($effectiveTemplate)
                     ? $validated['landing_page_template_id']
                     : null;
+            } elseif ($templateChanged) {
+                $landingPage->landing_page_template_id = null;
             }
-            if (array_key_exists('ftp_url', $validated)) {
+
+            if (self::templateSupportsFtpUrl($effectiveTemplate) && array_key_exists('ftp_url', $validated)) {
                 $landingPage->ftp_url = $validated['ftp_url'];
+            } elseif (! self::templateSupportsFtpUrl($effectiveTemplate)) {
+                $landingPage->ftp_url = null;
             }
 
             // Update external landing page fields

--- a/app/Http/Controllers/LandingPagePreviewController.php
+++ b/app/Http/Controllers/LandingPagePreviewController.php
@@ -126,19 +126,17 @@ class LandingPagePreviewController extends Controller
             ? $previewData['landing_page_template_id']
             : null;
 
-        if ($landingPageTemplateId !== null) {
-            $templateConfig = LandingPageTemplate::find($landingPageTemplateId);
+        $templateConfig = LandingPageTemplate::resolveCustomTemplate($landingPageTemplateId, $resourceTypeSlug);
 
-            if ($templateConfig !== null
-                && $templateConfig->template_type === LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug)) {
-                $sectionOrder = [
-                    'rightColumn' => $templateConfig->right_column_order,
-                    'leftColumn' => $templateConfig->left_column_order,
-                ];
-                $customLogoUrl = $templateConfig->logo_url;
-            } else {
-                $landingPageTemplateId = null;
-            }
+        if ($templateConfig !== null) {
+            $landingPageTemplateId = $templateConfig->id;
+            $sectionOrder = [
+                'rightColumn' => $templateConfig->right_column_order,
+                'leftColumn' => LandingPageTemplate::normalizeLeftColumnOrder($templateConfig->left_column_order, $templateConfig->template_type),
+            ];
+            $customLogoUrl = $templateConfig->logo_url;
+        } else {
+            $landingPageTemplateId = null;
         }
 
         $ftpUrl = LandingPageController::templateSupportsFtpUrl($template)

--- a/app/Http/Controllers/LandingPagePreviewController.php
+++ b/app/Http/Controllers/LandingPagePreviewController.php
@@ -55,6 +55,14 @@ class LandingPagePreviewController extends Controller
             ], 422);
         }
 
+        if (LandingPageController::templateSupportsCustomTemplateId($validated['template'])
+            && ($customTemplateError = LandingPageTemplate::customTemplateScopeError($validated['landing_page_template_id'] ?? null, $resource->resourceType?->slug))) {
+            return response()->json([
+                'message' => $customTemplateError,
+                'error' => 'invalid_template_for_resource_type',
+            ], 422);
+        }
+
         // Store preview data in session
         $sessionKey = "landing_page_preview.{$resource->id}";
 
@@ -64,7 +72,12 @@ class LandingPagePreviewController extends Controller
 
         Session::put($sessionKey, [
             'template' => $validated['template'],
-            'ftp_url' => $validated['ftp_url'] ?? null,
+            'landing_page_template_id' => LandingPageController::templateSupportsCustomTemplateId($validated['template'])
+                ? ($validated['landing_page_template_id'] ?? null)
+                : null,
+            'ftp_url' => LandingPageController::templateSupportsFtpUrl($validated['template'])
+                ? ($validated['ftp_url'] ?? null)
+                : null,
             'links' => $isLinksTemplate ? ($validated['links'] ?? []) : [],
             'resource_id' => $resource->id,
         ]);
@@ -101,6 +114,24 @@ class LandingPagePreviewController extends Controller
         // Prepare the same frontend payload as LandingPagePublicController
         $resourceData = $transformer->transform($resource);
 
+        $sectionOrder = null;
+        $customLogoUrl = null;
+        $landingPageTemplateId = is_int($previewData['landing_page_template_id'] ?? null)
+            ? $previewData['landing_page_template_id']
+            : null;
+
+        if ($landingPageTemplateId !== null) {
+            $templateConfig = LandingPageTemplate::find($landingPageTemplateId);
+
+            if ($templateConfig !== null) {
+                $sectionOrder = [
+                    'rightColumn' => $templateConfig->right_column_order,
+                    'leftColumn' => $templateConfig->left_column_order,
+                ];
+                $customLogoUrl = $templateConfig->logo_url;
+            }
+        }
+
         // Temporary landing page array for preview rendering.
         // Note: contact_url is not included here because it's computed from the public_url
         // in the LandingPage model. For previews, the ContactSection uses the resource's
@@ -109,6 +140,7 @@ class LandingPagePreviewController extends Controller
             'id' => null,
             'resource_id' => $resource->id,
             'template' => $template,
+            'landing_page_template_id' => $landingPageTemplateId,
             'ftp_url' => $previewData['ftp_url'] ?? null,
             'files' => [],
             'links' => is_array($previewData['links'] ?? null) ? $previewData['links'] : [],
@@ -122,6 +154,8 @@ class LandingPagePreviewController extends Controller
             'resource' => $resourceData,
             'landingPage' => $tempLandingPage,
             'isPreview' => true,
+            'sectionOrder' => $sectionOrder,
+            'customLogoUrl' => $customLogoUrl,
         ]);
     }
 

--- a/app/Http/Controllers/LandingPagePreviewController.php
+++ b/app/Http/Controllers/LandingPagePreviewController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\LandingPage\StoreLandingPagePreviewRequest;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Services\LandingPageResourceTransformer;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -45,15 +46,13 @@ class LandingPagePreviewController extends Controller
             ], 422);
         }
 
-        // Validate that IGSN-only templates can only be used with PhysicalObject resources
-        if (in_array($validated['template'], LandingPageController::IGSN_ONLY_TEMPLATES, true)) {
-            $resource->loadMissing('resourceType');
-            if ($resource->resourceType?->slug !== 'physical-object') {
-                return response()->json([
-                    'message' => 'The IGSN template can only be used with Physical Object resources.',
-                    'error' => 'invalid_template_for_resource_type',
-                ], 422);
-            }
+        $resource->loadMissing('resourceType');
+
+        if ($templateError = LandingPageTemplate::builtInTemplateScopeError($validated['template'], $resource->resourceType?->slug)) {
+            return response()->json([
+                'message' => $templateError,
+                'error' => 'invalid_template_for_resource_type',
+            ], 422);
         }
 
         // Store preview data in session

--- a/app/Http/Controllers/LandingPagePreviewController.php
+++ b/app/Http/Controllers/LandingPagePreviewController.php
@@ -103,34 +103,51 @@ class LandingPagePreviewController extends Controller
             abort(404, 'Preview session is invalid. Please open preview again from the setup modal.');
         }
 
-        $template = is_string($previewData['template'] ?? null) ? $previewData['template'] : 'default_gfz';
-        if (! in_array($template, LandingPageController::ALLOWED_TEMPLATES, true)) {
-            $template = 'default_gfz';
+        $rawTemplate = is_string($previewData['template'] ?? null) ? $previewData['template'] : LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
+        if (! in_array($rawTemplate, LandingPageController::ALLOWED_TEMPLATES, true)) {
+            $rawTemplate = LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
         }
 
         // Load the same shape used for public landing pages, because the React template expects it.
-        $resource->load($transformer->requiredRelations());
+        $resource->load(array_unique([
+            ...$transformer->requiredRelations(),
+            'resourceType',
+        ]));
+        $resourceTypeSlug = $resource->resourceType?->slug;
+        $template = LandingPageTemplate::normalizeBuiltInTemplateForResource($rawTemplate, $resourceTypeSlug);
 
         // Prepare the same frontend payload as LandingPagePublicController
         $resourceData = $transformer->transform($resource);
 
         $sectionOrder = null;
         $customLogoUrl = null;
-        $landingPageTemplateId = is_int($previewData['landing_page_template_id'] ?? null)
+        $landingPageTemplateId = LandingPageController::templateSupportsCustomTemplateId($template)
+            && is_int($previewData['landing_page_template_id'] ?? null)
             ? $previewData['landing_page_template_id']
             : null;
 
         if ($landingPageTemplateId !== null) {
             $templateConfig = LandingPageTemplate::find($landingPageTemplateId);
 
-            if ($templateConfig !== null) {
+            if ($templateConfig !== null
+                && $templateConfig->template_type === LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug)) {
                 $sectionOrder = [
                     'rightColumn' => $templateConfig->right_column_order,
                     'leftColumn' => $templateConfig->left_column_order,
                 ];
                 $customLogoUrl = $templateConfig->logo_url;
+            } else {
+                $landingPageTemplateId = null;
             }
         }
+
+        $ftpUrl = LandingPageController::templateSupportsFtpUrl($template)
+            ? ($previewData['ftp_url'] ?? null)
+            : null;
+        $links = $template !== LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_SLUG
+            && is_array($previewData['links'] ?? null)
+            ? $previewData['links']
+            : [];
 
         // Temporary landing page array for preview rendering.
         // Note: contact_url is not included here because it's computed from the public_url
@@ -141,9 +158,9 @@ class LandingPagePreviewController extends Controller
             'resource_id' => $resource->id,
             'template' => $template,
             'landing_page_template_id' => $landingPageTemplateId,
-            'ftp_url' => $previewData['ftp_url'] ?? null,
+            'ftp_url' => $ftpUrl,
             'files' => [],
-            'links' => is_array($previewData['links'] ?? null) ? $previewData['links'] : [],
+            'links' => $links,
             'status' => 'preview',
             'preview_token' => null,
             'published_at' => null,

--- a/app/Http/Controllers/LandingPagePreviewController.php
+++ b/app/Http/Controllers/LandingPagePreviewController.php
@@ -104,6 +104,10 @@ class LandingPagePreviewController extends Controller
         }
 
         $rawTemplate = is_string($previewData['template'] ?? null) ? $previewData['template'] : LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
+        if ($rawTemplate === 'external') {
+            abort(404, 'External landing pages do not support session-based previews. Please open the external URL directly from the setup modal.');
+        }
+
         if (! in_array($rawTemplate, LandingPageController::ALLOWED_TEMPLATES, true)) {
             $rawTemplate = LandingPageTemplate::DEFAULT_TEMPLATE_SLUG;
         }

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -286,16 +286,15 @@ class LandingPagePublicController extends Controller
         // Build section order and logo from custom template (if set)
         $sectionOrder = null;
         $customLogoUrl = null;
-        $effectiveLandingPageTemplate = null;
+        $effectiveLandingPageTemplate = LandingPageController::templateSupportsCustomTemplateId($effectiveTemplate)
+            ? LandingPageTemplate::resolveCustomTemplate($landingPage->landing_page_template_id, $resourceTypeSlug)
+            : null;
 
-        if (LandingPageController::templateSupportsCustomTemplateId($effectiveTemplate)
-            && $landingPage->landingPageTemplate !== null
-            && $landingPage->landingPageTemplate->template_type === LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug)) {
-            $effectiveLandingPageTemplate = $landingPage->landingPageTemplate;
+        if ($effectiveLandingPageTemplate !== null) {
             $tmpl = $effectiveLandingPageTemplate;
             $sectionOrder = [
                 'rightColumn' => $tmpl->right_column_order,
-                'leftColumn' => $tmpl->left_column_order,
+                'leftColumn' => LandingPageTemplate::normalizeLeftColumnOrder($tmpl->left_column_order, $tmpl->template_type),
             ];
             $customLogoUrl = $tmpl->logo_url;
         }

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -308,18 +308,7 @@ class LandingPagePublicController extends Controller
                 return $exporter->export($resource);
             });
 
-        $landingPageData = $landingPage->toArray();
-        $landingPageData['template'] = $effectiveTemplate;
-        $landingPageData['ftp_url'] = LandingPageController::templateSupportsFtpUrl($effectiveTemplate)
-            ? ($landingPageData['ftp_url'] ?? null)
-            : null;
-        $landingPageData['links'] = $effectiveTemplate !== 'external'
-            && ! in_array($effectiveTemplate, LandingPageController::IGSN_ONLY_TEMPLATES, true)
-            && is_array($landingPageData['links'] ?? null)
-            ? $landingPageData['links']
-            : [];
-        $landingPageData['landing_page_template_id'] = $effectiveLandingPageTemplate?->id;
-        $landingPageData['landing_page_template'] = $effectiveLandingPageTemplate?->toArray();
+        $landingPageData = LandingPageController::serializeLandingPagePayload($resource, $landingPage);
 
         $data = [
             'resource' => $resourceData,

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -287,7 +287,7 @@ class LandingPagePublicController extends Controller
         $sectionOrder = null;
         $customLogoUrl = null;
         $effectiveLandingPageTemplate = LandingPageController::templateSupportsCustomTemplateId($effectiveTemplate)
-            ? LandingPageTemplate::resolveCustomTemplate($landingPage->landing_page_template_id, $resourceTypeSlug)
+            ? LandingPageTemplate::resolveCustomTemplate($landingPage->landingPageTemplate, $resourceTypeSlug)
             : null;
 
         if ($effectiveLandingPageTemplate !== null) {
@@ -310,6 +310,14 @@ class LandingPagePublicController extends Controller
 
         $landingPageData = $landingPage->toArray();
         $landingPageData['template'] = $effectiveTemplate;
+        $landingPageData['ftp_url'] = LandingPageController::templateSupportsFtpUrl($effectiveTemplate)
+            ? ($landingPageData['ftp_url'] ?? null)
+            : null;
+        $landingPageData['links'] = $effectiveTemplate !== 'external'
+            && ! in_array($effectiveTemplate, LandingPageController::IGSN_ONLY_TEMPLATES, true)
+            && is_array($landingPageData['links'] ?? null)
+            ? $landingPageData['links']
+            : [];
         $landingPageData['landing_page_template_id'] = $effectiveLandingPageTemplate?->id;
         $landingPageData['landing_page_template'] = $effectiveLandingPageTemplate?->toArray();
 

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -275,6 +275,8 @@ class LandingPagePublicController extends Controller
         // Load resource with all necessary relationships
         $resource = Resource::with($transformer->requiredRelations())
             ->findOrFail($landingPage->resource_id);
+        $resourceTypeSlug = $resource->resourceType?->slug;
+        $effectiveTemplate = LandingPageTemplate::normalizeBuiltInTemplateForResource($landingPage->template, $resourceTypeSlug);
 
         // Eager-load file and link entries for download URL display
         $landingPage->loadMissing(['files', 'links', 'landingPageTemplate']);
@@ -284,9 +286,13 @@ class LandingPagePublicController extends Controller
         // Build section order and logo from custom template (if set)
         $sectionOrder = null;
         $customLogoUrl = null;
+        $effectiveLandingPageTemplate = null;
 
-        if ($landingPage->landing_page_template_id !== null && $landingPage->landingPageTemplate !== null) {
-            $tmpl = $landingPage->landingPageTemplate;
+        if (LandingPageController::templateSupportsCustomTemplateId($effectiveTemplate)
+            && $landingPage->landingPageTemplate !== null
+            && $landingPage->landingPageTemplate->template_type === LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug)) {
+            $effectiveLandingPageTemplate = $landingPage->landingPageTemplate;
+            $tmpl = $effectiveLandingPageTemplate;
             $sectionOrder = [
                 'rightColumn' => $tmpl->right_column_order,
                 'leftColumn' => $tmpl->left_column_order,
@@ -303,19 +309,21 @@ class LandingPagePublicController extends Controller
                 return $exporter->export($resource);
             });
 
+        $landingPageData = $landingPage->toArray();
+        $landingPageData['template'] = $effectiveTemplate;
+        $landingPageData['landing_page_template_id'] = $effectiveLandingPageTemplate?->id;
+        $landingPageData['landing_page_template'] = $effectiveLandingPageTemplate?->toArray();
+
         $data = [
             'resource' => $resourceData,
-            'landingPage' => $landingPage->toArray(),
+            'landingPage' => $landingPageData,
             'isPreview' => (bool) $previewToken,
             'schemaOrgJsonLd' => $schemaOrgJsonLd,
             'sectionOrder' => $sectionOrder,
             'customLogoUrl' => $customLogoUrl,
         ];
 
-        // Use the template specified in landing page configuration
-        $template = $landingPage->template ?? 'default_gfz';
-
-        return Inertia::render("LandingPages/{$template}", $data);
+        return Inertia::render("LandingPages/{$effectiveTemplate}", $data);
     }
 
     /**

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -38,7 +38,7 @@ class LandingPageTemplateController extends Controller
             ->get();
 
         return Inertia::render('landing-page-templates', [
-            'templates' => $templates,
+            'templates' => $this->serializeTemplates($templates),
         ]);
     }
 
@@ -70,7 +70,7 @@ class LandingPageTemplateController extends Controller
 
         return response()->json([
             'message' => 'Template created successfully',
-            'template' => $template,
+            'template' => $this->serializeTemplate($template),
         ], 201);
     }
 
@@ -109,7 +109,7 @@ class LandingPageTemplateController extends Controller
 
         return response()->json([
             'message' => 'Template updated successfully',
-            'template' => $landingPageTemplate,
+            'template' => $this->serializeTemplate($landingPageTemplate),
         ]);
     }
 
@@ -191,7 +191,7 @@ class LandingPageTemplateController extends Controller
 
         return response()->json([
             'message' => 'Logo uploaded successfully',
-            'template' => $landingPageTemplate,
+            'template' => $this->serializeTemplate($landingPageTemplate),
         ]);
     }
 
@@ -220,7 +220,7 @@ class LandingPageTemplateController extends Controller
 
         return response()->json([
             'message' => 'Logo removed successfully',
-            'template' => $landingPageTemplate,
+            'template' => $this->serializeTemplate($landingPageTemplate),
         ]);
     }
 
@@ -251,7 +251,36 @@ class LandingPageTemplateController extends Controller
             ]);
 
         return response()->json([
-            'templates' => $templates,
+            'templates' => $this->serializeTemplates($templates),
         ]);
+    }
+
+    /**
+     * @param  iterable<LandingPageTemplate>  $templates
+     * @return list<array<string, mixed>>
+     */
+    private function serializeTemplates(iterable $templates): array
+    {
+        $serialized = [];
+
+        foreach ($templates as $template) {
+            $serialized[] = $this->serializeTemplate($template);
+        }
+
+        return $serialized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeTemplate(LandingPageTemplate $template): array
+    {
+        $payload = $template->toArray();
+        $payload['left_column_order'] = LandingPageTemplate::normalizeLeftColumnOrder(
+            $template->left_column_order,
+            $template->template_type,
+        );
+
+        return $payload;
     }
 }

--- a/app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php
+++ b/app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php
@@ -28,6 +28,7 @@ class StoreLandingPagePreviewRequest extends FormRequest
     {
         $rules = [
             'template' => ['required', 'string', Rule::in(LandingPageController::ALLOWED_TEMPLATES)],
+            'landing_page_template_id' => ['nullable', 'integer', 'exists:landing_page_templates,id'],
             'ftp_url' => ['nullable', new SafeUrl, 'max:2048'],
         ];
 

--- a/app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php
+++ b/app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php
@@ -28,7 +28,7 @@ class StoreLandingPagePreviewRequest extends FormRequest
     {
         $rules = [
             'template' => ['required', 'string', Rule::in(LandingPageController::ALLOWED_TEMPLATES)],
-            'landing_page_template_id' => ['nullable', 'integer', 'exists:landing_page_templates,id'],
+            'landing_page_template_id' => ['nullable', 'integer'],
             'ftp_url' => ['nullable', new SafeUrl, 'max:2048'],
         ];
 

--- a/app/Http/Requests/LandingPage/UpdateLandingPageRequest.php
+++ b/app/Http/Requests/LandingPage/UpdateLandingPageRequest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Http\Requests\LandingPage;
 
 use App\Http\Controllers\LandingPageController;
-use App\Models\LandingPage;
-use App\Models\Resource;
 use App\Rules\SafeUrl;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -35,34 +33,15 @@ class UpdateLandingPageRequest extends FormRequest
             'template' => ['sometimes', 'string', Rule::in(LandingPageController::ALLOWED_TEMPLATES)],
             'landing_page_template_id' => ['nullable', 'integer', 'exists:landing_page_templates,id'],
             'ftp_url' => ['nullable', new SafeUrl, 'max:2048'],
+            'links' => ['nullable', 'array', 'max:10'],
+            'links.*.url' => ['required', new SafeUrl, 'max:2048'],
+            'links.*.label' => ['required', 'string', 'max:255'],
+            'links.*.position' => ['required', 'integer', 'min:0', 'max:9', 'distinct'],
             'external_domain_id' => ['required_if:template,external', 'integer', 'exists:landing_page_domains,id'],
             'external_path' => ['required_if:template,external', 'string', 'max:2048'],
             'is_published' => 'sometimes|boolean',
             'status' => 'sometimes|string|in:draft,published',
         ];
-
-        // Determine effective template: explicit input falls back to the
-        // current persisted template so partial updates validate links
-        // consistently with the resource's existing configuration.
-        $resource = $this->route('resource');
-        $currentTemplate = null;
-
-        if ($resource instanceof Resource) {
-            /** @var LandingPage|null $landingPage */
-            $landingPage = $resource->landingPage;
-            $currentTemplate = $landingPage?->template;
-        }
-
-        $effectiveTemplate = $this->input('template', $currentTemplate);
-        $supportsLinks = $effectiveTemplate !== 'external'
-            && ! in_array($effectiveTemplate, LandingPageController::IGSN_ONLY_TEMPLATES, true);
-
-        if ($supportsLinks) {
-            $rules['links'] = ['nullable', 'array', 'max:10'];
-            $rules['links.*.url'] = ['required', new SafeUrl, 'max:2048'];
-            $rules['links.*.label'] = ['required', 'string', 'max:255'];
-            $rules['links.*.position'] = ['required', 'integer', 'min:0', 'max:9', 'distinct'];
-        }
 
         return $rules;
     }

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -27,13 +27,14 @@ class UpdateLandingPageTemplateRequest extends FormRequest
     {
         /** @var LandingPageTemplate $template */
         $template = $this->route('landingPageTemplate');
+        $allowedLeftColumnSections = LandingPageTemplate::leftColumnSectionsForTemplateType($template->template_type);
 
         return [
             'name' => ['sometimes', 'filled', 'string', 'min:1', 'max:255', Rule::unique('landing_page_templates', 'name')->ignore($template->id)],
             'right_column_order' => ['sometimes', 'array'],
             'right_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)],
             'left_column_order' => ['sometimes', 'array'],
-            'left_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::LEFT_COLUMN_SECTIONS)],
+            'left_column_order.*' => ['required', 'string', Rule::in($allowedLeftColumnSections)],
         ];
     }
 
@@ -43,6 +44,10 @@ class UpdateLandingPageTemplateRequest extends FormRequest
     public function withValidator(\Illuminate\Validation\Validator $validator): void
     {
         $validator->after(function (\Illuminate\Validation\Validator $validator): void {
+            /** @var LandingPageTemplate $template */
+            $template = $this->route('landingPageTemplate');
+            $allowedLeftColumnSections = LandingPageTemplate::leftColumnSectionsForTemplateType($template->template_type);
+
             // Validate right column order contains exactly all valid sections
             if ($this->has('right_column_order') && ! $validator->errors()->has('right_column_order')) {
                 $rightOrder = $this->input('right_column_order', []);
@@ -57,7 +62,7 @@ class UpdateLandingPageTemplateRequest extends FormRequest
             // Validate left column order contains exactly all valid sections
             if ($this->has('left_column_order') && ! $validator->errors()->has('left_column_order')) {
                 $leftOrder = $this->input('left_column_order', []);
-                if (is_array($leftOrder) && ! LandingPageTemplate::isValidSectionOrder($leftOrder, LandingPageTemplate::LEFT_COLUMN_SECTIONS)) {
+                if (is_array($leftOrder) && ! LandingPageTemplate::isValidSectionOrder($leftOrder, $allowedLeftColumnSections)) {
                     $validator->errors()->add(
                         'left_column_order',
                         'Left column order must contain exactly all valid section keys without duplicates.'

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -319,7 +319,7 @@ class LandingPageTemplate extends Model
             return null;
         }
 
-        return $expectedTemplateType === self::TEMPLATE_TYPE_IGSN
+        return $template->template_type === self::TEMPLATE_TYPE_IGSN
             ? 'The selected custom landing page template is only available for IGSN landing pages.'
             : 'The selected custom landing page template is only available for regular resource landing pages.';
     }

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -277,6 +277,24 @@ class LandingPageTemplate extends Model
     }
 
     /**
+     * Return a validation error when a built-in template is used with the wrong resource scope.
+     */
+    public static function builtInTemplateScopeError(string $template, ?string $resourceTypeSlug): ?string
+    {
+        $isPhysicalObject = $resourceTypeSlug === 'physical-object';
+
+        if ($template === self::IGSN_DEFAULT_TEMPLATE_SLUG && ! $isPhysicalObject) {
+            return 'The IGSN template can only be used with Physical Object resources.';
+        }
+
+        if ($template === self::DEFAULT_TEMPLATE_SLUG && $isPhysicalObject) {
+            return 'The Default GFZ Data Services template cannot be used with Physical Object resources. Use the IGSN template instead.';
+        }
+
+        return null;
+    }
+
+    /**
      * Ensure the immutable default template (resource type) exists and has required defaults.
      */
     public static function ensureDefaultTemplateExists(): self

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -385,13 +385,15 @@ class LandingPageTemplate extends Model
         return $normalized;
     }
 
-    public static function resolveCustomTemplate(?int $templateId, ?string $resourceTypeSlug): ?self
+    public static function resolveCustomTemplate(int|self|null $templateOrId, ?string $resourceTypeSlug): ?self
     {
-        if ($templateId === null) {
+        if ($templateOrId === null) {
             return null;
         }
 
-        $template = self::query()->find($templateId);
+        $template = $templateOrId instanceof self
+            ? $templateOrId
+            : self::query()->find($templateOrId);
 
         if ($template === null || $template->isDefault()) {
             return null;

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -294,6 +294,19 @@ class LandingPageTemplate extends Model
         return null;
     }
 
+    public static function normalizeBuiltInTemplateForResource(?string $template, ?string $resourceTypeSlug): string
+    {
+        $effectiveTemplate = $template ?? self::DEFAULT_TEMPLATE_SLUG;
+
+        if (self::builtInTemplateScopeError($effectiveTemplate, $resourceTypeSlug) === null) {
+            return $effectiveTemplate;
+        }
+
+        return self::expectedTemplateTypeForResource($resourceTypeSlug) === self::TEMPLATE_TYPE_IGSN
+            ? self::IGSN_DEFAULT_TEMPLATE_SLUG
+            : self::DEFAULT_TEMPLATE_SLUG;
+    }
+
     public static function expectedTemplateTypeForResource(?string $resourceTypeSlug): string
     {
         return $resourceTypeSlug === 'physical-object'

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -102,6 +102,31 @@ class LandingPageTemplate extends Model
     ];
 
     /**
+     * Valid left-column sections for regular resource landing pages.
+     *
+     * @var list<string>
+     */
+    public const RESOURCE_LEFT_COLUMN_SECTIONS = [
+        'files',
+        'contact',
+        'model_description',
+        'related_work',
+    ];
+
+    /**
+     * Valid left-column sections for IGSN landing pages.
+     *
+     * @var list<string>
+     */
+    public const IGSN_LEFT_COLUMN_SECTIONS = [
+        'general',
+        'acquisition',
+        'contact',
+        'model_description',
+        'related_work',
+    ];
+
+    /**
      * Valid section keys for the left column.
      *
      * @var list<string>
@@ -314,6 +339,69 @@ class LandingPageTemplate extends Model
             : self::TEMPLATE_TYPE_RESOURCE;
     }
 
+    /**
+     * Return the allowed left-column sections for a given template type.
+     *
+     * @return list<string>
+     */
+    public static function leftColumnSectionsForTemplateType(string $templateType): array
+    {
+        return $templateType === self::TEMPLATE_TYPE_IGSN
+            ? self::IGSN_LEFT_COLUMN_SECTIONS
+            : self::RESOURCE_LEFT_COLUMN_SECTIONS;
+    }
+
+    /**
+     * Normalize a stored left-column order against the canonical sections for its template type.
+     *
+     * Unknown keys are dropped, duplicates are removed, and missing canonical
+     * sections are appended while preserving the existing relative order.
+     *
+     * @param  array<int, string>  $order
+     * @return list<string>
+     */
+    public static function normalizeLeftColumnOrder(array $order, string $templateType): array
+    {
+        $canonical = self::leftColumnSectionsForTemplateType($templateType);
+        $canonicalSet = array_fill_keys($canonical, true);
+        $seen = [];
+        $normalized = [];
+
+        foreach ($order as $key) {
+            if (! isset($canonicalSet[$key]) || isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $normalized[] = $key;
+        }
+
+        foreach ($canonical as $key) {
+            if (! isset($seen[$key])) {
+                $normalized[] = $key;
+            }
+        }
+
+        return $normalized;
+    }
+
+    public static function resolveCustomTemplate(?int $templateId, ?string $resourceTypeSlug): ?self
+    {
+        if ($templateId === null) {
+            return null;
+        }
+
+        $template = self::query()->find($templateId);
+
+        if ($template === null || $template->isDefault()) {
+            return null;
+        }
+
+        return $template->template_type === self::expectedTemplateTypeForResource($resourceTypeSlug)
+            ? $template
+            : null;
+    }
+
     public static function customTemplateScopeError(?int $templateId, ?string $resourceTypeSlug): ?string
     {
         if ($templateId === null) {
@@ -324,6 +412,10 @@ class LandingPageTemplate extends Model
 
         if ($template === null) {
             return null;
+        }
+
+        if ($template->isDefault()) {
+            return 'The selected landing page template is a built-in default and cannot be used as a custom override.';
         }
 
         $expectedTemplateType = self::expectedTemplateTypeForResource($resourceTypeSlug);
@@ -405,7 +497,7 @@ class LandingPageTemplate extends Model
                             'logo_path' => null,
                             'logo_filename' => null,
                             'right_column_order' => self::RIGHT_COLUMN_SECTIONS,
-                            'left_column_order' => self::LEFT_COLUMN_SECTIONS,
+                            'left_column_order' => self::leftColumnSectionsForTemplateType($templateType),
                             'created_by' => null,
                         ]
                     );
@@ -442,7 +534,7 @@ class LandingPageTemplate extends Model
                 'is_default' => true,
                 'template_type' => $templateType,
                 'right_column_order' => self::RIGHT_COLUMN_SECTIONS,
-                'left_column_order' => self::LEFT_COLUMN_SECTIONS,
+                'left_column_order' => self::leftColumnSectionsForTemplateType($templateType),
                 'created_by' => null,           // System-owned, not created by a user
                 'logo_path' => null,            // No custom logo
                 'logo_filename' => null,        // No custom logo

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -294,6 +294,36 @@ class LandingPageTemplate extends Model
         return null;
     }
 
+    public static function expectedTemplateTypeForResource(?string $resourceTypeSlug): string
+    {
+        return $resourceTypeSlug === 'physical-object'
+            ? self::TEMPLATE_TYPE_IGSN
+            : self::TEMPLATE_TYPE_RESOURCE;
+    }
+
+    public static function customTemplateScopeError(?int $templateId, ?string $resourceTypeSlug): ?string
+    {
+        if ($templateId === null) {
+            return null;
+        }
+
+        $template = self::query()->find($templateId);
+
+        if ($template === null) {
+            return null;
+        }
+
+        $expectedTemplateType = self::expectedTemplateTypeForResource($resourceTypeSlug);
+
+        if ($template->template_type === $expectedTemplateType) {
+            return null;
+        }
+
+        return $expectedTemplateType === self::TEMPLATE_TYPE_IGSN
+            ? 'The selected custom landing page template is only available for IGSN landing pages.'
+            : 'The selected custom landing page template is only available for regular resource landing pages.';
+    }
+
     /**
      * Ensure the immutable default template (resource type) exists and has required defaults.
      */

--- a/app/Services/Resources/ResourceQueryBuilder.php
+++ b/app/Services/Resources/ResourceQueryBuilder.php
@@ -271,6 +271,8 @@ final readonly class ResourceQueryBuilder
      */
     public function applySorting(Builder $query, string $sortKey, string $sortDirection): void
     {
+        $direction = $sortDirection === 'asc' ? 'asc' : 'desc';
+
         switch ($sortKey) {
             case 'title':
                 // Sort by the MainTitle so the displayed title (see
@@ -292,13 +294,13 @@ final readonly class ResourceQueryBuilder
                             ['MainTitle']
                         );
                 })
-                    ->orderBy('titles.value', $sortDirection)
+                    ->orderBy('titles.value', $direction)
                     ->select('resources.*');
                 break;
 
             case 'resourcetypegeneral':
                 $query->leftJoin('resource_types', 'resources.resource_type_id', '=', 'resource_types.id')
-                    ->orderBy('resource_types.name', $sortDirection)
+                    ->orderBy('resource_types.name', $direction)
                     ->select('resources.*');
                 break;
 
@@ -338,11 +340,11 @@ final readonly class ResourceQueryBuilder
             case 'publicstatus':
                 // Status (draft/curation/review/published) is computed at serialization time,
                 // not stored in the DB, so we fall back to sorting by id.
-                $query->orderBy('id', $sortDirection);
+                $query->orderBy('id', $direction);
                 break;
 
             case 'year':
-                $query->orderBy('publication_year', $sortDirection);
+                $query->orderBy('publication_year', $direction);
                 break;
 
             case 'created_at':
@@ -393,7 +395,7 @@ final readonly class ResourceQueryBuilder
                 break;
 
             default:
-                $query->orderBy($sortKey, $sortDirection);
+                $query->orderBy($sortKey, $direction);
                 break;
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1128,16 +1128,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.7.0",
+            "version": "v13.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "f13b85b2cce7ef5e8f3bcdf2b6c6364bbdedae0b"
+                "reference": "e7db333a025a1e93ebca7744953069d7719f4bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/f13b85b2cce7ef5e8f3bcdf2b6c6364bbdedae0b",
-                "reference": "f13b85b2cce7ef5e8f3bcdf2b6c6364bbdedae0b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e7db333a025a1e93ebca7744953069d7719f4bcf",
+                "reference": "e7db333a025a1e93ebca7744953069d7719f4bcf",
                 "shasum": ""
             },
             "require": {
@@ -1178,8 +1178,8 @@
                 "symfony/http-kernel": "^7.4.0 || ^8.0.0",
                 "symfony/mailer": "^7.4.0 || ^8.0.0",
                 "symfony/mime": "^7.4.0 || ^8.0.0",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php84": "^1.36",
+                "symfony/polyfill-php85": "^1.36",
                 "symfony/polyfill-php86": "^1.36",
                 "symfony/process": "^7.4.5 || ^8.0.5",
                 "symfony/routing": "^7.4.0 || ^8.0.0",
@@ -1348,7 +1348,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-28T17:18:25+00:00"
+            "time": "2026-05-05T21:01:14+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -1541,16 +1541,16 @@
         },
         {
             "name": "laravel/wayfinder",
-            "version": "v0.1.16",
+            "version": "v0.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/wayfinder.git",
-                "reference": "6a5c695dedb77a793bba6dc062bdddea94253517"
+                "reference": "6930cbf3052adef0047af20ca8566f7a4a406dba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/wayfinder/zipball/6a5c695dedb77a793bba6dc062bdddea94253517",
-                "reference": "6a5c695dedb77a793bba6dc062bdddea94253517",
+                "url": "https://api.github.com/repos/laravel/wayfinder/zipball/6930cbf3052adef0047af20ca8566f7a4a406dba",
+                "reference": "6930cbf3052adef0047af20ca8566f7a4a406dba",
                 "shasum": ""
             },
             "require": {
@@ -1600,7 +1600,7 @@
                 "issues": "https://github.com/laravel/wayfinder/issues",
                 "source": "https://github.com/laravel/wayfinder"
             },
-            "time": "2026-04-07T17:07:48+00:00"
+            "time": "2026-05-05T20:16:56+00:00"
         },
         {
             "name": "league/commonmark",

--- a/database/factories/LandingPageTemplateFactory.php
+++ b/database/factories/LandingPageTemplateFactory.php
@@ -35,7 +35,7 @@ class LandingPageTemplateFactory extends Factory
             'logo_path' => null,
             'logo_filename' => null,
             'right_column_order' => LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
-            'left_column_order' => LandingPageTemplate::LEFT_COLUMN_SECTIONS,
+            'left_column_order' => LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS,
             'created_by' => User::factory(),
         ];
     }
@@ -50,6 +50,7 @@ class LandingPageTemplateFactory extends Factory
             'slug' => LandingPageTemplate::DEFAULT_TEMPLATE_SLUG,
             'is_default' => true,
             'template_type' => LandingPageTemplate::TEMPLATE_TYPE_RESOURCE,
+            'left_column_order' => LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS,
             'created_by' => null,
         ]);
     }
@@ -64,6 +65,7 @@ class LandingPageTemplateFactory extends Factory
             'slug' => LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_SLUG,
             'is_default' => true,
             'template_type' => LandingPageTemplate::TEMPLATE_TYPE_IGSN,
+            'left_column_order' => LandingPageTemplate::IGSN_LEFT_COLUMN_SECTIONS,
             'created_by' => null,
         ]);
     }
@@ -75,6 +77,7 @@ class LandingPageTemplateFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'template_type' => LandingPageTemplate::TEMPLATE_TYPE_IGSN,
+            'left_column_order' => LandingPageTemplate::IGSN_LEFT_COLUMN_SECTIONS,
         ]);
     }
 

--- a/database/factories/ResourceContributorFactory.php
+++ b/database/factories/ResourceContributorFactory.php
@@ -23,7 +23,7 @@ class ResourceContributorFactory extends Factory
      */
     public function configure(): static
     {
-        $this->afterCreating(function (ResourceContributor $contributor): void {
+        return $this->afterCreating(function (ResourceContributor $contributor): void {
             // Assign default "Other" contributor type via pivot table if none assigned yet
             if (! $contributor->relationLoaded('contributorTypes') || $contributor->contributorTypes->isEmpty()) {
                 $otherType = ContributorType::where('slug', 'Other')->first()
@@ -34,8 +34,6 @@ class ResourceContributorFactory extends Factory
                 $contributor->contributorTypes()->sync([$otherType->id]);
             }
         });
-
-        return $this;
     }
 
     /**

--- a/database/factories/ResourceContributorFactory.php
+++ b/database/factories/ResourceContributorFactory.php
@@ -23,7 +23,7 @@ class ResourceContributorFactory extends Factory
      */
     public function configure(): static
     {
-        return $this->afterCreating(function (ResourceContributor $contributor): void {
+        $this->afterCreating(function (ResourceContributor $contributor): void {
             // Assign default "Other" contributor type via pivot table if none assigned yet
             if (! $contributor->relationLoaded('contributorTypes') || $contributor->contributorTypes->isEmpty()) {
                 $otherType = ContributorType::where('slug', 'Other')->first()
@@ -34,6 +34,8 @@ class ResourceContributorFactory extends Factory
                 $contributor->contributorTypes()->sync([$otherType->id]);
             }
         });
+
+        return $this;
     }
 
     /**

--- a/database/factories/ResourceContributorFactory.php
+++ b/database/factories/ResourceContributorFactory.php
@@ -20,10 +20,12 @@ class ResourceContributorFactory extends Factory
 
     /**
      * Configure the model factory.
+     *
+     * @return $this
      */
-    public function configure(): static
+    public function configure()
     {
-        return $this->afterCreating(function (ResourceContributor $contributor): void {
+        $this->afterCreating = $this->afterCreating->concat([function (ResourceContributor $contributor): void {
             // Assign default "Other" contributor type via pivot table if none assigned yet
             if (! $contributor->relationLoaded('contributorTypes') || $contributor->contributorTypes->isEmpty()) {
                 $otherType = ContributorType::where('slug', 'Other')->first()
@@ -33,7 +35,9 @@ class ResourceContributorFactory extends Factory
                     ]);
                 $contributor->contributorTypes()->sync([$otherType->id]);
             }
-        });
+        }]);
+
+        return $this;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6500,13 +6500,13 @@
       }
     },
     "node_modules/@valibot/to-json-schema": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.6.0.tgz",
-      "integrity": "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.7.0.tgz",
+      "integrity": "sha512-Y3pPVibbIOHzohrlxSINvO7w/bvXkoYS3BQHoImV9ynE+bXKf171bdMucPurV2zp7gdmt0L1HCcNAsbo7cFRQw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "valibot": "^1.3.0"
+        "valibot": "^1.4.0"
       }
     },
     "node_modules/@vis.gl/react-google-maps": {
@@ -8711,9 +8711,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.351",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
+      "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
       "dev": true,
       "license": "ISC"
     },
@@ -10746,9 +10746,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -14992,9 +14992,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
-      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.0.tgz",
+      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6270,17 +6270,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6293,7 +6293,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -6309,16 +6309,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6334,14 +6334,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6356,14 +6356,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6374,9 +6374,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6391,15 +6391,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6416,9 +6416,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6430,16 +6430,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6458,16 +6458,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6482,13 +6482,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -10236,13 +10236,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12619,9 +12619,9 @@
       }
     },
     "node_modules/publint": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.18.tgz",
-      "integrity": "sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.19.tgz",
+      "integrity": "sha512-J3p4GOocCRFyLLFRzGfIhAwWgk0Kkcdxj5iFspFvCYbyiJs5IhCM8gsIkcNeQL+tdpV671RtJQiTFSUKhl1Wjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14646,16 +14646,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
-      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.1",
-        "@typescript-eslint/parser": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1"
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10034,9 +10034,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.6.tgz",
+      "integrity": "sha512-uwrF08UBQfxk49i9WcUeCx045wjB1zXEHNJmbYHPVVspxmjwSeWCoKbB8DEIvs3XkBJV6lcRAyLaWJ2+u3MMCw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10755,9 +10755,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10839,9 +10839,9 @@
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -11583,9 +11583,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.2.tgz",
-      "integrity": "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.3.tgz",
+      "integrity": "sha512-kk8G5cocVlJ4wsKMGZegn2H6XLOEKjbA+nSJE2354e/SRp4mDicCHUYnMXpymzVcVDCs+GUAsmNqSn+yHv4T2A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -11601,7 +11601,7 @@
         "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
-        "rettime": "^0.11.7",
+        "rettime": "^0.11.11",
         "statuses": "^2.0.2",
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.1",
@@ -12367,9 +12367,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -14869,9 +14869,9 @@
       }
     },
     "node_modules/unstorage/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -15677,9 +15677,9 @@
       "license": "Unlicense"
     },
     "node_modules/zod": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -184,6 +184,10 @@
         ],
         "fixes": [
             {
+                "title": "IGSN Landing Page Setup Now Hides Resource-Only Template",
+                "description": "The 'Setup IGSN Landing Page' modal on /igsns no longer offers the built-in 'Default GFZ Data Services' template, which is intended for regular resources only. Physical samples now consistently default to the IGSN-specific template in the UI, legacy invalid selections are remapped to the IGSN template when the modal loads, and the backend rejects create, update, and preview requests that try to assign the resource-only template to Physical Object records."
+            },
+            {
                 "title": "DataCite import no longer fails on long edition values",
                 "description": "Widened the related_items.edition column from VARCHAR(64) to VARCHAR(255). Previously, importing DOIs from the DataCite API could fail with 'SQLSTATE[22001]: Data too long for column edition' when a related item carried a long conference or edition description, causing the entire import job to abort and roll back the resource."
             },

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -7,6 +7,8 @@ import {
     getHydratedLandingPageTemplateId,
     getPayloadLandingPageTemplateId,
     getPreferredIgsnTemplate,
+    getPreviewableExternalUrl,
+    normalizeExternalPath,
 } from '@/components/landing-pages/modals/landing-page-modal-helpers';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -162,6 +164,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         setIsSaving(true);
 
         try {
+            const normalizedExternalPath = normalizeExternalPath(externalPath);
             // Note: No ftp_url for IGSN landing pages
             const payload: Record<string, string | number | null> = {
                 template,
@@ -171,7 +174,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
 
             if (isExternal) {
                 payload.external_domain_id = externalDomainId ? Number(externalDomainId) : null;
-                payload.external_path = externalPath || null;
+                payload.external_path = normalizedExternalPath;
             }
 
             const url = `/resources/${resource.id}/landing-page`;
@@ -291,13 +294,12 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
     };
 
     const computedExternalUrl = useMemo(() => {
-        if (!isExternal || !externalDomainId) return null;
-
-        const domain = availableDomains.find((availableDomain) => availableDomain.id === Number(externalDomainId));
-
-        if (!domain) return null;
-
-        return domain.domain + (externalPath || '').replace(/^\/+/, '');
+        return getPreviewableExternalUrl({
+            availableDomains,
+            externalDomainId,
+            externalPath,
+            isExternal,
+        });
     }, [availableDomains, externalDomainId, externalPath, isExternal]);
 
     /**

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -330,7 +330,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         if (isExternal) {
             if (computedExternalUrl) {
                 window.open(computedExternalUrl, '_blank', 'noopener,noreferrer');
-            } else if (currentConfig?.external_url) {
+            } else if (!hasUnsavedChanges && currentConfig?.external_url) {
                 window.open(currentConfig.external_url, '_blank', 'noopener,noreferrer');
             } else {
                 toast.error('Please select a domain and enter a path to preview the external URL.');

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -12,6 +12,33 @@ import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig } from '@/types/landing-page';
 
+const IGSN_TEMPLATE_KEYS = new Set(getIgsnTemplateOptions().map((option) => option.value));
+
+function normalizeIgsnTemplate(template?: string | null): string {
+    if (template && IGSN_TEMPLATE_KEYS.has(template)) {
+        return template;
+    }
+
+    return getDefaultIgsnTemplate();
+}
+
+function normalizeIgsnConfig(config?: LandingPageConfig | null): LandingPageConfig | null {
+    if (!config) {
+        return null;
+    }
+
+    const template = normalizeIgsnTemplate(config.template);
+
+    if (template === config.template) {
+        return config;
+    }
+
+    return {
+        ...config,
+        template,
+    };
+}
+
 interface IgsnResource {
     id: number;
     doi?: string | null;
@@ -36,22 +63,25 @@ interface SetupIgsnLandingPageModalProps {
  * - Uses FlaskConical icon instead of Globe
  */
 export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig }: SetupIgsnLandingPageModalProps) {
-    const [template, setTemplate] = useState<string>(existingConfig?.template ?? getDefaultIgsnTemplate());
-    const [isPublished, setIsPublished] = useState<boolean>((existingConfig?.status ?? 'draft') === 'published');
-    const [previewUrl, setPreviewUrl] = useState<string>(existingConfig?.preview_url ?? '');
+    const normalizedExistingConfig = normalizeIgsnConfig(existingConfig);
+
+    const [template, setTemplate] = useState<string>(normalizedExistingConfig?.template ?? getDefaultIgsnTemplate());
+    const [isPublished, setIsPublished] = useState<boolean>((normalizedExistingConfig?.status ?? 'draft') === 'published');
+    const [previewUrl, setPreviewUrl] = useState<string>(normalizedExistingConfig?.preview_url ?? '');
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
-    const [currentConfig, setCurrentConfig] = useState<LandingPageConfig | null>(existingConfig ?? null);
+    const [currentConfig, setCurrentConfig] = useState<LandingPageConfig | null>(normalizedExistingConfig);
 
     // Load existing config when modal opens
     useEffect(() => {
         if (isOpen && resource.id) {
             if (existingConfig) {
                 // Use existing config passed as prop
-                setCurrentConfig(existingConfig);
-                setTemplate(existingConfig.template);
-                setIsPublished(existingConfig.status === 'published');
-                setPreviewUrl(existingConfig.preview_url ?? '');
+                const config = normalizeIgsnConfig(existingConfig);
+                setCurrentConfig(config);
+                setTemplate(config?.template ?? getDefaultIgsnTemplate());
+                setIsPublished((config?.status ?? 'draft') === 'published');
+                setPreviewUrl(config?.preview_url ?? '');
             } else {
                 // Load from server
                 loadLandingPageConfig();
@@ -70,11 +100,11 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         setIsLoading(true);
         try {
             const response = await axios.get<{ landing_page: LandingPageConfig }>(`/resources/${resource.id}/landing-page`);
-            const config = response.data.landing_page;
+            const config = normalizeIgsnConfig(response.data.landing_page);
             setCurrentConfig(config);
-            setTemplate(config.template);
-            setIsPublished(config.status === 'published');
-            setPreviewUrl(config.preview_url);
+            setTemplate(config?.template ?? getDefaultIgsnTemplate());
+            setIsPublished((config?.status ?? 'draft') === 'published');
+            setPreviewUrl(config?.preview_url ?? '');
         } catch (error) {
             if (isAxiosError(error) && error.response?.status === 404) {
                 // No landing page exists yet, use defaults

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -518,12 +518,11 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                                     <p className="text-sm text-muted-foreground">Path appended to the domain (e.g. /sample/12345)</p>
                                 </div>
 
-                                {externalDomainId && (
+                                {computedExternalUrl && (
                                     <div className="space-y-1">
                                         <Label className="text-xs text-muted-foreground">Resulting URL</Label>
                                         <p className="break-all rounded bg-white/80 px-2 py-1 font-mono text-xs text-blue-800 dark:bg-gray-900/50 dark:text-blue-200">
-                                            {(availableDomains.find((domain) => domain.id === Number(externalDomainId))?.domain ?? '') +
-                                                (externalPath || '').replace(/^\/+/, '')}
+                                            {computedExternalUrl}
                                         </p>
                                     </div>
                                 )}

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -1,5 +1,5 @@
 import axios, { isAxiosError } from 'axios';
-import { Copy, Eye, FlaskConical } from 'lucide-react';
+import { Copy, ExternalLink, Eye, FlaskConical } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -10,7 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig, type LandingPageTemplateSummary } from '@/types/landing-page';
+import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageTemplateSummary } from '@/types/landing-page';
 
 const IGSN_TEMPLATE_KEYS = new Set(getIgsnTemplateOptions().map((option) => option.value));
 
@@ -62,7 +62,7 @@ interface SetupIgsnLandingPageModalProps {
  *
  * This is a simplified version of SetupLandingPageModal, specifically designed for IGSNs:
  * - No FTP URL field (not applicable to physical samples)
- * - Only IGSN-specific templates available
+ * - Supports IGSN renderers plus the shared external redirect template
  * - Uses FlaskConical icon instead of Globe
  */
 export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig }: SetupIgsnLandingPageModalProps) {
@@ -74,10 +74,15 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [currentConfig, setCurrentConfig] = useState<LandingPageConfig | null>(existingConfig ?? null);
+    const [externalDomainId, setExternalDomainId] = useState<string>(String(existingConfig?.external_domain_id ?? ''));
+    const [externalPath, setExternalPath] = useState<string>(existingConfig?.external_path ?? '');
+    const [availableDomains, setAvailableDomains] = useState<LandingPageDomain[]>([]);
     const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateSummary[]>([]);
     const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
         getHydratedLandingPageTemplateId(initialTemplate, existingConfig),
     );
+
+    const isExternal = template === 'external';
 
     const eligibleCustomTemplates = useMemo(
         () => customTemplates.filter((customTemplate) => !customTemplate.is_default && customTemplate.template_type === 'igsn'),
@@ -91,6 +96,8 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         setTemplate(preferredTemplate);
         setIsPublished(config.status === 'published');
         setPreviewUrl(config.preview_url ?? '');
+        setExternalDomainId(String(config.external_domain_id ?? ''));
+        setExternalPath(config.external_path ?? '');
         setLandingPageTemplateId(getHydratedLandingPageTemplateId(preferredTemplate, config));
     }, []);
 
@@ -104,6 +111,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                 // Load from server
                 loadLandingPageConfig();
             }
+            loadAvailableDomains();
             loadCustomTemplates();
         } else if (!isOpen) {
             // Reset state when modal closes
@@ -111,10 +119,26 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
             setTemplate(getDefaultIgsnTemplate());
             setIsPublished(false);
             setPreviewUrl('');
+            setExternalDomainId('');
+            setExternalPath('');
             setLandingPageTemplateId(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [applyConfigState, existingConfig, isOpen, resource.id]);
+
+    const loadAvailableDomains = async () => {
+        try {
+            const response = await axios.get<{ domains: LandingPageDomain[] }>('/api/landing-page-domains/list');
+            setAvailableDomains(response.data.domains ?? []);
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.status === 404) {
+                setAvailableDomains([]);
+                return;
+            }
+
+            console.error('Failed to load landing page domains:', error);
+        }
+    };
 
     const loadCustomTemplates = async () => {
         try {
@@ -142,6 +166,8 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                 setTemplate(getDefaultIgsnTemplate());
                 setIsPublished(false);
                 setPreviewUrl('');
+                setExternalDomainId('');
+                setExternalPath('');
                 setLandingPageTemplateId(null);
             } else {
                 console.error('Failed to load landing page config:', error);
@@ -162,11 +188,16 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
 
         try {
             // Note: No ftp_url for IGSN landing pages
-            const payload = {
+            const payload: Record<string, string | number | null> = {
                 template,
                 landing_page_template_id: getPayloadLandingPageTemplateId(template, landingPageTemplateId),
                 status: isPublished ? 'published' : 'draft',
             };
+
+            if (isExternal) {
+                payload.external_domain_id = externalDomainId ? Number(externalDomainId) : null;
+                payload.external_path = externalPath || null;
+            }
 
             const url = `/resources/${resource.id}/landing-page`;
 
@@ -258,10 +289,18 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
      */
     const hasUnsavedChanges = useMemo(() => {
         if (!currentConfig) return false;
-        return template !== currentConfig.template
+        const baseChanges = template !== currentConfig.template
             || isPublished !== (currentConfig.status === 'published')
             || landingPageTemplateId !== (currentConfig.landing_page_template_id ?? null);
-    }, [currentConfig, landingPageTemplateId, template, isPublished]);
+
+        if (isExternal) {
+            return baseChanges
+                || externalDomainId !== String(currentConfig.external_domain_id ?? '')
+                || externalPath !== (currentConfig.external_path ?? '');
+        }
+
+        return baseChanges;
+    }, [currentConfig, externalDomainId, externalPath, isExternal, landingPageTemplateId, template, isPublished]);
 
     const copyToClipboard = async (text: string, label: string) => {
         try {
@@ -274,10 +313,32 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         }
     };
 
+    const computedExternalUrl = useMemo(() => {
+        if (!isExternal || !externalDomainId) return null;
+
+        const domain = availableDomains.find((availableDomain) => availableDomain.id === Number(externalDomainId));
+
+        if (!domain) return null;
+
+        return domain.domain + (externalPath || '').replace(/^\/+/, '');
+    }, [availableDomains, externalDomainId, externalPath, isExternal]);
+
     /**
      * Open a preview of the landing page.
      */
     const openPreview = async () => {
+        if (isExternal) {
+            if (computedExternalUrl) {
+                window.open(computedExternalUrl, '_blank', 'noopener,noreferrer');
+            } else if (currentConfig?.external_url) {
+                window.open(currentConfig.external_url, '_blank', 'noopener,noreferrer');
+            } else {
+                toast.error('Please select a domain and enter a path to preview the external URL.');
+            }
+
+            return;
+        }
+
         // If there are unsaved changes or no saved config, use session-based preview
         if (hasUnsavedChanges || !currentConfig) {
             if (!resource.id) {
@@ -437,6 +498,58 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                             </Select>
                             <p className="text-sm text-muted-foreground">Choose the design template for your IGSN landing page</p>
                         </div>
+
+                        {isExternal && (
+                            <div className="space-y-4 rounded-lg border border-blue-200 bg-blue-50/50 p-4 dark:border-blue-800 dark:bg-blue-950/20">
+                                <div className="flex items-center gap-2 text-sm font-medium text-blue-900 dark:text-blue-100">
+                                    <ExternalLink className="size-4" />
+                                    External URL Configuration
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="external-domain">Domain</Label>
+                                    <Select value={externalDomainId} onValueChange={setExternalDomainId}>
+                                        <SelectTrigger id="external-domain">
+                                            <SelectValue placeholder="Select a domain" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {availableDomains.map((domain) => (
+                                                <SelectItem key={domain.id} value={String(domain.id)}>
+                                                    {domain.domain}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    {availableDomains.length === 0 && (
+                                        <p className="text-xs text-amber-600 dark:text-amber-400">
+                                            No domains configured. An administrator can add domains in Editor Settings.
+                                        </p>
+                                    )}
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="external-path">Path</Label>
+                                    <Input
+                                        id="external-path"
+                                        type="text"
+                                        placeholder="/path/to/landing-page"
+                                        value={externalPath}
+                                        onChange={(event) => setExternalPath(event.target.value)}
+                                    />
+                                    <p className="text-sm text-muted-foreground">Path appended to the domain (e.g. /sample/12345)</p>
+                                </div>
+
+                                {externalDomainId && (
+                                    <div className="space-y-1">
+                                        <Label className="text-xs text-muted-foreground">Resulting URL</Label>
+                                        <p className="break-all rounded bg-white/80 px-2 py-1 font-mono text-xs text-blue-800 dark:bg-gray-900/50 dark:text-blue-200">
+                                            {(availableDomains.find((domain) => domain.id === Number(externalDomainId))?.domain ?? '') +
+                                                (externalPath || '').replace(/^\/+/, '')}
+                                        </p>
+                                    </div>
+                                )}
+                            </div>
+                        )}
 
                         {/* No FTP URL field for IGSN landing pages */}
 

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -269,7 +269,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         if (!currentConfig) return false;
         const currentTemplate = getPreferredIgsnTemplate(currentConfig.template);
         const currentLandingPageTemplateId = getHydratedLandingPageTemplateId(currentTemplate, currentConfig);
-        const baseChanges = template !== currentConfig.template
+        const baseChanges = template !== currentTemplate
             || isPublished !== (currentConfig.status === 'published')
             || landingPageTemplateId !== currentLandingPageTemplateId;
 

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -31,6 +31,10 @@ function getHydratedLandingPageTemplateId(template: string, config?: LandingPage
         return null;
     }
 
+    if (config.landing_page_template?.is_default) {
+        return null;
+    }
+
     if (config.landing_page_template?.template_type === 'resource') {
         return null;
     }
@@ -289,9 +293,11 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
      */
     const hasUnsavedChanges = useMemo(() => {
         if (!currentConfig) return false;
+        const currentTemplate = getPreferredIgsnTemplate(currentConfig.template);
+        const currentLandingPageTemplateId = getHydratedLandingPageTemplateId(currentTemplate, currentConfig);
         const baseChanges = template !== currentConfig.template
             || isPublished !== (currentConfig.status === 'published')
-            || landingPageTemplateId !== (currentConfig.landing_page_template_id ?? null);
+            || landingPageTemplateId !== currentLandingPageTemplateId;
 
         if (isExternal) {
             return baseChanges

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -3,6 +3,11 @@ import { Copy, ExternalLink, Eye, FlaskConical } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
+import {
+    getHydratedLandingPageTemplateId,
+    getPayloadLandingPageTemplateId,
+    getPreferredIgsnTemplate,
+} from '@/components/landing-pages/modals/landing-page-modal-helpers';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -11,40 +16,6 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSepa
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageTemplateSummary } from '@/types/landing-page';
-
-const IGSN_TEMPLATE_KEYS = new Set(getIgsnTemplateOptions().map((option) => option.value));
-
-function getPreferredIgsnTemplate(template?: string | null): string {
-    if (template && IGSN_TEMPLATE_KEYS.has(template)) {
-        return template;
-    }
-
-    return getDefaultIgsnTemplate();
-}
-
-function templateSupportsCustomTemplateId(template: string): boolean {
-    return template === getDefaultIgsnTemplate();
-}
-
-function getHydratedLandingPageTemplateId(template: string, config?: LandingPageConfig | null): number | null {
-    if (!config || !templateSupportsCustomTemplateId(template)) {
-        return null;
-    }
-
-    if (config.landing_page_template?.is_default) {
-        return null;
-    }
-
-    if (config.landing_page_template?.template_type === 'resource') {
-        return null;
-    }
-
-    return config.landing_page_template_id ?? null;
-}
-
-function getPayloadLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
-    return templateSupportsCustomTemplateId(template) ? (landingPageTemplateId ?? null) : null;
-}
 
 interface IgsnResource {
     id: number;

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -14,29 +14,12 @@ import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig 
 
 const IGSN_TEMPLATE_KEYS = new Set(getIgsnTemplateOptions().map((option) => option.value));
 
-function normalizeIgsnTemplate(template?: string | null): string {
+function getPreferredIgsnTemplate(template?: string | null): string {
     if (template && IGSN_TEMPLATE_KEYS.has(template)) {
         return template;
     }
 
     return getDefaultIgsnTemplate();
-}
-
-function normalizeIgsnConfig(config?: LandingPageConfig | null): LandingPageConfig | null {
-    if (!config) {
-        return null;
-    }
-
-    const template = normalizeIgsnTemplate(config.template);
-
-    if (template === config.template) {
-        return config;
-    }
-
-    return {
-        ...config,
-        template,
-    };
 }
 
 interface IgsnResource {
@@ -63,25 +46,22 @@ interface SetupIgsnLandingPageModalProps {
  * - Uses FlaskConical icon instead of Globe
  */
 export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig }: SetupIgsnLandingPageModalProps) {
-    const normalizedExistingConfig = normalizeIgsnConfig(existingConfig);
-
-    const [template, setTemplate] = useState<string>(normalizedExistingConfig?.template ?? getDefaultIgsnTemplate());
-    const [isPublished, setIsPublished] = useState<boolean>((normalizedExistingConfig?.status ?? 'draft') === 'published');
-    const [previewUrl, setPreviewUrl] = useState<string>(normalizedExistingConfig?.preview_url ?? '');
+    const [template, setTemplate] = useState<string>(getPreferredIgsnTemplate(existingConfig?.template));
+    const [isPublished, setIsPublished] = useState<boolean>((existingConfig?.status ?? 'draft') === 'published');
+    const [previewUrl, setPreviewUrl] = useState<string>(existingConfig?.preview_url ?? '');
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
-    const [currentConfig, setCurrentConfig] = useState<LandingPageConfig | null>(normalizedExistingConfig);
+    const [currentConfig, setCurrentConfig] = useState<LandingPageConfig | null>(existingConfig ?? null);
 
     // Load existing config when modal opens
     useEffect(() => {
         if (isOpen && resource.id) {
             if (existingConfig) {
                 // Use existing config passed as prop
-                const config = normalizeIgsnConfig(existingConfig);
-                setCurrentConfig(config);
-                setTemplate(config?.template ?? getDefaultIgsnTemplate());
-                setIsPublished((config?.status ?? 'draft') === 'published');
-                setPreviewUrl(config?.preview_url ?? '');
+                setCurrentConfig(existingConfig);
+                setTemplate(getPreferredIgsnTemplate(existingConfig.template));
+                setIsPublished(existingConfig.status === 'published');
+                setPreviewUrl(existingConfig.preview_url ?? '');
             } else {
                 // Load from server
                 loadLandingPageConfig();
@@ -100,11 +80,11 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
         setIsLoading(true);
         try {
             const response = await axios.get<{ landing_page: LandingPageConfig }>(`/resources/${resource.id}/landing-page`);
-            const config = normalizeIgsnConfig(response.data.landing_page);
+            const config = response.data.landing_page;
             setCurrentConfig(config);
-            setTemplate(config?.template ?? getDefaultIgsnTemplate());
-            setIsPublished((config?.status ?? 'draft') === 'published');
-            setPreviewUrl(config?.preview_url ?? '');
+            setTemplate(getPreferredIgsnTemplate(config.template));
+            setIsPublished(config.status === 'published');
+            setPreviewUrl(config.preview_url ?? '');
         } catch (error) {
             if (isAxiosError(error) && error.response?.status === 404) {
                 // No landing page exists yet, use defaults
@@ -158,6 +138,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
             if (response.data.landing_page) {
                 const updatedConfig = response.data.landing_page;
                 setCurrentConfig(updatedConfig);
+                setTemplate(getPreferredIgsnTemplate(updatedConfig.template));
                 setPreviewUrl(updatedConfig.preview_url ?? '');
                 setIsPublished(updatedConfig.status === 'published');
             }

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -31,10 +31,6 @@ function getHydratedLandingPageTemplateId(template: string, config?: LandingPage
         return null;
     }
 
-    if (template !== config.template) {
-        return null;
-    }
-
     if (config.landing_page_template?.template_type === 'resource') {
         return null;
     }

--- a/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupIgsnLandingPageModal.tsx
@@ -1,16 +1,16 @@
 import axios, { isAxiosError } from 'axios';
 import { Copy, Eye, FlaskConical } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig } from '@/types/landing-page';
+import { getDefaultIgsnTemplate, getIgsnTemplateOptions, type LandingPageConfig, type LandingPageTemplateSummary } from '@/types/landing-page';
 
 const IGSN_TEMPLATE_KEYS = new Set(getIgsnTemplateOptions().map((option) => option.value));
 
@@ -20,6 +20,30 @@ function getPreferredIgsnTemplate(template?: string | null): string {
     }
 
     return getDefaultIgsnTemplate();
+}
+
+function templateSupportsCustomTemplateId(template: string): boolean {
+    return template === getDefaultIgsnTemplate();
+}
+
+function getHydratedLandingPageTemplateId(template: string, config?: LandingPageConfig | null): number | null {
+    if (!config || !templateSupportsCustomTemplateId(template)) {
+        return null;
+    }
+
+    if (template !== config.template) {
+        return null;
+    }
+
+    if (config.landing_page_template?.template_type === 'resource') {
+        return null;
+    }
+
+    return config.landing_page_template_id ?? null;
+}
+
+function getPayloadLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
+    return templateSupportsCustomTemplateId(template) ? (landingPageTemplateId ?? null) : null;
 }
 
 interface IgsnResource {
@@ -46,45 +70,75 @@ interface SetupIgsnLandingPageModalProps {
  * - Uses FlaskConical icon instead of Globe
  */
 export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig }: SetupIgsnLandingPageModalProps) {
-    const [template, setTemplate] = useState<string>(getPreferredIgsnTemplate(existingConfig?.template));
+    const initialTemplate = getPreferredIgsnTemplate(existingConfig?.template);
+
+    const [template, setTemplate] = useState<string>(initialTemplate);
     const [isPublished, setIsPublished] = useState<boolean>((existingConfig?.status ?? 'draft') === 'published');
     const [previewUrl, setPreviewUrl] = useState<string>(existingConfig?.preview_url ?? '');
     const [isLoading, setIsLoading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [currentConfig, setCurrentConfig] = useState<LandingPageConfig | null>(existingConfig ?? null);
+    const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateSummary[]>([]);
+    const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
+        getHydratedLandingPageTemplateId(initialTemplate, existingConfig),
+    );
+
+    const eligibleCustomTemplates = useMemo(
+        () => customTemplates.filter((customTemplate) => !customTemplate.is_default && customTemplate.template_type === 'igsn'),
+        [customTemplates],
+    );
+
+    const applyConfigState = useCallback((config: LandingPageConfig) => {
+        const preferredTemplate = getPreferredIgsnTemplate(config.template);
+
+        setCurrentConfig(config);
+        setTemplate(preferredTemplate);
+        setIsPublished(config.status === 'published');
+        setPreviewUrl(config.preview_url ?? '');
+        setLandingPageTemplateId(getHydratedLandingPageTemplateId(preferredTemplate, config));
+    }, []);
 
     // Load existing config when modal opens
     useEffect(() => {
         if (isOpen && resource.id) {
             if (existingConfig) {
                 // Use existing config passed as prop
-                setCurrentConfig(existingConfig);
-                setTemplate(getPreferredIgsnTemplate(existingConfig.template));
-                setIsPublished(existingConfig.status === 'published');
-                setPreviewUrl(existingConfig.preview_url ?? '');
+                applyConfigState(existingConfig);
             } else {
                 // Load from server
                 loadLandingPageConfig();
             }
+            loadCustomTemplates();
         } else if (!isOpen) {
             // Reset state when modal closes
             setCurrentConfig(null);
             setTemplate(getDefaultIgsnTemplate());
             setIsPublished(false);
             setPreviewUrl('');
+            setLandingPageTemplateId(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen, resource.id]);
+    }, [applyConfigState, existingConfig, isOpen, resource.id]);
+
+    const loadCustomTemplates = async () => {
+        try {
+            const response = await axios.get<{ templates: LandingPageTemplateSummary[] }>('/api/landing-page-templates');
+            setCustomTemplates(response.data.templates ?? []);
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.status === 404) {
+                setCustomTemplates([]);
+                return;
+            }
+
+            console.error('Failed to load custom templates:', error);
+        }
+    };
 
     const loadLandingPageConfig = async () => {
         setIsLoading(true);
         try {
             const response = await axios.get<{ landing_page: LandingPageConfig }>(`/resources/${resource.id}/landing-page`);
-            const config = response.data.landing_page;
-            setCurrentConfig(config);
-            setTemplate(getPreferredIgsnTemplate(config.template));
-            setIsPublished(config.status === 'published');
-            setPreviewUrl(config.preview_url ?? '');
+            applyConfigState(response.data.landing_page);
         } catch (error) {
             if (isAxiosError(error) && error.response?.status === 404) {
                 // No landing page exists yet, use defaults
@@ -92,6 +146,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                 setTemplate(getDefaultIgsnTemplate());
                 setIsPublished(false);
                 setPreviewUrl('');
+                setLandingPageTemplateId(null);
             } else {
                 console.error('Failed to load landing page config:', error);
                 toast.error('Failed to load landing page configuration');
@@ -113,6 +168,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
             // Note: No ftp_url for IGSN landing pages
             const payload = {
                 template,
+                landing_page_template_id: getPayloadLandingPageTemplateId(template, landingPageTemplateId),
                 status: isPublished ? 'published' : 'draft',
             };
 
@@ -136,11 +192,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
 
             // Update local state with response data
             if (response.data.landing_page) {
-                const updatedConfig = response.data.landing_page;
-                setCurrentConfig(updatedConfig);
-                setTemplate(getPreferredIgsnTemplate(updatedConfig.template));
-                setPreviewUrl(updatedConfig.preview_url ?? '');
-                setIsPublished(updatedConfig.status === 'published');
+                applyConfigState(response.data.landing_page);
             }
 
             // Clear session-based preview if it exists
@@ -210,8 +262,10 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
      */
     const hasUnsavedChanges = useMemo(() => {
         if (!currentConfig) return false;
-        return template !== currentConfig.template || isPublished !== (currentConfig.status === 'published');
-    }, [currentConfig, template, isPublished]);
+        return template !== currentConfig.template
+            || isPublished !== (currentConfig.status === 'published')
+            || landingPageTemplateId !== (currentConfig.landing_page_template_id ?? null);
+    }, [currentConfig, landingPageTemplateId, template, isPublished]);
 
     const copyToClipboard = async (text: string, label: string) => {
         try {
@@ -239,6 +293,7 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                 // Note: No ftp_url for IGSN landing pages
                 const payload = {
                     template,
+                    landing_page_template_id: getPayloadLandingPageTemplateId(template, landingPageTemplateId),
                 };
 
                 const response = await axios.post<{ preview_url: string }>(`/resources/${resource.id}/landing-page/preview`, payload);
@@ -332,19 +387,56 @@ export default function SetupIgsnLandingPageModal({ resource, isOpen, onClose, o
                         {/* Template Selection */}
                         <div className="space-y-2">
                             <Label htmlFor="template">Landing Page Template</Label>
-                            <Select value={template} onValueChange={setTemplate}>
+                            <Select
+                                value={landingPageTemplateId ? `custom:${landingPageTemplateId}` : template}
+                                onValueChange={(value) => {
+                                    if (value.startsWith('custom:')) {
+                                        const id = Number.parseInt(value.replace('custom:', ''), 10);
+
+                                        if (!Number.isNaN(id)) {
+                                            setTemplate(getDefaultIgsnTemplate());
+                                            setLandingPageTemplateId(id);
+                                        }
+
+                                        return;
+                                    }
+
+                                    setTemplate(value);
+                                    setLandingPageTemplateId(null);
+                                }}
+                            >
                                 <SelectTrigger id="template">
                                     <SelectValue placeholder="Select a template" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    {templateOptions.map((tmpl) => (
-                                        <SelectItem key={tmpl.value} value={tmpl.value}>
-                                            <div className="flex flex-col">
-                                                <span>{tmpl.label}</span>
-                                                <span className="text-xs text-muted-foreground">{tmpl.description}</span>
-                                            </div>
-                                        </SelectItem>
-                                    ))}
+                                    <SelectGroup>
+                                        <SelectLabel>Built-in Templates</SelectLabel>
+                                        {templateOptions.map((tmpl) => (
+                                            <SelectItem key={tmpl.value} value={tmpl.value}>
+                                                <div className="flex flex-col">
+                                                    <span>{tmpl.label}</span>
+                                                    <span className="text-xs text-muted-foreground">{tmpl.description}</span>
+                                                </div>
+                                            </SelectItem>
+                                        ))}
+                                    </SelectGroup>
+
+                                    {eligibleCustomTemplates.length > 0 && (
+                                        <>
+                                            <SelectSeparator />
+                                            <SelectGroup>
+                                                <SelectLabel>Custom Templates</SelectLabel>
+                                                {eligibleCustomTemplates.map((customTemplate) => (
+                                                    <SelectItem key={customTemplate.id} value={`custom:${customTemplate.id}`}>
+                                                        <div className="flex flex-col">
+                                                            <span>{customTemplate.name}</span>
+                                                            <span className="text-xs text-muted-foreground">Custom IGSN template</span>
+                                                        </div>
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectGroup>
+                                        </>
+                                    )}
                                 </SelectContent>
                             </Select>
                             <p className="text-sm text-muted-foreground">Choose the design template for your IGSN landing page</p>

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -11,6 +11,8 @@ import {
     getHydratedLandingPageTemplateId,
     getPayloadLandingPageTemplateId,
     getPreferredTemplateForResource,
+    getPreviewableExternalUrl,
+    normalizeExternalPath,
 } from '@/components/landing-pages/modals/landing-page-modal-helpers';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -243,6 +245,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         setIsSaving(true);
 
         try {
+            const normalizedExternalPath = normalizeExternalPath(externalPath);
             const payload: Record<string, unknown> = {
                 template,
                 ftp_url: supportsFtpUrl ? ftpUrl || null : null,
@@ -252,7 +255,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
             if (isExternal) {
                 payload.external_domain_id = externalDomainId ? Number(externalDomainId) : null;
-                payload.external_path = externalPath || null;
+                payload.external_path = normalizedExternalPath;
             }
 
             if (supportsLinks) {
@@ -405,10 +408,12 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
      * Compute the external URL from the current domain selection and path.
      */
     const computedExternalUrl = useMemo(() => {
-        if (!isExternal || !externalDomainId) return null;
-        const domain = availableDomains.find((d) => d.id === Number(externalDomainId));
-        if (!domain) return null;
-        return domain.domain + (externalPath || '').replace(/^\/+/, '');
+        return getPreviewableExternalUrl({
+            availableDomains,
+            externalDomainId,
+            externalPath,
+            isExternal,
+        });
     }, [isExternal, externalDomainId, externalPath, availableDomains]);
 
     const openPreview = async () => {
@@ -416,7 +421,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         if (isExternal) {
             if (computedExternalUrl) {
                 window.open(computedExternalUrl, '_blank', 'noopener,noreferrer');
-            } else if (currentConfig?.external_url) {
+            } else if (!hasUnsavedChanges && currentConfig?.external_url) {
                 window.open(currentConfig.external_url, '_blank', 'noopener,noreferrer');
             } else {
                 toast.error('Please select a domain and enter a path to preview the external URL.');

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -32,6 +32,21 @@ interface SetupLandingPageModalProps {
     existingConfig?: LandingPageConfig | null;
 }
 
+function getPreferredTemplateForResource(resourceType?: string, template?: string | null): string {
+    const defaultTemplate = isIgsnLandingPageResourceType(resourceType) ? 'default_gfz_igsn' : getDefaultTemplate();
+    const validTemplates = new Set(getTemplateOptions(resourceType).map((option) => option.value));
+
+    if (template && validTemplates.has(template)) {
+        return template;
+    }
+
+    return defaultTemplate;
+}
+
+function getPreferredLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
+    return template === 'default_gfz' ? (landingPageTemplateId ?? null) : null;
+}
+
 function SortableLinkItem({
     link,
     index,
@@ -91,10 +106,10 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     // initial state, the reset-on-close branch, and the 404 fallback inside
     // `loadLandingPageConfig` so a freshly opened IGSN modal always points at
     // the correct built-in template.
-    const defaultTemplateForResource =
-        isIgsnLandingPageResourceType(resource.resourcetypegeneral) ? 'default_gfz_igsn' : getDefaultTemplate();
+    const defaultTemplateForResource = getPreferredTemplateForResource(resource.resourcetypegeneral);
+    const initialTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, existingConfig?.template);
 
-    const [template, setTemplate] = useState<string>(existingConfig?.template ?? defaultTemplateForResource);
+    const [template, setTemplate] = useState<string>(initialTemplate);
     const [ftpUrl, setFtpUrl] = useState<string>(existingConfig?.ftp_url ?? '');
     const [isPublished, setIsPublished] = useState<boolean>((existingConfig?.status ?? 'draft') === 'published');
     const [previewUrl, setPreviewUrl] = useState<string>(existingConfig?.preview_url ?? '');
@@ -111,7 +126,9 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateSummary[]>([]);
 
     // Landing page template ID (for custom templates)
-    const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(existingConfig?.landing_page_template_id ?? null);
+    const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
+        getPreferredLandingPageTemplateId(initialTemplate, existingConfig?.landing_page_template_id),
+    );
 
     // Additional links state
     const [links, setLinks] = useState<LandingPageLink[]>(existingConfig?.links ?? []);
@@ -145,30 +162,31 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         [resource.resourcetypegeneral],
     );
 
+    const applyConfigState = useCallback((config: LandingPageConfig) => {
+        const preferredTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, config.template);
+
+        setCurrentConfig(config);
+        setTemplate(preferredTemplate);
+        setFtpUrl(config.ftp_url ?? '');
+        setIsPublished(config.status === 'published');
+        setPreviewUrl(config.preview_url ?? '');
+        setExternalDomainId(String(config.external_domain_id ?? ''));
+        setExternalPath(config.external_path ?? '');
+        setLinks(config.links ?? []);
+        setLandingPageTemplateId(getPreferredLandingPageTemplateId(preferredTemplate, config.landing_page_template_id));
+    }, [resource.resourcetypegeneral]);
+
     // Load existing config when modal opens
     useEffect(() => {
         if (isOpen && resource.id) {
             if (existingConfig) {
-                // Use existing config passed as prop
-                setCurrentConfig(existingConfig);
-                setTemplate(existingConfig.template);
-                setFtpUrl(existingConfig.ftp_url ?? '');
-                setIsPublished(existingConfig.status === 'published');
-                setPreviewUrl(existingConfig.preview_url ?? '');
-                setExternalDomainId(String(existingConfig.external_domain_id ?? ''));
-                setExternalPath(existingConfig.external_path ?? '');
-                setLinks(existingConfig.links ?? []);
-                setLandingPageTemplateId(existingConfig.landing_page_template_id ?? null);
+                applyConfigState(existingConfig);
             } else {
-                // Load from server
                 loadLandingPageConfig();
             }
-            // Load available domains for external landing pages
             loadAvailableDomains();
-            // Load custom templates for the dropdown
             loadCustomTemplates();
         } else if (!isOpen) {
-            // Reset state when modal closes
             setCurrentConfig(null);
             setTemplate(defaultTemplateForResource);
             setFtpUrl('');
@@ -180,7 +198,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setLandingPageTemplateId(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen, resource.id]);
+    }, [applyConfigState, defaultTemplateForResource, existingConfig, isOpen, resource.id]);
 
     const loadAvailableDomains = async () => {
         try {
@@ -205,19 +223,9 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         setIsLoading(true);
         try {
             const response = await axios.get<{ landing_page: LandingPageConfig }>(`/resources/${resource.id}/landing-page`);
-            const config = response.data.landing_page;
-            setCurrentConfig(config);
-            setTemplate(config.template);
-            setFtpUrl(config.ftp_url ?? '');
-            setIsPublished(config.status === 'published');
-            setPreviewUrl(config.preview_url);
-            setExternalDomainId(String(config.external_domain_id ?? ''));
-            setExternalPath(config.external_path ?? '');
-            setLinks(config.links ?? []);
-            setLandingPageTemplateId(config.landing_page_template_id ?? null);
+            applyConfigState(response.data.landing_page);
         } catch (error) {
             if (isAxiosError(error) && error.response?.status === 404) {
-                // No landing page exists yet, use defaults
                 setCurrentConfig(null);
                 setTemplate(defaultTemplateForResource);
                 setFtpUrl('');
@@ -249,16 +257,14 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 template,
                 ftp_url: supportsFtpUrl ? ftpUrl || null : null,
                 status: isPublished ? 'published' : 'draft',
-                landing_page_template_id: landingPageTemplateId,
+                landing_page_template_id: getPreferredLandingPageTemplateId(template, landingPageTemplateId),
             };
 
-            // Add external fields when template is 'external'
             if (isExternal) {
                 payload.external_domain_id = externalDomainId ? Number(externalDomainId) : null;
                 payload.external_path = externalPath || null;
             }
 
-            // Add additional links when template supports them (filter out incomplete rows)
             if (supportsLinks) {
                 payload.links = links
                     .filter((link) => link.url.trim() !== '' && link.label.trim() !== '')
@@ -270,8 +276,6 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             }
 
             const url = `/resources/${resource.id}/landing-page`;
-
-            // Determine if we should update or create
             const shouldUpdate = currentConfig !== null;
 
             const response = shouldUpdate
@@ -287,28 +291,16 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
             toast.success(response.data.message);
 
-            // Update local state with response data
             if (response.data.landing_page) {
-                const updatedConfig = response.data.landing_page;
-                setCurrentConfig(updatedConfig);
-                setTemplate(updatedConfig.template ?? getDefaultTemplate());
-                setFtpUrl(updatedConfig.ftp_url ?? '');
-                setPreviewUrl(updatedConfig.preview_url ?? '');
-                setIsPublished(updatedConfig.status === 'published');
-                setExternalDomainId(String(updatedConfig.external_domain_id ?? ''));
-                setExternalPath(updatedConfig.external_path ?? '');
-                setLinks(updatedConfig.links ?? []);
-                setLandingPageTemplateId(updatedConfig.landing_page_template_id ?? null);
+                applyConfigState(response.data.landing_page);
             }
 
-            // Clear session-based preview if it exists
             try {
                 await axios.delete(`/resources/${resource.id}/landing-page/preview`);
             } catch {
                 // Ignore errors from clearing preview session
             }
 
-            // Call success callback to notify parent component
             onSuccess?.();
         } catch (error) {
             console.error('Failed to save landing page:', error);

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -52,6 +52,10 @@ function getHydratedLandingPageTemplateId(template: string, config?: LandingPage
         return null;
     }
 
+    if (config.landing_page_template?.is_default) {
+        return null;
+    }
+
     const expectedTemplateType = template === 'default_gfz_igsn' ? 'igsn' : 'resource';
     const templateType = config.landing_page_template?.template_type;
 
@@ -381,12 +385,14 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const hasUnsavedChanges = useMemo(() => {
         if (!currentConfig) return false;
         const isExternalTemplate = template === 'external';
+        const currentTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, currentConfig.template);
+        const currentLandingPageTemplateId = getHydratedLandingPageTemplateId(currentTemplate, currentConfig);
         const baseChanges =
             template !== currentConfig.template ||
             // ftpUrl is irrelevant for external and IGSN templates.
             (supportsFtpUrl && ftpUrl !== (currentConfig.ftp_url ?? '')) ||
             isPublished !== (currentConfig.status === 'published') ||
-            landingPageTemplateId !== (currentConfig.landing_page_template_id ?? null);
+            landingPageTemplateId !== currentLandingPageTemplateId;
 
         // Check if links have changed
         const currentLinks = currentConfig.links ?? [];
@@ -405,7 +411,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             );
         }
         return baseChanges || linksChanged;
-    }, [currentConfig, template, ftpUrl, isPublished, externalDomainId, externalPath, links, landingPageTemplateId, supportsFtpUrl]);
+    }, [currentConfig, template, ftpUrl, isPublished, externalDomainId, externalPath, links, landingPageTemplateId, resource.resourcetypegeneral, supportsFtpUrl]);
 
     const copyToClipboard = async (text: string, label: string) => {
         try {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -685,12 +685,11 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                 </div>
 
                                 {/* External URL Preview */}
-                                {externalDomainId && (
+                                {computedExternalUrl && (
                                     <div className="space-y-1">
                                         <Label className="text-xs text-muted-foreground">Resulting URL</Label>
                                         <p className="break-all rounded bg-white/80 px-2 py-1 font-mono text-xs text-blue-800 dark:bg-gray-900/50 dark:text-blue-200">
-                                            {(availableDomains.find((d) => d.id === Number(externalDomainId))?.domain ?? '') +
-                                                (externalPath || '').replace(/^\/+/, '')}
+                                            {computedExternalUrl}
                                         </p>
                                     </div>
                                 )}

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -7,6 +7,11 @@ import { Copy, ExternalLink, Eye, Globe, GripVertical, Plus, X } from 'lucide-re
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
+import {
+    getHydratedLandingPageTemplateId,
+    getPayloadLandingPageTemplateId,
+    getPreferredTemplateForResource,
+} from '@/components/landing-pages/modals/landing-page-modal-helpers';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -14,7 +19,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { getDefaultTemplate, getTemplateOptions, isIgsnLandingPageResourceType, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
+import { getTemplateOptions, isIgsnLandingPageResourceType, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
 
 interface Resource {
     id: number;
@@ -30,44 +35,6 @@ interface SetupLandingPageModalProps {
     onClose: () => void;
     onSuccess?: () => void;
     existingConfig?: LandingPageConfig | null;
-}
-
-function getPreferredTemplateForResource(resourceType?: string, template?: string | null): string {
-    const defaultTemplate = isIgsnLandingPageResourceType(resourceType) ? 'default_gfz_igsn' : getDefaultTemplate();
-    const validTemplates = new Set(getTemplateOptions(resourceType).map((option) => option.value));
-
-    if (template && validTemplates.has(template)) {
-        return template;
-    }
-
-    return defaultTemplate;
-}
-
-function templateSupportsCustomTemplateId(template: string): boolean {
-    return template === 'default_gfz' || template === 'default_gfz_igsn';
-}
-
-function getHydratedLandingPageTemplateId(template: string, config?: LandingPageConfig | null): number | null {
-    if (!config || !templateSupportsCustomTemplateId(template)) {
-        return null;
-    }
-
-    if (config.landing_page_template?.is_default) {
-        return null;
-    }
-
-    const expectedTemplateType = template === 'default_gfz_igsn' ? 'igsn' : 'resource';
-    const templateType = config.landing_page_template?.template_type;
-
-    if (templateType && templateType !== expectedTemplateType) {
-        return null;
-    }
-
-    return config.landing_page_template_id ?? null;
-}
-
-function getPayloadLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
-    return templateSupportsCustomTemplateId(template) ? (landingPageTemplateId ?? null) : null;
 }
 
 function SortableLinkItem({

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -248,10 +248,13 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             const normalizedExternalPath = normalizeExternalPath(externalPath);
             const payload: Record<string, unknown> = {
                 template,
-                ftp_url: supportsFtpUrl ? ftpUrl || null : null,
                 status: isPublished ? 'published' : 'draft',
                 landing_page_template_id: getPayloadLandingPageTemplateId(template, landingPageTemplateId),
             };
+
+            if (supportsFtpUrl) {
+                payload.ftp_url = ftpUrl || null;
+            }
 
             if (isExternal) {
                 payload.external_domain_id = externalDomainId ? Number(externalDomainId) : null;

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -14,7 +14,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { getDefaultTemplate, getTemplateOptions, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
+import { getDefaultTemplate, getTemplateOptions, isIgsnLandingPageResourceType, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
 
 interface Resource {
     id: number;
@@ -92,7 +92,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     // `loadLandingPageConfig` so a freshly opened IGSN modal always points at
     // the correct built-in template.
     const defaultTemplateForResource =
-        resource.resourcetypegeneral === 'PhysicalObject' ? 'default_gfz_igsn' : getDefaultTemplate();
+        isIgsnLandingPageResourceType(resource.resourcetypegeneral) ? 'default_gfz_igsn' : getDefaultTemplate();
 
     const [template, setTemplate] = useState<string>(existingConfig?.template ?? defaultTemplateForResource);
     const [ftpUrl, setFtpUrl] = useState<string>(existingConfig?.ftp_url ?? '');
@@ -131,7 +131,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     //   `external`. Everything else stays on the resource template path.
     // - Custom templates: filtered strictly to the resource's eligible
     //   `template_type` (PhysicalObject → `igsn`, otherwise → `resource`).
-    const isPhysicalObject = resource.resourcetypegeneral === 'PhysicalObject';
+    const isPhysicalObject = isIgsnLandingPageResourceType(resource.resourcetypegeneral);
     const eligibleTemplateType: 'resource' | 'igsn' = isPhysicalObject ? 'igsn' : 'resource';
     const eligibleCustomTemplates = useMemo(
         () => customTemplates.filter(

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -118,6 +118,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
     const isExternal = template === 'external';
     const isIgsn = template === 'default_gfz_igsn';
+    const supportsFtpUrl = !isExternal && !isIgsn;
     const supportsLinks = !isExternal && !isIgsn;
     const MAX_LINKS = 10;
 
@@ -246,7 +247,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         try {
             const payload: Record<string, unknown> = {
                 template,
-                ftp_url: isExternal ? null : ftpUrl || null,
+                ftp_url: supportsFtpUrl ? ftpUrl || null : null,
                 status: isPublished ? 'published' : 'draft',
                 landing_page_template_id: landingPageTemplateId,
             };
@@ -371,8 +372,8 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         const isExternalTemplate = template === 'external';
         const baseChanges =
             template !== currentConfig.template ||
-            // ftpUrl is irrelevant for external templates (backend forces it to null)
-            (!isExternalTemplate && ftpUrl !== (currentConfig.ftp_url ?? '')) ||
+            // ftpUrl is irrelevant for external and IGSN templates.
+            (supportsFtpUrl && ftpUrl !== (currentConfig.ftp_url ?? '')) ||
             isPublished !== (currentConfig.status === 'published') ||
             landingPageTemplateId !== (currentConfig.landing_page_template_id ?? null);
 
@@ -393,7 +394,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             );
         }
         return baseChanges || linksChanged;
-    }, [currentConfig, template, ftpUrl, isPublished, externalDomainId, externalPath, links, landingPageTemplateId]);
+    }, [currentConfig, template, ftpUrl, isPublished, externalDomainId, externalPath, links, landingPageTemplateId, supportsFtpUrl]);
 
     const copyToClipboard = async (text: string, label: string) => {
         try {
@@ -448,10 +449,11 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             }
 
             try {
-                const payload: Record<string, unknown> = {
-                    template,
-                    ftp_url: ftpUrl || null,
-                };
+                const payload: Record<string, unknown> = { template };
+
+                if (supportsFtpUrl) {
+                    payload.ftp_url = ftpUrl || null;
+                }
 
                 // Include complete links for templates that support them (filter out incomplete rows)
                 if (supportsLinks) {
@@ -705,7 +707,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                         )}
 
                         {/* FTP URL (hidden for external landing pages, disabled when imported files exist) */}
-                        {!isExternal && (
+                        {supportsFtpUrl && (
                             <div className="space-y-2">
                                 <Label htmlFor="ftp-url">Download URL (FTP)</Label>
                                 <Input

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -358,7 +358,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         const currentTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, currentConfig.template);
         const currentLandingPageTemplateId = getHydratedLandingPageTemplateId(currentTemplate, currentConfig);
         const baseChanges =
-            template !== currentConfig.template ||
+            template !== currentTemplate ||
             // ftpUrl is irrelevant for external and IGSN templates.
             (supportsFtpUrl && ftpUrl !== (currentConfig.ftp_url ?? '')) ||
             isPublished !== (currentConfig.status === 'published') ||

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -43,8 +43,34 @@ function getPreferredTemplateForResource(resourceType?: string, template?: strin
     return defaultTemplate;
 }
 
-function getPreferredLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
-    return template === 'default_gfz' ? (landingPageTemplateId ?? null) : null;
+function templateSupportsCustomTemplateId(template: string): boolean {
+    return template === 'default_gfz' || template === 'default_gfz_igsn';
+}
+
+function getHydratedLandingPageTemplateId(template: string, config?: LandingPageConfig | null): number | null {
+    if (!config || !templateSupportsCustomTemplateId(template)) {
+        return null;
+    }
+
+    if (template !== config.template) {
+        return null;
+    }
+
+    const templateType = config.landing_page_template?.template_type;
+
+    if (template === 'default_gfz' && templateType === 'igsn') {
+        return null;
+    }
+
+    if (template === 'default_gfz_igsn' && templateType === 'resource') {
+        return null;
+    }
+
+    return config.landing_page_template_id ?? null;
+}
+
+function getPayloadLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
+    return templateSupportsCustomTemplateId(template) ? (landingPageTemplateId ?? null) : null;
 }
 
 function SortableLinkItem({
@@ -127,7 +153,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
     // Landing page template ID (for custom templates)
     const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
-        getPreferredLandingPageTemplateId(initialTemplate, existingConfig?.landing_page_template_id),
+        getHydratedLandingPageTemplateId(initialTemplate, existingConfig),
     );
 
     // Additional links state
@@ -173,7 +199,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         setExternalDomainId(String(config.external_domain_id ?? ''));
         setExternalPath(config.external_path ?? '');
         setLinks(config.links ?? []);
-        setLandingPageTemplateId(getPreferredLandingPageTemplateId(preferredTemplate, config.landing_page_template_id));
+        setLandingPageTemplateId(getHydratedLandingPageTemplateId(preferredTemplate, config));
     }, [resource.resourcetypegeneral]);
 
     // Load existing config when modal opens
@@ -257,7 +283,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 template,
                 ftp_url: supportsFtpUrl ? ftpUrl || null : null,
                 status: isPublished ? 'published' : 'draft',
-                landing_page_template_id: getPreferredLandingPageTemplateId(template, landingPageTemplateId),
+                landing_page_template_id: getPayloadLandingPageTemplateId(template, landingPageTemplateId),
             };
 
             if (isExternal) {
@@ -446,6 +472,8 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 if (supportsFtpUrl) {
                     payload.ftp_url = ftpUrl || null;
                 }
+
+                payload.landing_page_template_id = getPayloadLandingPageTemplateId(template, landingPageTemplateId);
 
                 // Include complete links for templates that support them (filter out incomplete rows)
                 if (supportsLinks) {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -52,17 +52,10 @@ function getHydratedLandingPageTemplateId(template: string, config?: LandingPage
         return null;
     }
 
-    if (template !== config.template) {
-        return null;
-    }
-
+    const expectedTemplateType = template === 'default_gfz_igsn' ? 'igsn' : 'resource';
     const templateType = config.landing_page_template?.template_type;
 
-    if (template === 'default_gfz' && templateType === 'igsn') {
-        return null;
-    }
-
-    if (template === 'default_gfz_igsn' && templateType === 'resource') {
+    if (templateType && templateType !== expectedTemplateType) {
         return null;
     }
 

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -125,13 +125,10 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     // custom templates are eligible.
     //
     // - Built-in templates: `getTemplateOptions(resource.resourcetypegeneral)`
-    //   returns every template whose `resourceTypes` either is `null`
-    //   (unrestricted, e.g. `default_gfz` and `external`) or explicitly lists
-    //   the resource type. PhysicalObject resources therefore see the standard
-    //   resource template + the IGSN-only template + external; everything else
-    //   sees the standard template + external. This is intentional so curators
-    //   retain the option to fall back to the resource renderer for unusual
-    //   IGSN configurations.
+    //   returns the built-in templates valid for the current setup flow.
+    //   PhysicalObject resources are treated as IGSN landing pages, so they
+    //   only see IGSN-compatible built-ins plus shared options such as
+    //   `external`. Everything else stays on the resource template path.
     // - Custom templates: filtered strictly to the resource's eligible
     //   `template_type` (PhysicalObject → `igsn`, otherwise → `resource`).
     const isPhysicalObject = resource.resourcetypegeneral === 'PhysicalObject';

--- a/resources/js/components/landing-pages/modals/landing-page-modal-helpers.ts
+++ b/resources/js/components/landing-pages/modals/landing-page-modal-helpers.ts
@@ -5,6 +5,7 @@ import {
     getTemplateOptions,
     isIgsnLandingPageResourceType,
     type LandingPageConfig,
+    type LandingPageDomain,
 } from '@/types/landing-page';
 
 type BuiltInTemplateType = 'resource' | 'igsn';
@@ -67,4 +68,40 @@ export function getHydratedLandingPageTemplateId(template: string, config?: Land
 
 export function getPayloadLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
     return templateSupportsCustomTemplateId(template) ? (landingPageTemplateId ?? null) : null;
+}
+
+export function normalizeExternalPath(externalPath?: string | null): string | null {
+    const normalizedExternalPath = externalPath?.trim() ?? '';
+
+    return normalizedExternalPath === '' ? null : normalizedExternalPath;
+}
+
+export function getPreviewableExternalUrl({
+    availableDomains,
+    externalDomainId,
+    externalPath,
+    isExternal,
+}: {
+    availableDomains: LandingPageDomain[];
+    externalDomainId: string;
+    externalPath: string;
+    isExternal: boolean;
+}): string | null {
+    if (!isExternal || !externalDomainId) {
+        return null;
+    }
+
+    const normalizedExternalPath = normalizeExternalPath(externalPath);
+
+    if (!normalizedExternalPath) {
+        return null;
+    }
+
+    const domain = availableDomains.find((availableDomain) => availableDomain.id === Number(externalDomainId));
+
+    if (!domain) {
+        return null;
+    }
+
+    return domain.domain + normalizedExternalPath.replace(/^\/+/, '');
 }

--- a/resources/js/components/landing-pages/modals/landing-page-modal-helpers.ts
+++ b/resources/js/components/landing-pages/modals/landing-page-modal-helpers.ts
@@ -1,0 +1,70 @@
+import {
+    getDefaultIgsnTemplate,
+    getDefaultTemplate,
+    getIgsnTemplateOptions,
+    getTemplateOptions,
+    isIgsnLandingPageResourceType,
+    type LandingPageConfig,
+} from '@/types/landing-page';
+
+type BuiltInTemplateType = 'resource' | 'igsn';
+
+const IGSN_TEMPLATE_KEYS = new Set(getIgsnTemplateOptions().map((option) => option.value));
+
+function getBuiltInTemplateType(template: string): BuiltInTemplateType | null {
+    if (template === getDefaultIgsnTemplate()) {
+        return 'igsn';
+    }
+
+    if (template === getDefaultTemplate()) {
+        return 'resource';
+    }
+
+    return null;
+}
+
+export function getPreferredTemplateForResource(resourceType?: string, template?: string | null): string {
+    const defaultTemplate = isIgsnLandingPageResourceType(resourceType) ? getDefaultIgsnTemplate() : getDefaultTemplate();
+    const validTemplates = new Set(getTemplateOptions(resourceType).map((option) => option.value));
+
+    if (template && validTemplates.has(template)) {
+        return template;
+    }
+
+    return defaultTemplate;
+}
+
+export function getPreferredIgsnTemplate(template?: string | null): string {
+    if (template && IGSN_TEMPLATE_KEYS.has(template)) {
+        return template;
+    }
+
+    return getDefaultIgsnTemplate();
+}
+
+export function templateSupportsCustomTemplateId(template: string): boolean {
+    return getBuiltInTemplateType(template) !== null;
+}
+
+export function getHydratedLandingPageTemplateId(template: string, config?: LandingPageConfig | null): number | null {
+    if (!config || !templateSupportsCustomTemplateId(template)) {
+        return null;
+    }
+
+    if (config.landing_page_template?.is_default) {
+        return null;
+    }
+
+    const expectedTemplateType = getBuiltInTemplateType(template);
+    const templateType = config.landing_page_template?.template_type;
+
+    if (expectedTemplateType !== null && templateType && templateType !== expectedTemplateType) {
+        return null;
+    }
+
+    return config.landing_page_template_id ?? null;
+}
+
+export function getPayloadLandingPageTemplateId(template: string, landingPageTemplateId?: number | null): number | null {
+    return templateSupportsCustomTemplateId(template) ? (landingPageTemplateId ?? null) : null;
+}

--- a/resources/js/lib/query-keys.ts
+++ b/resources/js/lib/query-keys.ts
@@ -1,4 +1,4 @@
-import { validate as doiValidate } from '@/routes/api/doi';
+import { validate as doiValidate } from '@/routes/api/doi/index';
 
 /**
  * Centralised QueryKey factory for TanStack Query.

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -63,14 +63,24 @@ const CANONICAL_RIGHT_ORDER: RightColumnSection[] = [
     'location',
 ];
 
-const CANONICAL_LEFT_ORDER: LeftColumnSection[] = [
+const RESOURCE_LEFT_ORDER: LeftColumnSection[] = [
     'files',
+    'contact',
+    'model_description',
+    'related_work',
+];
+
+const IGSN_LEFT_ORDER: LeftColumnSection[] = [
     'general',
     'acquisition',
     'contact',
     'model_description',
     'related_work',
 ];
+
+function getCanonicalLeftOrder(templateType: LandingPageTemplateConfig['template_type']): LeftColumnSection[] {
+    return templateType === 'igsn' ? IGSN_LEFT_ORDER : RESOURCE_LEFT_ORDER;
+}
 
 /**
  * Merge a stored section order with the canonical list:
@@ -145,6 +155,13 @@ function normalizeRightColumnOrder(stored: readonly RightColumnSection[]): Right
     }
 
     return locationBeforeMetadata ? ['location', ...metadataItems] : [...metadataItems, 'location'];
+}
+
+function normalizeLeftColumnOrder(
+    stored: readonly LeftColumnSection[],
+    templateType: LandingPageTemplateConfig['template_type'],
+): LeftColumnSection[] {
+    return normalizeOrder<LeftColumnSection>(stored, getCanonicalLeftOrder(templateType));
 }
 
 interface PageProps extends SharedData {
@@ -291,7 +308,7 @@ export default function LandingPageTemplatesPage() {
         setEditTemplate(tmpl);
         setEditName(tmpl.name);
         setEditRightOrder(normalizeRightColumnOrder(tmpl.right_column_order));
-        setEditLeftOrder(normalizeOrder<LeftColumnSection>(tmpl.left_column_order, CANONICAL_LEFT_ORDER));
+        setEditLeftOrder(normalizeLeftColumnOrder(tmpl.left_column_order, tmpl.template_type));
         setEditOpen(true);
     };
 
@@ -302,7 +319,7 @@ export default function LandingPageTemplatesPage() {
             await axios.put(`/landing-pages/${editTemplate.id}`, {
                 name: editName.trim(),
                 right_column_order: normalizeRightColumnOrder(editRightOrder),
-                left_column_order: editLeftOrder,
+                left_column_order: normalizeLeftColumnOrder(editLeftOrder, editTemplate.template_type),
             });
             toast.success('Template updated successfully');
             setEditOpen(false);
@@ -483,7 +500,7 @@ export default function LandingPageTemplatesPage() {
                                     <div>
                                         <span className="font-medium text-foreground">Left Column:</span>
                                         <ol className="mt-0.5 list-inside list-decimal space-y-0.5">
-                                            {tmpl.left_column_order.map((key) => (
+                                            {normalizeLeftColumnOrder(tmpl.left_column_order, tmpl.template_type).map((key) => (
                                                 <li key={key}>{LEFT_SECTION_LABELS[key] ?? key}</li>
                                             ))}
                                         </ol>
@@ -622,6 +639,11 @@ export default function LandingPageTemplatesPage() {
                                 title="Left Column (sidebar)"
                                 items={editLeftOrder}
                                 labels={LEFT_SECTION_LABELS}
+                                description={
+                                    editTemplate?.template_type === 'igsn'
+                                        ? 'IGSN templates use the General and Acquisition modules instead of Files & Downloads.'
+                                        : 'Resource templates render files, contact details, and related material in the sidebar.'
+                                }
                                 onReorder={(items) => setEditLeftOrder(items as LeftColumnSection[])}
                             />
                         </div>

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -691,8 +691,16 @@ export const LANDING_PAGE_TEMPLATES: Record<string, TemplateMetadata> = {
     },
 } as const;
 
+function normalizeLandingPageResourceType(resourceType?: string): string {
+    return (resourceType ?? '').replace(/[\s_-]+/g, '').toLowerCase();
+}
+
+export function isIgsnLandingPageResourceType(resourceType?: string): boolean {
+    return normalizeLandingPageResourceType(resourceType) === 'physicalobject';
+}
+
 function getTemplateScope(resourceType?: string): 'resource' | 'igsn' {
-    return resourceType === 'PhysicalObject' ? 'igsn' : 'resource';
+    return isIgsnLandingPageResourceType(resourceType) ? 'igsn' : 'resource';
 }
 
 /**
@@ -718,7 +726,11 @@ export function getTemplateOptions(resourceType?: string): LandingPageTemplateOp
             // If no resourceType provided, only show unrestricted templates
             if (!resourceType) return !template.resourceTypes;
             // Check if resourceType is in the allowed list
-            return template.resourceTypes.includes(resourceType);
+            const normalizedResourceType = normalizeLandingPageResourceType(resourceType);
+
+            return template.resourceTypes.some(
+                (allowedResourceType) => normalizeLandingPageResourceType(allowedResourceType) === normalizedResourceType,
+            );
         })
         .map((template) => ({
             value: template.key,

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -173,6 +173,9 @@ export interface LandingPageConfig {
     /** FK to landing_page_templates table (null = use built-in default) */
     landing_page_template_id?: number | null;
 
+    /** Loaded custom template relation for hydrating dropdown state */
+    landing_page_template?: LandingPageTemplateSummary | null;
+
     /** FTP URL for dataset downloads (optional) */
     ftp_url?: string | null;
 

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -726,7 +726,9 @@ export function getTemplateOptions(resourceType?: string): LandingPageTemplateOp
 
             // If no resourceTypes restriction, template is available for all
             if (!template.resourceTypes) return true;
-            // If no resourceType provided, only show unrestricted templates
+            // If no resourceType is provided, we still keep the current scope filter
+            // (defaulting to the regular resource flow) and only skip templates that
+            // require an explicit resource type match.
             if (!resourceType) return !template.resourceTypes;
             // Check if resourceType is in the allowed list
             const normalizedResourceType = normalizeLandingPageResourceType(resourceType);

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -640,6 +640,9 @@ export interface TemplateMetadata {
     /** Template version (for migration tracking) */
     version?: string;
 
+    /** Restrict template to resource or IGSN setup flows */
+    scopes?: Array<'resource' | 'igsn'>;
+
     /** Restrict template to specific resource types. null/undefined = all types allowed */
     resourceTypes?: string[] | null;
 }
@@ -665,7 +668,8 @@ export const LANDING_PAGE_TEMPLATES: Record<string, TemplateMetadata> = {
         description: 'Standard template with all features',
         category: 'official',
         version: '1.0',
-        resourceTypes: null, // Available for all resource types
+        scopes: ['resource'],
+        resourceTypes: null,
     },
     default_gfz_igsn: {
         key: 'default_gfz_igsn',
@@ -673,6 +677,7 @@ export const LANDING_PAGE_TEMPLATES: Record<string, TemplateMetadata> = {
         description: 'Simplified template for physical samples (IGSN)',
         category: 'official',
         version: '1.0',
+        scopes: ['igsn'],
         resourceTypes: ['PhysicalObject'], // Only for IGSNs
     },
     external: {
@@ -681,9 +686,14 @@ export const LANDING_PAGE_TEMPLATES: Record<string, TemplateMetadata> = {
         description: 'Redirect to an external URL instead of generating a landing page',
         category: 'official',
         version: '1.0',
-        resourceTypes: null, // Available for all resource types (null = no restrictions)
+        scopes: ['resource', 'igsn'],
+        resourceTypes: null,
     },
 } as const;
+
+function getTemplateScope(resourceType?: string): 'resource' | 'igsn' {
+    return resourceType === 'PhysicalObject' ? 'igsn' : 'resource';
+}
 
 /**
  * Template Options for Select Dropdown
@@ -695,8 +705,14 @@ export const LANDING_PAGE_TEMPLATES: Record<string, TemplateMetadata> = {
  * @returns Array of template options with value, label, and description
  */
 export function getTemplateOptions(resourceType?: string): LandingPageTemplateOption[] {
+    const scope = getTemplateScope(resourceType);
+
     return Object.values(LANDING_PAGE_TEMPLATES)
         .filter((template) => {
+            if (template.scopes && !template.scopes.includes(scope)) {
+                return false;
+            }
+
             // If no resourceTypes restriction, template is available for all
             if (!template.resourceTypes) return true;
             // If no resourceType provided, only show unrestricted templates

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -125,7 +125,7 @@ describe('IGSN Template Restriction on Creation', function () {
 
         $response->assertStatus(422)
             ->assertJson([
-                'message' => 'The selected custom landing page template is only available for IGSN landing pages.',
+                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
                 'error' => 'invalid_template_for_resource_type',
             ]);
     });
@@ -231,7 +231,7 @@ describe('IGSN Template Restriction on Update', function () {
 
         $response->assertStatus(422)
             ->assertJson([
-                'message' => 'The selected custom landing page template is only available for IGSN landing pages.',
+                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
                 'error' => 'invalid_template_for_resource_type',
             ]);
 

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -106,7 +106,7 @@ describe('IGSN Template Restriction on Creation', function () {
         expect(LandingPage::where('resource_id', $resource->id)->first())->toBeNull();
     });
 
-    test('ignores stale regular resource custom template id when creating the igsn template', function () {
+    test('rejects assigning a regular resource custom template to a PhysicalObject resource on create', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 
         $physicalObjectType = ResourceType::firstOrCreate(
@@ -123,11 +123,57 @@ describe('IGSN Template Restriction on Creation', function () {
                 'landing_page_template_id' => $template->id,
             ]);
 
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+    });
+
+    test('can assign an igsn custom template on create', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::factory()->igsn()->create(['created_by' => $user->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz_igsn',
+                'status' => 'draft',
+                'landing_page_template_id' => $template->id,
+            ]);
+
         $response->assertCreated()
             ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
-            ->assertJsonPath('landing_page.landing_page_template_id', null);
+            ->assertJsonPath('landing_page.landing_page_template_id', $template->id);
 
-        expect(LandingPage::where('resource_id', $resource->id)->first()->landing_page_template_id)->toBeNull();
+        expect(LandingPage::where('resource_id', $resource->id)->first()->landing_page_template_id)->toBe($template->id);
+    });
+
+    test('clears ftp_url when creating an igsn landing page', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz_igsn',
+                'status' => 'draft',
+                'ftp_url' => 'https://datapub.gfz-potsdam.de/download/sample.zip',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('landing_page.ftp_url', null);
+
+        expect(LandingPage::where('resource_id', $resource->id)->first()->ftp_url)->toBeNull();
     });
 });
 
@@ -209,7 +255,7 @@ describe('IGSN Template Restriction on Update', function () {
         expect($landingPage->fresh()->template)->toBe('default_gfz_igsn');
     });
 
-    test('ignores stale regular resource custom template id when switching a PhysicalObject resource to the igsn template', function () {
+    test('rejects assigning a regular resource custom template to a PhysicalObject resource on update', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 
         $physicalObjectType = ResourceType::firstOrCreate(
@@ -231,11 +277,98 @@ describe('IGSN Template Restriction on Update', function () {
                 'landing_page_template_id' => $template->id,
             ]);
 
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+
+        expect($landingPage->fresh()->landing_page_template_id)->toBe($template->id);
+    });
+
+    test('can assign an igsn custom template on update', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::factory()->igsn()->create(['created_by' => $user->id]);
+        $landingPage = LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz_igsn',
+            'landing_page_template_id' => null,
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'landing_page_template_id' => $template->id,
+            ]);
+
         $response->assertOk()
             ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
-            ->assertJsonPath('landing_page.landing_page_template_id', null);
+            ->assertJsonPath('landing_page.landing_page_template_id', $template->id);
+
+        expect($landingPage->fresh()->landing_page_template_id)->toBe($template->id);
+    });
+
+    test('switching a legacy PhysicalObject page to the igsn template clears a stale custom template id when the field is omitted', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::factory()->create(['created_by' => $user->id]);
+        $landingPage = LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz_igsn',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
+            ->assertJsonPath('landing_page.landing_page_template_id', null)
+            ->assertJsonPath('landing_page.ftp_url', null);
 
         expect($landingPage->fresh()->landing_page_template_id)->toBeNull();
+        expect($landingPage->fresh()->ftp_url)->toBeNull();
+    });
+
+    test('clears ftp_url when updating an igsn landing page', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $landingPage = LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz_igsn',
+            'ftp_url' => null,
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'ftp_url' => 'https://datapub.gfz-potsdam.de/download/new.zip',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.ftp_url', null);
+
+        expect($landingPage->fresh()->ftp_url)->toBeNull();
     });
 });
 

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -345,6 +345,40 @@ describe('IGSN Template Restriction on Update', function () {
         expect($landingPage->fresh()->ftp_url)->toBeNull();
     });
 
+    test('publishing a legacy PhysicalObject page normalizes the built-in template and clears a stale resource custom template id when the field is omitted', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::factory()->create(['created_by' => $user->id]);
+        $landingPage = LandingPage::factory()->draft()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'status' => 'published',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
+            ->assertJsonPath('landing_page.landing_page_template_id', null)
+            ->assertJsonPath('landing_page.ftp_url', null)
+            ->assertJsonPath('landing_page.is_published', true);
+
+        expect($landingPage->fresh()->template)->toBe('default_gfz_igsn');
+        expect($landingPage->fresh()->landing_page_template_id)->toBeNull();
+        expect($landingPage->fresh()->ftp_url)->toBeNull();
+        expect($landingPage->fresh()->is_published)->toBeTrue();
+    });
+
     test('clears ftp_url when updating an igsn landing page', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\UserRole;
 use App\Http\Controllers\LandingPageController;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\User;
@@ -104,6 +105,30 @@ describe('IGSN Template Restriction on Creation', function () {
 
         expect(LandingPage::where('resource_id', $resource->id)->first())->toBeNull();
     });
+
+    test('cannot assign a regular resource custom template to a PhysicalObject resource on create', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::factory()->create(['created_by' => $user->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz_igsn',
+                'status' => 'draft',
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected custom landing page template is only available for IGSN landing pages.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+    });
 });
 
 describe('IGSN Template Restriction on Update', function () {
@@ -182,6 +207,35 @@ describe('IGSN Template Restriction on Update', function () {
             ]);
 
         expect($landingPage->fresh()->template)->toBe('default_gfz_igsn');
+    });
+
+    test('cannot assign a regular resource custom template to a PhysicalObject resource on update', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::factory()->create(['created_by' => $user->id]);
+        $landingPage = LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz_igsn',
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected custom landing page template is only available for IGSN landing pages.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+
+        expect($landingPage->fresh()->landing_page_template_id)->toBeNull();
     });
 });
 

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -31,6 +31,10 @@ describe('IGSN Template Configuration', function () {
     test('default_gfz is not in igsn only templates', function () {
         expect(LandingPageController::IGSN_ONLY_TEMPLATES)->not->toContain('default_gfz');
     });
+
+    test('resource only templates contains default_gfz', function () {
+        expect(LandingPageController::RESOURCE_ONLY_TEMPLATES)->toContain('default_gfz');
+    });
 });
 
 describe('IGSN Template Restriction on Creation', function () {
@@ -77,7 +81,7 @@ describe('IGSN Template Restriction on Creation', function () {
         expect(LandingPage::where('resource_id', $resource->id)->first()->template)->toBe('default_gfz_igsn');
     });
 
-    test('can use default_gfz template for PhysicalObject resource', function () {
+    test('cannot use default_gfz template for PhysicalObject resource', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 
         $physicalObjectType = ResourceType::firstOrCreate(
@@ -92,8 +96,13 @@ describe('IGSN Template Restriction on Creation', function () {
                 'status' => 'draft',
             ]);
 
-        $response->assertCreated();
-        expect(LandingPage::where('resource_id', $resource->id)->first()->template)->toBe('default_gfz');
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The Default GFZ Data Services template cannot be used with Physical Object resources. Use the IGSN template instead.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+
+        expect(LandingPage::where('resource_id', $resource->id)->first())->toBeNull();
     });
 });
 
@@ -146,6 +155,34 @@ describe('IGSN Template Restriction on Update', function () {
         $response->assertOk();
         expect($landingPage->fresh()->template)->toBe('default_gfz_igsn');
     });
+
+    test('cannot change template to default_gfz for PhysicalObject resource', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $landingPage = LandingPage::factory()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz_igsn',
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The Default GFZ Data Services template cannot be used with Physical Object resources. Use the IGSN template instead.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+
+        expect($landingPage->fresh()->template)->toBe('default_gfz_igsn');
+    });
 });
 
 describe('IGSN Template Preview Session', function () {
@@ -186,6 +223,27 @@ describe('IGSN Template Preview Session', function () {
 
         $response->assertCreated()
             ->assertJsonStructure(['preview_url']);
+    });
+
+    test('cannot create default_gfz preview for PhysicalObject resource', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+
+        $response = $this->actingAs($user)
+            ->postJson("/resources/{$resource->id}/landing-page/preview", [
+                'template' => 'default_gfz',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The Default GFZ Data Services template cannot be used with Physical Object resources. Use the IGSN template instead.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
     });
 });
 

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -106,7 +106,7 @@ describe('IGSN Template Restriction on Creation', function () {
         expect(LandingPage::where('resource_id', $resource->id)->first())->toBeNull();
     });
 
-    test('cannot assign a regular resource custom template to a PhysicalObject resource on create', function () {
+    test('ignores stale regular resource custom template id when creating the igsn template', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 
         $physicalObjectType = ResourceType::firstOrCreate(
@@ -123,11 +123,11 @@ describe('IGSN Template Restriction on Creation', function () {
                 'landing_page_template_id' => $template->id,
             ]);
 
-        $response->assertStatus(422)
-            ->assertJson([
-                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
-                'error' => 'invalid_template_for_resource_type',
-            ]);
+        $response->assertCreated()
+            ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
+
+        expect(LandingPage::where('resource_id', $resource->id)->first()->landing_page_template_id)->toBeNull();
     });
 });
 
@@ -209,7 +209,7 @@ describe('IGSN Template Restriction on Update', function () {
         expect($landingPage->fresh()->template)->toBe('default_gfz_igsn');
     });
 
-    test('cannot assign a regular resource custom template to a PhysicalObject resource on update', function () {
+    test('ignores stale regular resource custom template id when switching a PhysicalObject resource to the igsn template', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 
         $physicalObjectType = ResourceType::firstOrCreate(
@@ -220,20 +220,20 @@ describe('IGSN Template Restriction on Update', function () {
         $template = LandingPageTemplate::factory()->create(['created_by' => $user->id]);
         $landingPage = LandingPage::factory()->create([
             'resource_id' => $resource->id,
-            'template' => 'default_gfz_igsn',
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
             'is_published' => false,
         ]);
 
         $response = $this->actingAs($user)
             ->putJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz_igsn',
                 'landing_page_template_id' => $template->id,
             ]);
 
-        $response->assertStatus(422)
-            ->assertJson([
-                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
-                'error' => 'invalid_template_for_resource_type',
-            ]);
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
 
         expect($landingPage->fresh()->landing_page_template_id)->toBeNull();
     });

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\UserRole;
 use App\Http\Controllers\LandingPageController;
 use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
 use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\ResourceType;
@@ -403,7 +404,7 @@ describe('IGSN Template Restriction on Update', function () {
         expect($landingPage->fresh()->is_published)->toBeTrue();
     });
 
-    test('rejects ftp_url and links when a legacy PhysicalObject page would be normalized without an explicit template', function () {
+    test('rejects ftp_url, links, and external-only fields when a legacy PhysicalObject page would be normalized without an explicit template', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 
         $physicalObjectType = ResourceType::firstOrCreate(
@@ -411,6 +412,7 @@ describe('IGSN Template Restriction on Update', function () {
             ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
         );
         $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $domain = LandingPageDomain::factory()->create();
         $landingPage = LandingPage::factory()->draft()->create([
             'resource_id' => $resource->id,
             'template' => 'default_gfz',
@@ -421,6 +423,8 @@ describe('IGSN Template Restriction on Update', function () {
         $response = $this->actingAs($user)
             ->putJson("/resources/{$resource->id}/landing-page", [
                 'ftp_url' => 'https://datapub.gfz-potsdam.de/download/new.zip',
+                'external_domain_id' => $domain->id,
+                'external_path' => 'samples/legacy-igsn',
                 'links' => [[
                     'url' => 'https://example.org/file.zip',
                     'label' => 'Supporting file',
@@ -429,11 +433,51 @@ describe('IGSN Template Restriction on Update', function () {
             ]);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['ftp_url', 'links']);
+            ->assertJsonValidationErrors(['ftp_url', 'links', 'external_domain_id', 'external_path']);
 
         expect($landingPage->fresh()->template)->toBe('default_gfz');
         expect($landingPage->fresh()->ftp_url)->toBe('https://datapub.gfz-potsdam.de/download/legacy.zip');
         expect($landingPage->fresh()->links)->toHaveCount(0);
+    });
+
+    test('get endpoint returns the normalized contract for a legacy PhysicalObject landing page', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $domain = LandingPageDomain::factory()->create();
+        $staleTemplate = LandingPageTemplate::factory()->create(['created_by' => $user->id]);
+        $landingPage = LandingPage::factory()->draft()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $staleTemplate->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+            'external_domain_id' => $domain->id,
+            'external_path' => 'samples/legacy-igsn',
+            'is_published' => false,
+        ]);
+        $landingPage->links()->create([
+            'url' => 'https://example.org/file.zip',
+            'label' => 'Supporting file',
+            'position' => 0,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson("/resources/{$resource->id}/landing-page");
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'default_gfz_igsn')
+            ->assertJsonPath('landing_page.landing_page_template_id', null)
+            ->assertJsonPath('landing_page.landing_page_template', null)
+            ->assertJsonPath('landing_page.ftp_url', null)
+            ->assertJsonPath('landing_page.external_domain_id', null)
+            ->assertJsonPath('landing_page.external_path', null)
+            ->assertJsonPath('landing_page.external_domain', null)
+            ->assertJsonPath('landing_page.external_url', null)
+            ->assertJsonPath('landing_page.links', []);
     });
 
     test('clears ftp_url when updating an igsn landing page', function () {

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -379,6 +379,39 @@ describe('IGSN Template Restriction on Update', function () {
         expect($landingPage->fresh()->is_published)->toBeTrue();
     });
 
+    test('rejects ftp_url and links when a legacy PhysicalObject page would be normalized without an explicit template', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $landingPage = LandingPage::factory()->draft()->create([
+            'resource_id' => $resource->id,
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+            'is_published' => false,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->putJson("/resources/{$resource->id}/landing-page", [
+                'ftp_url' => 'https://datapub.gfz-potsdam.de/download/new.zip',
+                'links' => [[
+                    'url' => 'https://example.org/file.zip',
+                    'label' => 'Supporting file',
+                    'position' => 0,
+                ]],
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ftp_url', 'links']);
+
+        expect($landingPage->fresh()->template)->toBe('default_gfz');
+        expect($landingPage->fresh()->ftp_url)->toBe('https://datapub.gfz-potsdam.de/download/legacy.zip');
+        expect($landingPage->fresh()->links)->toHaveCount(0);
+    });
+
     test('clears ftp_url when updating an igsn landing page', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 

--- a/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
+++ b/tests/pest/Feature/LandingPages/IgsnLandingPageTest.php
@@ -154,6 +154,30 @@ describe('IGSN Template Restriction on Creation', function () {
         expect(LandingPage::where('resource_id', $resource->id)->first()->landing_page_template_id)->toBe($template->id);
     });
 
+    test('rejects assigning the built-in igsn default template id as a custom override on create', function () {
+        $user = User::factory()->create(['role' => UserRole::CURATOR]);
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create(['resource_type_id' => $physicalObjectType->id]);
+        $template = LandingPageTemplate::ensureIgsnDefaultTemplateExists();
+
+        $response = $this->actingAs($user)
+            ->postJson("/resources/{$resource->id}/landing-page", [
+                'template' => 'default_gfz_igsn',
+                'status' => 'draft',
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected landing page template is a built-in default and cannot be used as a custom override.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+    });
+
     test('clears ftp_url when creating an igsn landing page', function () {
         $user = User::factory()->create(['role' => UserRole::CURATOR]);
 

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -459,6 +459,32 @@ describe('External Landing Page Update', function () {
 
         expect($this->resource->fresh()->landingPage->landing_page_template_id)->toBeNull();
     });
+
+    test('switching to external clears an existing custom template id even when the field is omitted', function () {
+        $domain = LandingPageDomain::factory()->withDomain('https://data.gfz.de/')->create();
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'external',
+            'external_domain_id' => $domain->id,
+            'external_path' => 'dataset/123',
+            'status' => 'draft',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'external')
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
+
+        expect($this->resource->fresh()->landingPage->landing_page_template_id)->toBeNull();
+    });
 });
 
 describe('Landing Page Template Assignment', function () {

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -367,6 +367,26 @@ describe('External Landing Page Creation', function () {
         $response->assertStatus(201);
         expect($this->resource->fresh()->landingPage->ftp_url)->toBeNull();
     });
+
+    test('ignores stale custom template id when creating an external landing page', function () {
+        $domain = LandingPageDomain::factory()->create();
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        $response = $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'external',
+            'external_domain_id' => $domain->id,
+            'external_path' => 'some/path',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
+
+        expect($this->resource->fresh()->landingPage->landing_page_template_id)->toBeNull();
+    });
 });
 
 describe('External Landing Page Update', function () {
@@ -411,6 +431,33 @@ describe('External Landing Page Update', function () {
             ->template->toBe('default_gfz')
             ->external_domain_id->toBeNull()
             ->external_path->toBeNull();
+    });
+
+    test('ignores stale custom template id when switching to external', function () {
+        $domain = LandingPageDomain::factory()->withDomain('https://data.gfz.de/')->create();
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'template' => 'default_gfz',
+            'landing_page_template_id' => null,
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'external',
+            'external_domain_id' => $domain->id,
+            'external_path' => 'dataset/123',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'external')
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
+
+        expect($this->resource->fresh()->landingPage->landing_page_template_id)->toBeNull();
     });
 });
 

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -485,6 +485,35 @@ describe('External Landing Page Update', function () {
 
         expect($this->resource->fresh()->landingPage->landing_page_template_id)->toBeNull();
     });
+
+    test('updating an existing external landing page clears a stale custom template id even when template is omitted', function () {
+        $domain = LandingPageDomain::factory()->withDomain('https://data.gfz.de/')->create();
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->external()->create([
+            'resource_id' => $this->resource->id,
+            'external_domain_id' => $domain->id,
+            'external_path' => 'dataset/original',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'external_path' => 'dataset/updated',
+            'status' => 'draft',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('landing_page.template', 'external')
+            ->assertJsonPath('landing_page.external_path', 'dataset/updated')
+            ->assertJsonPath('landing_page.landing_page_template_id', null);
+
+        $updated = $this->resource->fresh()->landingPage;
+        expect($updated)
+            ->external_path->toBe('dataset/updated')
+            ->landing_page_template_id->toBeNull();
+    });
 });
 
 describe('Landing Page Template Assignment', function () {

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -555,7 +555,10 @@ describe('Landing Page Template Assignment', function () {
             'landing_page_template_id' => $template->id,
         ]);
 
-        $response->assertOk();
+        $response->assertOk()
+            ->assertJsonPath('landing_page.landing_page_template_id', $template->id)
+            ->assertJsonPath('landing_page.landing_page_template.id', $template->id)
+            ->assertJsonPath('landing_page.landing_page_template.name', $template->name);
 
         $landingPage = $this->resource->fresh()->landingPage;
         expect($landingPage->landing_page_template_id)->toBe($template->id);

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -504,7 +504,7 @@ describe('Landing Page Template Assignment', function () {
 
         $response->assertStatus(422)
             ->assertJson([
-                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
+                'message' => 'The selected custom landing page template is only available for IGSN landing pages.',
                 'error' => 'invalid_template_for_resource_type',
             ]);
     });
@@ -528,7 +528,7 @@ describe('Landing Page Template Assignment', function () {
 
         $response->assertStatus(422)
             ->assertJson([
-                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
+                'message' => 'The selected custom landing page template is only available for IGSN landing pages.',
                 'error' => 'invalid_template_for_resource_type',
             ]);
     });

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -605,6 +605,23 @@ describe('Landing Page Template Assignment', function () {
                 'error' => 'invalid_template_for_resource_type',
             ]);
     });
+
+    test('rejects assigning the built-in resource default template id as a custom override on create', function () {
+        $template = LandingPageTemplate::ensureDefaultTemplateExists();
+
+        $response = $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected landing page template is a built-in default and cannot be used as a custom override.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+    });
 });
 
 describe('Landing Page GET Endpoint', function () {

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -529,7 +529,10 @@ describe('Landing Page Template Assignment', function () {
             'landing_page_template_id' => $template->id,
         ]);
 
-        $response->assertStatus(201);
+        $response->assertStatus(201)
+            ->assertJsonPath('landing_page.landing_page_template_id', $template->id)
+            ->assertJsonPath('landing_page.landing_page_template.id', $template->id)
+            ->assertJsonPath('landing_page.landing_page_template.name', $template->name);
 
         $landingPage = $this->resource->fresh()->landingPage;
         expect($landingPage->landing_page_template_id)->toBe($template->id);
@@ -556,6 +559,43 @@ describe('Landing Page Template Assignment', function () {
 
         $landingPage = $this->resource->fresh()->landingPage;
         expect($landingPage->landing_page_template_id)->toBe($template->id);
+    });
+
+    test('rejects unsupported fields when explicitly switching to an external template', function () {
+        $domain = LandingPageDomain::factory()->withDomain('https://data.gfz.de/')->create();
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/original.zip',
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'external',
+            'external_domain_id' => $domain->id,
+            'external_path' => 'dataset/123',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/updated.zip',
+            'links' => [
+                [
+                    'url' => 'https://example.org/details',
+                    'label' => 'Details',
+                    'position' => 0,
+                ],
+            ],
+            'status' => 'draft',
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJson([
+                'message' => 'The request includes fields that are not supported for this landing page template.',
+            ])
+            ->assertJsonValidationErrors(['ftp_url', 'links']);
+
+        expect($this->resource->fresh()->landingPage)
+            ->template->toBe('default_gfz')
+            ->ftp_url->toBe('https://datapub.gfz-potsdam.de/download/original.zip')
+            ->external_domain_id->toBeNull()
+            ->external_path->toBeNull();
     });
 
     test('can clear template assignment by setting null', function () {

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -489,6 +489,49 @@ describe('Landing Page Template Assignment', function () {
 
         $response->assertJsonValidationErrors(['landing_page_template_id']);
     });
+
+    test('rejects assigning an igsn custom template to a regular resource on create', function () {
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        $response = $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+    });
+
+    test('rejects assigning an igsn custom template to a regular resource on update', function () {
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'landing_page_template_id' => null,
+        ]);
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJson([
+                'message' => 'The selected custom landing page template is only available for regular resource landing pages.',
+                'error' => 'invalid_template_for_resource_type',
+            ]);
+    });
 });
 
 describe('Landing Page GET Endpoint', function () {

--- a/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
@@ -112,6 +112,35 @@ describe('Session Preview Creation', function () {
             ->toHaveKey('landing_page_template_id', $template->id)
             ->toHaveKey('ftp_url', null);
     });
+
+    test('allows a deleted custom template id in the preview payload and renders without a custom override', function () {
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+        ]);
+        $deletedTemplateId = $template->id;
+        $template->delete();
+
+        $response = $this->postJson("/resources/{$this->resource->id}/landing-page/preview", [
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $deletedTemplateId,
+        ]);
+
+        $response->assertCreated();
+
+        $sessionKey = "landing_page_preview.{$this->resource->id}";
+        expect(Session::get($sessionKey))
+            ->toHaveKey('landing_page_template_id', $deletedTemplateId);
+
+        $previewResponse = $this->get("/resources/{$this->resource->id}/landing-page/preview");
+
+        $previewResponse->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz')
+                ->where('landingPage.landing_page_template_id', null)
+                ->where('sectionOrder', null)
+                ->where('customLogoUrl', null)
+            );
+    });
 });
 
 describe('Session Preview Display', function () {

--- a/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
@@ -265,6 +265,27 @@ describe('Session Preview Display', function () {
                 ->where('sectionOrder', null)
             );
     });
+
+    test('preview display ignores built-in default template ids passed as custom overrides', function () {
+        $defaultTemplate = LandingPageTemplate::ensureDefaultTemplateExists();
+
+        Session::put("landing_page_preview.{$this->resource->id}", [
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $defaultTemplate->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'resource_id' => $this->resource->id,
+        ]);
+
+        $response = $this->get("/resources/{$this->resource->id}/landing-page/preview");
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz')
+                ->where('landingPage.landing_page_template_id', null)
+                ->where('customLogoUrl', null)
+                ->where('sectionOrder', null)
+            );
+    });
 });
 
 describe('Session Preview Deletion', function () {

--- a/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
@@ -155,6 +155,17 @@ describe('Session Preview Display', function () {
         );
     });
 
+    test('returns 404 when a stale preview session contains the external template', function () {
+        Session::put("landing_page_preview.{$this->resource->id}", [
+            'template' => 'external',
+            'resource_id' => $this->resource->id,
+        ]);
+
+        $response = $this->get("/resources/{$this->resource->id}/landing-page/preview");
+
+        $response->assertStatus(404);
+    });
+
     test('preview display passes custom section order and logo for igsn custom templates', function () {
         $physicalObjectType = ResourceType::firstOrCreate(
             ['slug' => 'physical-object'],

--- a/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
@@ -156,6 +156,14 @@ describe('Session Preview Display', function () {
     });
 
     test('preview display passes custom section order and logo for igsn custom templates', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create([
+            'created_by_user_id' => $this->user->id,
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
         $template = LandingPageTemplate::factory()->igsn()->create([
             'created_by' => $this->user->id,
             'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
@@ -163,14 +171,14 @@ describe('Session Preview Display', function () {
             'logo_path' => 'landing-page-logos/test/custom-igsn-logo.png',
         ]);
 
-        Session::put("landing_page_preview.{$this->resource->id}", [
+        Session::put("landing_page_preview.{$resource->id}", [
             'template' => 'default_gfz_igsn',
             'landing_page_template_id' => $template->id,
             'ftp_url' => null,
-            'resource_id' => $this->resource->id,
+            'resource_id' => $resource->id,
         ]);
 
-        $response = $this->get("/resources/{$this->resource->id}/landing-page/preview");
+        $response = $this->get("/resources/{$resource->id}/landing-page/preview");
 
         $response->assertStatus(200)
             ->assertInertia(fn ($page) => $page
@@ -181,6 +189,80 @@ describe('Session Preview Display', function () {
                     ->has('leftColumn')
                 )
                 ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/custom-igsn-logo.png'))
+            );
+    });
+
+    test('preview display normalizes a legacy Physical Object session to the igsn renderer and keeps a matching igsn custom template', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create([
+            'created_by_user_id' => $this->user->id,
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+            'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            'left_column_order' => ['contact', 'general', 'acquisition', 'model_description', 'related_work'],
+            'logo_path' => 'landing-page-logos/test/normalized-igsn-logo.png',
+        ]);
+
+        Session::put("landing_page_preview.{$resource->id}", [
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+            'links' => [['url' => 'https://example.org/file.zip', 'label' => 'Legacy link', 'position' => 0]],
+            'resource_id' => $resource->id,
+        ]);
+
+        $response = $this->get("/resources/{$resource->id}/landing-page/preview");
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz_igsn')
+                ->where('landingPage.template', 'default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', $template->id)
+                ->where('landingPage.ftp_url', null)
+                ->where('landingPage.links', [])
+                ->has('sectionOrder', fn ($order) => $order
+                    ->has('rightColumn')
+                    ->has('leftColumn')
+                )
+                ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/normalized-igsn-logo.png'))
+            );
+    });
+
+    test('preview display clears a mismatched custom template when the session renderer is normalized', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create([
+            'created_by_user_id' => $this->user->id,
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->user->id,
+            'logo_path' => 'landing-page-logos/test/resource-logo.png',
+        ]);
+
+        Session::put("landing_page_preview.{$resource->id}", [
+            'template' => 'default_gfz',
+            'landing_page_template_id' => $template->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+            'resource_id' => $resource->id,
+        ]);
+
+        $response = $this->get("/resources/{$resource->id}/landing-page/preview");
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz_igsn')
+                ->where('landingPage.template', 'default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', null)
+                ->where('customLogoUrl', null)
+                ->where('sectionOrder', null)
             );
     });
 });

--- a/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePreviewControllerTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\LandingPagePreviewController;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
+use App\Models\ResourceType;
 use App\Models\User;
 use Illuminate\Support\Facades\Session;
 
@@ -80,6 +82,36 @@ describe('Session Preview Creation', function () {
         $sessionKey = "landing_page_preview.{$this->resource->id}";
         expect(Session::has($sessionKey))->toBeFalse();
     });
+
+    test('stores igsn custom template preview data and clears ftp_url for Physical Object resources', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+        $resource = Resource::factory()->create([
+            'created_by_user_id' => $this->user->id,
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+            'logo_path' => 'landing-page-logos/test/igsn-logo.png',
+        ]);
+
+        $response = $this->postJson("/resources/{$resource->id}/landing-page/preview", [
+            'template' => 'default_gfz_igsn',
+            'landing_page_template_id' => $template->id,
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/should-clear.zip',
+        ]);
+
+        $response->assertCreated();
+
+        $sessionKey = "landing_page_preview.{$resource->id}";
+        $sessionData = Session::get($sessionKey);
+
+        expect($sessionData)
+            ->toHaveKey('landing_page_template_id', $template->id)
+            ->toHaveKey('ftp_url', null);
+    });
 });
 
 describe('Session Preview Display', function () {
@@ -121,6 +153,35 @@ describe('Session Preview Display', function () {
             ->where('landingPage.template', 'default_gfz')
             ->where('landingPage.ftp_url', 'https://datapub.gfz-potsdam.de/download/test.zip')
         );
+    });
+
+    test('preview display passes custom section order and logo for igsn custom templates', function () {
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->user->id,
+            'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            'left_column_order' => ['contact', 'general', 'acquisition', 'model_description', 'related_work'],
+            'logo_path' => 'landing-page-logos/test/custom-igsn-logo.png',
+        ]);
+
+        Session::put("landing_page_preview.{$this->resource->id}", [
+            'template' => 'default_gfz_igsn',
+            'landing_page_template_id' => $template->id,
+            'ftp_url' => null,
+            'resource_id' => $this->resource->id,
+        ]);
+
+        $response = $this->get("/resources/{$this->resource->id}/landing-page/preview");
+
+        $response->assertStatus(200)
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', $template->id)
+                ->has('sectionOrder', fn ($order) => $order
+                    ->has('rightColumn')
+                    ->has('leftColumn')
+                )
+                ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/custom-igsn-logo.png'))
+            );
     });
 });
 

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -522,7 +522,7 @@ describe('Landing Page with Custom Template', function () {
         $template = LandingPageTemplate::factory()->igsn()->create([
             'created_by' => \App\Models\User::factory()->admin()->create()->id,
             'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
-            'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
+            'left_column_order' => ['contact', 'general', 'acquisition', 'model_description', 'related_work'],
             'logo_path' => 'landing-page-logos/test/igsn-logo.png',
         ]);
 
@@ -548,6 +548,42 @@ describe('Landing Page with Custom Template', function () {
                     ->has('leftColumn')
                 )
                 ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/igsn-logo.png'))
+            );
+    });
+
+    test('normalizes legacy igsn custom template left-column order before rendering', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/test.public.igsn.001a',
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => \App\Models\User::factory()->admin()->create()->id,
+            'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
+        ]);
+
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $resource->id,
+                'doi_prefix' => '10.5880/test.public.igsn.001a',
+                'slug' => 'legacy-igsn-left-order-test',
+                'template' => 'default_gfz_igsn',
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', $template->id)
+                ->where('sectionOrder.leftColumn', ['contact', 'model_description', 'related_work', 'general', 'acquisition'])
             );
     });
 
@@ -585,6 +621,30 @@ describe('Landing Page with Custom Template', function () {
             ->assertInertia(fn ($page) => $page
                 ->component('LandingPages/default_gfz_igsn')
                 ->where('landingPage.template', 'default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', null)
+                ->where('sectionOrder', null)
+                ->where('customLogoUrl', null)
+            );
+    });
+
+    test('ignores built-in default template ids in the public payload', function () {
+        $defaultTemplate = LandingPageTemplate::ensureDefaultTemplateExists();
+
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.003',
+                'slug' => 'default-template-id-test',
+                'template' => 'default_gfz',
+                'landing_page_template_id' => $defaultTemplate->id,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz')
                 ->where('landingPage.landing_page_template_id', null)
                 ->where('sectionOrder', null)
                 ->where('customLogoUrl', null)

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -550,4 +550,44 @@ describe('Landing Page with Custom Template', function () {
                 ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/igsn-logo.png'))
             );
     });
+
+    test('normalizes legacy Physical Object landing pages and clears mismatched resource custom templates', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/test.public.igsn.002',
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => \App\Models\User::factory()->admin()->create()->id,
+            'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
+            'logo_path' => 'landing-page-logos/test/resource-logo.png',
+        ]);
+
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $resource->id,
+                'doi_prefix' => '10.5880/test.public.igsn.002',
+                'slug' => 'legacy-igsn-mismatch-test',
+                'template' => 'default_gfz',
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz_igsn')
+                ->where('landingPage.template', 'default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', null)
+                ->where('sectionOrder', null)
+                ->where('customLogoUrl', null)
+            );
+    });
 });

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Http\Controllers\LandingPagePublicController;
 use App\Models\LandingPage;
 use App\Models\LandingPageDomain;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
+use App\Models\ResourceType;
 use Illuminate\Support\Facades\Cache;
 
 covers(LandingPagePublicController::class);
@@ -503,6 +505,49 @@ describe('Landing Page with Custom Template', function () {
                 ->component('LandingPages/default_gfz')
                 ->where('sectionOrder', null)
                 ->where('customLogoUrl', null)
+            );
+    });
+
+    test('normalizes legacy Physical Object landing pages to the igsn renderer and keeps matching igsn custom templates', function () {
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true]
+        );
+
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/test.public.igsn.001',
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => \App\Models\User::factory()->admin()->create()->id,
+            'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+            'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
+            'logo_path' => 'landing-page-logos/test/igsn-logo.png',
+        ]);
+
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $resource->id,
+                'doi_prefix' => '10.5880/test.public.igsn.001',
+                'slug' => 'legacy-igsn-template-test',
+                'template' => 'default_gfz',
+                'landing_page_template_id' => $template->id,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz_igsn')
+                ->where('landingPage.template', 'default_gfz_igsn')
+                ->where('landingPage.landing_page_template_id', $template->id)
+                ->has('sectionOrder', fn ($order) => $order
+                    ->has('rightColumn')
+                    ->has('leftColumn')
+                )
+                ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/igsn-logo.png'))
             );
     });
 });

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -534,7 +534,13 @@ describe('Landing Page with Custom Template', function () {
                 'slug' => 'legacy-igsn-template-test',
                 'template' => 'default_gfz',
                 'landing_page_template_id' => $template->id,
+                'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
             ]);
+        $landingPage->links()->create([
+            'url' => 'https://example.org/file.zip',
+            'label' => 'Legacy link',
+            'position' => 0,
+        ]);
 
         $response = $this->get(landingPageUrl($landingPage));
 
@@ -542,6 +548,8 @@ describe('Landing Page with Custom Template', function () {
             ->assertInertia(fn ($page) => $page
                 ->component('LandingPages/default_gfz_igsn')
                 ->where('landingPage.template', 'default_gfz_igsn')
+                ->where('landingPage.ftp_url', null)
+                ->where('landingPage.links', [])
                 ->where('landingPage.landing_page_template_id', $template->id)
                 ->has('sectionOrder', fn ($order) => $order
                     ->has('rightColumn')

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -525,6 +525,7 @@ describe('Landing Page with Custom Template', function () {
             'left_column_order' => ['contact', 'general', 'acquisition', 'model_description', 'related_work'],
             'logo_path' => 'landing-page-logos/test/igsn-logo.png',
         ]);
+        $domain = LandingPageDomain::factory()->withDomain('https://legacy.example.org/')->create();
 
         $landingPage = LandingPage::factory()
             ->published()
@@ -535,6 +536,8 @@ describe('Landing Page with Custom Template', function () {
                 'template' => 'default_gfz',
                 'landing_page_template_id' => $template->id,
                 'ftp_url' => 'https://datapub.gfz-potsdam.de/download/legacy.zip',
+                'external_domain_id' => $domain->id,
+                'external_path' => 'stale/external/path',
             ]);
         $landingPage->links()->create([
             'url' => 'https://example.org/file.zip',
@@ -550,6 +553,10 @@ describe('Landing Page with Custom Template', function () {
                 ->where('landingPage.template', 'default_gfz_igsn')
                 ->where('landingPage.ftp_url', null)
                 ->where('landingPage.links', [])
+                ->where('landingPage.external_domain_id', null)
+                ->where('landingPage.external_path', null)
+                ->where('landingPage.external_domain', null)
+                ->where('landingPage.external_url', null)
                 ->where('landingPage.landing_page_template_id', $template->id)
                 ->has('sectionOrder', fn ($order) => $order
                     ->has('rightColumn')

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -546,6 +546,29 @@ describe('API List', function (): void {
             ]);
     });
 
+    it('normalizes legacy igsn left-column orders in the API list response', function (): void {
+        $template = LandingPageTemplate::factory()->igsn()->create([
+            'created_by' => $this->admin->id,
+            'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
+        ]);
+
+        $response = $this->actingAs($this->curator)
+            ->getJson('/api/landing-page-templates');
+
+        $serializedTemplate = collect($response->json('templates'))
+            ->firstWhere('id', $template->id);
+
+        expect($serializedTemplate)
+            ->not->toBeNull()
+            ->and($serializedTemplate['left_column_order'])->toBe([
+                'contact',
+                'model_description',
+                'related_work',
+                'general',
+                'acquisition',
+            ]);
+    });
+
     it('ensures both system default templates exist when listing', function (): void {
         // Remove all templates to simulate a fresh environment.
         LandingPageTemplate::query()->delete();

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -133,7 +133,7 @@ describe('Clone', function (): void {
             ->and($template->is_default)->toBeFalse()
             ->and($template->created_by)->toBe($this->admin->id)
             ->and($template->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
-            ->and($template->left_column_order)->toBe(LandingPageTemplate::LEFT_COLUMN_SECTIONS);
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS);
     });
 
     it('rejects duplicate names', function (): void {
@@ -256,7 +256,8 @@ describe('Clone', function (): void {
 
         expect($template)->not->toBeNull()
             ->and($template?->is_default)->toBeFalse()
-            ->and($template?->template_type)->toBe(LandingPageTemplate::TEMPLATE_TYPE_IGSN);
+            ->and($template?->template_type)->toBe(LandingPageTemplate::TEMPLATE_TYPE_IGSN)
+            ->and($template?->left_column_order)->toBe(LandingPageTemplate::IGSN_LEFT_COLUMN_SECTIONS);
     });
 
     it('rejects invalid template_type values', function (): void {
@@ -291,7 +292,7 @@ describe('Update', function (): void {
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
 
         $newRightOrder = locationFirstRightColumnOrder();
-        $newLeftOrder = ['contact', 'files', 'general', 'acquisition', 'model_description', 'related_work'];
+        $newLeftOrder = ['contact', 'files', 'related_work', 'model_description'];
 
         $response = $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", [
@@ -372,6 +373,17 @@ describe('Update', function (): void {
             ->putJson("/landing-pages/{$template->id}", [
                 'name' => 'Valid Name',
                 'left_column_order' => ['files', 'nonexistent'],
+            ])
+            ->assertJsonValidationErrors(['left_column_order']);
+    });
+
+    it('rejects files in the left column for igsn templates', function (): void {
+        $template = LandingPageTemplate::factory()->igsn()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'name' => 'Valid Name',
+                'left_column_order' => ['files', 'contact', 'model_description', 'related_work', 'general'],
             ])
             ->assertJsonValidationErrors(['left_column_order']);
     });
@@ -754,7 +766,14 @@ describe('Factory', function (): void {
             ->and($template->logo_path)->toBeNull()
             ->and($template->logo_filename)->toBeNull()
             ->and($template->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
-            ->and($template->left_column_order)->toBe(LandingPageTemplate::LEFT_COLUMN_SECTIONS);
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS);
+    });
+
+    it('creates an igsn template with igsn left-column defaults', function (): void {
+        $template = LandingPageTemplate::factory()->igsn()->create(['created_by' => $this->admin->id]);
+
+        expect($template->template_type)->toBe(LandingPageTemplate::TEMPLATE_TYPE_IGSN)
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::IGSN_LEFT_COLUMN_SECTIONS);
     });
 
     it('creates a default template via state', function (): void {
@@ -800,7 +819,7 @@ describe('Seeder', function (): void {
             ->and($default->name)->toBe('Default GFZ Data Services')
             ->and($default->is_default)->toBeTrue()
             ->and($default->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
-            ->and($default->left_column_order)->toBe(LandingPageTemplate::LEFT_COLUMN_SECTIONS);
+            ->and($default->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS);
     });
 
     it('does not duplicate default template when seeder runs again', function (): void {
@@ -818,7 +837,8 @@ describe('Seeder', function (): void {
         expect($igsn)->not->toBeNull()
             ->and($igsn?->name)->toBe(LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_NAME)
             ->and($igsn?->is_default)->toBeTrue()
-            ->and($igsn?->template_type)->toBe(LandingPageTemplate::TEMPLATE_TYPE_IGSN);
+            ->and($igsn?->template_type)->toBe(LandingPageTemplate::TEMPLATE_TYPE_IGSN)
+            ->and($igsn?->left_column_order)->toBe(LandingPageTemplate::IGSN_LEFT_COLUMN_SECTIONS);
     });
 
     it('does not duplicate the IGSN default when seeder runs again', function (): void {
@@ -906,7 +926,7 @@ describe('Update Edge Cases', function (): void {
     it('validates left column section order completeness', function (): void {
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
 
-        // Only 2 of 6 required left column sections
+        // Only 2 of 4 required left column sections
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", [
                 'left_column_order' => ['files', 'contact'],

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
+import { toast } from 'sonner';
 import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -33,6 +34,7 @@ const mockedAxiosGet = axios.get as Mock;
 const mockedAxiosPost = axios.post as Mock;
 const mockedAxiosPut = axios.put as Mock;
 const mockedAxiosDelete = axios.delete as Mock;
+const mockedToastError = toast.error as Mock;
 
 vi.mock('@inertiajs/react', () => ({
     router: {
@@ -326,6 +328,50 @@ describe('SetupIgsnLandingPageModal', () => {
 
             expect(mockWindowOpen).toHaveBeenCalledWith('https://example.org/sample/preview', '_blank', 'noopener,noreferrer');
             expect(mockedAxiosPost).not.toHaveBeenCalled();
+
+            vi.unstubAllGlobals();
+        });
+
+        it('does not fall back to the saved external URL when unsaved edits make the current external preview invalid', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+            const existingExternalConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                template: 'external',
+                external_domain_id: 99,
+                external_path: '/saved-sample',
+                external_url: 'https://saved.example.org/saved-sample',
+            };
+
+            render(
+                <SetupIgsnLandingPageModal
+                    resource={mockResource}
+                    existingConfig={existingExternalConfig}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Path/i)).toHaveValue('/saved-sample');
+            });
+
+            await user.clear(screen.getByLabelText(/Path/i));
+            await user.type(screen.getByLabelText(/Path/i), '/changed-sample');
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            expect(mockWindowOpen).not.toHaveBeenCalled();
+            expect(mockedToastError).toHaveBeenCalledWith('Please select a domain and enter a path to preview the external URL.');
 
             vi.unstubAllGlobals();
         });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -48,6 +48,11 @@ vi.mock('sonner', () => ({
 }));
 
 describe('SetupIgsnLandingPageModal', () => {
+    const mockDomains = [
+        { id: 1, domain: 'https://example.org/' },
+        { id: 2, domain: 'https://samples.example.org/' },
+    ];
+
     const mockResource = {
         id: 456,
         doi: 'IEFGZ0001',
@@ -207,6 +212,122 @@ describe('SetupIgsnLandingPageModal', () => {
 
             expect(screen.queryByText('Default GFZ Data Services')).not.toBeInTheDocument();
             expect(optionsList).toHaveTextContent('Default GFZ IGSN Template');
+            expect(optionsList).toHaveTextContent('External Landing Page');
+        });
+    });
+
+    describe('External Landing Pages', () => {
+        it('renders external configuration fields when the external template is selected', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+            await user.click(screen.getByText('External Landing Page'));
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Domain/i)).toBeInTheDocument();
+                expect(screen.getByLabelText(/Path/i)).toBeInTheDocument();
+            });
+        });
+
+        it('saves an external landing page with domain and path', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: {
+                        ...mockExistingConfig,
+                        template: 'external',
+                        external_domain_id: 1,
+                        external_path: '/sample/123',
+                        external_url: 'https://example.org/sample/123',
+                    },
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({ data: {} });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+            await user.click(screen.getByText('External Landing Page'));
+
+            await user.click(screen.getByLabelText(/Domain/i));
+            await user.click(screen.getByText('https://example.org/'));
+            await user.type(screen.getByLabelText(/Path/i), '/sample/123');
+
+            await user.click(screen.getByRole('button', { name: /Create Preview/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'external',
+                        external_domain_id: 1,
+                        external_path: '/sample/123',
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+
+        it('opens the computed external URL directly for preview', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+            await user.click(screen.getByText('External Landing Page'));
+
+            await user.click(screen.getByLabelText(/Domain/i));
+            await user.click(screen.getByText('https://example.org/'));
+            await user.type(screen.getByLabelText(/Path/i), '/sample/preview');
+
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            expect(mockWindowOpen).toHaveBeenCalledWith('https://example.org/sample/preview', '_blank', 'noopener,noreferrer');
+            expect(mockedAxiosPost).not.toHaveBeenCalled();
+
+            vi.unstubAllGlobals();
         });
     });
 

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -186,6 +186,28 @@ describe('SetupIgsnLandingPageModal', () => {
                 expect(screen.getByText(/Default GFZ IGSN Template/i)).toBeInTheDocument();
             });
         });
+
+        it('does not offer the resource-only default_gfz template', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('combobox'));
+
+            const optionsList = screen.getByRole('listbox');
+
+            expect(screen.queryByText('Default GFZ Data Services')).not.toBeInTheDocument();
+            expect(optionsList).toHaveTextContent('Default GFZ IGSN Template');
+        });
     });
 
     describe('API Integration', () => {
@@ -258,6 +280,43 @@ describe('SetupIgsnLandingPageModal', () => {
             // Click update button
             const updateButton = screen.getByRole('button', { name: /Update/i });
             await user.click(updateButton);
+
+            await waitFor(() => {
+                expect(axios.put).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                    }),
+                );
+            });
+        });
+
+        it('normalizes a legacy default_gfz config to the IGSN template before updating', async () => {
+            const legacyConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                template: 'default_gfz',
+            };
+
+            mockedAxiosGet.mockResolvedValue({ data: { landing_page: legacyConfig } });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...legacyConfig,
+                        template: 'default_gfz_igsn',
+                    },
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({ data: {} });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
 
             await waitFor(() => {
                 expect(axios.put).toHaveBeenCalledWith(
@@ -405,9 +464,8 @@ describe('SetupIgsnLandingPageModal', () => {
             const templateSelect = screen.getByRole('combobox');
             await user.click(templateSelect);
 
-            // Select the default_gfz template (which should also be available for PhysicalObjects)
-            const defaultOption = screen.getByText('Default GFZ Data Services');
-            await user.click(defaultOption);
+            const externalOption = screen.getByText('External Landing Page');
+            await user.click(externalOption);
 
             await waitFor(() => {
                 expect(screen.getByText(/You have unsaved changes/i)).toBeInTheDocument();

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -410,6 +410,195 @@ describe('SetupIgsnLandingPageModal', () => {
         });
     });
 
+    describe('Custom Templates', () => {
+        const mockIgsnCustomTemplate = {
+            id: 7,
+            name: 'Custom Sample Layout',
+            slug: 'custom-sample-layout',
+            is_default: false,
+            template_type: 'igsn' as const,
+            logo_path: null,
+            logo_url: null,
+            right_column_order: [],
+            left_column_order: [],
+        };
+
+        const mockResourceCustomTemplate = {
+            id: 8,
+            name: 'Regular Resource Layout',
+            slug: 'regular-resource-layout',
+            is_default: false,
+            template_type: 'resource' as const,
+            logo_path: null,
+            logo_url: null,
+            right_column_order: [],
+            left_column_order: [],
+        };
+
+        it('shows only igsn custom templates in the dropdown', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [mockIgsnCustomTemplate, mockResourceCustomTemplate],
+                        },
+                    });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+
+            await waitFor(() => {
+                expect(screen.getByText('Custom Templates')).toBeInTheDocument();
+            });
+
+            expect(screen.getByText('Custom Sample Layout')).toBeInTheDocument();
+            expect(screen.queryByText('Regular Resource Layout')).not.toBeInTheDocument();
+        });
+
+        it('keeps an igsn custom template id in the save payload', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [mockIgsnCustomTemplate],
+                        },
+                    });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: {
+                        ...mockExistingConfig,
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: mockIgsnCustomTemplate.id,
+                        landing_page_template: mockIgsnCustomTemplate,
+                    },
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({ data: {} });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+
+            await waitFor(() => {
+                expect(screen.getByText('Custom Sample Layout')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('Custom Sample Layout'));
+            await user.click(screen.getByRole('button', { name: /Create Preview/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: mockIgsnCustomTemplate.id,
+                    }),
+                );
+            });
+        });
+
+        it('restores a saved igsn custom template selection when loading config from the server', async () => {
+            const configWithCustomTemplate: LandingPageConfig = {
+                ...mockExistingConfig,
+                landing_page_template_id: mockIgsnCustomTemplate.id,
+                landing_page_template: mockIgsnCustomTemplate,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [mockIgsnCustomTemplate],
+                        },
+                    });
+                }
+
+                if (url.includes(`/resources/${mockResource.id}/landing-page`)) {
+                    return Promise.resolve({ data: { landing_page: configWithCustomTemplate } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('Custom Sample Layout');
+            });
+        });
+
+        it('keeps an igsn custom template id in the preview payload', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [mockIgsnCustomTemplate],
+                        },
+                    });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: { preview_url: '/resources/456/landing-page/preview?session=igsn-custom' },
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+
+            await waitFor(() => {
+                expect(screen.getByText('Custom Sample Layout')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('Custom Sample Layout'));
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: mockIgsnCustomTemplate.id,
+                    }),
+                );
+            });
+
+            vi.unstubAllGlobals();
+        });
+    });
+
     describe('Draft Removal', () => {
         it('shows remove preview button for draft landing pages', async () => {
             mockedAxiosGet.mockResolvedValue({

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -332,6 +332,39 @@ describe('SetupIgsnLandingPageModal', () => {
             vi.unstubAllGlobals();
         });
 
+        it('shows the resulting external URL using the normalized previewable path', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+            await user.click(screen.getByText('External Landing Page'));
+            await user.click(screen.getByLabelText(/Domain/i));
+            await user.click(screen.getByText('https://example.org/'));
+            await user.type(screen.getByLabelText(/Path/i), '  /sample/preview  ');
+
+            expect(screen.getByText('Resulting URL')).toBeInTheDocument();
+            expect(screen.getByText('https://example.org/sample/preview')).toBeInTheDocument();
+
+            await user.clear(screen.getByLabelText(/Path/i));
+            await user.type(screen.getByLabelText(/Path/i), '   ');
+
+            expect(screen.queryByText('Resulting URL')).not.toBeInTheDocument();
+            expect(screen.queryByText('https://example.org/sample/preview')).not.toBeInTheDocument();
+        });
+
         it('does not preview the bare external domain when the path is empty', async () => {
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-domains')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -332,6 +332,40 @@ describe('SetupIgsnLandingPageModal', () => {
             vi.unstubAllGlobals();
         });
 
+        it('does not preview the bare external domain when the path is empty', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+            await user.click(screen.getByText('External Landing Page'));
+
+            await user.click(screen.getByLabelText(/Domain/i));
+            await user.click(screen.getByText('https://example.org/'));
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            expect(mockWindowOpen).not.toHaveBeenCalled();
+            expect(mockedToastError).toHaveBeenCalledWith('Please select a domain and enter a path to preview the external URL.');
+            expect(mockedAxiosPost).not.toHaveBeenCalled();
+
+            vi.unstubAllGlobals();
+        });
+
         it('does not fall back to the saved external URL when unsaved edits make the current external preview invalid', async () => {
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-domains')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -626,7 +626,7 @@ describe('SetupIgsnLandingPageModal', () => {
             });
         });
 
-        it('treats a legacy default_gfz config as unsaved for preview generation', async () => {
+        it('does not treat a legacy default_gfz config as unsaved for preview generation', async () => {
             const legacyConfig: LandingPageConfig = {
                 ...mockExistingConfig,
                 template: 'default_gfz',
@@ -634,9 +634,6 @@ describe('SetupIgsnLandingPageModal', () => {
             };
 
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: legacyConfig } });
-            mockedAxiosPost.mockResolvedValue({
-                data: { preview_url: '/resources/456/landing-page/preview?session=1' },
-            });
 
             const mockWindowOpen = vi.fn();
             vi.stubGlobal('open', mockWindowOpen);
@@ -649,17 +646,12 @@ describe('SetupIgsnLandingPageModal', () => {
                 expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
             });
 
+            expect(screen.queryByText(/You have unsaved changes/i)).not.toBeInTheDocument();
+
             await user.click(screen.getByRole('button', { name: /^Preview$/i }));
 
-            await waitFor(() => {
-                expect(axios.post).toHaveBeenCalledWith(
-                    expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
-                    expect.objectContaining({ template: 'default_gfz_igsn' }),
-                );
-            });
-
-            expect(mockWindowOpen).toHaveBeenCalledWith('/resources/456/landing-page/preview?session=1', '_blank', 'noopener,noreferrer');
-            expect(mockWindowOpen).not.toHaveBeenCalledWith('http://localhost/legacy-preview', '_blank', 'noopener,noreferrer');
+            expect(mockedAxiosPost).not.toHaveBeenCalled();
+            expect(mockWindowOpen).toHaveBeenCalledWith('http://localhost/legacy-preview', '_blank', 'noopener,noreferrer');
 
             vi.unstubAllGlobals();
         });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -780,6 +780,74 @@ describe('SetupIgsnLandingPageModal', () => {
             });
         });
 
+        it('drops a persisted built-in igsn default template id when the loaded relation is the default template', async () => {
+            const configWithBuiltInDefault: LandingPageConfig = {
+                ...mockExistingConfig,
+                landing_page_template_id: 1,
+                landing_page_template: {
+                    id: 1,
+                    name: 'Default GFZ IGSN',
+                    slug: 'default_gfz_igsn',
+                    is_default: true,
+                    template_type: 'igsn',
+                    logo_path: null,
+                    logo_url: null,
+                    right_column_order: [],
+                    left_column_order: [],
+                },
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                configWithBuiltInDefault.landing_page_template,
+                                mockIgsnCustomTemplate,
+                            ],
+                        },
+                    });
+                }
+
+                if (url.includes(`/resources/${mockResource.id}/landing-page`)) {
+                    return Promise.resolve({ data: { landing_page: configWithBuiltInDefault } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...configWithBuiltInDefault,
+                        landing_page_template_id: null,
+                    },
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({ data: {} });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            expect(screen.queryByText(/You have unsaved changes/i)).not.toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+
         it('keeps an igsn custom template id in the preview payload', async () => {
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-templates')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -328,6 +328,70 @@ describe('SetupIgsnLandingPageModal', () => {
             });
         });
 
+        it('preserves a matching igsn custom template when a legacy default_gfz config is normalized', async () => {
+            const legacyConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                template: 'default_gfz',
+                landing_page_template_id: 7,
+                landing_page_template: {
+                    id: 7,
+                    name: 'Legacy Sample Layout',
+                    slug: 'legacy-sample-layout',
+                    is_default: false,
+                    template_type: 'igsn',
+                    logo_path: null,
+                    logo_url: null,
+                    right_column_order: [],
+                    left_column_order: [],
+                },
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [legacyConfig.landing_page_template],
+                        },
+                    });
+                }
+
+                if (url.includes(`/resources/${mockResource.id}/landing-page`)) {
+                    return Promise.resolve({ data: { landing_page: legacyConfig } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...legacyConfig,
+                        template: 'default_gfz_igsn',
+                    },
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({ data: {} });
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('Legacy Sample Layout');
+            });
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
+
+            await waitFor(() => {
+                expect(axios.put).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: 7,
+                    }),
+                );
+            });
+        });
+
         it('treats a legacy default_gfz config as unsaved for preview generation', async () => {
             const legacyConfig: LandingPageConfig = {
                 ...mockExistingConfig,

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupIgsnLandingPageModal.test.tsx
@@ -327,6 +327,44 @@ describe('SetupIgsnLandingPageModal', () => {
                 );
             });
         });
+
+        it('treats a legacy default_gfz config as unsaved for preview generation', async () => {
+            const legacyConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                template: 'default_gfz',
+                preview_url: 'http://localhost/legacy-preview',
+            };
+
+            mockedAxiosGet.mockResolvedValue({ data: { landing_page: legacyConfig } });
+            mockedAxiosPost.mockResolvedValue({
+                data: { preview_url: '/resources/456/landing-page/preview?session=1' },
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+
+            render(<SetupIgsnLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            await waitFor(() => {
+                expect(axios.post).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
+                    expect.objectContaining({ template: 'default_gfz_igsn' }),
+                );
+            });
+
+            expect(mockWindowOpen).toHaveBeenCalledWith('/resources/456/landing-page/preview?session=1', '_blank', 'noopener,noreferrer');
+            expect(mockWindowOpen).not.toHaveBeenCalledWith('http://localhost/legacy-preview', '_blank', 'noopener,noreferrer');
+
+            vi.unstubAllGlobals();
+        });
     });
 
     describe('Preview Functionality', () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -251,7 +251,7 @@ describe('SetupLandingPageModal', () => {
             render(
                 <SetupLandingPageModal
                     resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    existingConfig={{ ...mockExistingConfig, template: 'default_gfz', landing_page_template_id: 7 }}
+                    existingConfig={{ ...mockExistingConfig, template: 'default_gfz', landing_page_template_id: null }}
                     isOpen={true}
                     onClose={mockOnClose}
                 />,
@@ -301,7 +301,7 @@ describe('SetupLandingPageModal', () => {
             const legacyConfig = {
                 ...mockExistingConfig,
                 template: 'default_gfz',
-                landing_page_template_id: 9,
+                landing_page_template_id: null,
                 status: 'draft' as const,
             };
 
@@ -349,6 +349,80 @@ describe('SetupLandingPageModal', () => {
                         template: 'default_gfz_igsn',
                         ftp_url: null,
                         landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+
+        it('preserves a matching igsn custom template when a legacy Physical Object config is normalized', async () => {
+            const legacyConfig = {
+                ...mockExistingConfig,
+                template: 'default_gfz',
+                landing_page_template_id: 9,
+                landing_page_template: {
+                    id: 9,
+                    name: 'Legacy Sample Layout',
+                    slug: 'legacy-sample-layout',
+                    is_default: false,
+                    template_type: 'igsn' as const,
+                    logo_path: null,
+                    logo_url: null,
+                    right_column_order: [],
+                    left_column_order: [],
+                },
+                status: 'draft' as const,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [legacyConfig.landing_page_template],
+                        },
+                    });
+                }
+
+                if (url.includes(`/resources/${mockResource.id}/landing-page`)) {
+                    return Promise.resolve({ data: { landing_page: legacyConfig } });
+                }
+
+                return Promise.reject({
+                    isAxiosError: true,
+                    response: { status: 404 },
+                });
+            });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...legacyConfig,
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
+                    },
+                },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('Legacy Sample Layout');
+            });
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
+
+            await waitFor(() => {
+                expect(axios.put).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: 9,
                     }),
                 );
             });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -184,6 +184,34 @@ describe('SetupLandingPageModal', () => {
             });
         });
 
+        it('treats the human-readable Physical Object name as an IGSN resource', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            await user.click(screen.getByRole('combobox'));
+
+            const optionsList = screen.getByRole('listbox');
+            expect(optionsList).toHaveTextContent('Default GFZ IGSN Template');
+            expect(optionsList).toHaveTextContent('External Landing Page');
+            expect(optionsList).not.toHaveTextContent('Default GFZ Data Services');
+        });
+
         it('loads existing configuration', async () => {
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: mockExistingConfig } });
 

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -277,11 +277,12 @@ describe('SetupLandingPageModal', () => {
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
                     expect.objectContaining({
                         template: 'default_gfz_igsn',
-                        ftp_url: null,
                         landing_page_template_id: null,
                     }),
                 );
             });
+
+            expect(mockedAxiosPut.mock.calls.at(-1)?.[1]).not.toHaveProperty('ftp_url');
         });
     });
 
@@ -354,11 +355,12 @@ describe('SetupLandingPageModal', () => {
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
                     expect.objectContaining({
                         template: 'default_gfz_igsn',
-                        ftp_url: null,
                         landing_page_template_id: null,
                     }),
                 );
             });
+
+            expect(mockedAxiosPut.mock.calls.at(-1)?.[1]).not.toHaveProperty('ftp_url');
         });
 
         it('preserves a matching igsn custom template when a legacy Physical Object config is normalized', async () => {
@@ -522,10 +524,11 @@ describe('SetupLandingPageModal', () => {
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
                     expect.objectContaining({
                         template: 'default_gfz_igsn',
-                        ftp_url: null,
                     }),
                 );
             });
+
+            expect(mockedAxiosPost.mock.calls.at(-1)?.[1]).not.toHaveProperty('ftp_url');
         });
 
         it('updates existing landing page config', async () => {
@@ -1418,10 +1421,11 @@ describe('SetupLandingPageModal', () => {
                     expect.objectContaining({
                         template: 'default_gfz_igsn',
                         landing_page_template_id: 7,
-                        ftp_url: null,
                     }),
                 );
             });
+
+            expect(mockedAxiosPost.mock.calls.at(-1)?.[1]).not.toHaveProperty('ftp_url');
         });
 
         it('keeps an igsn custom template id in the preview payload for Physical Object resources', async () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1828,6 +1828,71 @@ describe('SetupLandingPageModal', () => {
             });
         });
 
+        it('drops a persisted built-in default template id when the loaded relation is the default template', async () => {
+            const serverConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+                template: 'default_gfz',
+                landing_page_template_id: 1,
+                landing_page_template: {
+                    id: 1,
+                    name: 'Default GFZ Data Services',
+                    slug: 'default_gfz',
+                    is_default: true,
+                    template_type: 'resource',
+                    logo_path: null,
+                    logo_url: null,
+                    right_column_order: [],
+                    left_column_order: [],
+                },
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve(customTemplatesResponse);
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.resolve({ data: { landing_page: serverConfig } });
+            });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...serverConfig,
+                        landing_page_template_id: null,
+                    },
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('Default GFZ Data Services');
+            });
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz',
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
+
         it('resets landing_page_template_id to null on 404 (no landing page exists)', async () => {
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-templates')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -229,6 +229,53 @@ describe('SetupLandingPageModal', () => {
                 expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
             });
         });
+
+        it('normalizes a legacy Physical Object config passed via props to the IGSN template', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...mockExistingConfig,
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
+                        landing_page_template_id: null,
+                    },
+                },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    existingConfig={{ ...mockExistingConfig, template: 'default_gfz', landing_page_template_id: 7 }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            expect(screen.queryByLabelText(/Download URL \(FTP\)/i)).not.toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
+
+            await waitFor(() => {
+                expect(axios.put).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
+                        landing_page_template_id: null,
+                    }),
+                );
+            });
+        });
     });
 
     describe('API Integration', () => {
@@ -246,6 +293,63 @@ describe('SetupLandingPageModal', () => {
             await waitFor(() => {
                 expect(axios.get).toHaveBeenCalledWith(
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                );
+            });
+        });
+
+        it('normalizes a legacy Physical Object config loaded from the server before update', async () => {
+            const legacyConfig = {
+                ...mockExistingConfig,
+                template: 'default_gfz',
+                landing_page_template_id: 9,
+                status: 'draft' as const,
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes(`/resources/${mockResource.id}/landing-page`)) {
+                    return Promise.resolve({ data: { landing_page: legacyConfig } });
+                }
+
+                return Promise.reject({
+                    isAxiosError: true,
+                    response: { status: 404 },
+                });
+            });
+            mockedAxiosPut.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...legacyConfig,
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
+                        landing_page_template_id: null,
+                    },
+                },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            await user.click(screen.getByRole('button', { name: /Update/i }));
+
+            await waitFor(() => {
+                expect(axios.put).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
+                        landing_page_template_id: null,
+                    }),
                 );
             });
         });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -810,6 +810,60 @@ describe('SetupLandingPageModal', () => {
             vi.unstubAllGlobals();
         });
 
+        it('does not treat a normalized legacy Physical Object config as unsaved for preview generation', async () => {
+            const legacyConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                template: 'default_gfz',
+                status: 'draft',
+                preview_url: 'http://localhost/legacy-preview',
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    existingConfig={legacyConfig}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+            });
+
+            expect(screen.queryByText(/You have unsaved changes/i)).not.toBeInTheDocument();
+
+            const previewButtons = screen.getAllByRole('button', { name: /Preview/i });
+            const previewButton = previewButtons.find(
+                (button) => button.className.includes('outline') || button.textContent?.trim() === 'Preview'
+            );
+
+            expect(previewButton).toBeDefined();
+            await user.click(previewButton!);
+
+            expect(mockedAxiosPost).not.toHaveBeenCalled();
+            expect(mockedToastError).not.toHaveBeenCalled();
+
+            vi.unstubAllGlobals();
+        });
+
         it('shows the resulting external URL using the normalized previewable path', async () => {
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-domains')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
+import { toast } from 'sonner';
 import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -37,6 +38,7 @@ const mockedAxiosGet = axios.get as Mock;
 const mockedAxiosPost = axios.post as Mock;
 const mockedAxiosPut = axios.put as Mock;
 const mockedAxiosDelete = axios.delete as Mock;
+const mockedToastError = toast.error as Mock;
 
 vi.mock('@inertiajs/react', () => ({
     router: {
@@ -52,6 +54,11 @@ vi.mock('sonner', () => ({
 }));
 
 describe('SetupLandingPageModal', () => {
+    const mockDomains = [
+        { id: 1, domain: 'https://example.org/' },
+        { id: 2, domain: 'https://resources.example.org/' },
+    ];
+
     const mockResource = {
         id: 123,
         doi: '10.5880/GFZ.TEST.2025.001',
@@ -799,6 +806,54 @@ describe('SetupLandingPageModal', () => {
                 '_blank',
                 'noopener,noreferrer',
             );
+
+            vi.unstubAllGlobals();
+        });
+
+        it('does not fall back to the saved external URL when unsaved edits clear the external path', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const mockWindowOpen = vi.fn();
+            vi.stubGlobal('open', mockWindowOpen);
+
+            const user = userEvent.setup();
+            const existingExternalConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                template: 'external',
+                ftp_url: null,
+                external_domain_id: 1,
+                external_path: '/saved-resource',
+                external_url: 'https://example.org/saved-resource',
+            };
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    existingConfig={existingExternalConfig}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/Path/i)).toHaveValue('/saved-resource');
+            });
+
+            await user.clear(screen.getByLabelText(/Path/i));
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            expect(mockWindowOpen).not.toHaveBeenCalled();
+            expect(mockedToastError).toHaveBeenCalledWith('Please select a domain and enter a path to preview the external URL.');
 
             vi.unstubAllGlobals();
         });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -210,6 +210,7 @@ describe('SetupLandingPageModal', () => {
             expect(optionsList).toHaveTextContent('Default GFZ IGSN Template');
             expect(optionsList).toHaveTextContent('External Landing Page');
             expect(optionsList).not.toHaveTextContent('Default GFZ Data Services');
+            expect(screen.queryByLabelText(/Download URL \(FTP\)/i)).not.toBeInTheDocument();
         });
 
         it('loads existing configuration', async () => {
@@ -294,6 +295,49 @@ describe('SetupLandingPageModal', () => {
                         template: 'default_gfz',
                         ftp_url: 'https://datapub.gfz-potsdam.de/download/new-data',
                         status: 'draft',
+                    }),
+                );
+            });
+        });
+
+        it('clears ftp_url when a Physical Object is saved through the shared modal', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...mockExistingConfig,
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
+                        status: 'draft',
+                    },
+                },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Create Preview/i }));
+
+            await waitFor(() => {
+                expect(axios.post).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        ftp_url: null,
                     }),
                 );
             });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -810,6 +810,49 @@ describe('SetupLandingPageModal', () => {
             vi.unstubAllGlobals();
         });
 
+        it('shows the resulting external URL using the normalized previewable path', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: mockDomains } });
+                }
+
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+            await user.click(screen.getByText('External Landing Page'));
+            await user.click(screen.getByLabelText(/Domain/i));
+            await user.click(screen.getByText('https://example.org/'));
+            await user.type(screen.getByLabelText(/Path/i), '  /dataset/preview  ');
+
+            expect(screen.getByText('Resulting URL')).toBeInTheDocument();
+            expect(screen.getByText('https://example.org/dataset/preview')).toBeInTheDocument();
+
+            await user.clear(screen.getByLabelText(/Path/i));
+            await user.type(screen.getByLabelText(/Path/i), '   ');
+
+            expect(screen.queryByText('Resulting URL')).not.toBeInTheDocument();
+            expect(screen.queryByText('https://example.org/dataset/preview')).not.toBeInTheDocument();
+        });
+
         it('does not fall back to the saved external URL when unsaved edits clear the external path', async () => {
             mockedAxiosGet.mockImplementation((url: string) => {
                 if (url.includes('/api/landing-page-domains')) {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1112,6 +1112,177 @@ describe('SetupLandingPageModal', () => {
             });
         });
 
+        it('keeps an igsn custom template id in the save payload for Physical Object resources', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                {
+                                    id: 7,
+                                    name: 'Custom Sample Layout',
+                                    slug: 'custom-sample-layout',
+                                    is_default: false,
+                                    template_type: 'igsn',
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                            ],
+                        },
+                    });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: {
+                        ...mockExistingConfig,
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: 7,
+                        landing_page_template: {
+                            id: 7,
+                            name: 'Custom Sample Layout',
+                            slug: 'custom-sample-layout',
+                            is_default: false,
+                            template_type: 'igsn',
+                            logo_path: null,
+                            logo_url: null,
+                            right_column_order: [],
+                            left_column_order: [],
+                        },
+                        ftp_url: null,
+                        status: 'draft',
+                    },
+                    preview_url: '/preview',
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+
+            await waitFor(() => {
+                expect(screen.getByText('Custom Sample Layout')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('Custom Sample Layout'));
+            await user.click(screen.getByRole('button', { name: /Create Preview/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: 7,
+                        ftp_url: null,
+                    }),
+                );
+            });
+        });
+
+        it('keeps an igsn custom template id in the preview payload for Physical Object resources', async () => {
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({
+                        data: {
+                            templates: [
+                                {
+                                    id: 8,
+                                    name: 'Preview Sample Layout',
+                                    slug: 'preview-sample-layout',
+                                    is_default: false,
+                                    template_type: 'igsn',
+                                    logo_url: null,
+                                    right_column_order: [],
+                                    left_column_order: [],
+                                },
+                            ],
+                        },
+                    });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockImplementation((url: string) => {
+                if (url.includes('/landing-page/preview')) {
+                    return Promise.resolve({ data: { preview_url: '/resources/123/landing-page/preview' } });
+                }
+
+                return Promise.resolve({
+                    data: {
+                        message: 'Landing page created',
+                        landing_page: { ...mockExistingConfig, status: 'draft' },
+                        preview_url: '/preview',
+                    },
+                });
+            });
+
+            const mockOpen = vi.fn();
+            vi.stubGlobal('open', mockOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByLabelText(/Landing Page Template/i));
+
+            await waitFor(() => {
+                expect(screen.getByText('Preview Sample Layout')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByText('Preview Sample Layout'));
+
+            const previewButtons = screen.getAllByRole('button', { name: /Preview/i });
+            const previewButton = previewButtons.find(
+                (btn) => btn.className.includes('outline') || btn.textContent?.trim() === 'Preview'
+            );
+
+            expect(previewButton).toBeDefined();
+            await user.click(previewButton!);
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
+                    expect.objectContaining({
+                        template: 'default_gfz_igsn',
+                        landing_page_template_id: 8,
+                    }),
+                );
+            });
+
+            vi.unstubAllGlobals();
+        });
+
         it('resets landing_page_template_id when switching to built-in template', async () => {
             const configWithCustomTemplate: LandingPageConfig = {
                 ...mockExistingConfig,

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import type { Mock } from 'vitest';
@@ -205,6 +205,7 @@ const defaultIgsnTemplate: LandingPageTemplateConfig = {
     name: 'Default GFZ IGSN',
     slug: 'default_gfz_igsn',
     template_type: 'igsn',
+    left_column_order: ['general', 'acquisition', 'contact', 'model_description', 'related_work'],
 };
 
 let mockTemplates: LandingPageTemplateConfig[] = [];
@@ -509,6 +510,43 @@ describe('LandingPageTemplatesPage', () => {
             expect(screen.getByText('Right Column (main content)')).toBeInTheDocument();
             expect(screen.getByText('Left Column (sidebar)')).toBeInTheDocument();
             expect(screen.getByText(/Description modules render inside one shared metadata card/i)).toBeInTheDocument();
+        });
+
+        it('normalizes IGSN left-column sections before saving and does not expose files in the dialog', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            mockTemplates = [
+                {
+                    ...defaultIgsnTemplate,
+                    id: 5,
+                    is_default: false,
+                    name: 'Legacy IGSN Template',
+                    created_by: 1,
+                    creator: { id: 1, name: 'Admin User' },
+                    landing_pages_count: 0,
+                    left_column_order: ['contact', 'files', 'model_description', 'related_work'] as LandingPageTemplateConfig['left_column_order'],
+                },
+            ];
+
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Edit/i }));
+
+            const dialog = screen.getByRole('dialog');
+            expect(within(dialog).queryByText('Files & Downloads')).not.toBeInTheDocument();
+            expect(within(dialog).getByText('General')).toBeInTheDocument();
+            expect(within(dialog).getByText('Acquisition')).toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    '/landing-pages/5',
+                    expect.objectContaining({
+                        left_column_order: ['contact', 'model_description', 'related_work', 'general', 'acquisition'],
+                    }),
+                );
+            });
         });
 
         it('normalizes middle location to the end before saving', async () => {

--- a/tests/vitest/types/__tests__/landing-page.test.ts
+++ b/tests/vitest/types/__tests__/landing-page.test.ts
@@ -6,6 +6,7 @@ import {
     getIgsnTemplateOptions,
     getTemplateMetadata,
     getTemplateOptions,
+    isIgsnLandingPageResourceType,
     isValidTemplate,
     LANDING_PAGE_TEMPLATES,
 } from '@/types/landing-page';
@@ -146,6 +147,25 @@ describe('Landing Page Template Registry', () => {
             const physicalObjectOptions = getTemplateOptions('PhysicalObject');
 
             expect(igsnOptions).toEqual(physicalObjectOptions);
+        });
+
+        it('should treat the human-readable Physical Object name as IGSN scope', () => {
+            expect(getTemplateOptions('Physical Object').map((option) => option.value)).toEqual(
+                getTemplateOptions('PhysicalObject').map((option) => option.value),
+            );
+        });
+    });
+
+    describe('isIgsnLandingPageResourceType()', () => {
+        it('recognizes Physical Object variants', () => {
+            expect(isIgsnLandingPageResourceType('PhysicalObject')).toBe(true);
+            expect(isIgsnLandingPageResourceType('Physical Object')).toBe(true);
+            expect(isIgsnLandingPageResourceType('physical-object')).toBe(true);
+        });
+
+        it('rejects non-IGSN resource types', () => {
+            expect(isIgsnLandingPageResourceType('Dataset')).toBe(false);
+            expect(isIgsnLandingPageResourceType(undefined)).toBe(false);
         });
     });
 

--- a/tests/vitest/types/__tests__/landing-page.test.ts
+++ b/tests/vitest/types/__tests__/landing-page.test.ts
@@ -29,7 +29,8 @@ describe('Landing Page Template Registry', () => {
                 description: expect.any(String),
                 category: 'official',
                 version: expect.any(String),
-                resourceTypes: null, // Available for all
+                scopes: ['resource'],
+                resourceTypes: null,
             });
         });
 
@@ -42,6 +43,7 @@ describe('Landing Page Template Registry', () => {
                 description: expect.any(String),
                 category: 'official',
                 version: expect.any(String),
+                scopes: ['igsn'],
                 resourceTypes: ['PhysicalObject'], // Only for IGSNs
             });
         });
@@ -97,11 +99,11 @@ describe('Landing Page Template Registry', () => {
             expect(igsnOption?.label).toBe('Default GFZ IGSN Template');
         });
 
-        it('should include both templates when resourceType is PhysicalObject', () => {
+        it('should only include IGSN-compatible built-in templates when resourceType is PhysicalObject', () => {
             const options = getTemplateOptions('PhysicalObject');
 
-            expect(options.length).toBe(3);
-            expect(options.map((o) => o.value)).toContain('default_gfz');
+            expect(options.length).toBe(2);
+            expect(options.map((o) => o.value)).not.toContain('default_gfz');
             expect(options.map((o) => o.value)).toContain('default_gfz_igsn');
             expect(options.map((o) => o.value)).toContain('external');
         });
@@ -132,11 +134,11 @@ describe('Landing Page Template Registry', () => {
             expect(igsnOption?.label).toBe('Default GFZ IGSN Template');
         });
 
-        it('should also include unrestricted templates', () => {
+        it('should exclude resource-only templates', () => {
             const options = getIgsnTemplateOptions();
             const defaultOption = options.find((opt) => opt.value === 'default_gfz');
 
-            expect(defaultOption).toBeDefined();
+            expect(defaultOption).toBeUndefined();
         });
 
         it('should be equivalent to getTemplateOptions with PhysicalObject', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig(({ command }) => {
             react(),
             tailwindcss(),
             wayfinder({
+                command: 'php artisan ernie:wayfinder-generate',
                 formVariants: true,
             }),
         ],


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the handling of landing page templates and sorting logic, as well as a new console command for Wayfinder definition generation. The main focus is on making template support logic more robust and maintainable, enforcing template-specific field validation, and ensuring consistent API responses. Additionally, sorting logic in the IGSN controller is made more secure against invalid input.

**Landing Page Template Handling Improvements:**

* Refactored template support logic in `LandingPageController` by introducing helper methods (`templateSupportsCustomTemplateId`, `templateSupportsFtpUrl`, etc.) and using constants from `LandingPageTemplate` for better maintainability and clarity. This also includes stricter validation for which templates support which fields and improved error reporting for unsupported fields. [[1]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR31-R89) [[2]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL45-R123) [[3]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL112-R197) [[4]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL333-R437) [[5]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL368-R482) [[6]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL404-R500)

* Updated creation and update logic for landing pages to use the new helper methods, ensuring that only supported fields are set for each template and that template-specific errors are returned early. [[1]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL177-R259) [[2]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL368-R482) [[3]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL404-R500)

* API responses for landing page creation and update now use a consistent serialization method (`serializeLandingPagePayload`), and always eager-load related entities including `files`. [[1]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL283-R371) [[2]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL429-R528)

**Sorting Logic Hardening:**

* In `IgsnController`, the `applySorting` method now normalizes the sort direction to either `'asc'` or `'desc'`, preventing invalid input from being passed to the query builder. All relevant usages of the sort direction have been updated accordingly. [[1]](diffhunk://#diff-da7810a9890d8f8e9f00dcf982edbc543e6edeee7926217669c14d1fb1d5f3e5R705-R709) [[2]](diffhunk://#diff-da7810a9890d8f8e9f00dcf982edbc543e6edeee7926217669c14d1fb1d5f3e5L719-R721) [[3]](diffhunk://#diff-da7810a9890d8f8e9f00dcf982edbc543e6edeee7926217669c14d1fb1d5f3e5L730-R732) [[4]](diffhunk://#diff-da7810a9890d8f8e9f00dcf982edbc543e6edeee7926217669c14d1fb1d5f3e5L743-R749)

**Wayfinder Definitions Generation:**

* Added a new Artisan command `GenerateWayfinderDefinitions` that wraps the existing `wayfinder:generate` command and post-processes the generated helper to normalize query parameter ordering for consistency.