### PR TITLE
Fix: FAIR assessment does not work

### DIFF
--- a/app/Http/Controllers/AssessmentController.php
+++ b/app/Http/Controllers/AssessmentController.php
@@ -26,9 +26,12 @@ class AssessmentController extends Controller
     public function index(): Response
     {
         $physicalObjectTypeId = $this->resourceCache->getPhysicalObjectTypeId();
+        $fujiHealth = $this->fujiService->healthStatus();
 
         return Inertia::render('assessment', [
             'fujiConfigured' => $this->fujiService->isConfigured(),
+            'fujiHealthy' => $fujiHealth['healthy'],
+            'fujiStatusMessage' => $fujiHealth['message'],
             'resourcesNeedingAttention' => $this->buildAttentionList(RunResourceAssessmentsJob::RESOURCE_SCOPE, $physicalObjectTypeId),
             'igsnsNeedingAttention' => $this->buildAttentionList(RunResourceAssessmentsJob::IGSN_SCOPE, $physicalObjectTypeId),
             'resourceAssessmentSummary' => $this->buildSummary(RunResourceAssessmentsJob::RESOURCE_SCOPE, $physicalObjectTypeId),
@@ -48,10 +51,10 @@ class AssessmentController extends Controller
 
     public function checkAll(): JsonResponse
     {
-        if (! $this->fujiService->isConfigured()) {
-            return response()->json([
-                'error' => 'F-UJI is not configured.',
-            ], 503);
+        $fujiUnavailableResponse = $this->fujiUnavailableResponse();
+
+        if ($fujiUnavailableResponse !== null) {
+            return $fujiUnavailableResponse;
         }
 
         $result = [];
@@ -236,10 +239,10 @@ class AssessmentController extends Controller
 
     private function startScopeJob(string $scope): JsonResponse
     {
-        if (! $this->fujiService->isConfigured()) {
-            return response()->json([
-                'error' => 'F-UJI is not configured.',
-            ], 503);
+        $fujiUnavailableResponse = $this->fujiUnavailableResponse();
+
+        if ($fujiUnavailableResponse !== null) {
+            return $fujiUnavailableResponse;
         }
 
         $started = $this->attemptScopeDispatch($scope);
@@ -253,5 +256,18 @@ class AssessmentController extends Controller
         return response()->json([
             'jobId' => $started['jobId'],
         ]);
+    }
+
+    private function fujiUnavailableResponse(): ?JsonResponse
+    {
+        $fujiHealth = $this->fujiService->healthStatus();
+
+        if ($fujiHealth['healthy']) {
+            return null;
+        }
+
+        return response()->json([
+            'error' => $fujiHealth['message'] ?? 'F-UJI is configured but unhealthy.',
+        ], 503);
     }
 }

--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services\Assessment;
 
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use RuntimeException;
 
 class FujiAssessmentService
@@ -19,6 +22,41 @@ class FujiAssessmentService
     }
 
     /**
+     * @return array{healthy: bool, message: string|null}
+     */
+    public function healthStatus(): array
+    {
+        if (! $this->isConfigured()) {
+            return [
+                'healthy' => false,
+                'message' => 'F-UJI is not configured.',
+            ];
+        }
+
+        try {
+            $response = $this->baseRequest()
+                ->get($this->healthEndpoint());
+        } catch (\Throwable $exception) {
+            return [
+                'healthy' => false,
+                'message' => sprintf('F-UJI health check failed: %s', $exception->getMessage()),
+            ];
+        }
+
+        if (! $response->successful()) {
+            return [
+                'healthy' => false,
+                'message' => $this->unsuccessfulResponseMessage('F-UJI health check failed', $response),
+            ];
+        }
+
+        return [
+            'healthy' => true,
+            'message' => null,
+        ];
+    }
+
+    /**
      * @return array{score: float, payload: array<string, mixed>, resolvedUrl: string|null, normalizedIdentifier: string|null}
      */
     public function assessIdentifier(string $identifier): array
@@ -27,18 +65,13 @@ class FujiAssessmentService
             throw new RuntimeException('F-UJI is not configured.');
         }
 
-        $response = Http::withBasicAuth(
-            $this->username() ?? '',
-            $this->password() ?? '',
-        )
+        $response = $this->baseRequest()
             ->acceptJson()
             ->asJson()
-            ->connectTimeout($this->connectTimeout())
-            ->timeout($this->timeout())
             ->post($this->endpoint(), $this->buildPayload($identifier));
 
         if (! $response->successful()) {
-            throw new RuntimeException(sprintf('F-UJI assessment failed with status %d.', $response->status()));
+            throw new RuntimeException($this->unsuccessfulResponseMessage('F-UJI assessment failed', $response));
         }
 
         /** @var array<string, mixed> $payload */
@@ -86,6 +119,11 @@ class FujiAssessmentService
         return rtrim($this->baseUrl() ?? '', '/') . '/fuji/api/v1/evaluate';
     }
 
+    private function healthEndpoint(): string
+    {
+        return rtrim($this->baseUrl() ?? '', '/') . '/fuji/api/v1/ui/';
+    }
+
     private function baseUrl(): ?string
     {
         $value = Config::get('fuji.base_url');
@@ -121,5 +159,27 @@ class FujiAssessmentService
     private function connectTimeout(): int
     {
         return max(1, (int) Config::get('fuji.connect_timeout', 10));
+    }
+
+    private function baseRequest(): PendingRequest
+    {
+        return Http::withBasicAuth(
+            $this->username() ?? '',
+            $this->password() ?? '',
+        )
+            ->connectTimeout($this->connectTimeout())
+            ->timeout($this->timeout());
+    }
+
+    private function unsuccessfulResponseMessage(string $prefix, Response $response): string
+    {
+        $message = sprintf('%s with status %d.', $prefix, $response->status());
+        $body = trim(preg_replace('/\s+/', ' ', $response->body()) ?? '');
+
+        if ($body === '') {
+            return $message;
+        }
+
+        return sprintf('%s Response: %s', $message, Str::limit($body, 200, '...'));
     }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -208,7 +208,7 @@ services:
       - FUJI_ENABLED=${FUJI_ENABLED:-true}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD:-change-me}
-      - TIKA_LOG_PATH=/tmp/tika.log
+      - TIKA_LOG_PATH=/tmp/tika
     volumes:
       - ./docker/fuji-entrypoint.sh:/usr/local/bin/fuji-entrypoint.sh:ro
     networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -130,7 +130,7 @@ services:
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
-      - TIKA_LOG_PATH=/tmp/tika.log
+      - TIKA_LOG_PATH=/tmp/tika
     volumes:
       - ./docker/fuji-entrypoint.sh:/usr/local/bin/fuji-entrypoint.sh:ro
     networks:

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -130,7 +130,7 @@ services:
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
-      - TIKA_LOG_PATH=/tmp/tika.log
+      - TIKA_LOG_PATH=/tmp/tika
     volumes:
       - ./docker/fuji-entrypoint.sh:/usr/local/bin/fuji-entrypoint.sh:ro
     networks:

--- a/docker/fuji-entrypoint.sh
+++ b/docker/fuji-entrypoint.sh
@@ -36,6 +36,10 @@ if [ -z "${FUJI_USERNAME:-}" ] || [ -z "${FUJI_PASSWORD:-}" ]; then
     exit 1
 fi
 
+tika_log_path="${TIKA_LOG_PATH:-/tmp/tika}"
+mkdir -p "$tika_log_path"
+export TIKA_LOG_PATH="$tika_log_path"
+
 python3 <<'PY'
 import json
 import os

--- a/resources/js/pages/assessment.tsx
+++ b/resources/js/pages/assessment.tsx
@@ -91,9 +91,9 @@ function AssessmentTable({ entries, summary, scope }: { entries: AssessmentEntry
         <Table>
             <TableHeader>
                 <TableRow>
-                    <TableHead className="w-[180px]">DOI</TableHead>
+                    <TableHead className="w-45">DOI</TableHead>
                     <TableHead>Main Title</TableHead>
-                    <TableHead className="w-[110px] text-right">Score</TableHead>
+                    <TableHead className="w-27.5 text-right">Score</TableHead>
                 </TableRow>
             </TableHeader>
             <TableBody>
@@ -111,6 +111,8 @@ function AssessmentTable({ entries, summary, scope }: { entries: AssessmentEntry
 
 export default function Assessment({
     fujiConfigured,
+    fujiHealthy,
+    fujiStatusMessage,
     resourcesNeedingAttention,
     igsnsNeedingAttention,
     resourceAssessmentSummary,
@@ -120,6 +122,7 @@ export default function Assessment({
         resource: { isChecking: false, progress: '' },
         igsn: { isChecking: false, progress: '' },
     });
+    const fujiAvailable = fujiConfigured && fujiHealthy;
     const pollingRefs = useRef<Record<AssessmentScope, ReturnType<typeof setTimeout> | null>>({
         resource: null,
         igsn: null,
@@ -274,6 +277,11 @@ export default function Assessment({
     }
 
     const isAnyChecking = states.resource.isChecking || states.igsn.isChecking;
+    const fujiAvailabilityMessage = !fujiConfigured
+        ? 'F-UJI is not configured for this environment.'
+        : !fujiHealthy
+          ? (fujiStatusMessage ?? 'F-UJI is configured but unhealthy.')
+          : null;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -286,7 +294,7 @@ export default function Assessment({
                         <p className="text-sm text-muted-foreground">Admin-only FAIR assessment dashboard for resources and IGSNs.</p>
                     </div>
 
-                    <LoadingButton onClick={handleCheckAll} disabled={!fujiConfigured} loading={isAnyChecking}>
+                    <LoadingButton onClick={handleCheckAll} disabled={!fujiAvailable} loading={isAnyChecking}>
                         {isAnyChecking ? (
                             'Checking...'
                         ) : (
@@ -298,9 +306,9 @@ export default function Assessment({
                     </LoadingButton>
                 </div>
 
-                {!fujiConfigured && (
+                {fujiAvailabilityMessage !== null && (
                     <div className="rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground">
-                        F-UJI is not configured for this environment.
+                        {fujiAvailabilityMessage}
                     </div>
                 )}
 
@@ -328,7 +336,7 @@ export default function Assessment({
                                     {summaryText(resourceAssessmentSummary)}
                                 </CardDescription>
                             </div>
-                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('resource')} disabled={!fujiConfigured} loading={states.resource.isChecking}>
+                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('resource')} disabled={!fujiAvailable} loading={states.resource.isChecking}>
                                 {states.resource.isChecking ? 'Checking...' : 'Check Resources'}
                             </LoadingButton>
                         </CardHeader>
@@ -345,7 +353,7 @@ export default function Assessment({
                                     {summaryText(igsnAssessmentSummary)}
                                 </CardDescription>
                             </div>
-                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('igsn')} disabled={!fujiConfigured} loading={states.igsn.isChecking}>
+                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('igsn')} disabled={!fujiAvailable} loading={states.igsn.isChecking}>
                                 {states.igsn.isChecking ? 'Checking...' : 'Check IGSNs'}
                             </LoadingButton>
                         </CardHeader>

--- a/resources/js/types/assessment.ts
+++ b/resources/js/types/assessment.ts
@@ -29,6 +29,8 @@ export interface AssessmentJobStatus {
 
 export interface AssessmentPageProps {
     fujiConfigured: boolean;
+    fujiHealthy: boolean;
+    fujiStatusMessage: string | null;
     resourcesNeedingAttention: AssessmentEntry[];
     igsnsNeedingAttention: AssessmentEntry[];
     resourceAssessmentSummary: AssessmentSummary;

--- a/tests/pest/Feature/Controllers/AssessmentControllerTest.php
+++ b/tests/pest/Feature/Controllers/AssessmentControllerTest.php
@@ -9,9 +9,12 @@ use App\Models\ResourceAssessment;
 use App\Models\ResourceType;
 use App\Models\Title;
 use App\Models\User;
+use App\Services\Assessment\FujiAssessmentService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
+use Mockery\MockInterface;
 
 covers(AssessmentController::class);
 
@@ -22,6 +25,9 @@ beforeEach(function (): void {
     Config::set('fuji.password', 'secret');
     Config::set('cache.default', 'array');
     Cache::flush();
+    Http::fake([
+        'https://fuji.test/fuji/api/v1/ui*' => Http::response('OK', 200),
+    ]);
 });
 
 describe('index', function () {
@@ -34,6 +40,9 @@ describe('index', function () {
             ->assertInertia(fn ($page) => $page
                 ->component('assessment')
                 ->where('auth.user.can_access_assessment', true)
+                ->where('fujiConfigured', true)
+                ->where('fujiHealthy', true)
+                ->where('fujiStatusMessage', null)
                 ->has('resourcesNeedingAttention')
                 ->has('igsnsNeedingAttention')
             );
@@ -188,6 +197,23 @@ describe('checkResources', function () {
             ->assertStatus(503)
             ->assertJson(['error' => 'F-UJI is not configured.']);
     });
+
+    it('returns 503 when F-UJI is configured but unhealthy', function () {
+        $this->mock(FujiAssessmentService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('healthStatus')
+                ->once()
+                ->andReturn([
+                    'healthy' => false,
+                    'message' => 'F-UJI health check failed with status 500. Response: Internal Server Error',
+                ]);
+        });
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $this->actingAs($user)
+            ->post('/assessment/check-resources')
+            ->assertStatus(503)
+            ->assertJsonPath('error', fn (string $error): bool => str_contains($error, 'F-UJI health check failed with status 500.'));
+    });
 });
 
 describe('checkIgsns', function () {
@@ -201,6 +227,23 @@ describe('checkIgsns', function () {
 
         expect($response->json('jobId'))->toBeString()->toMatch('/^[a-f0-9-]{36}$/');
         Queue::assertPushed(RunResourceAssessmentsJob::class, 1);
+    });
+
+    it('returns 503 when F-UJI is configured but unhealthy', function () {
+        $this->mock(FujiAssessmentService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('healthStatus')
+                ->once()
+                ->andReturn([
+                    'healthy' => false,
+                    'message' => 'F-UJI health check failed with status 500. Response: Internal Server Error',
+                ]);
+        });
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $this->actingAs($user)
+            ->post('/assessment/check-igsns')
+            ->assertStatus(503)
+            ->assertJsonPath('error', fn (string $error): bool => str_contains($error, 'F-UJI health check failed with status 500.'));
     });
 });
 
@@ -266,6 +309,23 @@ describe('checkAll', function () {
             ->post('/assessment/check-all')
             ->assertStatus(503)
             ->assertJson(['error' => 'F-UJI is not configured.']);
+    });
+
+    it('returns 503 when F-UJI is configured but unhealthy', function () {
+        $this->mock(FujiAssessmentService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('healthStatus')
+                ->once()
+                ->andReturn([
+                    'healthy' => false,
+                    'message' => 'F-UJI health check failed with status 500. Response: Internal Server Error',
+                ]);
+        });
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $this->actingAs($user)
+            ->post('/assessment/check-all')
+            ->assertStatus(503)
+            ->assertJsonPath('error', fn (string $error): bool => str_contains($error, 'F-UJI health check failed with status 500.'));
     });
 
     it('returns 409 when all assessment jobs are already running', function () {

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -31,6 +31,51 @@ describe('isConfigured', function (): void {
     });
 });
 
+describe('healthStatus', function (): void {
+    it('returns healthy when the F-UJI ui endpoint responds successfully', function (): void {
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/ui/' => Http::response('OK', 200),
+        ]);
+
+        expect($this->service->healthStatus())->toBe([
+            'healthy' => true,
+            'message' => null,
+        ]);
+    });
+
+    it('returns the configuration error when F-UJI is not configured', function (): void {
+        Config::set('fuji.enabled', false);
+
+        expect($this->service->healthStatus())->toBe([
+            'healthy' => false,
+            'message' => 'F-UJI is not configured.',
+        ]);
+    });
+
+    it('returns a failure message when the health endpoint is unsuccessful', function (): void {
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/ui/' => Http::response('Internal Server Error', 500),
+        ]);
+
+        $status = $this->service->healthStatus();
+
+        expect($status['healthy'])->toBeFalse()
+            ->and($status['message'])->toContain('status 500')
+            ->and($status['message'])->toContain('Internal Server Error');
+    });
+
+    it('returns a failure message when the health request cannot connect', function (): void {
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/ui/' => Http::failedConnection(),
+        ]);
+
+        $status = $this->service->healthStatus();
+
+        expect($status['healthy'])->toBeFalse()
+            ->and($status['message'])->toContain('F-UJI health check failed');
+    });
+});
+
 describe('assessIdentifier', function (): void {
     it('throws immediately when F-UJI is not configured', function (): void {
         Config::set('fuji.enabled', false);
@@ -86,7 +131,8 @@ describe('assessIdentifier', function (): void {
         ]);
 
         expect(fn () => $this->service->assessIdentifier('10.5880/test.001'))
-            ->toThrow(RuntimeException::class, 'status 500');
+            ->toThrow(RuntimeException::class, 'status 500')
+            ->toThrow(RuntimeException::class, 'Unavailable');
     });
 
     it('includes the configured metric version in the request payload', function (): void {

--- a/tests/vitest/pages/__tests__/assessment.test.tsx
+++ b/tests/vitest/pages/__tests__/assessment.test.tsx
@@ -60,6 +60,8 @@ function createAxiosError(status: number, data: Record<string, unknown> = {}) {
 function makeProps(overrides: Partial<AssessmentPageProps> = {}): AssessmentPageProps {
     return {
         fujiConfigured: true,
+        fujiHealthy: true,
+        fujiStatusMessage: null,
         resourcesNeedingAttention: [
             {
                 id: 1,
@@ -482,11 +484,20 @@ describe('Assessment page', () => {
     });
 
     it('disables all check buttons when F-UJI is not configured', () => {
-        render(<AssessmentPage {...makeProps({ fujiConfigured: false })} />);
+        render(<AssessmentPage {...makeProps({ fujiConfigured: false, fujiHealthy: false, fujiStatusMessage: 'F-UJI is not configured.' })} />);
 
         expect(screen.getByRole('button', { name: 'Check all' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Check Resources' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Check IGSNs' })).toBeDisabled();
         expect(screen.getByText('F-UJI is not configured for this environment.')).toBeInTheDocument();
+    });
+
+    it('disables all check buttons and shows the health message when F-UJI is unhealthy', () => {
+        render(<AssessmentPage {...makeProps({ fujiHealthy: false, fujiStatusMessage: 'F-UJI health check failed with status 500.' })} />);
+
+        expect(screen.getByRole('button', { name: 'Check all' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Check Resources' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Check IGSNs' })).toBeDisabled();
+        expect(screen.getByText('F-UJI health check failed with status 500.')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
This pull request introduces a health check for the F-UJI service and improves error handling and user feedback when F-UJI is unavailable or unhealthy. It refactors both backend and frontend to distinguish between F-UJI being unconfigured and being unhealthy, disables assessment actions when F-UJI is down, and adds comprehensive tests for these scenarios.

**Backend: F-UJI Health Check and Error Handling**
- Added a `healthStatus` method to `FujiAssessmentService` to check if F-UJI is healthy and return a status message.
- Refactored controller actions (`checkAll`, `startScopeJob`) to use a shared `fujiUnavailableResponse` method, which returns a 503 error with an appropriate message if F-UJI is unhealthy or unconfigured. [[1]](diffhunk://#diff-d27244b57a3a17b29aea08fedce4faff0631b9d3642053293e41fe4ae5b46ab7L51-R57) [[2]](diffhunk://#diff-d27244b57a3a17b29aea08fedce4faff0631b9d3642053293e41fe4ae5b46ab7L239-R245) [[3]](diffhunk://#diff-d27244b57a3a17b29aea08fedce4faff0631b9d3642053293e41fe4ae5b46ab7R260-R272)
- Improved error messages for failed F-UJI requests to include response details. [[1]](diffhunk://#diff-0da954e8b5e0be1e2f4e2dca1eff26fa8ad18f78aa3a5a5ae4eee77eb1112dd5L30-R74) [[2]](diffhunk://#diff-0da954e8b5e0be1e2f4e2dca1eff26fa8ad18f78aa3a5a5ae4eee77eb1112dd5R163-R184)

**Frontend: Improved User Feedback and UI State**
- The assessment page now receives and displays both `fujiConfigured` and `fujiHealthy` states, and shows a detailed message when F-UJI is unavailable for any reason. [[1]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961R114-R115) [[2]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961R280-R284) [[3]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L301-R311) [[4]](diffhunk://#diff-b62b94aa2a03f40d44fdd288f41916cc11bc9334c4a161c8048de94f39107d66R32-R33)
- Assessment action buttons are disabled if F-UJI is not available (either unconfigured or unhealthy). [[1]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L289-R297) [[2]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L331-R339) [[3]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L348-R356)

**Infrastructure: TIKA Log Path**
- Changed the `TIKA_LOG_PATH` environment variable in Docker Compose files to point to a directory (`/tmp/tika`) and ensured the directory is created in the entrypoint script, improving logging reliability. [[1]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1L211-R211) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L133-R133) [[3]](diffhunk://#diff-d8396a664b141a2a235d5b7a53e228a431bd976c8940879a6667742f3cfe09a3L133-R133) [[4]](diffhunk://#diff-342bae4c80cc7e5893eb64cd59402c085619cef1b1e28446b46c1ecb9c98085fR39-R42)

**Testing: Health Check Scenarios**
- Added tests to verify that the API returns a 503 error with a clear message when F-UJI is unhealthy, in addition to when it is unconfigured. [[1]](diffhunk://#diff-4110826745ce91b966e44bb24513184e738fca5f69bda72528a473cefe942ce1R200-R216) [[2]](diffhunk://#diff-4110826745ce91b966e44bb24513184e738fca5f69bda72528a473cefe942ce1R231-R247)
- Updated existing tests and test setup to account for the new health check logic. [[1]](diffhunk://#diff-4110826745ce91b966e44bb24513184e738fca5f69bda72528a473cefe942ce1R28-R30) [[2]](diffhunk://#diff-4110826745ce91b966e44bb24513184e738fca5f69bda72528a473cefe942ce1R43-R45)

**Other UI Tweaks**
- Adjusted table column widths in the assessment page for improved display.

These changes ensure that users and administrators receive clear feedback about F-UJI service availability and prevent actions that would fail due to F-UJI being down.