### PR TITLE
Fix: Year filters not usable

### DIFF
--- a/app/Http/Controllers/OldDatasetController.php
+++ b/app/Http/Controllers/OldDatasetController.php
@@ -819,11 +819,13 @@ class OldDatasetController extends Controller
             $yearMin = DB::connection(self::DATASET_CONNECTION)
                 ->table('resource')
                 ->whereNotNull('publicationyear')
+                ->where('publicationyear', '>', 0)
                 ->min('publicationyear');
 
             $yearMax = DB::connection(self::DATASET_CONNECTION)
                 ->table('resource')
                 ->whereNotNull('publicationyear')
+                ->where('publicationyear', '>', 0)
                 ->max('publicationyear');
 
             if ($yearMin === null || $yearMax === null) {

--- a/app/Http/Controllers/OldDatasetController.php
+++ b/app/Http/Controllers/OldDatasetController.php
@@ -826,6 +826,12 @@ class OldDatasetController extends Controller
                 ->whereNotNull('publicationyear')
                 ->max('publicationyear');
 
+            if ($yearMin === null || $yearMax === null) {
+                $currentYear = (int) now()->year;
+                $yearMin = $currentYear;
+                $yearMax = $currentYear;
+            }
+
             // Define available statuses (based on actual database values in metaworks.resource.publicstatus)
             // Confirmed via tinker query: only 'pending' and 'released' exist
             $statuses = ['pending', 'released'];
@@ -834,8 +840,8 @@ class OldDatasetController extends Controller
                 'resource_types' => $resourceTypes,
                 'curators' => $curators,
                 'year_range' => [
-                    'min' => $yearMin,
-                    'max' => $yearMax,
+                    'min' => (int) $yearMin,
+                    'max' => (int) $yearMax,
                 ],
                 'statuses' => $statuses,
             ]);

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0dev",
-        "date": "2026-05-04",
+        "date": "2026-05-11",
         "features": [
             {
                 "title": "Role-Based Guided Tours",
@@ -187,6 +187,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "Publication Year Range Filters No Longer Reload Mid-Entry",
+                "description": "The Publication Year range filters on both /resources and /old-datasets now wait for an explicit Apply action instead of refreshing the list on every keystroke. Users can enter both year boundaries first, review the draft range inside the popover, and clear draft values without triggering a premature reload."
+            },
             {
                 "title": "IGSN Landing Page Setup Now Hides Resource-Only Template",
                 "description": "The 'Setup IGSN Landing Page' modal on /igsns no longer offers the built-in 'Default GFZ Data Services' template, which is intended for regular resources only. Physical samples now consistently default to the IGSN-specific template in the UI, legacy invalid selections are remapped to the IGSN template when the modal loads, and the backend rejects create, update, and preview requests that try to assign the resource-only template to Physical Object records."

--- a/resources/js/components/old-datasets-filters.tsx
+++ b/resources/js/components/old-datasets-filters.tsx
@@ -212,10 +212,6 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
     }, []);
 
     const applyYearRange = useCallback(() => {
-        if (!hasPendingYearRangeChanges) {
-            return;
-        }
-
         const newFilters = { ...filters };
         const yearFrom = parseYearInput(yearFromInput);
         const yearTo = parseYearInput(yearToInput);
@@ -233,7 +229,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         }
 
         onFilterChange(newFilters);
-    }, [filters, hasPendingYearRangeChanges, onFilterChange, yearFromInput, yearToInput]);
+    }, [filters, onFilterChange, yearFromInput, yearToInput]);
 
     const clearYearRange = useCallback(() => {
         setYearFromInput('');

--- a/resources/js/components/old-datasets-filters.tsx
+++ b/resources/js/components/old-datasets-filters.tsx
@@ -202,6 +202,10 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         const yearFrom = parseYearInput(yearFromInput, yearRangeBounds);
         const yearTo = parseYearInput(yearToInput, yearRangeBounds);
 
+        if (yearFrom === filters.year_from && yearTo === filters.year_to) {
+            return;
+        }
+
         if (yearFrom !== undefined) {
             newFilters.year_from = yearFrom;
         } else {
@@ -311,7 +315,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
             {/* Filter Controls */}
             <div className="flex flex-wrap items-center gap-2">
                 {/* Search Input */}
-                <div className="relative w-full sm:w-auto sm:min-w-70">
+                <div className="relative w-full sm:w-auto sm:min-w-[280px]">
                     <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
                         ref={searchInputRef}
@@ -327,7 +331,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
                 {/* Resource Type Select */}
                 <Select value={resourceTypeValue} onValueChange={handleResourceTypeChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by resource type">
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by resource type">
                         <SelectValue placeholder="Resource Type" />
                     </SelectTrigger>
                     <SelectContent>
@@ -342,7 +346,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
                 {/* Status Select */}
                 <Select value={statusValue} onValueChange={handleStatusChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by publication status">
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by publication status">
                         <SelectValue placeholder="Status" />
                     </SelectTrigger>
                     <SelectContent>
@@ -357,7 +361,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
                 {/* Curator Select */}
                 <Select value={curatorValue} onValueChange={handleCuratorChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by curator">
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by curator">
                         <SelectValue placeholder="Curator" />
                     </SelectTrigger>
                     <SelectContent>
@@ -376,7 +380,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                         <Button
                             variant="outline"
                             size="default"
-                            className={`w-full justify-start font-normal sm:w-45 ${
+                            className={`w-full justify-start font-normal sm:w-[180px] ${
                                 filters.year_from || filters.year_to ? 'border-primary' : ''
                             }`}
                             disabled={isLoading || !filterOptions}

--- a/resources/js/components/old-datasets-filters.tsx
+++ b/resources/js/components/old-datasets-filters.tsx
@@ -90,6 +90,8 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
     const committedYearTo = formatYearInput(filters.year_to);
     const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
     const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
+    const yearRangeMin = filterOptions?.year_range?.min;
+    const yearRangeMax = filterOptions?.year_range?.max;
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -420,11 +422,11 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                                     <Input
                                         id="year-from"
                                         type="number"
-                                        placeholder={filterOptions?.year_range?.min.toString()}
+                                        placeholder={yearRangeMin == null ? undefined : String(yearRangeMin)}
                                         value={yearFromInput}
                                         onChange={(e) => handleYearFromChange(e.target.value)}
-                                        min={filterOptions?.year_range?.min}
-                                        max={filterOptions?.year_range?.max}
+                                        min={yearRangeMin ?? undefined}
+                                        max={yearRangeMax ?? undefined}
                                         className="h-9"
                                         disabled={isLoading || !filterOptions}
                                     />
@@ -436,11 +438,11 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                                     <Input
                                         id="year-to"
                                         type="number"
-                                        placeholder={filterOptions?.year_range?.max.toString()}
+                                        placeholder={yearRangeMax == null ? undefined : String(yearRangeMax)}
                                         value={yearToInput}
                                         onChange={(e) => handleYearToChange(e.target.value)}
-                                        min={filterOptions?.year_range?.min}
-                                        max={filterOptions?.year_range?.max}
+                                        min={yearRangeMin ?? undefined}
+                                        max={yearRangeMax ?? undefined}
                                         className="h-9"
                                         disabled={isLoading || !filterOptions}
                                     />

--- a/resources/js/components/old-datasets-filters.tsx
+++ b/resources/js/components/old-datasets-filters.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { formatYearInput, parseYearInput } from '@/lib/year-range-input';
+import { useBufferedYearRangeFilter } from '@/hooks/use-buffered-year-range-filter';
 import type { FilterOptions, FilterState } from '@/types/old-datasets';
 
 /**
@@ -66,16 +66,22 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
     const [resourceTypeValue, setResourceTypeValue] = useState(filters.resource_type?.[0] || 'all');
     const [statusValue, setStatusValue] = useState(filters.status?.[0] || 'all');
     const [curatorValue, setCuratorValue] = useState(filters.curator?.[0] || 'all');
-    const [yearFromInput, setYearFromInput] = useState(() => formatYearInput(filters.year_from));
-    const [yearToInput, setYearToInput] = useState(() => formatYearInput(filters.year_to));
-
-    const committedYearFrom = formatYearInput(filters.year_from);
-    const committedYearTo = formatYearInput(filters.year_to);
-    const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
-    const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
-    const yearRangeBounds = filterOptions?.year_range;
-    const yearRangeMin = yearRangeBounds?.min;
-    const yearRangeMax = yearRangeBounds?.max;
+    const {
+        yearFromInput,
+        yearToInput,
+        hasYearRangeInput,
+        hasEffectiveYearRangeChange,
+        yearRangeMin,
+        yearRangeMax,
+        handleYearFromChange,
+        handleYearToChange,
+        applyYearRange,
+        clearYearRange,
+    } = useBufferedYearRangeFilter({
+        filters,
+        onFilterChange,
+        bounds: filterOptions?.year_range,
+    });
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -83,11 +89,6 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         setStatusValue(filters.status?.[0] || 'all');
         setCuratorValue(filters.curator?.[0] || 'all');
     }, [filters.resource_type, filters.status, filters.curator]);
-
-    useEffect(() => {
-        setYearFromInput(committedYearFrom);
-        setYearToInput(committedYearTo);
-    }, [committedYearFrom, committedYearTo]);
 
     // Debounced search handler
     const handleSearchChange = useCallback(
@@ -188,52 +189,6 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         },
         [filters, onFilterChange],
     );
-
-    const handleYearFromChange = useCallback((value: string) => {
-        setYearFromInput(value);
-    }, []);
-
-    const handleYearToChange = useCallback((value: string) => {
-        setYearToInput(value);
-    }, []);
-
-    const applyYearRange = useCallback(() => {
-        const newFilters = { ...filters };
-        const yearFrom = parseYearInput(yearFromInput, yearRangeBounds);
-        const yearTo = parseYearInput(yearToInput, yearRangeBounds);
-
-        if (yearFrom === filters.year_from && yearTo === filters.year_to) {
-            return;
-        }
-
-        if (yearFrom !== undefined) {
-            newFilters.year_from = yearFrom;
-        } else {
-            delete newFilters.year_from;
-        }
-
-        if (yearTo !== undefined) {
-            newFilters.year_to = yearTo;
-        } else {
-            delete newFilters.year_to;
-        }
-
-        onFilterChange(newFilters);
-    }, [filters, onFilterChange, yearFromInput, yearRangeBounds, yearToInput]);
-
-    const clearYearRange = useCallback(() => {
-        setYearFromInput('');
-        setYearToInput('');
-
-        if (filters.year_from === undefined && filters.year_to === undefined) {
-            return;
-        }
-
-        const newFilters = { ...filters };
-        delete newFilters.year_from;
-        delete newFilters.year_to;
-        onFilterChange(newFilters);
-    }, [filters, onFilterChange]);
 
     const handleCreatedFromChange = useCallback(
         (value: string) => {
@@ -442,7 +397,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                                     size="sm"
                                     className="flex-1"
                                     onClick={applyYearRange}
-                                    disabled={!hasPendingYearRangeChanges || isLoading || !filterOptions}
+                                    disabled={!hasEffectiveYearRangeChange || isLoading || !filterOptions}
                                 >
                                     Apply
                                 </Button>

--- a/resources/js/components/old-datasets-filters.tsx
+++ b/resources/js/components/old-datasets-filters.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { formatYearInput, parseYearInput } from '@/lib/year-range-input';
 import type { FilterOptions, FilterState } from '@/types/old-datasets';
 
 /**
@@ -21,24 +22,6 @@ const MIN_SEARCH_LENGTH = 3;
  * Increased to allow users to finish typing before search is triggered.
  */
 const SEARCH_DEBOUNCE_MS = 1000;
-
-const parseYearInput = (value: string): number | undefined => {
-    const trimmed = value.trim();
-
-    if (trimmed.length === 0) {
-        return undefined;
-    }
-
-    const year = Number.parseInt(trimmed, 10);
-
-    if (Number.isNaN(year) || year <= 0) {
-        return undefined;
-    }
-
-    return year;
-};
-
-const formatYearInput = (value?: number): string => (value === undefined ? '' : String(value));
 
 interface OldDatasetsFiltersProps {
     filters: FilterState;
@@ -90,8 +73,9 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
     const committedYearTo = formatYearInput(filters.year_to);
     const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
     const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
-    const yearRangeMin = filterOptions?.year_range?.min;
-    const yearRangeMax = filterOptions?.year_range?.max;
+    const yearRangeBounds = filterOptions?.year_range;
+    const yearRangeMin = yearRangeBounds?.min;
+    const yearRangeMax = yearRangeBounds?.max;
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -215,8 +199,8 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
     const applyYearRange = useCallback(() => {
         const newFilters = { ...filters };
-        const yearFrom = parseYearInput(yearFromInput);
-        const yearTo = parseYearInput(yearToInput);
+        const yearFrom = parseYearInput(yearFromInput, yearRangeBounds);
+        const yearTo = parseYearInput(yearToInput, yearRangeBounds);
 
         if (yearFrom !== undefined) {
             newFilters.year_from = yearFrom;
@@ -231,7 +215,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         }
 
         onFilterChange(newFilters);
-    }, [filters, onFilterChange, yearFromInput, yearToInput]);
+    }, [filters, onFilterChange, yearFromInput, yearRangeBounds, yearToInput]);
 
     const clearYearRange = useCallback(() => {
         setYearFromInput('');

--- a/resources/js/components/old-datasets-filters.tsx
+++ b/resources/js/components/old-datasets-filters.tsx
@@ -22,6 +22,24 @@ const MIN_SEARCH_LENGTH = 3;
  */
 const SEARCH_DEBOUNCE_MS = 1000;
 
+const parseYearInput = (value: string): number | undefined => {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    const year = Number.parseInt(trimmed, 10);
+
+    if (Number.isNaN(year) || year <= 0) {
+        return undefined;
+    }
+
+    return year;
+};
+
+const formatYearInput = (value?: number): string => (value === undefined ? '' : String(value));
+
 interface OldDatasetsFiltersProps {
     filters: FilterState;
     onFilterChange: (filters: FilterState) => void;
@@ -65,6 +83,13 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
     const [resourceTypeValue, setResourceTypeValue] = useState(filters.resource_type?.[0] || 'all');
     const [statusValue, setStatusValue] = useState(filters.status?.[0] || 'all');
     const [curatorValue, setCuratorValue] = useState(filters.curator?.[0] || 'all');
+    const [yearFromInput, setYearFromInput] = useState(() => formatYearInput(filters.year_from));
+    const [yearToInput, setYearToInput] = useState(() => formatYearInput(filters.year_to));
+
+    const committedYearFrom = formatYearInput(filters.year_from);
+    const committedYearTo = formatYearInput(filters.year_to);
+    const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
+    const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -72,6 +97,11 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         setStatusValue(filters.status?.[0] || 'all');
         setCuratorValue(filters.curator?.[0] || 'all');
     }, [filters.resource_type, filters.status, filters.curator]);
+
+    useEffect(() => {
+        setYearFromInput(committedYearFrom);
+        setYearToInput(committedYearTo);
+    }, [committedYearFrom, committedYearTo]);
 
     // Debounced search handler
     const handleSearchChange = useCallback(
@@ -173,33 +203,51 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
         [filters, onFilterChange],
     );
 
-    const handleYearFromChange = useCallback(
-        (value: string) => {
-            const newFilters = { ...filters };
-            const year = parseInt(value, 10);
-            if (!Number.isNaN(year) && year > 0) {
-                newFilters.year_from = year;
-            } else {
-                delete newFilters.year_from;
-            }
-            onFilterChange(newFilters);
-        },
-        [filters, onFilterChange],
-    );
+    const handleYearFromChange = useCallback((value: string) => {
+        setYearFromInput(value);
+    }, []);
 
-    const handleYearToChange = useCallback(
-        (value: string) => {
-            const newFilters = { ...filters };
-            const year = parseInt(value, 10);
-            if (!Number.isNaN(year) && year > 0) {
-                newFilters.year_to = year;
-            } else {
-                delete newFilters.year_to;
-            }
-            onFilterChange(newFilters);
-        },
-        [filters, onFilterChange],
-    );
+    const handleYearToChange = useCallback((value: string) => {
+        setYearToInput(value);
+    }, []);
+
+    const applyYearRange = useCallback(() => {
+        if (!hasPendingYearRangeChanges) {
+            return;
+        }
+
+        const newFilters = { ...filters };
+        const yearFrom = parseYearInput(yearFromInput);
+        const yearTo = parseYearInput(yearToInput);
+
+        if (yearFrom !== undefined) {
+            newFilters.year_from = yearFrom;
+        } else {
+            delete newFilters.year_from;
+        }
+
+        if (yearTo !== undefined) {
+            newFilters.year_to = yearTo;
+        } else {
+            delete newFilters.year_to;
+        }
+
+        onFilterChange(newFilters);
+    }, [filters, hasPendingYearRangeChanges, onFilterChange, yearFromInput, yearToInput]);
+
+    const clearYearRange = useCallback(() => {
+        setYearFromInput('');
+        setYearToInput('');
+
+        if (filters.year_from === undefined && filters.year_to === undefined) {
+            return;
+        }
+
+        const newFilters = { ...filters };
+        delete newFilters.year_from;
+        delete newFilters.year_to;
+        onFilterChange(newFilters);
+    }, [filters, onFilterChange]);
 
     const handleCreatedFromChange = useCallback(
         (value: string) => {
@@ -281,7 +329,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
             {/* Filter Controls */}
             <div className="flex flex-wrap items-center gap-2">
                 {/* Search Input */}
-                <div className="relative w-full sm:w-auto sm:min-w-[280px]">
+                <div className="relative w-full sm:w-auto sm:min-w-70">
                     <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
                         ref={searchInputRef}
@@ -297,7 +345,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
                 {/* Resource Type Select */}
                 <Select value={resourceTypeValue} onValueChange={handleResourceTypeChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by resource type">
+                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by resource type">
                         <SelectValue placeholder="Resource Type" />
                     </SelectTrigger>
                     <SelectContent>
@@ -312,7 +360,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
                 {/* Status Select */}
                 <Select value={statusValue} onValueChange={handleStatusChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by publication status">
+                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by publication status">
                         <SelectValue placeholder="Status" />
                     </SelectTrigger>
                     <SelectContent>
@@ -327,7 +375,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
 
                 {/* Curator Select */}
                 <Select value={curatorValue} onValueChange={handleCuratorChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by curator">
+                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by curator">
                         <SelectValue placeholder="Curator" />
                     </SelectTrigger>
                     <SelectContent>
@@ -346,7 +394,7 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                         <Button
                             variant="outline"
                             size="default"
-                            className={`w-full justify-start font-normal sm:w-[180px] ${
+                            className={`w-full justify-start font-normal sm:w-45 ${
                                 filters.year_from || filters.year_to ? 'border-primary' : ''
                             }`}
                             disabled={isLoading || !filterOptions}
@@ -377,11 +425,12 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                                         id="year-from"
                                         type="number"
                                         placeholder={filterOptions?.year_range?.min.toString()}
-                                        value={filters.year_from || ''}
+                                        value={yearFromInput}
                                         onChange={(e) => handleYearFromChange(e.target.value)}
                                         min={filterOptions?.year_range?.min}
                                         max={filterOptions?.year_range?.max}
                                         className="h-9"
+                                        disabled={isLoading || !filterOptions}
                                     />
                                 </div>
                                 <div className="space-y-2">
@@ -392,29 +441,38 @@ export function OldDatasetsFilters({ filters, onFilterChange, filterOptions, res
                                         id="year-to"
                                         type="number"
                                         placeholder={filterOptions?.year_range?.max.toString()}
-                                        value={filters.year_to || ''}
+                                        value={yearToInput}
                                         onChange={(e) => handleYearToChange(e.target.value)}
                                         min={filterOptions?.year_range?.min}
                                         max={filterOptions?.year_range?.max}
                                         className="h-9"
+                                        disabled={isLoading || !filterOptions}
                                     />
                                 </div>
                             </div>
-                            {(filters.year_from || filters.year_to) && (
+                            <div className="flex gap-2 pt-1">
                                 <Button
-                                    variant="outline"
+                                    type="button"
                                     size="sm"
-                                    onClick={() => {
-                                        const newFilters = { ...filters };
-                                        delete newFilters.year_from;
-                                        delete newFilters.year_to;
-                                        onFilterChange(newFilters);
-                                    }}
-                                    className="w-full"
+                                    className="flex-1"
+                                    onClick={applyYearRange}
+                                    disabled={!hasPendingYearRangeChanges || isLoading || !filterOptions}
                                 >
-                                    Clear Year Range
+                                    Apply
                                 </Button>
-                            )}
+                                {hasYearRangeInput && (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={clearYearRange}
+                                        disabled={isLoading}
+                                    >
+                                        <X className="mr-1 h-3 w-3" />
+                                        Clear
+                                    </Button>
+                                )}
+                            </div>
                         </div>
                     </PopoverContent>
                 </Popover>

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { formatYearInput, parseYearInput } from '@/lib/year-range-input';
 import type { ResourceFilterOptions, ResourceFilterState } from '@/types/resources';
 
 /**
@@ -21,24 +22,6 @@ const MIN_SEARCH_LENGTH = 3;
  * Increased to allow users to finish typing before search is triggered.
  */
 const SEARCH_DEBOUNCE_MS = 1000;
-
-const parseYearInput = (value: string): number | undefined => {
-    const trimmed = value.trim();
-
-    if (trimmed.length === 0) {
-        return undefined;
-    }
-
-    const year = Number.parseInt(trimmed, 10);
-
-    if (Number.isNaN(year) || year <= 0) {
-        return undefined;
-    }
-
-    return year;
-};
-
-const formatYearInput = (value?: number): string => (value === undefined ? '' : String(value));
 
 interface ResourcesFiltersProps {
     filters: ResourceFilterState;
@@ -90,6 +73,9 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
     const committedYearTo = formatYearInput(filters.year_to);
     const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
     const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
+    const yearRangeBounds = filterOptions?.year_range;
+    const yearRangeMin = yearRangeBounds?.min;
+    const yearRangeMax = yearRangeBounds?.max;
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -213,8 +199,8 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
     const applyYearRange = useCallback(() => {
         const newFilters = { ...filters };
-        const yearFrom = parseYearInput(yearFromInput);
-        const yearTo = parseYearInput(yearToInput);
+        const yearFrom = parseYearInput(yearFromInput, yearRangeBounds);
+        const yearTo = parseYearInput(yearToInput, yearRangeBounds);
 
         if (yearFrom !== undefined) {
             newFilters.year_from = yearFrom;
@@ -229,7 +215,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         }
 
         onFilterChange(newFilters);
-    }, [filters, onFilterChange, yearFromInput, yearToInput]);
+    }, [filters, onFilterChange, yearFromInput, yearRangeBounds, yearToInput]);
 
     const clearYearRange = useCallback(() => {
         setYearFromInput('');
@@ -431,11 +417,11 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                     <Input
                                         id="year-from"
                                         type="number"
-                                        placeholder={filterOptions ? String(filterOptions.year_range.min) : undefined}
+                                        placeholder={yearRangeMin == null ? undefined : String(yearRangeMin)}
                                         value={yearFromInput}
                                         onChange={(e) => handleYearFromChange(e.target.value)}
-                                        min={filterOptions?.year_range?.min ?? undefined}
-                                        max={filterOptions?.year_range?.max ?? undefined}
+                                        min={yearRangeMin ?? undefined}
+                                        max={yearRangeMax ?? undefined}
                                         className="h-9"
                                         disabled={isLoading || !filterOptions}
                                     />
@@ -447,11 +433,11 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                     <Input
                                         id="year-to"
                                         type="number"
-                                        placeholder={filterOptions ? String(filterOptions.year_range.max) : undefined}
+                                        placeholder={yearRangeMax == null ? undefined : String(yearRangeMax)}
                                         value={yearToInput}
                                         onChange={(e) => handleYearToChange(e.target.value)}
-                                        min={filterOptions?.year_range?.min ?? undefined}
-                                        max={filterOptions?.year_range?.max ?? undefined}
+                                        min={yearRangeMin ?? undefined}
+                                        max={yearRangeMax ?? undefined}
                                         className="h-9"
                                         disabled={isLoading || !filterOptions}
                                     />

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -22,6 +22,24 @@ const MIN_SEARCH_LENGTH = 3;
  */
 const SEARCH_DEBOUNCE_MS = 1000;
 
+const parseYearInput = (value: string): number | undefined => {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    const year = Number.parseInt(trimmed, 10);
+
+    if (Number.isNaN(year) || year <= 0) {
+        return undefined;
+    }
+
+    return year;
+};
+
+const formatYearInput = (value?: number): string => (value === undefined ? '' : String(value));
+
 interface ResourcesFiltersProps {
     filters: ResourceFilterState;
     onFilterChange: (filters: ResourceFilterState) => void;
@@ -65,6 +83,13 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
     const [resourceTypeValue, setResourceTypeValue] = useState(filters.resource_type?.[0] || 'all');
     const [statusValue, setStatusValue] = useState(filters.status?.[0] || 'all');
     const [curatorValue, setCuratorValue] = useState(filters.curator?.[0] || 'all');
+    const [yearFromInput, setYearFromInput] = useState(() => formatYearInput(filters.year_from));
+    const [yearToInput, setYearToInput] = useState(() => formatYearInput(filters.year_to));
+
+    const committedYearFrom = formatYearInput(filters.year_from);
+    const committedYearTo = formatYearInput(filters.year_to);
+    const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
+    const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -72,6 +97,11 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         setStatusValue(filters.status?.[0] || 'all');
         setCuratorValue(filters.curator?.[0] || 'all');
     }, [filters.resource_type, filters.status, filters.curator]);
+
+    useEffect(() => {
+        setYearFromInput(committedYearFrom);
+        setYearToInput(committedYearTo);
+    }, [committedYearFrom, committedYearTo]);
 
     // Debounced search handler
     const handleSearchChange = useCallback(
@@ -173,33 +203,51 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         [filters, onFilterChange],
     );
 
-    const handleYearFromChange = useCallback(
-        (value: string) => {
-            const newFilters = { ...filters };
-            const year = parseInt(value, 10);
-            if (!Number.isNaN(year) && year > 0) {
-                newFilters.year_from = year;
-            } else {
-                delete newFilters.year_from;
-            }
-            onFilterChange(newFilters);
-        },
-        [filters, onFilterChange],
-    );
+    const handleYearFromChange = useCallback((value: string) => {
+        setYearFromInput(value);
+    }, []);
 
-    const handleYearToChange = useCallback(
-        (value: string) => {
-            const newFilters = { ...filters };
-            const year = parseInt(value, 10);
-            if (!Number.isNaN(year) && year > 0) {
-                newFilters.year_to = year;
-            } else {
-                delete newFilters.year_to;
-            }
-            onFilterChange(newFilters);
-        },
-        [filters, onFilterChange],
-    );
+    const handleYearToChange = useCallback((value: string) => {
+        setYearToInput(value);
+    }, []);
+
+    const applyYearRange = useCallback(() => {
+        if (!hasPendingYearRangeChanges) {
+            return;
+        }
+
+        const newFilters = { ...filters };
+        const yearFrom = parseYearInput(yearFromInput);
+        const yearTo = parseYearInput(yearToInput);
+
+        if (yearFrom !== undefined) {
+            newFilters.year_from = yearFrom;
+        } else {
+            delete newFilters.year_from;
+        }
+
+        if (yearTo !== undefined) {
+            newFilters.year_to = yearTo;
+        } else {
+            delete newFilters.year_to;
+        }
+
+        onFilterChange(newFilters);
+    }, [filters, hasPendingYearRangeChanges, onFilterChange, yearFromInput, yearToInput]);
+
+    const clearYearRange = useCallback(() => {
+        setYearFromInput('');
+        setYearToInput('');
+
+        if (filters.year_from === undefined && filters.year_to === undefined) {
+            return;
+        }
+
+        const newFilters = { ...filters };
+        delete newFilters.year_from;
+        delete newFilters.year_to;
+        onFilterChange(newFilters);
+    }, [filters, onFilterChange]);
 
     const handleCreatedFromChange = useCallback(
         (value: string) => {
@@ -292,7 +340,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
             {/* Filter Controls */}
             <div className="flex flex-wrap items-center gap-2">
                 {/* Search Input */}
-                <div className="relative w-full sm:w-auto sm:min-w-[280px]">
+                <div className="relative w-full sm:w-auto sm:min-w-70">
                     <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
                         ref={searchInputRef}
@@ -308,7 +356,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
                 {/* Resource Type Select */}
                 <Select value={resourceTypeValue} onValueChange={handleResourceTypeChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by resource type">
+                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by resource type">
                         <SelectValue placeholder="Resource Type" />
                     </SelectTrigger>
                     <SelectContent>
@@ -323,7 +371,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
                 {/* Status Select */}
                 <Select value={statusValue} onValueChange={handleStatusChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by publication status">
+                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by publication status">
                         <SelectValue placeholder="Status" />
                     </SelectTrigger>
                     <SelectContent>
@@ -338,7 +386,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
                 {/* Curator Select */}
                 <Select value={curatorValue} onValueChange={handleCuratorChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by curator">
+                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by curator">
                         <SelectValue placeholder="Curator" />
                     </SelectTrigger>
                     <SelectContent>
@@ -357,7 +405,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                         <Button
                             variant="outline"
                             size="default"
-                            className={`w-full justify-start font-normal sm:w-[180px] ${
+                            className={`w-full justify-start font-normal sm:w-45 ${
                                 filters.year_from || filters.year_to ? 'border-primary' : ''
                             }`}
                             disabled={isLoading || !filterOptions}
@@ -392,11 +440,12 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                                 ? undefined
                                                 : String(filterOptions.year_range.min)
                                         }
-                                        value={filters.year_from || ''}
+                                        value={yearFromInput}
                                         onChange={(e) => handleYearFromChange(e.target.value)}
                                         min={filterOptions?.year_range?.min ?? undefined}
                                         max={filterOptions?.year_range?.max ?? undefined}
                                         className="h-9"
+                                        disabled={isLoading || !filterOptions}
                                     />
                                 </div>
                                 <div className="space-y-2">
@@ -411,29 +460,38 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                                 ? undefined
                                                 : String(filterOptions.year_range.max)
                                         }
-                                        value={filters.year_to || ''}
+                                        value={yearToInput}
                                         onChange={(e) => handleYearToChange(e.target.value)}
                                         min={filterOptions?.year_range?.min ?? undefined}
                                         max={filterOptions?.year_range?.max ?? undefined}
                                         className="h-9"
+                                        disabled={isLoading || !filterOptions}
                                     />
                                 </div>
                             </div>
-                            {(filters.year_from || filters.year_to) && (
+                            <div className="flex gap-2 pt-1">
                                 <Button
-                                    variant="outline"
+                                    type="button"
                                     size="sm"
-                                    onClick={() => {
-                                        const newFilters = { ...filters };
-                                        delete newFilters.year_from;
-                                        delete newFilters.year_to;
-                                        onFilterChange(newFilters);
-                                    }}
-                                    className="w-full"
+                                    className="flex-1"
+                                    onClick={applyYearRange}
+                                    disabled={!hasPendingYearRangeChanges || isLoading || !filterOptions}
                                 >
-                                    Clear Year Range
+                                    Apply
                                 </Button>
-                            )}
+                                {hasYearRangeInput && (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={clearYearRange}
+                                        disabled={isLoading}
+                                    >
+                                        <X className="mr-1 h-3 w-3" />
+                                        Clear
+                                    </Button>
+                                )}
+                            </div>
                         </div>
                     </PopoverContent>
                 </Popover>

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { formatYearInput, parseYearInput } from '@/lib/year-range-input';
+import { useBufferedYearRangeFilter } from '@/hooks/use-buffered-year-range-filter';
 import type { ResourceFilterOptions, ResourceFilterState } from '@/types/resources';
 
 /**
@@ -66,16 +66,22 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
     const [resourceTypeValue, setResourceTypeValue] = useState(filters.resource_type?.[0] || 'all');
     const [statusValue, setStatusValue] = useState(filters.status?.[0] || 'all');
     const [curatorValue, setCuratorValue] = useState(filters.curator?.[0] || 'all');
-    const [yearFromInput, setYearFromInput] = useState(() => formatYearInput(filters.year_from));
-    const [yearToInput, setYearToInput] = useState(() => formatYearInput(filters.year_to));
-
-    const committedYearFrom = formatYearInput(filters.year_from);
-    const committedYearTo = formatYearInput(filters.year_to);
-    const hasPendingYearRangeChanges = yearFromInput !== committedYearFrom || yearToInput !== committedYearTo;
-    const hasYearRangeInput = yearFromInput !== '' || yearToInput !== '';
-    const yearRangeBounds = filterOptions?.year_range;
-    const yearRangeMin = yearRangeBounds?.min;
-    const yearRangeMax = yearRangeBounds?.max;
+    const {
+        yearFromInput,
+        yearToInput,
+        hasYearRangeInput,
+        hasEffectiveYearRangeChange,
+        yearRangeMin,
+        yearRangeMax,
+        handleYearFromChange,
+        handleYearToChange,
+        applyYearRange,
+        clearYearRange,
+    } = useBufferedYearRangeFilter({
+        filters,
+        onFilterChange,
+        bounds: filterOptions?.year_range,
+    });
 
     // Sync Select values when filters change externally
     useEffect(() => {
@@ -83,11 +89,6 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         setStatusValue(filters.status?.[0] || 'all');
         setCuratorValue(filters.curator?.[0] || 'all');
     }, [filters.resource_type, filters.status, filters.curator]);
-
-    useEffect(() => {
-        setYearFromInput(committedYearFrom);
-        setYearToInput(committedYearTo);
-    }, [committedYearFrom, committedYearTo]);
 
     // Debounced search handler
     const handleSearchChange = useCallback(
@@ -188,52 +189,6 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         },
         [filters, onFilterChange],
     );
-
-    const handleYearFromChange = useCallback((value: string) => {
-        setYearFromInput(value);
-    }, []);
-
-    const handleYearToChange = useCallback((value: string) => {
-        setYearToInput(value);
-    }, []);
-
-    const applyYearRange = useCallback(() => {
-        const newFilters = { ...filters };
-        const yearFrom = parseYearInput(yearFromInput, yearRangeBounds);
-        const yearTo = parseYearInput(yearToInput, yearRangeBounds);
-
-        if (yearFrom === filters.year_from && yearTo === filters.year_to) {
-            return;
-        }
-
-        if (yearFrom !== undefined) {
-            newFilters.year_from = yearFrom;
-        } else {
-            delete newFilters.year_from;
-        }
-
-        if (yearTo !== undefined) {
-            newFilters.year_to = yearTo;
-        } else {
-            delete newFilters.year_to;
-        }
-
-        onFilterChange(newFilters);
-    }, [filters, onFilterChange, yearFromInput, yearRangeBounds, yearToInput]);
-
-    const clearYearRange = useCallback(() => {
-        setYearFromInput('');
-        setYearToInput('');
-
-        if (filters.year_from === undefined && filters.year_to === undefined) {
-            return;
-        }
-
-        const newFilters = { ...filters };
-        delete newFilters.year_from;
-        delete newFilters.year_to;
-        onFilterChange(newFilters);
-    }, [filters, onFilterChange]);
 
     const handleCreatedFromChange = useCallback(
         (value: string) => {
@@ -453,7 +408,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                     size="sm"
                                     className="flex-1"
                                     onClick={applyYearRange}
-                                    disabled={!hasPendingYearRangeChanges || isLoading || !filterOptions}
+                                    disabled={!hasEffectiveYearRangeChange || isLoading || !filterOptions}
                                 >
                                     Apply
                                 </Button>

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -212,10 +212,6 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
     }, []);
 
     const applyYearRange = useCallback(() => {
-        if (!hasPendingYearRangeChanges) {
-            return;
-        }
-
         const newFilters = { ...filters };
         const yearFrom = parseYearInput(yearFromInput);
         const yearTo = parseYearInput(yearToInput);
@@ -233,7 +229,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         }
 
         onFilterChange(newFilters);
-    }, [filters, hasPendingYearRangeChanges, onFilterChange, yearFromInput, yearToInput]);
+    }, [filters, onFilterChange, yearFromInput, yearToInput]);
 
     const clearYearRange = useCallback(() => {
         setYearFromInput('');

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -202,6 +202,10 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         const yearFrom = parseYearInput(yearFromInput, yearRangeBounds);
         const yearTo = parseYearInput(yearToInput, yearRangeBounds);
 
+        if (yearFrom === filters.year_from && yearTo === filters.year_to) {
+            return;
+        }
+
         if (yearFrom !== undefined) {
             newFilters.year_from = yearFrom;
         } else {
@@ -322,7 +326,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
             {/* Filter Controls */}
             <div className="flex flex-wrap items-center gap-2">
                 {/* Search Input */}
-                <div className="relative w-full sm:w-auto sm:min-w-70">
+                <div className="relative w-full sm:w-auto sm:min-w-[280px]">
                     <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                     <Input
                         ref={searchInputRef}
@@ -338,7 +342,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
                 {/* Resource Type Select */}
                 <Select value={resourceTypeValue} onValueChange={handleResourceTypeChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by resource type">
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by resource type">
                         <SelectValue placeholder="Resource Type" />
                     </SelectTrigger>
                     <SelectContent>
@@ -353,7 +357,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
                 {/* Status Select */}
                 <Select value={statusValue} onValueChange={handleStatusChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by publication status">
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by publication status">
                         <SelectValue placeholder="Status" />
                     </SelectTrigger>
                     <SelectContent>
@@ -368,7 +372,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
                 {/* Curator Select */}
                 <Select value={curatorValue} onValueChange={handleCuratorChange} disabled={isLoading || !filterOptions}>
-                    <SelectTrigger size="sm" className="w-full sm:w-45" aria-label="Filter by curator">
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by curator">
                         <SelectValue placeholder="Curator" />
                     </SelectTrigger>
                     <SelectContent>
@@ -387,7 +391,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                         <Button
                             variant="outline"
                             size="default"
-                            className={`w-full justify-start font-normal sm:w-45 ${
+                            className={`w-full justify-start font-normal sm:w-[180px] ${
                                 filters.year_from || filters.year_to ? 'border-primary' : ''
                             }`}
                             disabled={isLoading || !filterOptions}

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -431,11 +431,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                     <Input
                                         id="year-from"
                                         type="number"
-                                        placeholder={
-                                            filterOptions?.year_range?.min === null || filterOptions?.year_range?.min === undefined
-                                                ? undefined
-                                                : String(filterOptions.year_range.min)
-                                        }
+                                        placeholder={filterOptions ? String(filterOptions.year_range.min) : undefined}
                                         value={yearFromInput}
                                         onChange={(e) => handleYearFromChange(e.target.value)}
                                         min={filterOptions?.year_range?.min ?? undefined}
@@ -451,11 +447,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                     <Input
                                         id="year-to"
                                         type="number"
-                                        placeholder={
-                                            filterOptions?.year_range?.max === null || filterOptions?.year_range?.max === undefined
-                                                ? undefined
-                                                : String(filterOptions.year_range.max)
-                                        }
+                                        placeholder={filterOptions ? String(filterOptions.year_range.max) : undefined}
                                         value={yearToInput}
                                         onChange={(e) => handleYearToChange(e.target.value)}
                                         min={filterOptions?.year_range?.min ?? undefined}

--- a/resources/js/hooks/use-buffered-year-range-filter.ts
+++ b/resources/js/hooks/use-buffered-year-range-filter.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { formatYearInput, parseYearInput, type YearRangeBounds } from '@/lib/year-range-input';
+
+interface YearRangeFilterState {
+    year_from?: number;
+    year_to?: number;
+}
+
+interface UseBufferedYearRangeFilterOptions<TFilters extends YearRangeFilterState> {
+    filters: TFilters;
+    onFilterChange: (filters: TFilters) => void;
+    bounds?: YearRangeBounds;
+}
+
+interface UseBufferedYearRangeFilterResult {
+    yearFromInput: string;
+    yearToInput: string;
+    hasYearRangeInput: boolean;
+    hasEffectiveYearRangeChange: boolean;
+    yearRangeMin?: number | null;
+    yearRangeMax?: number | null;
+    handleYearFromChange: (value: string) => void;
+    handleYearToChange: (value: string) => void;
+    applyYearRange: () => void;
+    clearYearRange: () => void;
+}
+
+export function useBufferedYearRangeFilter<TFilters extends YearRangeFilterState>({
+    filters,
+    onFilterChange,
+    bounds,
+}: UseBufferedYearRangeFilterOptions<TFilters>): UseBufferedYearRangeFilterResult {
+    const [yearFromInput, setYearFromInput] = useState(() => formatYearInput(filters.year_from));
+    const [yearToInput, setYearToInput] = useState(() => formatYearInput(filters.year_to));
+
+    const committedYearFrom = formatYearInput(filters.year_from);
+    const committedYearTo = formatYearInput(filters.year_to);
+    const parsedYearFrom = useMemo(() => parseYearInput(yearFromInput, bounds), [bounds, yearFromInput]);
+    const parsedYearTo = useMemo(() => parseYearInput(yearToInput, bounds), [bounds, yearToInput]);
+
+    useEffect(() => {
+        setYearFromInput(committedYearFrom);
+        setYearToInput(committedYearTo);
+    }, [committedYearFrom, committedYearTo]);
+
+    const applyYearRange = useCallback(() => {
+        if (parsedYearFrom === filters.year_from && parsedYearTo === filters.year_to) {
+            return;
+        }
+
+        const nextFilters: TFilters = { ...filters };
+
+        if (parsedYearFrom !== undefined) {
+            nextFilters.year_from = parsedYearFrom;
+        } else {
+            delete nextFilters.year_from;
+        }
+
+        if (parsedYearTo !== undefined) {
+            nextFilters.year_to = parsedYearTo;
+        } else {
+            delete nextFilters.year_to;
+        }
+
+        onFilterChange(nextFilters);
+    }, [filters, onFilterChange, parsedYearFrom, parsedYearTo]);
+
+    const clearYearRange = useCallback(() => {
+        setYearFromInput('');
+        setYearToInput('');
+
+        if (filters.year_from === undefined && filters.year_to === undefined) {
+            return;
+        }
+
+        const nextFilters: TFilters = { ...filters };
+        delete nextFilters.year_from;
+        delete nextFilters.year_to;
+        onFilterChange(nextFilters);
+    }, [filters, onFilterChange]);
+
+    return {
+        yearFromInput,
+        yearToInput,
+        hasYearRangeInput: yearFromInput !== '' || yearToInput !== '',
+        hasEffectiveYearRangeChange: parsedYearFrom !== filters.year_from || parsedYearTo !== filters.year_to,
+        yearRangeMin: bounds?.min,
+        yearRangeMax: bounds?.max,
+        handleYearFromChange: setYearFromInput,
+        handleYearToChange: setYearToInput,
+        applyYearRange,
+        clearYearRange,
+    };
+}

--- a/resources/js/lib/year-range-input.ts
+++ b/resources/js/lib/year-range-input.ts
@@ -1,0 +1,32 @@
+export interface YearRangeBounds {
+    min?: number | null;
+    max?: number | null;
+}
+
+const YEAR_INTEGER_PATTERN = /^\d+$/;
+
+export const parseYearInput = (value: string, bounds?: YearRangeBounds): number | undefined => {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0 || !YEAR_INTEGER_PATTERN.test(trimmed)) {
+        return undefined;
+    }
+
+    const year = Number(trimmed);
+
+    if (!Number.isSafeInteger(year) || year <= 0) {
+        return undefined;
+    }
+
+    if (bounds?.min != null && year < bounds.min) {
+        return undefined;
+    }
+
+    if (bounds?.max != null && year > bounds.max) {
+        return undefined;
+    }
+
+    return year;
+};
+
+export const formatYearInput = (value?: number): string => (value === undefined ? '' : String(value));

--- a/tests/pest/Feature/OldDatasetFilterOptionsTest.php
+++ b/tests/pest/Feature/OldDatasetFilterOptionsTest.php
@@ -25,10 +25,12 @@ function mockOldDatasetFilterOptionsConnection(?int $yearMin, ?int $yearMax): vo
 
     $yearMinQuery = Mockery::mock(Builder::class);
     $yearMinQuery->shouldReceive('whereNotNull')->once()->with('publicationyear')->andReturnSelf();
+    $yearMinQuery->shouldReceive('where')->once()->with('publicationyear', '>', 0)->andReturnSelf();
     $yearMinQuery->shouldReceive('min')->once()->with('publicationyear')->andReturn($yearMin);
 
     $yearMaxQuery = Mockery::mock(Builder::class);
     $yearMaxQuery->shouldReceive('whereNotNull')->once()->with('publicationyear')->andReturnSelf();
+    $yearMaxQuery->shouldReceive('where')->once()->with('publicationyear', '>', 0)->andReturnSelf();
     $yearMaxQuery->shouldReceive('max')->once()->with('publicationyear')->andReturn($yearMax);
 
     $connection = Mockery::mock(Connection::class);
@@ -72,6 +74,23 @@ it('falls back to the current year when legacy datasets have no publication year
             'year_range' => [
                 'min' => $currentYear,
                 'max' => $currentYear,
+            ],
+            'statuses' => ['pending', 'released'],
+        ]);
+});
+
+it('returns only positive publication year bounds for legacy datasets', function (): void {
+    mockOldDatasetFilterOptionsConnection(yearMin: 2001, yearMax: 2024);
+
+    $this->actingAs($this->admin)
+        ->get('/old-datasets/filter-options')
+        ->assertOk()
+        ->assertJson([
+            'resource_types' => ['Dataset'],
+            'curators' => ['Alice'],
+            'year_range' => [
+                'min' => 2001,
+                'max' => 2024,
             ],
             'statuses' => ['pending', 'released'],
         ]);

--- a/tests/pest/Feature/OldDatasetFilterOptionsTest.php
+++ b/tests/pest/Feature/OldDatasetFilterOptionsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Support\Facades\DB;
+
+function mockOldDatasetFilterOptionsConnection(?int $yearMin, ?int $yearMax): void
+{
+    $resourceTypesQuery = Mockery::mock(Builder::class);
+    $resourceTypesQuery->shouldReceive('distinct')->once()->andReturnSelf();
+    $resourceTypesQuery->shouldReceive('whereNotNull')->once()->with('resourcetypegeneral')->andReturnSelf();
+    $resourceTypesQuery->shouldReceive('where')->once()->with('resourcetypegeneral', '!=', '')->andReturnSelf();
+    $resourceTypesQuery->shouldReceive('pluck')->once()->with('resourcetypegeneral')->andReturn(collect(['Dataset']));
+
+    $curatorsQuery = Mockery::mock(Builder::class);
+    $curatorsQuery->shouldReceive('distinct')->once()->andReturnSelf();
+    $curatorsQuery->shouldReceive('whereNotNull')->once()->with('curator')->andReturnSelf();
+    $curatorsQuery->shouldReceive('where')->once()->with('curator', '!=', '')->andReturnSelf();
+    $curatorsQuery->shouldReceive('pluck')->once()->with('curator')->andReturn(collect(['Alice']));
+
+    $yearMinQuery = Mockery::mock(Builder::class);
+    $yearMinQuery->shouldReceive('whereNotNull')->once()->with('publicationyear')->andReturnSelf();
+    $yearMinQuery->shouldReceive('min')->once()->with('publicationyear')->andReturn($yearMin);
+
+    $yearMaxQuery = Mockery::mock(Builder::class);
+    $yearMaxQuery->shouldReceive('whereNotNull')->once()->with('publicationyear')->andReturnSelf();
+    $yearMaxQuery->shouldReceive('max')->once()->with('publicationyear')->andReturn($yearMax);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('table')
+        ->times(4)
+        ->with('resource')
+        ->andReturn($resourceTypesQuery, $curatorsQuery, $yearMinQuery, $yearMaxQuery);
+    $connection->shouldReceive('raw')
+        ->andReturnUsing(fn (string $value): Expression => new Expression($value));
+
+    $realManager = DB::getFacadeRoot();
+    test()->originalDbManager = $realManager;
+
+    $mock = Mockery::mock($realManager)->makePartial();
+    $mock->shouldReceive('connection')->with('metaworks')->andReturn($connection);
+
+    DB::swap($mock);
+}
+
+beforeEach(function (): void {
+    $this->admin = User::factory()->create(['role' => UserRole::ADMIN]);
+});
+
+afterEach(function (): void {
+    if (isset(test()->originalDbManager)) {
+        DB::swap(test()->originalDbManager);
+    }
+});
+
+it('falls back to the current year when legacy datasets have no publication year range', function (): void {
+    mockOldDatasetFilterOptionsConnection(yearMin: null, yearMax: null);
+
+    $currentYear = (int) now()->year;
+
+    $this->actingAs($this->admin)
+        ->get('/old-datasets/filter-options')
+        ->assertOk()
+        ->assertJson([
+            'resource_types' => ['Dataset'],
+            'curators' => ['Alice'],
+            'year_range' => [
+                'min' => $currentYear,
+                'max' => $currentYear,
+            ],
+            'statuses' => ['pending', 'released'],
+        ]);
+});

--- a/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
@@ -173,120 +173,120 @@ describe('OldDatasetsFilters Component', () => {
         expect(mockOnFilterChange).toHaveBeenCalled();
     }, 15000);
 
-            it('buffers year range changes until Apply is clicked', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} />);
+    it('buffers year range changes until Apply is clicked', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} />);
 
-                await user.type(screen.getByLabelText('From Year'), '2018');
-                await user.type(screen.getByLabelText('To Year'), '2022');
+        await user.type(screen.getByLabelText('From Year'), '2018');
+        await user.type(screen.getByLabelText('To Year'), '2022');
 
-                expect(mockOnFilterChange).not.toHaveBeenCalled();
+        expect(mockOnFilterChange).not.toHaveBeenCalled();
 
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2018, year_to: 2022 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2018, year_to: 2022 });
+    }, 15000);
 
-            it('does not emit changes when Apply is triggered without pending year edits', async () => {
-                render(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2018, year_to: 2022 }} />);
+    it('does not emit changes when Apply is triggered without pending year edits', async () => {
+        render(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2018, year_to: 2022 }} />);
 
-                const applyButton = screen.getByRole('button', { name: 'Apply' });
-                expect(applyButton).toBeDisabled();
-            }, 15000);
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        expect(applyButton).toBeDisabled();
+    }, 15000);
 
-            it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'] }} />);
+    it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'] }} />);
 
-                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).not.toHaveBeenCalled();
-            }, 15000);
+        expect(mockOnFilterChange).not.toHaveBeenCalled();
+    }, 15000);
 
-            it('disables year range controls when filter options are unavailable', () => {
-                render(<OldDatasetsFilters {...defaultProps} filterOptions={null} />);
+    it('disables year range controls when filter options are unavailable', () => {
+        render(<OldDatasetsFilters {...defaultProps} filterOptions={null} />);
 
-                expect(screen.getByLabelText('Filter by publication year range')).toBeDisabled();
-                expect(screen.getByLabelText('From Year')).toBeDisabled();
-                expect(screen.getByLabelText('To Year')).toBeDisabled();
-                expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
-            });
+        expect(screen.getByLabelText('Filter by publication year range')).toBeDisabled();
+        expect(screen.getByLabelText('From Year')).toBeDisabled();
+        expect(screen.getByLabelText('To Year')).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    });
 
-            it('removes year_from on Apply when the draft value is cleared', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+    it('removes year_from on Apply when the draft value is cleared', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
 
-                await user.clear(screen.getByLabelText('From Year'));
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.clear(screen.getByLabelText('From Year'));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_to: 2022 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_to: 2022 });
+    }, 15000);
 
-            it('removes year_to on Apply when the draft value is invalid', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+    it('removes year_to on Apply when the draft value is invalid', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
 
-                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '0' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '0' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
+    }, 15000);
 
-            it('removes decimal year values on Apply instead of truncating them', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+    it('removes decimal year values on Apply instead of truncating them', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
 
-                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '2021.9' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '2021.9' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
+    }, 15000);
 
-            it('removes out-of-range year values on Apply', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+    it('removes out-of-range year values on Apply', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
 
-                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_to: 2022 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_to: 2022 });
+    }, 15000);
 
-            it('clears local year draft values without triggering a reload when nothing is committed', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} />);
+    it('clears local year draft values without triggering a reload when nothing is committed', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} />);
 
-                const fromYearInput = screen.getByLabelText('From Year');
+        const fromYearInput = screen.getByLabelText('From Year');
 
-                await user.type(fromYearInput, '2018');
-                await user.click(screen.getByRole('button', { name: 'Clear' }));
+        await user.type(fromYearInput, '2018');
+        await user.click(screen.getByRole('button', { name: 'Clear' }));
 
-                expect(mockOnFilterChange).not.toHaveBeenCalled();
-                expect(fromYearInput).toHaveValue(null);
-                expect(screen.getByLabelText('To Year')).toHaveValue(null);
-            }, 15000);
+        expect(mockOnFilterChange).not.toHaveBeenCalled();
+        expect(fromYearInput).toHaveValue(null);
+        expect(screen.getByLabelText('To Year')).toHaveValue(null);
+    }, 15000);
 
-            it('clears committed year range values while preserving other filters', async () => {
-                const user = userEvent.setup();
-                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+    it('clears committed year range values while preserving other filters', async () => {
+        const user = userEvent.setup();
+        render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
 
-                await user.click(screen.getByRole('button', { name: 'Clear' }));
+        await user.click(screen.getByRole('button', { name: 'Clear' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'] });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'] });
+    }, 15000);
 
-            it('syncs local year inputs when the parent filters change', () => {
-                const { rerender } = render(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2018 }} />);
+    it('syncs local year inputs when the parent filters change', () => {
+        const { rerender } = render(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2018 }} />);
 
-                expect(screen.getByLabelText('From Year')).toHaveValue(2018);
-                expect(screen.getByLabelText('To Year')).toHaveValue(null);
+        expect(screen.getByLabelText('From Year')).toHaveValue(2018);
+        expect(screen.getByLabelText('To Year')).toHaveValue(null);
 
-                rerender(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2019, year_to: 2024 }} />);
+        rerender(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2019, year_to: 2024 }} />);
 
-                expect(screen.getByLabelText('From Year')).toHaveValue(2019);
-                expect(screen.getByLabelText('To Year')).toHaveValue(2024);
-            });
+        expect(screen.getByLabelText('From Year')).toHaveValue(2019);
+        expect(screen.getByLabelText('To Year')).toHaveValue(2024);
+    });
 
     it('disables filters when loading', () => {
         render(<OldDatasetsFilters {...defaultProps} isLoading={true} />);

--- a/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -185,6 +185,42 @@ describe('OldDatasetsFilters Component', () => {
                 await user.click(screen.getByRole('button', { name: 'Apply' }));
 
                 expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2018, year_to: 2022 });
+            }, 15000);
+
+            it('does not emit changes when Apply is triggered without pending year edits', async () => {
+                render(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2018, year_to: 2022 }} />);
+
+                const applyButton = screen.getByRole('button', { name: 'Apply' });
+                expect(applyButton).toBeDisabled();
+            }, 15000);
+
+            it('disables year range controls when filter options are unavailable', () => {
+                render(<OldDatasetsFilters {...defaultProps} filterOptions={null} />);
+
+                expect(screen.getByLabelText('Filter by publication year range')).toBeDisabled();
+                expect(screen.getByLabelText('From Year')).toBeDisabled();
+                expect(screen.getByLabelText('To Year')).toBeDisabled();
+                expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+            });
+
+            it('removes year_from on Apply when the draft value is cleared', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+
+                await user.clear(screen.getByLabelText('From Year'));
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_to: 2022 });
+            }, 15000);
+
+            it('removes year_to on Apply when the draft value is invalid', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+
+                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '0' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
             }, 15000);
 
             it('clears local year draft values without triggering a reload when nothing is committed', async () => {

--- a/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
@@ -194,6 +194,16 @@ describe('OldDatasetsFilters Component', () => {
                 expect(applyButton).toBeDisabled();
             }, 15000);
 
+            it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'] }} />);
+
+                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).not.toHaveBeenCalled();
+            }, 15000);
+
             it('disables year range controls when filter options are unavailable', () => {
                 render(<OldDatasetsFilters {...defaultProps} filterOptions={null} />);
 

--- a/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
@@ -173,6 +173,55 @@ describe('OldDatasetsFilters Component', () => {
         expect(mockOnFilterChange).toHaveBeenCalled();
     }, 15000);
 
+            it('buffers year range changes until Apply is clicked', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} />);
+
+                await user.type(screen.getByLabelText('From Year'), '2018');
+                await user.type(screen.getByLabelText('To Year'), '2022');
+
+                expect(mockOnFilterChange).not.toHaveBeenCalled();
+
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2018, year_to: 2022 });
+            }, 15000);
+
+            it('clears local year draft values without triggering a reload when nothing is committed', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} />);
+
+                const fromYearInput = screen.getByLabelText('From Year');
+
+                await user.type(fromYearInput, '2018');
+                await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+                expect(mockOnFilterChange).not.toHaveBeenCalled();
+                expect(fromYearInput).toHaveValue(null);
+                expect(screen.getByLabelText('To Year')).toHaveValue(null);
+            }, 15000);
+
+            it('clears committed year range values while preserving other filters', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+
+                await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'] });
+            }, 15000);
+
+            it('syncs local year inputs when the parent filters change', () => {
+                const { rerender } = render(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2018 }} />);
+
+                expect(screen.getByLabelText('From Year')).toHaveValue(2018);
+                expect(screen.getByLabelText('To Year')).toHaveValue(null);
+
+                rerender(<OldDatasetsFilters {...defaultProps} filters={{ year_from: 2019, year_to: 2024 }} />);
+
+                expect(screen.getByLabelText('From Year')).toHaveValue(2019);
+                expect(screen.getByLabelText('To Year')).toHaveValue(2024);
+            });
+
     it('disables filters when loading', () => {
         render(<OldDatasetsFilters {...defaultProps} isLoading={true} />);
         

--- a/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
@@ -194,13 +194,21 @@ describe('OldDatasetsFilters Component', () => {
         expect(applyButton).toBeDisabled();
     }, 15000);
 
-    it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
+    it('disables Apply when only invalid year edits would be a no-op and still allows clearing', async () => {
         const user = userEvent.setup();
         render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'] }} />);
 
         fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        const clearButton = screen.getByRole('button', { name: 'Clear' });
+
+        expect(applyButton).toBeDisabled();
+        expect(clearButton).toBeEnabled();
+
+        await user.click(clearButton);
+
+        expect(screen.getByLabelText('From Year')).toHaveValue(null);
         expect(mockOnFilterChange).not.toHaveBeenCalled();
     }, 15000);
 

--- a/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/old-datasets-filters.test.tsx
@@ -223,6 +223,26 @@ describe('OldDatasetsFilters Component', () => {
                 expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
             }, 15000);
 
+            it('removes decimal year values on Apply instead of truncating them', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+
+                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '2021.9' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_from: 2018 });
+            }, 15000);
+
+            it('removes out-of-range year values on Apply', async () => {
+                const user = userEvent.setup();
+                render(<OldDatasetsFilters {...defaultProps} filters={{ curator: ['Alice'], year_from: 2018, year_to: 2022 }} />);
+
+                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ curator: ['Alice'], year_to: 2022 });
+            }, 15000);
+
             it('clears local year draft values without triggering a reload when nothing is committed', async () => {
                 const user = userEvent.setup();
                 render(<OldDatasetsFilters {...defaultProps} />);

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -197,6 +197,16 @@ describe('ResourcesFilters Component', () => {
                 expect(applyButton).toBeDisabled();
             }, 15000);
 
+            it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'] }} />);
+
+                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).not.toHaveBeenCalled();
+            }, 15000);
+
             it('renders resource type badges with the display name instead of the slug', () => {
                 render(<ResourcesFilters {...defaultProps} filters={{ resource_type: ['dataset'] }} />);
 

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -239,6 +239,26 @@ describe('ResourcesFilters Component', () => {
                 expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
             }, 15000);
 
+            it('removes decimal year values on Apply instead of truncating them', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+
+                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '2021.9' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
+            }, 15000);
+
+            it('removes out-of-range year values on Apply', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+
+                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_to: 2024 });
+            }, 15000);
+
             it('clears local year draft values without triggering a reload when nothing is committed', async () => {
                 const user = userEvent.setup();
                 render(<ResourcesFilters {...defaultProps} />);

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -176,6 +176,55 @@ describe('ResourcesFilters Component', () => {
         expect(mockOnFilterChange).toHaveBeenCalled();
     }, 15000);
 
+            it('buffers year range changes until Apply is clicked', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} />);
+
+                await user.type(screen.getByLabelText('From Year'), '2021');
+                await user.type(screen.getByLabelText('To Year'), '2024');
+
+                expect(mockOnFilterChange).not.toHaveBeenCalled();
+
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2021, year_to: 2024 });
+            }, 15000);
+
+            it('clears local year draft values without triggering a reload when nothing is committed', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} />);
+
+                const fromYearInput = screen.getByLabelText('From Year');
+
+                await user.type(fromYearInput, '2021');
+                await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+                expect(mockOnFilterChange).not.toHaveBeenCalled();
+                expect(fromYearInput).toHaveValue(null);
+                expect(screen.getByLabelText('To Year')).toHaveValue(null);
+            }, 15000);
+
+            it('clears committed year range values while preserving other filters', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+
+                await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'] });
+            }, 15000);
+
+            it('syncs local year inputs when the parent filters change', () => {
+                const { rerender } = render(<ResourcesFilters {...defaultProps} filters={{ year_from: 2021 }} />);
+
+                expect(screen.getByLabelText('From Year')).toHaveValue(2021);
+                expect(screen.getByLabelText('To Year')).toHaveValue(null);
+
+                rerender(<ResourcesFilters {...defaultProps} filters={{ year_from: 2022, year_to: 2025 }} />);
+
+                expect(screen.getByLabelText('From Year')).toHaveValue(2022);
+                expect(screen.getByLabelText('To Year')).toHaveValue(2025);
+            });
+
     it('disables filters when loading', () => {
         render(<ResourcesFilters {...defaultProps} isLoading={true} />);
         

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -197,13 +197,21 @@ describe('ResourcesFilters Component', () => {
         expect(applyButton).toBeDisabled();
     }, 15000);
 
-    it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
+    it('disables Apply when only invalid year edits would be a no-op and still allows clearing', async () => {
         const user = userEvent.setup();
         render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'] }} />);
 
         fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
-        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        const clearButton = screen.getByRole('button', { name: 'Clear' });
+
+        expect(applyButton).toBeDisabled();
+        expect(clearButton).toBeEnabled();
+
+        await user.click(clearButton);
+
+        expect(screen.getByLabelText('From Year')).toHaveValue(null);
         expect(mockOnFilterChange).not.toHaveBeenCalled();
     }, 15000);
 

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -188,6 +188,63 @@ describe('ResourcesFilters Component', () => {
                 await user.click(screen.getByRole('button', { name: 'Apply' }));
 
                 expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2021, year_to: 2024 });
+            }, 15000);
+
+            it('does not emit changes when Apply is triggered without pending year edits', async () => {
+                render(<ResourcesFilters {...defaultProps} filters={{ year_from: 2021, year_to: 2024 }} />);
+
+                const applyButton = screen.getByRole('button', { name: 'Apply' });
+                expect(applyButton).toBeDisabled();
+            }, 15000);
+
+            it('renders resource type badges with the display name instead of the slug', () => {
+                render(<ResourcesFilters {...defaultProps} filters={{ resource_type: ['dataset'] }} />);
+
+                expect(screen.getByText('Type: Dataset')).toBeInTheDocument();
+            });
+
+            it('disables year range controls when filter options are unavailable', () => {
+                render(<ResourcesFilters {...defaultProps} filterOptions={null} />);
+
+                expect(screen.getByLabelText('Filter by publication year range')).toBeDisabled();
+                expect(screen.getByLabelText('From Year')).toBeDisabled();
+                expect(screen.getByLabelText('To Year')).toBeDisabled();
+                expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+            });
+
+            it('omits year placeholders when the backend has no year bounds', () => {
+                render(
+                    <ResourcesFilters
+                        {...defaultProps}
+                        filterOptions={{
+                            ...defaultProps.filterOptions,
+                            year_range: { min: null, max: null },
+                        }}
+                    />,
+                );
+
+                expect(screen.getByLabelText('From Year')).not.toHaveAttribute('placeholder');
+                expect(screen.getByLabelText('To Year')).not.toHaveAttribute('placeholder');
+            });
+
+            it('removes year_from on Apply when the draft value is cleared', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+
+                await user.clear(screen.getByLabelText('From Year'));
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_to: 2024 });
+            }, 15000);
+
+            it('removes year_to on Apply when the draft value is invalid', async () => {
+                const user = userEvent.setup();
+                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+
+                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '0' } });
+                await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
             }, 15000);
 
             it('clears local year draft values without triggering a reload when nothing is committed', async () => {

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -176,133 +176,133 @@ describe('ResourcesFilters Component', () => {
         expect(mockOnFilterChange).toHaveBeenCalled();
     }, 15000);
 
-            it('buffers year range changes until Apply is clicked', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} />);
+    it('buffers year range changes until Apply is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} />);
 
-                await user.type(screen.getByLabelText('From Year'), '2021');
-                await user.type(screen.getByLabelText('To Year'), '2024');
+        await user.type(screen.getByLabelText('From Year'), '2021');
+        await user.type(screen.getByLabelText('To Year'), '2024');
 
-                expect(mockOnFilterChange).not.toHaveBeenCalled();
+        expect(mockOnFilterChange).not.toHaveBeenCalled();
 
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2021, year_to: 2024 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ year_from: 2021, year_to: 2024 });
+    }, 15000);
 
-            it('does not emit changes when Apply is triggered without pending year edits', async () => {
-                render(<ResourcesFilters {...defaultProps} filters={{ year_from: 2021, year_to: 2024 }} />);
+    it('does not emit changes when Apply is triggered without pending year edits', async () => {
+        render(<ResourcesFilters {...defaultProps} filters={{ year_from: 2021, year_to: 2024 }} />);
 
-                const applyButton = screen.getByRole('button', { name: 'Apply' });
-                expect(applyButton).toBeDisabled();
-            }, 15000);
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+        expect(applyButton).toBeDisabled();
+    }, 15000);
 
-            it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'] }} />);
+    it('does not emit changes when Apply is triggered with only invalid year edits', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'] }} />);
 
-                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).not.toHaveBeenCalled();
-            }, 15000);
+        expect(mockOnFilterChange).not.toHaveBeenCalled();
+    }, 15000);
 
-            it('renders resource type badges with the display name instead of the slug', () => {
-                render(<ResourcesFilters {...defaultProps} filters={{ resource_type: ['dataset'] }} />);
+    it('renders resource type badges with the display name instead of the slug', () => {
+        render(<ResourcesFilters {...defaultProps} filters={{ resource_type: ['dataset'] }} />);
 
-                expect(screen.getByText('Type: Dataset')).toBeInTheDocument();
-            });
+        expect(screen.getByText('Type: Dataset')).toBeInTheDocument();
+    });
 
-            it('disables year range controls when filter options are unavailable', () => {
-                render(<ResourcesFilters {...defaultProps} filterOptions={null} />);
+    it('disables year range controls when filter options are unavailable', () => {
+        render(<ResourcesFilters {...defaultProps} filterOptions={null} />);
 
-                expect(screen.getByLabelText('Filter by publication year range')).toBeDisabled();
-                expect(screen.getByLabelText('From Year')).toBeDisabled();
-                expect(screen.getByLabelText('To Year')).toBeDisabled();
-                expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
-            });
+        expect(screen.getByLabelText('Filter by publication year range')).toBeDisabled();
+        expect(screen.getByLabelText('From Year')).toBeDisabled();
+        expect(screen.getByLabelText('To Year')).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+    });
 
-            it('shows year placeholders from the backend bounds', () => {
-                render(<ResourcesFilters {...defaultProps} />);
+    it('shows year placeholders from the backend bounds', () => {
+        render(<ResourcesFilters {...defaultProps} />);
 
-                expect(screen.getByLabelText('From Year')).toHaveAttribute('placeholder', '2000');
-                expect(screen.getByLabelText('To Year')).toHaveAttribute('placeholder', '2025');
-            });
+        expect(screen.getByLabelText('From Year')).toHaveAttribute('placeholder', '2000');
+        expect(screen.getByLabelText('To Year')).toHaveAttribute('placeholder', '2025');
+    });
 
-            it('removes year_from on Apply when the draft value is cleared', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+    it('removes year_from on Apply when the draft value is cleared', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
 
-                await user.clear(screen.getByLabelText('From Year'));
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        await user.clear(screen.getByLabelText('From Year'));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_to: 2024 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_to: 2024 });
+    }, 15000);
 
-            it('removes year_to on Apply when the draft value is invalid', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+    it('removes year_to on Apply when the draft value is invalid', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
 
-                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '0' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '0' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
+    }, 15000);
 
-            it('removes decimal year values on Apply instead of truncating them', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+    it('removes decimal year values on Apply instead of truncating them', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
 
-                fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '2021.9' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('To Year'), { target: { value: '2021.9' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_from: 2021 });
+    }, 15000);
 
-            it('removes out-of-range year values on Apply', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+    it('removes out-of-range year values on Apply', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
 
-                fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
-                await user.click(screen.getByRole('button', { name: 'Apply' }));
+        fireEvent.change(screen.getByLabelText('From Year'), { target: { value: '1999' } });
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_to: 2024 });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'], year_to: 2024 });
+    }, 15000);
 
-            it('clears local year draft values without triggering a reload when nothing is committed', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} />);
+    it('clears local year draft values without triggering a reload when nothing is committed', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} />);
 
-                const fromYearInput = screen.getByLabelText('From Year');
+        const fromYearInput = screen.getByLabelText('From Year');
 
-                await user.type(fromYearInput, '2021');
-                await user.click(screen.getByRole('button', { name: 'Clear' }));
+        await user.type(fromYearInput, '2021');
+        await user.click(screen.getByRole('button', { name: 'Clear' }));
 
-                expect(mockOnFilterChange).not.toHaveBeenCalled();
-                expect(fromYearInput).toHaveValue(null);
-                expect(screen.getByLabelText('To Year')).toHaveValue(null);
-            }, 15000);
+        expect(mockOnFilterChange).not.toHaveBeenCalled();
+        expect(fromYearInput).toHaveValue(null);
+        expect(screen.getByLabelText('To Year')).toHaveValue(null);
+    }, 15000);
 
-            it('clears committed year range values while preserving other filters', async () => {
-                const user = userEvent.setup();
-                render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
+    it('clears committed year range values while preserving other filters', async () => {
+        const user = userEvent.setup();
+        render(<ResourcesFilters {...defaultProps} filters={{ status: ['published'], year_from: 2021, year_to: 2024 }} />);
 
-                await user.click(screen.getByRole('button', { name: 'Clear' }));
+        await user.click(screen.getByRole('button', { name: 'Clear' }));
 
-                expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'] });
-            }, 15000);
+        expect(mockOnFilterChange).toHaveBeenCalledWith({ status: ['published'] });
+    }, 15000);
 
-            it('syncs local year inputs when the parent filters change', () => {
-                const { rerender } = render(<ResourcesFilters {...defaultProps} filters={{ year_from: 2021 }} />);
+    it('syncs local year inputs when the parent filters change', () => {
+        const { rerender } = render(<ResourcesFilters {...defaultProps} filters={{ year_from: 2021 }} />);
 
-                expect(screen.getByLabelText('From Year')).toHaveValue(2021);
-                expect(screen.getByLabelText('To Year')).toHaveValue(null);
+        expect(screen.getByLabelText('From Year')).toHaveValue(2021);
+        expect(screen.getByLabelText('To Year')).toHaveValue(null);
 
-                rerender(<ResourcesFilters {...defaultProps} filters={{ year_from: 2022, year_to: 2025 }} />);
+        rerender(<ResourcesFilters {...defaultProps} filters={{ year_from: 2022, year_to: 2025 }} />);
 
-                expect(screen.getByLabelText('From Year')).toHaveValue(2022);
-                expect(screen.getByLabelText('To Year')).toHaveValue(2025);
-            });
+        expect(screen.getByLabelText('From Year')).toHaveValue(2022);
+        expect(screen.getByLabelText('To Year')).toHaveValue(2025);
+    });
 
     it('disables filters when loading', () => {
         render(<ResourcesFilters {...defaultProps} isLoading={true} />);

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -212,19 +212,11 @@ describe('ResourcesFilters Component', () => {
                 expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
             });
 
-            it('omits year placeholders when the backend has no year bounds', () => {
-                render(
-                    <ResourcesFilters
-                        {...defaultProps}
-                        filterOptions={{
-                            ...defaultProps.filterOptions,
-                            year_range: { min: null, max: null },
-                        }}
-                    />,
-                );
+            it('shows year placeholders from the backend bounds', () => {
+                render(<ResourcesFilters {...defaultProps} />);
 
-                expect(screen.getByLabelText('From Year')).not.toHaveAttribute('placeholder');
-                expect(screen.getByLabelText('To Year')).not.toHaveAttribute('placeholder');
+                expect(screen.getByLabelText('From Year')).toHaveAttribute('placeholder', '2000');
+                expect(screen.getByLabelText('To Year')).toHaveAttribute('placeholder', '2025');
             });
 
             it('removes year_from on Apply when the draft value is cleared', async () => {

--- a/tests/vitest/lib/year-range-input.test.ts
+++ b/tests/vitest/lib/year-range-input.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatYearInput, parseYearInput } from '@/lib/year-range-input';
+
+describe('parseYearInput', () => {
+    it('returns undefined for empty input', () => {
+        expect(parseYearInput('')).toBeUndefined();
+        expect(parseYearInput('   ')).toBeUndefined();
+    });
+
+    it('accepts trimmed integer values', () => {
+        expect(parseYearInput(' 2021 ')).toBe(2021);
+    });
+
+    it('rejects non-integer numeric input instead of truncating it', () => {
+        expect(parseYearInput('2021.9')).toBeUndefined();
+        expect(parseYearInput('1e3')).toBeUndefined();
+    });
+
+    it('rejects values outside the provided bounds', () => {
+        const bounds = { min: 2000, max: 2025 };
+
+        expect(parseYearInput('1999', bounds)).toBeUndefined();
+        expect(parseYearInput('2026', bounds)).toBeUndefined();
+        expect(parseYearInput('2021', bounds)).toBe(2021);
+    });
+});
+
+describe('formatYearInput', () => {
+    it('formats undefined as an empty string', () => {
+        expect(formatYearInput(undefined)).toBe('');
+    });
+
+    it('formats numeric years as strings', () => {
+        expect(formatYearInput(2021)).toBe('2021');
+    });
+});


### PR DESCRIPTION
This pull request improves the user experience and robustness of the Publication Year range filters on both the `/resources` and `/old-datasets` pages. The main change is that year range filters now use a buffered input pattern: users can enter both boundaries and review their input before applying, instead of triggering a reload on every keystroke. This is achieved by introducing a reusable React hook and updating both backend and frontend logic to support safer year bounds and type consistency.

**Frontend improvements to year range filters:**

* Added a new `useBufferedYearRangeFilter` React hook to manage year range input state, allowing users to enter and review year boundaries before applying, and to clear inputs without triggering a reload. This hook is now used in both `ResourcesFilters` and `OldDatasetsFilters` components (`resources/js/hooks/use-buffered-year-range-filter.ts`, `resources/js/components/resources-filters.tsx`, `resources/js/components/old-datasets-filters.tsx`). [[1]](diffhunk://#diff-fdef38a92d9e46c73216a23971f5bcef15a98b4ec8d8291bd8ebaf08198468c0R1-R95) [[2]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R11) [[3]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R69-R84) [[4]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2L176-L203) [[5]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2L390-R385) [[6]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2L409-R428) [[7]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9R11) [[8]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9R69-R84) [[9]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9L176-L203) [[10]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9L379-R374) [[11]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9L394-R417)
* Updated the year range filter UI to include "Apply" and "Clear" buttons, disable inputs while loading, and ensure that changes are only applied when the user explicitly clicks "Apply". [[1]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2L390-R385) [[2]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2L409-R428) [[3]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9L379-R374) [[4]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9L394-R417)
* Removed old immediate-update handlers for year range inputs, fully replacing them with the buffered pattern. [[1]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2L176-L203) [[2]](diffhunk://#diff-3802abe9afb937b411dc50fac02e09a8df9529c29741953e48d4a6cde5db70f9L176-L203)

**Backend improvements for year range safety and consistency:**

* Updated the backend (`OldDatasetController.php`) to ignore invalid or zero publication years when calculating year range bounds, and to ensure the returned min/max are always integers (defaulting to the current year if no valid data is found). [[1]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49R822-R836) [[2]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L837-R846)

**Changelog and documentation:**

* Updated the changelog to document the new buffered year filter behavior and the date of the release. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR190-R193)

These changes make the year range filters more user-friendly and robust, preventing unnecessary reloads and ensuring consistent, valid filter options.