### PR TITLE
Fix: Handle F-UJI unavailability and improve resilience

### DIFF
--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -106,16 +106,26 @@ class FujiAssessmentService
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE);
         }
 
-        /** @var array<string, mixed> $payload */
-        $payload = $response->json();
-        $score = data_get($payload, 'summary.score_percent.FAIR');
+        try {
+            $payload = $response->json();
 
-        if (! is_numeric($score)) {
-            throw new RuntimeException('F-UJI response does not contain summary.score_percent.FAIR.');
+            if (! is_array($payload)) {
+                throw new RuntimeException('F-UJI response is not a JSON object.');
+            }
+
+            $score = data_get($payload, 'summary.score_percent.FAIR');
+
+            if (! is_numeric($score)) {
+                throw new RuntimeException('F-UJI response does not contain summary.score_percent.FAIR.');
+            }
+
+            $resolvedUrl = data_get($payload, 'resolved_url');
+            $normalizedIdentifier = data_get($payload, 'request.normalized_object_identifier');
+        } catch (\Throwable $exception) {
+            $this->logAssessmentInvalidPayloadOnce($response, $identifier, $exception);
+
+            throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
         }
-
-        $resolvedUrl = data_get($payload, 'resolved_url');
-        $normalizedIdentifier = data_get($payload, 'request.normalized_object_identifier');
 
         return [
             'score' => round((float) $score, 2),
@@ -254,6 +264,30 @@ class FujiAssessmentService
 
         $this->logUnsuccessfulResponse('assessment', $response, [
             'identifier' => $identifier,
+        ]);
+    }
+
+    private function logAssessmentInvalidPayloadOnce(Response $response, string $identifier, \Throwable $exception): void
+    {
+        $fingerprint = sprintf(
+            'payload:%d:%s:%s',
+            $response->status(),
+            sha1($this->responseBodyExcerpt($response) ?? ''),
+            $exception->getMessage(),
+        );
+
+        if (! $this->shouldLogAssessmentFailure($fingerprint)) {
+            return;
+        }
+
+        Log::warning('F-UJI returned invalid assessment payload', [
+            'identifier' => $identifier,
+            'operation' => 'assessment',
+            'base_url' => $this->baseUrl(),
+            'status' => $response->status(),
+            'body' => $this->responseBodyExcerpt($response),
+            'error' => $exception->getMessage(),
+            'exception_class' => $exception::class,
         ]);
     }
 

--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -86,24 +86,12 @@ class FujiAssessmentService
                 ->asJson()
                 ->post($this->endpoint(), $this->buildPayload($identifier));
         } catch (ConnectionException $exception) {
-            $this->logTransportFailure('assessment', $exception, [
-                'identifier' => $identifier,
-            ]);
-
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
         } catch (\Throwable $exception) {
-            $this->logTransportFailure('assessment', $exception, [
-                'identifier' => $identifier,
-            ]);
-
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
         }
 
         if (! $response->successful()) {
-            $this->logUnsuccessfulResponse('assessment', $response, [
-                'identifier' => $identifier,
-            ]);
-
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE);
         }
 

--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -256,7 +256,7 @@ class FujiAssessmentService
 
     private function logAssessmentUnsuccessfulResponseOnce(Response $response, string $identifier): void
     {
-        $fingerprint = sprintf('response:%d:%s', $response->status(), sha1($this->responseBodyExcerpt($response) ?? ''));
+        $fingerprint = sprintf('response:%d:%s', $response->status(), $this->responseBodyFingerprint($response));
 
         if (! $this->shouldLogAssessmentFailure($fingerprint)) {
             return;
@@ -272,7 +272,7 @@ class FujiAssessmentService
         $fingerprint = sprintf(
             'payload:%d:%s:%s',
             $response->status(),
-            sha1($this->responseBodyExcerpt($response) ?? ''),
+            $this->responseBodyFingerprint($response),
             $exception->getMessage(),
         );
 
@@ -311,5 +311,10 @@ class FujiAssessmentService
         }
 
         return Str::limit($body, 200, '...');
+    }
+
+    private function responseBodyFingerprint(Response $response): string
+    {
+        return sha1($response->body());
     }
 }

--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -61,7 +61,7 @@ class FujiAssessmentService
 
             return [
                 'healthy' => false,
-                'message' => $this->healthFailureMessage($response),
+                'message' => self::UNAVAILABLE_MESSAGE,
             ];
         }
 
@@ -104,7 +104,7 @@ class FujiAssessmentService
                 'identifier' => $identifier,
             ]);
 
-            throw new RuntimeException($this->unsuccessfulResponseMessage('F-UJI assessment failed', $response));
+            throw new RuntimeException(self::UNAVAILABLE_MESSAGE);
         }
 
         /** @var array<string, mixed> $payload */
@@ -204,11 +204,6 @@ class FujiAssessmentService
             ->timeout($this->timeout());
     }
 
-    private function healthFailureMessage(Response $response): string
-    {
-        return sprintf('F-UJI health check failed with status %d.', $response->status());
-    }
-
     /**
      * @param array<string, mixed> $context
      */
@@ -235,18 +230,6 @@ class FujiAssessmentService
             'status' => $response->status(),
             'body' => $this->responseBodyExcerpt($response),
         ]);
-    }
-
-    private function unsuccessfulResponseMessage(string $prefix, Response $response): string
-    {
-        $message = sprintf('%s with status %d.', $prefix, $response->status());
-        $body = $this->responseBodyExcerpt($response);
-
-        if ($body === null) {
-            return $message;
-        }
-
-        return sprintf('%s Response: %s', $message, $body);
     }
 
     private function responseBodyExcerpt(Response $response): ?string

--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace App\Services\Assessment;
 
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use RuntimeException;
 
 class FujiAssessmentService
 {
+    private const UNAVAILABLE_MESSAGE = 'F-UJI is currently unavailable. Please try again shortly.';
+
     public function isConfigured(): bool
     {
         return (bool) Config::get('fuji.enabled', false)
@@ -36,17 +40,28 @@ class FujiAssessmentService
         try {
             $response = $this->baseRequest()
                 ->get($this->healthEndpoint());
-        } catch (\Throwable $exception) {
+        } catch (ConnectionException $exception) {
+            $this->logTransportFailure('health check', $exception);
+
             return [
                 'healthy' => false,
-                'message' => sprintf('F-UJI health check failed: %s', $exception->getMessage()),
+                'message' => self::UNAVAILABLE_MESSAGE,
+            ];
+        } catch (\Throwable $exception) {
+            $this->logTransportFailure('health check', $exception);
+
+            return [
+                'healthy' => false,
+                'message' => self::UNAVAILABLE_MESSAGE,
             ];
         }
 
         if (! $response->successful()) {
+            $this->logUnsuccessfulResponse('health check', $response);
+
             return [
                 'healthy' => false,
-                'message' => $this->unsuccessfulResponseMessage('F-UJI health check failed', $response),
+                'message' => $this->healthFailureMessage($response),
             ];
         }
 
@@ -65,12 +80,30 @@ class FujiAssessmentService
             throw new RuntimeException('F-UJI is not configured.');
         }
 
-        $response = $this->baseRequest()
-            ->acceptJson()
-            ->asJson()
-            ->post($this->endpoint(), $this->buildPayload($identifier));
+        try {
+            $response = $this->baseRequest()
+                ->acceptJson()
+                ->asJson()
+                ->post($this->endpoint(), $this->buildPayload($identifier));
+        } catch (ConnectionException $exception) {
+            $this->logTransportFailure('assessment', $exception, [
+                'identifier' => $identifier,
+            ]);
+
+            throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
+        } catch (\Throwable $exception) {
+            $this->logTransportFailure('assessment', $exception, [
+                'identifier' => $identifier,
+            ]);
+
+            throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
+        }
 
         if (! $response->successful()) {
+            $this->logUnsuccessfulResponse('assessment', $response, [
+                'identifier' => $identifier,
+            ]);
+
             throw new RuntimeException($this->unsuccessfulResponseMessage('F-UJI assessment failed', $response));
         }
 
@@ -171,15 +204,59 @@ class FujiAssessmentService
             ->timeout($this->timeout());
     }
 
+    private function healthFailureMessage(Response $response): string
+    {
+        return sprintf('F-UJI health check failed with status %d.', $response->status());
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function logTransportFailure(string $operation, \Throwable $exception, array $context = []): void
+    {
+        Log::warning('F-UJI request failed', [
+            ...$context,
+            'operation' => $operation,
+            'base_url' => $this->baseUrl(),
+            'exception_class' => $exception::class,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function logUnsuccessfulResponse(string $operation, Response $response, array $context = []): void
+    {
+        Log::warning('F-UJI returned unsuccessful response', [
+            ...$context,
+            'operation' => $operation,
+            'base_url' => $this->baseUrl(),
+            'status' => $response->status(),
+            'body' => $this->responseBodyExcerpt($response),
+        ]);
+    }
+
     private function unsuccessfulResponseMessage(string $prefix, Response $response): string
     {
         $message = sprintf('%s with status %d.', $prefix, $response->status());
-        $body = trim(preg_replace('/\s+/', ' ', $response->body()) ?? '');
+        $body = $this->responseBodyExcerpt($response);
 
-        if ($body === '') {
+        if ($body === null) {
             return $message;
         }
 
-        return sprintf('%s Response: %s', $message, Str::limit($body, 200, '...'));
+        return sprintf('%s Response: %s', $message, $body);
+    }
+
+    private function responseBodyExcerpt(Response $response): ?string
+    {
+        $body = trim(preg_replace('/\s+/', ' ', $response->body()) ?? '');
+
+        if ($body === '') {
+            return null;
+        }
+
+        return Str::limit($body, 200, '...');
     }
 }

--- a/app/Services/Assessment/FujiAssessmentService.php
+++ b/app/Services/Assessment/FujiAssessmentService.php
@@ -17,6 +17,11 @@ class FujiAssessmentService
 {
     private const UNAVAILABLE_MESSAGE = 'F-UJI is currently unavailable. Please try again shortly.';
 
+    /**
+     * @var array<string, true>
+     */
+    private array $loggedAssessmentFailureFingerprints = [];
+
     public function isConfigured(): bool
     {
         return (bool) Config::get('fuji.enabled', false)
@@ -86,12 +91,18 @@ class FujiAssessmentService
                 ->asJson()
                 ->post($this->endpoint(), $this->buildPayload($identifier));
         } catch (ConnectionException $exception) {
+            $this->logAssessmentTransportFailureOnce($exception, $identifier);
+
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
         } catch (\Throwable $exception) {
+            $this->logAssessmentTransportFailureOnce($exception, $identifier);
+
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE, previous: $exception);
         }
 
         if (! $response->successful()) {
+            $this->logAssessmentUnsuccessfulResponseOnce($response, $identifier);
+
             throw new RuntimeException(self::UNAVAILABLE_MESSAGE);
         }
 
@@ -218,6 +229,43 @@ class FujiAssessmentService
             'status' => $response->status(),
             'body' => $this->responseBodyExcerpt($response),
         ]);
+    }
+
+    private function logAssessmentTransportFailureOnce(\Throwable $exception, string $identifier): void
+    {
+        $fingerprint = sprintf('transport:%s:%s', $exception::class, $exception->getMessage());
+
+        if (! $this->shouldLogAssessmentFailure($fingerprint)) {
+            return;
+        }
+
+        $this->logTransportFailure('assessment', $exception, [
+            'identifier' => $identifier,
+        ]);
+    }
+
+    private function logAssessmentUnsuccessfulResponseOnce(Response $response, string $identifier): void
+    {
+        $fingerprint = sprintf('response:%d:%s', $response->status(), sha1($this->responseBodyExcerpt($response) ?? ''));
+
+        if (! $this->shouldLogAssessmentFailure($fingerprint)) {
+            return;
+        }
+
+        $this->logUnsuccessfulResponse('assessment', $response, [
+            'identifier' => $identifier,
+        ]);
+    }
+
+    private function shouldLogAssessmentFailure(string $fingerprint): bool
+    {
+        if (isset($this->loggedAssessmentFailureFingerprints[$fingerprint])) {
+            return false;
+        }
+
+        $this->loggedAssessmentFailureFingerprints[$fingerprint] = true;
+
+        return true;
     }
 
     private function responseBodyExcerpt(Response $response): ?string

--- a/composer.lock
+++ b/composer.lock
@@ -1541,16 +1541,16 @@
         },
         {
             "name": "laravel/wayfinder",
-            "version": "v0.1.18",
+            "version": "v0.1.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/wayfinder.git",
-                "reference": "29598f386cdeef2cf4144f32bdaefc7542ac38ce"
+                "reference": "91d958a6f99fe9187c6eda84e62aa93d79330be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/wayfinder/zipball/29598f386cdeef2cf4144f32bdaefc7542ac38ce",
-                "reference": "29598f386cdeef2cf4144f32bdaefc7542ac38ce",
+                "url": "https://api.github.com/repos/laravel/wayfinder/zipball/91d958a6f99fe9187c6eda84e62aa93d79330be5",
+                "reference": "91d958a6f99fe9187c6eda84e62aa93d79330be5",
                 "shasum": ""
             },
             "require": {
@@ -1600,7 +1600,7 @@
                 "issues": "https://github.com/laravel/wayfinder/issues",
                 "source": "https://github.com/laravel/wayfinder"
             },
-            "time": "2026-05-08T14:41:03+00:00"
+            "time": "2026-05-12T01:44:17+00:00"
         },
         {
             "name": "league/commonmark",
@@ -2438,16 +2438,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2523,9 +2523,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
       - dockerized-laravel-network
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -112,6 +112,12 @@ services:
       - dockerized-laravel-network
     ports:
       - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u\"$$MYSQL_USER\" -p\"$$MYSQL_PASSWORD\" --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   redis:
     image: redis:alpine
@@ -121,6 +127,12 @@ services:
       - dockerized-laravel-network
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   fuji:
     image: ghcr.io/pangaea-data-publisher/fuji@sha256:ce91f8c5998655c34f570d68f52254cb5dfa29d659808c571c8e6f9249948a0e
@@ -158,9 +170,9 @@ services:
       - dockerized-laravel-network
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     environment:
       - APP_KEY=${APP_KEY}
       - APP_URL=https://ernie.rz-vm499.gfz.de

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,7 @@ services:
       - dockerized-laravel-network
     depends_on:
       - db
+      - fuji
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -45,7 +46,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
+      - FUJI_BASE_URL=${FUJI_BASE_URL}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}
@@ -177,7 +178,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
+      - FUJI_BASE_URL=${FUJI_BASE_URL}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,8 +12,10 @@ services:
     networks:
       - dockerized-laravel-network
     depends_on:
-      - db
-      - fuji
+      db:
+        condition: service_started
+      fuji:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -157,9 +159,12 @@ services:
     networks:
       - dockerized-laravel-network
     depends_on:
-      - db
-      - redis
-      - fuji
+      db:
+        condition: service_started
+      redis:
+        condition: service_started
+      fuji:
+        condition: service_healthy
     environment:
       - APP_KEY=${APP_KEY}
       - APP_URL=https://ernie.rz-vm499.gfz.de

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,8 +14,6 @@ services:
     depends_on:
       db:
         condition: service_started
-      fuji:
-        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -163,8 +161,6 @@ services:
         condition: service_started
       redis:
         condition: service_started
-      fuji:
-        condition: service_healthy
     environment:
       - APP_KEY=${APP_KEY}
       - APP_URL=https://ernie.rz-vm499.gfz.de

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,7 +46,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}
@@ -178,7 +178,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,7 +46,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}
@@ -178,7 +178,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -13,6 +13,7 @@ services:
       - dockerized-laravel-network
     depends_on:
       - db
+      - fuji
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -45,7 +46,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
+      - FUJI_BASE_URL=${FUJI_BASE_URL}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}
@@ -249,7 +250,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
+      - FUJI_BASE_URL=${FUJI_BASE_URL}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -14,8 +14,6 @@ services:
     depends_on:
       db:
         condition: service_started
-      fuji:
-        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -235,8 +233,6 @@ services:
         condition: service_started
       redis:
         condition: service_started
-      fuji:
-        condition: service_healthy
     environment:
       - APP_KEY=${APP_KEY}
       - APP_URL=https://ernie.rz-vm182.gfz.de

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -14,6 +14,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -12,8 +12,10 @@ services:
     networks:
       - dockerized-laravel-network
     depends_on:
-      - db
-      - fuji
+      db:
+        condition: service_started
+      fuji:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -229,9 +231,12 @@ services:
     networks:
       - dockerized-laravel-network
     depends_on:
-      - db
-      - redis
-      - fuji
+      db:
+        condition: service_started
+      redis:
+        condition: service_started
+      fuji:
+        condition: service_healthy
     environment:
       - APP_KEY=${APP_KEY}
       - APP_URL=https://ernie.rz-vm182.gfz.de

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -46,7 +46,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}
@@ -250,7 +250,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:-http://fuji:1071}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -46,7 +46,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}
@@ -250,7 +250,7 @@ services:
       - CACHE_STORE=redis
       - QUEUE_CONNECTION=database
       - FUJI_ENABLED=${FUJI_ENABLED:-false}
-      - FUJI_BASE_URL=${FUJI_BASE_URL}
+      - FUJI_BASE_URL=${FUJI_BASE_URL:?FUJI_BASE_URL is required}
       - FUJI_USERNAME=${FUJI_USERNAME:-ernie}
       - FUJI_PASSWORD=${FUJI_PASSWORD}
       - FUJI_TIMEOUT=${FUJI_TIMEOUT:-120}

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -13,7 +13,7 @@ services:
       - dockerized-laravel-network
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 9000"]
       interval: 5s
@@ -112,6 +112,12 @@ services:
       - dockerized-laravel-network
     ports:
       - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u\"$$MYSQL_USER\" -p\"$$MYSQL_PASSWORD\" --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   redis:
     image: redis:alpine
@@ -121,6 +127,12 @@ services:
       - dockerized-laravel-network
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   fuji:
     image: ghcr.io/pangaea-data-publisher/fuji@sha256:ce91f8c5998655c34f570d68f52254cb5dfa29d659808c571c8e6f9249948a0e
@@ -230,9 +242,9 @@ services:
       - dockerized-laravel-network
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     environment:
       - APP_KEY=${APP_KEY}
       - APP_URL=https://ernie.rz-vm182.gfz.de

--- a/package-lock.json
+++ b/package-lock.json
@@ -6281,17 +6281,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6304,7 +6304,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -6320,16 +6320,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6345,14 +6345,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6367,14 +6367,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6385,9 +6385,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6402,15 +6402,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6427,9 +6427,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6441,16 +6441,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6469,16 +6469,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6493,13 +6493,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -8656,9 +8656,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
-      "integrity": "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==",
+      "version": "5.21.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -14397,16 +14397,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,9 +1217,9 @@
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.41.8",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
-      "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1661,13 +1661,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6165,13 +6165,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.21.0"
       }
     },
     "node_modules/@types/nprogress": {
@@ -12108,13 +12108,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12127,9 +12127,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14495,9 +14495,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/resources/js/pages/assessment.tsx
+++ b/resources/js/pages/assessment.tsx
@@ -122,7 +122,7 @@ export default function Assessment({
         resource: { isChecking: false, progress: '' },
         igsn: { isChecking: false, progress: '' },
     });
-    const fujiAvailable = fujiConfigured && fujiHealthy;
+    const fujiConfiguredForActions = fujiConfigured;
     const pollingRefs = useRef<Record<AssessmentScope, ReturnType<typeof setTimeout> | null>>({
         resource: null,
         igsn: null,
@@ -294,7 +294,7 @@ export default function Assessment({
                         <p className="text-sm text-muted-foreground">Admin-only FAIR assessment dashboard for resources and IGSNs.</p>
                     </div>
 
-                    <LoadingButton onClick={handleCheckAll} disabled={!fujiAvailable} loading={isAnyChecking}>
+                    <LoadingButton onClick={handleCheckAll} disabled={!fujiConfiguredForActions} loading={isAnyChecking}>
                         {isAnyChecking ? (
                             'Checking...'
                         ) : (
@@ -336,7 +336,7 @@ export default function Assessment({
                                     {summaryText(resourceAssessmentSummary)}
                                 </CardDescription>
                             </div>
-                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('resource')} disabled={!fujiAvailable} loading={states.resource.isChecking}>
+                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('resource')} disabled={!fujiConfiguredForActions} loading={states.resource.isChecking}>
                                 {states.resource.isChecking ? 'Checking...' : 'Check Resources'}
                             </LoadingButton>
                         </CardHeader>
@@ -353,7 +353,7 @@ export default function Assessment({
                                     {summaryText(igsnAssessmentSummary)}
                                 </CardDescription>
                             </div>
-                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('igsn')} disabled={!fujiAvailable} loading={states.igsn.isChecking}>
+                            <LoadingButton variant="outline" size="sm" onClick={() => handleCheck('igsn')} disabled={!fujiConfiguredForActions} loading={states.igsn.isChecking}>
                                 {states.igsn.isChecking ? 'Checking...' : 'Check IGSNs'}
                             </LoadingButton>
                         </CardHeader>

--- a/resources/js/pages/assessment.tsx
+++ b/resources/js/pages/assessment.tsx
@@ -31,6 +31,8 @@ const ENDPOINTS: Record<AssessmentScope, string> = {
     igsn: '/assessment/check-igsns',
 };
 
+const FUJI_UNAVAILABLE_MESSAGE = 'F-UJI is currently unavailable. Please try again shortly.';
+
 type AssessmentErrorPayload = {
     error?: string;
     progress?: string;
@@ -221,7 +223,7 @@ export default function Assessment({
             }
 
             if (axios.isAxiosError(error) && error.response?.status === 503) {
-                toast.error(error.response.data?.error ?? 'F-UJI is not configured.');
+                toast.error(getAssessmentErrorMessage(error, FUJI_UNAVAILABLE_MESSAGE));
 
                 return;
             }
@@ -267,7 +269,7 @@ export default function Assessment({
             }
 
             if (axios.isAxiosError(error) && error.response?.status === 503) {
-                toast.error(error.response.data?.error ?? 'F-UJI is not configured.');
+                toast.error(getAssessmentErrorMessage(error, FUJI_UNAVAILABLE_MESSAGE));
 
                 return;
             }

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -564,9 +564,9 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
                             <p className="text-sm text-amber-900 dark:text-amber-100">
-                                <strong>Important:</strong> A record is skipped when it has no DOI, no landing page, or the landing page is
-                                not published. The Assessment page also requires the internal F-UJI service to be configured in the current
-                                environment.
+                                <strong>Important:</strong> A record is skipped when it has no DOI. Missing or draft local landing pages do
+                                not prevent an assessment run. If the dashboard shows a temporary F-UJI warning, you can still start a
+                                check and the server will validate F-UJI availability again before queueing the job.
                             </p>
                         </div>
                     </>

--- a/tests/pest/Feature/Controllers/AssessmentControllerTest.php
+++ b/tests/pest/Feature/Controllers/AssessmentControllerTest.php
@@ -48,6 +48,32 @@ describe('index', function () {
             );
     });
 
+    it('renders the page with an unhealthy F-UJI warning when the service is temporarily unavailable', function () {
+        $this->mock(FujiAssessmentService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('healthStatus')
+                ->once()
+                ->andReturn([
+                    'healthy' => false,
+                    'message' => 'F-UJI is currently unavailable. Please try again shortly.',
+                ]);
+            $mock->shouldReceive('isConfigured')
+                ->once()
+                ->andReturn(true);
+        });
+
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $this->actingAs($user)
+            ->get('/assessment')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('assessment')
+                ->where('fujiConfigured', true)
+                ->where('fujiHealthy', false)
+                ->where('fujiStatusMessage', 'F-UJI is currently unavailable. Please try again shortly.')
+            );
+    });
+
     it('rejects unauthenticated users', function () {
         $this->get('/assessment')
             ->assertRedirect('/login');
@@ -204,7 +230,7 @@ describe('checkResources', function () {
                 ->once()
                 ->andReturn([
                     'healthy' => false,
-                    'message' => 'F-UJI health check failed with status 500. Response: Internal Server Error',
+                    'message' => 'F-UJI is currently unavailable. Please try again shortly.',
                 ]);
         });
         $user = User::factory()->create(['role' => 'admin']);
@@ -212,7 +238,7 @@ describe('checkResources', function () {
         $this->actingAs($user)
             ->post('/assessment/check-resources')
             ->assertStatus(503)
-            ->assertJsonPath('error', fn (string $error): bool => str_contains($error, 'F-UJI health check failed with status 500.'));
+            ->assertJson(['error' => 'F-UJI is currently unavailable. Please try again shortly.']);
     });
 });
 
@@ -235,7 +261,7 @@ describe('checkIgsns', function () {
                 ->once()
                 ->andReturn([
                     'healthy' => false,
-                    'message' => 'F-UJI health check failed with status 500. Response: Internal Server Error',
+                    'message' => 'F-UJI is currently unavailable. Please try again shortly.',
                 ]);
         });
         $user = User::factory()->create(['role' => 'admin']);
@@ -243,7 +269,7 @@ describe('checkIgsns', function () {
         $this->actingAs($user)
             ->post('/assessment/check-igsns')
             ->assertStatus(503)
-            ->assertJsonPath('error', fn (string $error): bool => str_contains($error, 'F-UJI health check failed with status 500.'));
+            ->assertJson(['error' => 'F-UJI is currently unavailable. Please try again shortly.']);
     });
 });
 
@@ -317,7 +343,7 @@ describe('checkAll', function () {
                 ->once()
                 ->andReturn([
                     'healthy' => false,
-                    'message' => 'F-UJI health check failed with status 500. Response: Internal Server Error',
+                    'message' => 'F-UJI is currently unavailable. Please try again shortly.',
                 ]);
         });
         $user = User::factory()->create(['role' => 'admin']);
@@ -325,7 +351,7 @@ describe('checkAll', function () {
         $this->actingAs($user)
             ->post('/assessment/check-all')
             ->assertStatus(503)
-            ->assertJsonPath('error', fn (string $error): bool => str_contains($error, 'F-UJI health check failed with status 500.'));
+            ->assertJson(['error' => 'F-UJI is currently unavailable. Please try again shortly.']);
     });
 
     it('returns 409 when all assessment jobs are already running', function () {

--- a/tests/pest/Unit/Jobs/RunResourceAssessmentsJobTest.php
+++ b/tests/pest/Unit/Jobs/RunResourceAssessmentsJobTest.php
@@ -166,6 +166,32 @@ describe('handle', function (): void {
             ->and($status['failedResources'])->toBe(1);
     });
 
+    it('stores a generic availability message when the F-UJI request cannot connect', function (): void {
+        $resource = Resource::factory()->withDoi('10.5880/test.004a')->create();
+        Title::factory()->for($resource)->create(['value' => 'Unavailable F-UJI resource']);
+        \App\Models\LandingPage::factory()->for($resource)->withDoi('10.5880/test.004a')->published()->create();
+
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::failedConnection(),
+        ]);
+
+        $jobId = (string) \Illuminate\Support\Str::uuid();
+        $job = new RunResourceAssessmentsJob(RunResourceAssessmentsJob::RESOURCE_SCOPE, $jobId);
+
+        $job->handle(app(\App\Services\Assessment\FujiAssessmentService::class), app(\App\Services\ResourceCacheService::class));
+
+        $assessment = ResourceAssessment::query()->where('resource_id', $resource->id)->first();
+        $status = Cache::get(RunResourceAssessmentsJob::getCacheKey(RunResourceAssessmentsJob::RESOURCE_SCOPE, $jobId));
+
+        expect($assessment)->not->toBeNull()
+            ->and($assessment?->status)->toBe(ResourceAssessment::STATUS_FAILED)
+            ->and($assessment?->error_message)->toBe('F-UJI is currently unavailable. Please try again shortly.')
+            ->and($status)->toBeArray()
+            ->and($status['status'])->toBe('completed')
+            ->and($status['assessedResources'])->toBe(0)
+            ->and($status['failedResources'])->toBe(1);
+    });
+
     it('completes with zero totals when the igsn scope has no physical-object type configured', function (): void {
         $jobId = (string) \Illuminate\Support\Str::uuid();
         $job = new RunResourceAssessmentsJob(RunResourceAssessmentsJob::IGSN_SCOPE, $jobId);

--- a/tests/pest/Unit/Jobs/RunResourceAssessmentsJobTest.php
+++ b/tests/pest/Unit/Jobs/RunResourceAssessmentsJobTest.php
@@ -192,6 +192,32 @@ describe('handle', function (): void {
             ->and($status['failedResources'])->toBe(1);
     });
 
+    it('stores a generic availability message when the F-UJI response payload is invalid', function (): void {
+        $resource = Resource::factory()->withDoi('10.5880/test.004b')->create();
+        Title::factory()->for($resource)->create(['value' => 'Invalid payload resource']);
+        \App\Models\LandingPage::factory()->for($resource)->withDoi('10.5880/test.004b')->published()->create();
+
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::response(['summary' => []], 200),
+        ]);
+
+        $jobId = (string) \Illuminate\Support\Str::uuid();
+        $job = new RunResourceAssessmentsJob(RunResourceAssessmentsJob::RESOURCE_SCOPE, $jobId);
+
+        $job->handle(app(\App\Services\Assessment\FujiAssessmentService::class), app(\App\Services\ResourceCacheService::class));
+
+        $assessment = ResourceAssessment::query()->where('resource_id', $resource->id)->first();
+        $status = Cache::get(RunResourceAssessmentsJob::getCacheKey(RunResourceAssessmentsJob::RESOURCE_SCOPE, $jobId));
+
+        expect($assessment)->not->toBeNull()
+            ->and($assessment?->status)->toBe(ResourceAssessment::STATUS_FAILED)
+            ->and($assessment?->error_message)->toBe('F-UJI is currently unavailable. Please try again shortly.')
+            ->and($status)->toBeArray()
+            ->and($status['status'])->toBe('completed')
+            ->and($status['assessedResources'])->toBe(0)
+            ->and($status['failedResources'])->toBe(1);
+    });
+
     it('completes with zero totals when the igsn scope has no physical-object type configured', function (): void {
         $jobId = (string) \Illuminate\Support\Str::uuid();
         $job = new RunResourceAssessmentsJob(RunResourceAssessmentsJob::IGSN_SCOPE, $jobId);

--- a/tests/pest/Unit/Jobs/RunResourceAssessmentsJobTest.php
+++ b/tests/pest/Unit/Jobs/RunResourceAssessmentsJobTest.php
@@ -159,7 +159,7 @@ describe('handle', function (): void {
 
         expect($assessment)->not->toBeNull()
             ->and($assessment?->status)->toBe(ResourceAssessment::STATUS_FAILED)
-            ->and($assessment?->error_message)->toContain('status 500')
+            ->and($assessment?->error_message)->toBe('F-UJI is currently unavailable. Please try again shortly.')
             ->and($status)->toBeArray()
             ->and($status['status'])->toBe('completed')
             ->and($status['assessedResources'])->toBe(0)

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -139,7 +139,7 @@ describe('assessIdentifier', function (): void {
             ->toThrow(RuntimeException::class, 'summary.score_percent.FAIR');
     });
 
-    it('throws a generic availability message when the F-UJI response is unsuccessful without emitting an extra warning log', function (): void {
+    it('throws a generic availability message when the F-UJI response is unsuccessful and logs the response details once', function (): void {
         Log::spy();
 
         Http::fake([
@@ -149,16 +149,62 @@ describe('assessIdentifier', function (): void {
         expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
             ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
 
-        Log::shouldNotHaveReceived('warning');
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned unsuccessful response'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+                && $context['base_url'] === 'https://fuji.test'
+                && $context['status'] === 500
+                && is_string($context['body'])
+                && str_contains($context['body'], 'Unavailable')
+            );
     });
 
-    it('throws a generic availability message when the F-UJI request cannot connect', function (): void {
+    it('throws a generic availability message when the F-UJI request cannot connect and logs the transport details once', function (): void {
+        Log::spy();
+
         Http::fake([
             'https://fuji.test/fuji/api/v1/evaluate' => Http::failedConnection(),
         ]);
 
         expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
             ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI request failed'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+                && $context['base_url'] === 'https://fuji.test'
+                && $context['exception_class'] === Illuminate\Http\Client\ConnectionException::class
+                && is_string($context['error'])
+            );
+    });
+
+    it('deduplicates identical transport failures within the same service instance', function (): void {
+        Log::spy();
+
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::failedConnection(),
+        ]);
+
+        $service = makeFujiAssessmentService();
+
+        foreach (['10.5880/test.001', '10.5880/test.002'] as $identifier) {
+            try {
+                $service->assessIdentifier($identifier);
+            } catch (RuntimeException) {
+                // Expected for repeated availability failures.
+            }
+        }
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI request failed'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+            );
     });
 
     it('includes the configured metric version in the request payload', function (): void {

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Services\Assessment\FujiAssessmentService;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 covers(FujiAssessmentService::class);
 
@@ -55,7 +56,9 @@ describe('healthStatus', function (): void {
         ]);
     });
 
-    it('returns a failure message when the health endpoint is unsuccessful', function (): void {
+    it('returns a generic availability message when the health endpoint is unsuccessful and logs the response details', function (): void {
+        Log::spy();
+
         Http::fake([
             'https://fuji.test/fuji/api/v1/ui/' => Http::response('Internal Server Error', 500),
         ]);
@@ -63,8 +66,16 @@ describe('healthStatus', function (): void {
         $status = makeFujiAssessmentService()->healthStatus();
 
         expect($status['healthy'])->toBeFalse()
-            ->and($status['message'])->toContain('status 500')
-            ->and($status['message'])->not->toContain('Internal Server Error');
+            ->and($status['message'])->toBe('F-UJI is currently unavailable. Please try again shortly.');
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned unsuccessful response'
+                && $context['operation'] === 'health check'
+                && $context['base_url'] === 'https://fuji.test'
+                && $context['status'] === 500
+                && $context['body'] === 'Internal Server Error'
+            );
     });
 
     it('returns a generic availability message when the health request cannot connect', function (): void {
@@ -128,14 +139,26 @@ describe('assessIdentifier', function (): void {
             ->toThrow(RuntimeException::class, 'summary.score_percent.FAIR');
     });
 
-    it('throws when the F-UJI response is unsuccessful', function (): void {
+    it('throws a generic availability message when the F-UJI response is unsuccessful and logs the response details', function (): void {
+        Log::spy();
+
         Http::fake([
             'https://fuji.test/fuji/api/v1/evaluate' => Http::response(['error' => 'Unavailable'], 500),
         ]);
 
         expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
-            ->toThrow(RuntimeException::class, 'status 500')
-            ->toThrow(RuntimeException::class, 'Unavailable');
+            ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned unsuccessful response'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+                && $context['base_url'] === 'https://fuji.test'
+                && $context['status'] === 500
+                && is_string($context['body'])
+                && str_contains($context['body'], 'Unavailable')
+            );
     });
 
     it('throws a generic availability message when the F-UJI request cannot connect', function (): void {

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -8,6 +8,11 @@ use Illuminate\Support\Facades\Http;
 
 covers(FujiAssessmentService::class);
 
+function makeFujiAssessmentService(): FujiAssessmentService
+{
+    return new FujiAssessmentService;
+}
+
 beforeEach(function (): void {
     Config::set('fuji.enabled', true);
     Config::set('fuji.base_url', 'https://fuji.test');
@@ -19,15 +24,13 @@ beforeEach(function (): void {
     Config::set('fuji.use_github', false);
     Config::set('fuji.test_debug', false);
     Config::set('fuji.metric_version', null);
-
-    $this->service = new FujiAssessmentService;
 });
 
 describe('isConfigured', function (): void {
     it('returns false when a required config value is missing', function (): void {
         Config::set('fuji.password', null);
 
-        expect($this->service->isConfigured())->toBeFalse();
+        expect(makeFujiAssessmentService()->isConfigured())->toBeFalse();
     });
 });
 
@@ -37,7 +40,7 @@ describe('healthStatus', function (): void {
             'https://fuji.test/fuji/api/v1/ui/' => Http::response('OK', 200),
         ]);
 
-        expect($this->service->healthStatus())->toBe([
+        expect(makeFujiAssessmentService()->healthStatus())->toBe([
             'healthy' => true,
             'message' => null,
         ]);
@@ -46,7 +49,7 @@ describe('healthStatus', function (): void {
     it('returns the configuration error when F-UJI is not configured', function (): void {
         Config::set('fuji.enabled', false);
 
-        expect($this->service->healthStatus())->toBe([
+        expect(makeFujiAssessmentService()->healthStatus())->toBe([
             'healthy' => false,
             'message' => 'F-UJI is not configured.',
         ]);
@@ -57,22 +60,22 @@ describe('healthStatus', function (): void {
             'https://fuji.test/fuji/api/v1/ui/' => Http::response('Internal Server Error', 500),
         ]);
 
-        $status = $this->service->healthStatus();
+        $status = makeFujiAssessmentService()->healthStatus();
 
         expect($status['healthy'])->toBeFalse()
             ->and($status['message'])->toContain('status 500')
-            ->and($status['message'])->toContain('Internal Server Error');
+            ->and($status['message'])->not->toContain('Internal Server Error');
     });
 
-    it('returns a failure message when the health request cannot connect', function (): void {
+    it('returns a generic availability message when the health request cannot connect', function (): void {
         Http::fake([
             'https://fuji.test/fuji/api/v1/ui/' => Http::failedConnection(),
         ]);
 
-        $status = $this->service->healthStatus();
+        $status = makeFujiAssessmentService()->healthStatus();
 
         expect($status['healthy'])->toBeFalse()
-            ->and($status['message'])->toContain('F-UJI health check failed');
+            ->and($status['message'])->toBe('F-UJI is currently unavailable. Please try again shortly.');
     });
 });
 
@@ -80,7 +83,7 @@ describe('assessIdentifier', function (): void {
     it('throws immediately when F-UJI is not configured', function (): void {
         Config::set('fuji.enabled', false);
 
-        expect(fn () => $this->service->assessIdentifier('10.5880/test.001'))
+        expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
             ->toThrow(RuntimeException::class, 'F-UJI is not configured.');
     });
 
@@ -99,7 +102,7 @@ describe('assessIdentifier', function (): void {
             ]),
         ]);
 
-        $result = $this->service->assessIdentifier('10.5880/test.001');
+        $result = makeFujiAssessmentService()->assessIdentifier('10.5880/test.001');
 
         expect($result['score'])->toBe(72.5)
             ->and($result['resolvedUrl'])->toBe('https://ernie.example.test/10.5880/test.001/example-dataset')
@@ -121,7 +124,7 @@ describe('assessIdentifier', function (): void {
             ]),
         ]);
 
-        expect(fn () => $this->service->assessIdentifier('10.5880/test.001'))
+        expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
             ->toThrow(RuntimeException::class, 'summary.score_percent.FAIR');
     });
 
@@ -130,9 +133,18 @@ describe('assessIdentifier', function (): void {
             'https://fuji.test/fuji/api/v1/evaluate' => Http::response(['error' => 'Unavailable'], 500),
         ]);
 
-        expect(fn () => $this->service->assessIdentifier('10.5880/test.001'))
+        expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
             ->toThrow(RuntimeException::class, 'status 500')
             ->toThrow(RuntimeException::class, 'Unavailable');
+    });
+
+    it('throws a generic availability message when the F-UJI request cannot connect', function (): void {
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::failedConnection(),
+        ]);
+
+        expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
+            ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
     });
 
     it('includes the configured metric version in the request payload', function (): void {
@@ -148,7 +160,7 @@ describe('assessIdentifier', function (): void {
             ]),
         ]);
 
-        $this->service->assessIdentifier('10.5880/test.001');
+        makeFujiAssessmentService()->assessIdentifier('10.5880/test.001');
 
         Http::assertSent(fn ($request): bool => $request['metric_version'] === 'metrics_v0.8');
     });

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -139,7 +139,7 @@ describe('assessIdentifier', function (): void {
             ->toThrow(RuntimeException::class, 'summary.score_percent.FAIR');
     });
 
-    it('throws a generic availability message when the F-UJI response is unsuccessful and logs the response details', function (): void {
+    it('throws a generic availability message when the F-UJI response is unsuccessful without emitting an extra warning log', function (): void {
         Log::spy();
 
         Http::fake([
@@ -149,16 +149,7 @@ describe('assessIdentifier', function (): void {
         expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
             ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
 
-        Log::shouldHaveReceived('warning')
-            ->once()
-            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned unsuccessful response'
-                && $context['operation'] === 'assessment'
-                && $context['identifier'] === '10.5880/test.001'
-                && $context['base_url'] === 'https://fuji.test'
-                && $context['status'] === 500
-                && is_string($context['body'])
-                && str_contains($context['body'], 'Unavailable')
-            );
+        Log::shouldNotHaveReceived('warning');
     });
 
     it('throws a generic availability message when the F-UJI request cannot connect', function (): void {

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -265,6 +265,37 @@ describe('assessIdentifier', function (): void {
             );
     });
 
+    it('does not deduplicate distinct unsuccessful responses that share the same excerpt prefix', function (): void {
+        Log::spy();
+
+        $sharedPrefix = str_repeat('same-prefix-', 19);
+        $firstBody = $sharedPrefix.'first-distinct-suffix';
+        $secondBody = $sharedPrefix.'second-distinct-suffix';
+
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::sequence()
+                ->push($firstBody, 500)
+                ->push($secondBody, 500),
+        ]);
+
+        $service = makeFujiAssessmentService();
+
+        foreach (['10.5880/test.001', '10.5880/test.002'] as $identifier) {
+            try {
+                $service->assessIdentifier($identifier);
+            } catch (RuntimeException) {
+                // Expected for repeated availability failures.
+            }
+        }
+
+        Log::shouldHaveReceived('warning')
+            ->twice()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned unsuccessful response'
+                && $context['operation'] === 'assessment'
+                && in_array($context['identifier'], ['10.5880/test.001', '10.5880/test.002'], true)
+            );
+    });
+
     it('includes the configured metric version in the request payload', function (): void {
         Config::set('fuji.metric_version', 'metrics_v0.8');
 

--- a/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
+++ b/tests/pest/Unit/Services/Assessment/FujiAssessmentServiceTest.php
@@ -128,7 +128,9 @@ describe('assessIdentifier', function (): void {
         });
     });
 
-    it('throws when the FAIR score is missing from the response', function (): void {
+    it('throws a generic availability message when the FAIR score is missing and logs the invalid payload details once', function (): void {
+        Log::spy();
+
         Http::fake([
             'https://fuji.test/fuji/api/v1/evaluate' => Http::response([
                 'summary' => [],
@@ -136,7 +138,38 @@ describe('assessIdentifier', function (): void {
         ]);
 
         expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
-            ->toThrow(RuntimeException::class, 'summary.score_percent.FAIR');
+            ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned invalid assessment payload'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+                && $context['base_url'] === 'https://fuji.test'
+                && $context['status'] === 200
+                && $context['error'] === 'F-UJI response does not contain summary.score_percent.FAIR.'
+            );
+    });
+
+    it('throws a generic availability message when the F-UJI response body is not a JSON object and logs the invalid payload once', function (): void {
+        Log::spy();
+
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::response('not-json', 200, ['Content-Type' => 'text/plain']),
+        ]);
+
+        expect(fn () => makeFujiAssessmentService()->assessIdentifier('10.5880/test.001'))
+            ->toThrow(RuntimeException::class, 'F-UJI is currently unavailable. Please try again shortly.');
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned invalid assessment payload'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+                && $context['status'] === 200
+                && $context['body'] === 'not-json'
+                && $context['error'] === 'F-UJI response is not a JSON object.'
+            );
     });
 
     it('throws a generic availability message when the F-UJI response is unsuccessful and logs the response details once', function (): void {
@@ -202,6 +235,31 @@ describe('assessIdentifier', function (): void {
         Log::shouldHaveReceived('warning')
             ->once()
             ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI request failed'
+                && $context['operation'] === 'assessment'
+                && $context['identifier'] === '10.5880/test.001'
+            );
+    });
+
+    it('deduplicates identical invalid payload failures within the same service instance', function (): void {
+        Log::spy();
+
+        Http::fake([
+            'https://fuji.test/fuji/api/v1/evaluate' => Http::response(['summary' => []], 200),
+        ]);
+
+        $service = makeFujiAssessmentService();
+
+        foreach (['10.5880/test.001', '10.5880/test.002'] as $identifier) {
+            try {
+                $service->assessIdentifier($identifier);
+            } catch (RuntimeException) {
+                // Expected for repeated invalid payload failures.
+            }
+        }
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'F-UJI returned invalid assessment payload'
                 && $context['operation'] === 'assessment'
                 && $context['identifier'] === '10.5880/test.001'
             );

--- a/tests/vitest/pages/__tests__/assessment.test.tsx
+++ b/tests/vitest/pages/__tests__/assessment.test.tsx
@@ -493,12 +493,12 @@ describe('Assessment page', () => {
     });
 
     it('keeps all check buttons enabled and shows the health message when F-UJI is unhealthy', () => {
-        render(<AssessmentPage {...makeProps({ fujiHealthy: false, fujiStatusMessage: 'F-UJI health check failed with status 500.' })} />);
+        render(<AssessmentPage {...makeProps({ fujiHealthy: false, fujiStatusMessage: 'F-UJI is currently unavailable. Please try again shortly.' })} />);
 
         expect(screen.getByRole('button', { name: 'Check all' })).toBeEnabled();
         expect(screen.getByRole('button', { name: 'Check Resources' })).toBeEnabled();
         expect(screen.getByRole('button', { name: 'Check IGSNs' })).toBeEnabled();
-        expect(screen.getByText('F-UJI health check failed with status 500.')).toBeInTheDocument();
+        expect(screen.getByText('F-UJI is currently unavailable. Please try again shortly.')).toBeInTheDocument();
     });
 
     it('still allows starting a check when F-UJI is unhealthy and surfaces the server-side 503 response', async () => {
@@ -510,7 +510,7 @@ describe('Assessment page', () => {
             <AssessmentPage
                 {...makeProps({
                     fujiHealthy: false,
-                    fujiStatusMessage: 'F-UJI health check failed with status 500.',
+                    fujiStatusMessage: 'F-UJI is currently unavailable. Please try again shortly.',
                 })}
             />
         );

--- a/tests/vitest/pages/__tests__/assessment.test.tsx
+++ b/tests/vitest/pages/__tests__/assessment.test.tsx
@@ -425,6 +425,18 @@ describe('Assessment page', () => {
         expect(mockToast.error).toHaveBeenCalledWith('Failed to start Resources assessment.');
     });
 
+    it('uses the standardized unavailable message when a resource start 503 has no error payload', async () => {
+        mockAxiosPost.mockRejectedValueOnce(createAxiosError(503, {}));
+
+        render(<AssessmentPage {...makeProps()} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Check Resources' }));
+        });
+
+        expect(mockToast.error).toHaveBeenCalledWith('F-UJI is currently unavailable. Please try again shortly.');
+    });
+
     it('starts all assessments, warns for partial errors, and polls the started scope', async () => {
         mockAxiosPost.mockResolvedValueOnce({
             data: {
@@ -481,6 +493,18 @@ describe('Assessment page', () => {
         });
 
         expect(mockToast.error).toHaveBeenCalledWith('Failed to start the assessment jobs.');
+    });
+
+    it('uses the standardized unavailable message when a check-all 503 has no error payload', async () => {
+        mockAxiosPost.mockRejectedValueOnce(createAxiosError(503, {}));
+
+        render(<AssessmentPage {...makeProps()} />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Check all' }));
+        });
+
+        expect(mockToast.error).toHaveBeenCalledWith('F-UJI is currently unavailable. Please try again shortly.');
     });
 
     it('disables all check buttons when F-UJI is not configured', () => {

--- a/tests/vitest/pages/__tests__/assessment.test.tsx
+++ b/tests/vitest/pages/__tests__/assessment.test.tsx
@@ -492,12 +492,34 @@ describe('Assessment page', () => {
         expect(screen.getByText('F-UJI is not configured for this environment.')).toBeInTheDocument();
     });
 
-    it('disables all check buttons and shows the health message when F-UJI is unhealthy', () => {
+    it('keeps all check buttons enabled and shows the health message when F-UJI is unhealthy', () => {
         render(<AssessmentPage {...makeProps({ fujiHealthy: false, fujiStatusMessage: 'F-UJI health check failed with status 500.' })} />);
 
-        expect(screen.getByRole('button', { name: 'Check all' })).toBeDisabled();
-        expect(screen.getByRole('button', { name: 'Check Resources' })).toBeDisabled();
-        expect(screen.getByRole('button', { name: 'Check IGSNs' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Check all' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Check Resources' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Check IGSNs' })).toBeEnabled();
         expect(screen.getByText('F-UJI health check failed with status 500.')).toBeInTheDocument();
+    });
+
+    it('still allows starting a check when F-UJI is unhealthy and surfaces the server-side 503 response', async () => {
+        mockAxiosPost.mockRejectedValueOnce(createAxiosError(503, {
+            error: 'F-UJI is currently unavailable. Please try again shortly.',
+        }));
+
+        render(
+            <AssessmentPage
+                {...makeProps({
+                    fujiHealthy: false,
+                    fujiStatusMessage: 'F-UJI health check failed with status 500.',
+                })}
+            />
+        );
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: 'Check Resources' }));
+        });
+
+        expect(mockAxiosPost).toHaveBeenCalledWith('/assessment/check-resources');
+        expect(mockToast.error).toHaveBeenCalledWith('F-UJI is currently unavailable. Please try again shortly.');
     });
 });


### PR DESCRIPTION
This pull request improves the reliability and user experience of the F-UJI assessment integration by standardizing error handling, enhancing logging, and making the system more resilient to temporary service outages. The changes ensure that users receive consistent, user-friendly messages when F-UJI is unavailable, while also adding robust logging for operational insight. Additionally, Docker Compose configurations are updated to use health checks for service dependencies, further increasing system stability.

**Backend: Improved Error Handling & Logging**

* Standardized the error message for F-UJI unavailability across all backend responses and replaced technical error details with a user-friendly message (`F-UJI is currently unavailable. Please try again shortly.`). [[1]](diffhunk://#diff-0da954e8b5e0be1e2f4e2dca1eff26fa8ad18f78aa3a5a5ae4eee77eb1112dd5R48-R69) [[2]](diffhunk://#diff-0da954e8b5e0be1e2f4e2dca1eff26fa8ad18f78aa3a5a5ae4eee77eb1112dd5R88-R115) [[3]](diffhunk://#diff-0da954e8b5e0be1e2f4e2dca1eff26fa8ad18f78aa3a5a5ae4eee77eb1112dd5R124-R128)
* Introduced detailed logging for transport failures, unsuccessful responses, and invalid payloads in `FujiAssessmentService`, with deduplication to avoid log spam.
* Added a constant for the unavailability message and a mechanism to track logged error fingerprints in `FujiAssessmentService`.

**Frontend: Consistent User Feedback**

* Updated the assessment page to use the new F-UJI unavailability message in all error toasts and button states, ensuring users are not blocked from attempting assessments if F-UJI is temporarily unhealthy. [[1]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961R34-R35) [[2]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L125-R127) [[3]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L224-R226) [[4]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L270-R272) [[5]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L297-R299) [[6]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L339-R341) [[7]](diffhunk://#diff-571105ae675d1e22a10b0c78c1e22846dc3808928c9358a318b2c4a47f230961L356-R358)
* Revised documentation and UI hints to clarify that temporary F-UJI outages do not prevent assessment attempts; the backend will always re-validate availability before processing.

**Infrastructure: Docker Compose Health Checks**

* Added health checks for `db` and `redis` services in both production and staging Docker Compose files, and updated `depends_on` to wait for healthy services before starting dependent containers. [[1]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L15-R18) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R117-R122) [[3]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R132-R137) [[4]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L159-R177) [[5]](diffhunk://#diff-d8396a664b141a2a235d5b7a53e228a431bd976c8940879a6667742f3cfe09a3L15-R18) [[6]](diffhunk://#diff-d8396a664b141a2a235d5b7a53e228a431bd976c8940879a6667742f3cfe09a3R117-R122) [[7]](diffhunk://#diff-d8396a664b141a2a235d5b7a53e228a431bd976c8940879a6667742f3cfe09a3R132-R137) [[8]](diffhunk://#diff-d8396a664b141a2a235d5b7a53e228a431bd976c8940879a6667742f3cfe09a3L231-R249)

**Testing: Enhanced Coverage**

* Added and updated feature tests to validate the new F-UJI unavailability behavior and messaging, ensuring both frontend and backend handle outages gracefully. [[1]](diffhunk://#diff-4110826745ce91b966e44bb24513184e738fca5f69bda72528a473cefe942ce1R51-R76) [[2]](diffhunk://#diff-4110826745ce91b966e44bb24513184e738fca5f69bda72528a473cefe942ce1L207-R241)