### PR TITLE
Feature: Better DOI UI labels and datacenter layout

### DIFF
--- a/database/seeders/PlaywrightTestSeeder.php
+++ b/database/seeders/PlaywrightTestSeeder.php
@@ -3,9 +3,11 @@
 namespace Database\Seeders;
 
 use App\Enums\UserRole;
+use App\Models\Description;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\ResourceCreator;
+use App\Models\Right;
 use App\Models\Title;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -211,6 +213,8 @@ class PlaywrightTestSeeder extends Seeder
             ]
         );
 
+        $this->ensureCompleteFixture($publishedResource);
+
         // 2) Review resource (shown with "Review" status)
         // Backend semantics: review requires BOTH DOI + landing page (is_published=false).
         // Prefer upgrading any legacy fixture with title "Playwright: Review Resource" into the canonical review fixture.
@@ -263,23 +267,30 @@ class PlaywrightTestSeeder extends Seeder
             ]
         );
 
+        $this->ensureCompleteFixture($reviewResource);
+
         // 3) Curation resource WITHOUT landing page (for "landing page required" negative cases)
         $noLandingPageTitle = Title::query()->where('value', 'Playwright: Curation Resource (no landing page)')->first();
-        if (! $noLandingPageTitle) {
-            $resource = Resource::factory()->create(array_merge($resourceAttributes, ['doi' => null]));
+        $noLandingPageResource = $noLandingPageTitle?->resource;
+        if (! $noLandingPageResource) {
+            $noLandingPageResource = Resource::factory()->create(array_merge($resourceAttributes, ['doi' => null]));
             Title::factory()->create([
-                'resource_id' => $resource->id,
+                'resource_id' => $noLandingPageResource->id,
                 'value' => 'Playwright: Curation Resource (no landing page)',
             ]);
             ResourceCreator::factory()->create([
-                'resource_id' => $resource->id,
+                'resource_id' => $noLandingPageResource->id,
                 'position' => 1,
             ]);
         }
 
+        $this->ensureCompleteFixture($noLandingPageResource);
+
         // 4) Curation resource WITH landing page but WITHOUT DOI (used for DOI registration modal tests)
         // Keep this last so it appears first in the /resources list (default sort: updated_at desc).
         $curationLandingPage = LandingPage::query()->where('slug', 'playwright-curation')->first();
+        $curationResource = $curationLandingPage?->resource;
+
         if (! $curationLandingPage) {
             $curationResource = Resource::factory()->create(array_merge($resourceAttributes, ['doi' => null]));
 
@@ -305,6 +316,30 @@ class PlaywrightTestSeeder extends Seeder
             ]);
         }
 
+        if ($curationResource instanceof Resource) {
+            $this->ensureCompleteFixture($curationResource);
+        }
+
         $this->command->info('Playwright E2E resources ensured successfully!');
+    }
+
+    private function ensureCompleteFixture(Resource $resource): void
+    {
+        if (! $resource->rights()->exists()) {
+            $license = Right::query()->where('identifier', 'CC-BY-4.0')->first()
+                ?? Right::factory()->ccBy4()->create();
+
+            $resource->rights()->syncWithoutDetaching([$license->id]);
+        }
+
+        $hasAbstract = $resource->descriptions()
+            ->whereHas('descriptionType', fn ($query) => $query->where('slug', 'Abstract'))
+            ->exists();
+
+        if (! $hasAbstract) {
+            Description::factory()->abstract()->create([
+                'resource_id' => $resource->id,
+            ]);
+        }
     }
 }

--- a/database/seeders/PlaywrightTestSeeder.php
+++ b/database/seeders/PlaywrightTestSeeder.php
@@ -334,6 +334,7 @@ class PlaywrightTestSeeder extends Seeder
 
         $hasAbstract = $resource->descriptions()
             ->whereHas('descriptionType', fn ($query) => $query->where('slug', 'Abstract'))
+            ->whereRaw("TRIM(COALESCE(value, '')) != ''")
             ->exists();
 
         if (! $hasAbstract) {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,18 +1,12 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-13",
+        "date": "2026-05-12",
         "features": [
             {
                 "title": "Single DOI Import for GFZ Legacy Resources",
                 "description": "The Resources page now distinguishes between importing all historical GFZ DataCite records and importing a single old resource. The former action was renamed to 'Import all old Resources'. A new adjacent action, 'Import old single Resource', opens a dialog where admins and group leaders can enter either a bare DOI or a doi.org URL for one dataset. Before the import starts, ERNIE now verifies that the DOI belongs to the GFZ legacy database; already imported resources are detected and skipped without overwriting the existing record."
-            }
-        ]
-    },
-    {
-        "version": "1.0.0",
-        "date": "2026-05-12",
-        "features": [
+            },
             {
                 "title": "Role-Based Guided Tours",
                 "description": "Beginners now receive a guided product tour on the Dashboard after login, covering the main dashboard cards, the sidebar navigation, the upload area, the Resources list, and the IGSN tools. The tour starts only once by default, is tracked per user, and can be reassigned later. Admins and Group Leaders can reopen eligible tours for Beginner and Curator accounts directly on the /users page via a new Assign Tours dialog. Newly added built-in tours can also be rolled out automatically to eligible users without manual data seeding."
@@ -99,6 +93,10 @@
             }
         ],
         "improvements": [
+            {
+                "title": "Clearer DOI Actions and Less Cluttered Metadata Entry",
+                "description": "The Dashboard no longer shows a redundant 'Upload metadata' quick action because the upload dropzone is already available on the same page. On the Resources page, the DataCite action now reads 'Register DOI' for records that are not yet published and only switches to 'Update metadata' for already published DOI records, matching the visible publication state more closely. In the Data Editor, the Datacenter field now takes more horizontal space and selected datacenter badges can wrap cleanly, preventing long names such as 'DEKORP - German Continental Seismic Reflection Program' from overlapping the adjacent Version field."
+            },
             {
                 "title": "Dashboard Action Hub and Refresh-Aware Feedback",
                 "description": "The authenticated workspace now feels more task-driven and easier to read. The Dashboard was redesigned into an action hub with role-aware quick actions, a separate resume-work area for recent drafts, compact overview cards, and an import hub that now stays visible in the first viewport instead of being pushed below large action cards. The authenticated header now shows the current workspace plus live navigation feedback, while sidebar badges use clearer emphasis for key counts and pending assistance. Administrators also get a compact FAIR average summary directly on the Assessment sidebar entry in the format Resources / IGSNs. Core feedback states were also upgraded: the editor bootstrap now uses skeleton placeholders with a retryable error state, the dashboard dropzone shows richer upload progress/success/failure messaging, and the Data Portal keeps current results visible while filters or pagination refresh in the background, including explicit refresh feedback and a one-click clear-filters recovery action when no matches remain."

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2239,7 +2239,7 @@ export default function DataCiteForm({
                                     setSelectedDatacenters(ids);
                                     setDatacenterTouched(true);
                                 }}
-                                className="md:col-span-2"
+                                className="min-w-0 md:col-span-3"
                                 required
                                 hasError={datacenterTouched && selectedDatacenters.length === 0}
                             />
@@ -2253,7 +2253,7 @@ export default function DataCiteForm({
                                 touched={getFieldState('version').touched}
                                 placeholder="1.0"
                                 labelTooltip="Semantic versioning (e.g., 1.2.3)"
-                                className="md:col-span-1"
+                                className="min-w-0 md:col-span-1"
                             />
                             <SelectField
                                 id="language"

--- a/resources/js/components/curation/fields/datacenter-field.tsx
+++ b/resources/js/components/curation/fields/datacenter-field.tsx
@@ -38,20 +38,20 @@ export function DatacenterField({ id, label, options, selected, onChange, classN
     };
 
     return (
-        <div className={cn('flex flex-col gap-2', className)}>
+        <div className={cn('flex min-w-0 flex-col gap-2', className)}>
             <Label htmlFor={id}>
                 {label}
                 {required && <span className="text-destructive ml-1">*</span>}
             </Label>
             {selectedOptions.length > 0 && (
-                <div className="flex flex-wrap gap-1">
+                <div className="flex min-w-0 flex-wrap gap-1">
                     {selectedOptions.map((option) => (
-                        <Badge key={option.id} variant="secondary" className="gap-1 pr-1 text-xs">
+                        <Badge key={option.id} variant="secondary" className="h-auto max-w-full items-start gap-1 whitespace-normal break-words pr-1 text-left text-xs">
                             {option.name}
                             <button
                                 type="button"
                                 aria-label={`Remove datacenter "${option.name}"`}
-                                className="text-muted-foreground hover:text-foreground rounded-sm"
+                                className="text-muted-foreground hover:text-foreground shrink-0 rounded-sm"
                                 onClick={() => onChange(selected.filter((sid) => sid !== option.id))}
                             >
                                 <X className="h-3 w-3" />
@@ -70,10 +70,10 @@ export function DatacenterField({ id, label, options, selected, onChange, classN
                         aria-expanded={open}
                         aria-required={required}
                         aria-invalid={hasError}
-                        className={cn('h-auto min-h-9 w-full justify-between font-normal', hasError && 'border-destructive')}
+                        className={cn('h-auto min-h-9 w-full min-w-0 justify-between font-normal', hasError && 'border-destructive')}
                         data-testid="datacenter-select"
                     >
-                        <span className="text-muted-foreground">
+                        <span className="min-w-0 flex-1 text-left text-muted-foreground">
                             {selectedOptions.length > 0
                                 ? `${selectedOptions.length} datacenter${selectedOptions.length > 1 ? 's' : ''} selected`
                                 : 'Select datacenters...'}

--- a/resources/js/components/curation/fields/datacenter-field.tsx
+++ b/resources/js/components/curation/fields/datacenter-field.tsx
@@ -46,16 +46,18 @@ export function DatacenterField({ id, label, options, selected, onChange, classN
             {selectedOptions.length > 0 && (
                 <div className="flex min-w-0 flex-wrap gap-1">
                     {selectedOptions.map((option) => (
-                        <Badge key={option.id} variant="secondary" className="h-auto max-w-full items-start gap-1 whitespace-normal break-words pr-1 text-left text-xs">
+                        <Badge key={option.id} variant="secondary" className="h-auto max-w-full items-start gap-1 whitespace-normal pr-1 text-left text-xs wrap-break-word">
                             {option.name}
-                            <button
+                            <Button
                                 type="button"
+                                variant="ghost"
+                                size="icon-xs"
                                 aria-label={`Remove datacenter "${option.name}"`}
-                                className="text-muted-foreground hover:text-foreground shrink-0 rounded-sm"
+                                className="size-4 shrink-0 rounded-sm p-0 text-muted-foreground hover:text-foreground"
                                 onClick={() => onChange(selected.filter((sid) => sid !== option.id))}
                             >
                                 <X className="h-3 w-3" />
-                            </button>
+                            </Button>
                         </Badge>
                     ))}
                 </div>

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -12,19 +12,7 @@ import { Label } from '@/components/ui/label';
 import { LoadingButton } from '@/components/ui/loading-button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { type User as AuthUser } from '@/types';
-
-interface Resource {
-    id: number;
-    doi?: string | null;
-    publicstatus?: string;
-    title?: string;
-    landingPage?: {
-        id: number;
-        is_published: boolean;
-        public_url: string;
-    } | null;
-    [key: string]: unknown;
-}
+import { type ResourceDoiActionItem as Resource,shouldUseUpdateMetadataLabel } from '@/types/resources';
 
 interface RegisterDoiModalProps {
     resource: Resource;
@@ -138,8 +126,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
     const [orcidWarnings, setOrcidWarnings] = useState<OrcidPreflightIssue[]>([]);
 
     const hasExistingDoi = Boolean(resource.doi);
-    const shouldUseUpdateLabel = hasExistingDoi
-        && (resource.publicstatus === 'published' || resource.landingPage?.is_published === true);
+    const shouldUseUpdateLabel = shouldUseUpdateMetadataLabel(resource);
     const hasLandingPage = Boolean(resource.landingPage);
     const isBeginner = auth.user?.role === 'beginner';
     const primaryActionLabel = shouldUseUpdateLabel ? 'Update metadata' : 'Register DOI';

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -138,15 +138,16 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
     const [orcidWarnings, setOrcidWarnings] = useState<OrcidPreflightIssue[]>([]);
 
     const hasExistingDoi = Boolean(resource.doi);
-        const shouldUseUpdateLabel = hasExistingDoi && (resource.publicstatus === 'published' || resource.landingPage?.status === 'published');
+    const shouldUseUpdateLabel = hasExistingDoi
+        && (resource.publicstatus === 'published' || resource.landingPage?.status === 'published');
     const hasLandingPage = Boolean(resource.landingPage);
     const isBeginner = auth.user?.role === 'beginner';
-        const primaryActionLabel = shouldUseUpdateLabel ? 'Update metadata' : 'Register DOI';
-        const existingDoiDescription = shouldUseUpdateLabel
-                ? `Update metadata for registered DOI: ${resource.doi}`
-                : hasExistingDoi
-                    ? `This resource already has DOI ${resource.doi}. Continue to sync the record with DataCite.`
-                    : 'Register a new DOI for this resource with DataCite.';
+    const primaryActionLabel = shouldUseUpdateLabel ? 'Update metadata' : 'Register DOI';
+    const existingDoiDescription = shouldUseUpdateLabel
+        ? `Update metadata for registered DOI: ${resource.doi}`
+        : hasExistingDoi
+            ? `This resource already has DOI ${resource.doi}. Continue to sync the record with DataCite.`
+            : 'Register a new DOI for this resource with DataCite.';
 
     // Load available prefixes from backend config
     useEffect(() => {

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -20,7 +20,7 @@ interface Resource {
     title?: string;
     landingPage?: {
         id: number;
-        status: string;
+        is_published: boolean;
         public_url: string;
     } | null;
     [key: string]: unknown;
@@ -139,7 +139,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
 
     const hasExistingDoi = Boolean(resource.doi);
     const shouldUseUpdateLabel = hasExistingDoi
-        && (resource.publicstatus === 'published' || resource.landingPage?.status === 'published');
+        && (resource.publicstatus === 'published' || resource.landingPage?.is_published === true);
     const hasLandingPage = Boolean(resource.landingPage);
     const isBeginner = auth.user?.role === 'beginner';
     const primaryActionLabel = shouldUseUpdateLabel ? 'Update metadata' : 'Register DOI';

--- a/resources/js/components/resources/modals/RegisterDoiModal.tsx
+++ b/resources/js/components/resources/modals/RegisterDoiModal.tsx
@@ -16,6 +16,7 @@ import { type User as AuthUser } from '@/types';
 interface Resource {
     id: number;
     doi?: string | null;
+    publicstatus?: string;
     title?: string;
     landingPage?: {
         id: number;
@@ -137,8 +138,15 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
     const [orcidWarnings, setOrcidWarnings] = useState<OrcidPreflightIssue[]>([]);
 
     const hasExistingDoi = Boolean(resource.doi);
+        const shouldUseUpdateLabel = hasExistingDoi && (resource.publicstatus === 'published' || resource.landingPage?.status === 'published');
     const hasLandingPage = Boolean(resource.landingPage);
     const isBeginner = auth.user?.role === 'beginner';
+        const primaryActionLabel = shouldUseUpdateLabel ? 'Update metadata' : 'Register DOI';
+        const existingDoiDescription = shouldUseUpdateLabel
+                ? `Update metadata for registered DOI: ${resource.doi}`
+                : hasExistingDoi
+                    ? `This resource already has DOI ${resource.doi}. Continue to sync the record with DataCite.`
+                    : 'Register a new DOI for this resource with DataCite.';
 
     // Load available prefixes from backend config
     useEffect(() => {
@@ -296,11 +304,9 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
                         <DataCiteIcon className="size-5" />
-                        {hasExistingDoi ? 'Update DOI Metadata' : 'Register DOI with DataCite'}
+                        {primaryActionLabel}
                     </DialogTitle>
-                    <DialogDescription>
-                        {hasExistingDoi ? `Update metadata for existing DOI: ${resource.doi}` : 'Register a new DOI for this resource with DataCite.'}
-                    </DialogDescription>
+                    <DialogDescription>{existingDoiDescription}</DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4 py-4">
@@ -347,7 +353,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                             <AlertDescription>
                                 This resource already has a DOI: <strong>{resource.doi}</strong>
                                 <br />
-                                Submitting will update the metadata at DataCite.
+                                {shouldUseUpdateLabel ? 'Submitting will update the metadata at DataCite.' : 'Submitting will sync this DOI record with DataCite.'}
                             </AlertDescription>
                         </Alert>
                     )}
@@ -476,7 +482,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                 disabled={isSubmitting || !hasLandingPage || (!hasExistingDoi && !selectedPrefix) || isLoadingConfig}
                                 data-testid="orcid-preflight-override"
                             >
-                                {hasExistingDoi ? 'Update anyway' : 'Register anyway'}
+                                {shouldUseUpdateLabel ? 'Update anyway' : 'Register anyway'}
                             </LoadingButton>
                         </>
                     ) : (
@@ -491,7 +497,7 @@ export default function RegisterDoiModal({ resource, isOpen, onClose, onSuccess 
                                 orcidBlockers.length > 0
                             }
                         >
-                            {hasExistingDoi ? 'Update Metadata' : 'Register DOI'}
+                            {primaryActionLabel}
                         </LoadingButton>
                     )}
                 </DialogFooter>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -8,7 +8,6 @@ import {
     type LucideIcon,
     Settings,
     Sparkles,
-    Upload,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -228,7 +227,6 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
     const [unicorns, setUnicorns] = useState<Array<{ id: number; x: number; y: number; size: number; rotation: number }>>([]);
     const [showConfetti, setShowConfetti] = useState(false);
     const easterEggTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const uploadSectionRef = useRef<HTMLDivElement | null>(null);
     const hoverCountRef = useRef(0);
     const lastHoveredCardRef = useRef<'welcome' | 'environment' | null>(null);
     const unicornIdCounterRef = useRef(0);
@@ -237,10 +235,6 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
     const igsnCountDisplay = typeof igsnCount === 'number' ? igsnCount : 0;
     const dataInstitutions = typeof dataInstitutionCount === 'number' ? dataInstitutionCount : 0;
     const igsnInstitutions = typeof igsnInstitutionCount === 'number' ? igsnInstitutionCount : 0;
-
-    const handleJumpToUpload = useCallback(() => {
-        uploadSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, []);
 
     const recentDraftHref = recentDrafts?.[0] ? editorRoute({ query: { resourceId: recentDrafts[0].id } }).url : '/resources';
 
@@ -261,12 +255,6 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
                         : 'Open the resource list to review published and draft records.',
                 href: recentDraftHref,
                 icon: FolderClock,
-            },
-            {
-                title: 'Upload metadata',
-                description: 'Import XML, JSON, JSON-LD, or IGSN CSV from one place.',
-                icon: Upload,
-                onClick: handleJumpToUpload,
             },
             {
                 title: 'Open IGSNs',
@@ -305,7 +293,7 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
         }
 
         return actions;
-    }, [auth.user, draftCount, handleJumpToUpload, recentDraftHref]);
+    }, [auth.user, draftCount, recentDraftHref]);
 
     // Easter Egg: Reset everything
     const resetEasterEgg = useCallback(() => {
@@ -518,7 +506,7 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
                     </div>
 
                     <div className="grid gap-4" data-testid="dashboard-side-column">
-                        <Card ref={uploadSectionRef} id="dashboard-upload-panel" data-testid="dashboard-upload-card" className="border-primary/10" data-tour="dashboard-upload">
+                        <Card id="dashboard-upload-panel" data-testid="dashboard-upload-card" className="border-primary/10" data-tour="dashboard-upload">
                             <CardHeader className="items-center text-center">
                                 <Badge variant="secondary" className="rounded-full px-3 py-1 text-xs uppercase tracking-[0.16em]">
                                     Import hub

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1524,7 +1524,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             Note: Opening an existing resource in the editor no longer triggers ORCID
                             validation for stored authors. The network check only runs when you actively edit
                             an ORCID / name field or when you press <strong>Register DOI</strong> or{' '}
-                            <strong>Update Metadata</strong>.
+                            <strong>Update metadata</strong>.
                         </p>
 
                         <h4>Test vs Production</h4>

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1482,10 +1482,8 @@ function ResourcesPage({
                                                                             variant="ghost"
                                                                             size="icon"
                                                                             onClick={() => handleRegisterDoi(resource)}
-                                                                            aria-label={`Register DOI for resource ${resourceLabel}`}
-                                                                            title={
-                                                                                resource.doi ? 'Update DOI metadata' : 'Register DOI with DataCite'
-                                                                            }
+                                                                            aria-label={`${resource.publicstatus === 'published' ? 'Update metadata' : 'Register DOI'} for resource ${resourceLabel}`}
+                                                                            title={resource.publicstatus === 'published' ? 'Update metadata' : 'Register DOI'}
                                                                             data-testid="datacite-button"
                                                                         >
                                                                             <DataCiteIcon

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -28,44 +28,17 @@ import { useCitationVocabularies } from '@/hooks/use-citation-vocabularies';
 import AppLayout from '@/layouts/app-layout';
 import { extractErrorMessageFromBlob, parseValidationErrorFromBlob } from '@/lib/blob-utils';
 import { editor as editorRoute } from '@/routes';
-import { type BreadcrumbItem,type User as AuthUser } from '@/types';
+import { type BreadcrumbItem, type User as AuthUser } from '@/types';
 import {
     type ResourceFilterOptions,
     type ResourceFilterState,
+    type ResourceListItem as Resource,
     type ResourceSortDirection,
     type ResourceSortKey,
     type ResourceSortState,
+    shouldUseUpdateMetadataLabel,
 } from '@/types/resources';
 import { parseResourceFiltersFromUrl } from '@/utils/filter-parser';
-
-interface Author {
-    givenName?: string | null;
-    familyName?: string | null;
-    name?: string;
-}
-
-interface LandingPage {
-    id: number;
-    status: string;
-    public_url: string;
-}
-
-interface Resource {
-    id: number;
-    doi?: string | null;
-    year: number;
-    version?: string | null;
-    created_at?: string;
-    updated_at?: string;
-    curator?: string;
-    publicstatus?: string;
-    resourcetypegeneral?: string;
-    title?: string;
-    first_author?: Author | null;
-    landingPage?: LandingPage | null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
-}
 
 interface PaginationInfo {
     current_page: number;
@@ -1482,8 +1455,8 @@ function ResourcesPage({
                                                                             variant="ghost"
                                                                             size="icon"
                                                                             onClick={() => handleRegisterDoi(resource)}
-                                                                            aria-label={`${resource.publicstatus === 'published' ? 'Update metadata' : 'Register DOI'} for resource ${resourceLabel}`}
-                                                                            title={resource.publicstatus === 'published' ? 'Update metadata' : 'Register DOI'}
+                                                                            aria-label={`${shouldUseUpdateMetadataLabel(resource) ? 'Update metadata' : 'Register DOI'} for resource ${resourceLabel}`}
+                                                                            title={shouldUseUpdateMetadataLabel(resource) ? 'Update metadata' : 'Register DOI'}
                                                                             data-testid="datacite-button"
                                                                         >
                                                                             <DataCiteIcon

--- a/resources/js/types/resources.ts
+++ b/resources/js/types/resources.ts
@@ -50,3 +50,41 @@ export interface ResourceFilterOptions {
     };
     statuses: string[];
 }
+
+export interface ResourceListAuthor {
+    givenName?: string | null;
+    familyName?: string | null;
+    name?: string;
+}
+
+export interface ResourceListLandingPage {
+    id: number;
+    is_published: boolean;
+    public_url: string;
+}
+
+export interface ResourceListItem {
+    id: number;
+    doi?: string | null;
+    year: number;
+    version?: string | null;
+    created_at?: string;
+    updated_at?: string;
+    curator?: string;
+    publicstatus?: string;
+    resourcetypegeneral?: string;
+    title?: string;
+    first_author?: ResourceListAuthor | null;
+    landingPage?: ResourceListLandingPage | null;
+    [key: string]: unknown;
+}
+
+export interface ResourceDoiActionItem extends Pick<ResourceListItem, 'id' | 'doi' | 'publicstatus' | 'title' | 'landingPage'> {
+    [key: string]: unknown;
+}
+
+export function shouldUseUpdateMetadataLabel(resource: Pick<ResourceListItem, 'doi' | 'publicstatus' | 'landingPage'>): boolean {
+    const hasExistingDoi = Boolean(resource.doi);
+
+    return hasExistingDoi && (resource.publicstatus === 'published' || resource.landingPage?.is_published === true);
+}

--- a/tests/pest/Feature/PlaywrightTestSeederTest.php
+++ b/tests/pest/Feature/PlaywrightTestSeederTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Enums\UserRole;
+use App\Models\Description;
+use App\Models\DescriptionType;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\ResourceCreator;
@@ -189,4 +191,42 @@ it('repairs legacy and incomplete Playwright fixtures idempotently', function ()
         ])->count())->toBe(3)
         ->and(Resource::query()->where('doi', PLAYWRIGHT_PUBLISHED_DOI)->count())->toBe(1)
         ->and(Resource::query()->where('doi', PLAYWRIGHT_REVIEW_DOI)->count())->toBe(1);
+});
+
+it('replaces blank abstract fixtures with a non-empty abstract', function (): void {
+    $abstractType = DescriptionType::query()->firstOrCreate(
+        ['slug' => 'Abstract'],
+        ['name' => 'Abstract', 'is_active' => true, 'is_elmo_active' => true],
+    );
+
+    $resource = Resource::factory()->withDoi(PLAYWRIGHT_PUBLISHED_DOI)->create();
+    Title::factory()->create([
+        'resource_id' => $resource->id,
+        'value' => 'Playwright: Published Resource',
+    ]);
+    ResourceCreator::factory()->create([
+        'resource_id' => $resource->id,
+        'position' => 1,
+    ]);
+    LandingPage::create([
+        'resource_id' => $resource->id,
+        'slug' => 'playwright-published',
+        'template' => 'default_gfz',
+        'is_published' => true,
+        'published_at' => now(),
+        'doi_prefix' => 'stale-prefix',
+    ]);
+    Description::query()->create([
+        'resource_id' => $resource->id,
+        'description_type_id' => $abstractType->id,
+        'value' => '   ',
+    ]);
+
+    test()->seed(PlaywrightTestSeeder::class);
+
+    $reloaded = loadPlaywrightResourceByDoi(PLAYWRIGHT_PUBLISHED_DOI);
+
+    expect($reloaded->descriptions->contains(fn ($description) => $description->isAbstract() && trim((string) $description->value) !== ''))
+        ->toBeTrue()
+        ->and($reloaded->isComplete())->toBeTrue();
 });

--- a/tests/pest/Feature/PlaywrightTestSeederTest.php
+++ b/tests/pest/Feature/PlaywrightTestSeederTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Models\LandingPage;
+use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\Title;
+use App\Models\User;
+use Database\Seeders\PlaywrightTestSeeder;
+use Illuminate\Support\Str;
+
+uses()->group('seeders', 'playwright');
+
+const PLAYWRIGHT_PUBLISHED_DOI = '10.1234/playwright-published';
+const PLAYWRIGHT_REVIEW_DOI = '10.1234/playwright-qa';
+const PLAYWRIGHT_LEGACY_REVIEW_DOI = '10.1234/playwright-review';
+
+function loadPlaywrightResourceByDoi(string $doi): Resource
+{
+    /** @var Resource $resource */
+    $resource = Resource::query()
+        ->with(['titles.titleType', 'creators.creatorable', 'rights', 'descriptions.descriptionType', 'landingPage'])
+        ->where('doi', $doi)
+        ->firstOrFail();
+
+    return $resource;
+}
+
+function loadPlaywrightResourceByTitle(string $title): Resource
+{
+    /** @var Resource $resource */
+    $resource = Resource::query()
+        ->with(['titles.titleType', 'creators.creatorable', 'rights', 'descriptions.descriptionType', 'landingPage'])
+        ->whereHas('titles', fn ($query) => $query->where('value', $title))
+        ->firstOrFail();
+
+    return $resource;
+}
+
+function expectPlaywrightFixtureToBeComplete(Resource $resource, string $publicStatus): void
+{
+    expect($resource->isComplete())->toBeTrue()
+        ->and($resource->publicStatus())->toBe($publicStatus)
+        ->and($resource->rights)->toHaveCount(1)
+        ->and(
+            $resource->descriptions->contains(
+                fn ($description) => $description->isAbstract() && trim((string) $description->value) !== ''
+            )
+        )->toBeTrue();
+}
+
+it('seeds complete Playwright fixtures with the expected public statuses', function (): void {
+    test()->seed(PlaywrightTestSeeder::class);
+
+    $testUser = User::query()->where('email', 'test@example.com')->firstOrFail();
+    $adminUser = User::query()->where('email', 'admin@example.com')->firstOrFail();
+    $groupLeader = User::query()->where('email', 'groupleader@example.com')->firstOrFail();
+    $curator = User::query()->where('email', 'curator@example.com')->firstOrFail();
+    $beginner = User::query()->where('email', 'beginner@example.com')->firstOrFail();
+
+    expect($testUser->role)->toBe(UserRole::ADMIN)
+        ->and($adminUser->role)->toBe(UserRole::ADMIN)
+        ->and($groupLeader->role)->toBe(UserRole::GROUP_LEADER)
+        ->and($curator->role)->toBe(UserRole::CURATOR)
+        ->and($beginner->role)->toBe(UserRole::BEGINNER);
+
+    $published = loadPlaywrightResourceByDoi(PLAYWRIGHT_PUBLISHED_DOI);
+    $review = loadPlaywrightResourceByDoi(PLAYWRIGHT_REVIEW_DOI);
+    $noLandingPage = loadPlaywrightResourceByTitle('Playwright: Curation Resource (no landing page)');
+    $curation = loadPlaywrightResourceByTitle('Playwright: Curation Resource (no DOI)');
+
+    expectPlaywrightFixtureToBeComplete($published, 'published');
+    expectPlaywrightFixtureToBeComplete($review, 'review');
+    expectPlaywrightFixtureToBeComplete($noLandingPage, 'curation');
+    expectPlaywrightFixtureToBeComplete($curation, 'curation');
+
+    expect($published->landingPage?->slug)->toBe('playwright-published')
+        ->and($published->landingPage?->is_published)->toBeTrue()
+        ->and($review->landingPage?->slug)->toBe('playwright-review')
+        ->and($review->landingPage?->is_published)->toBeFalse()
+        ->and($noLandingPage->landingPage)->toBeNull()
+        ->and($curation->landingPage?->slug)->toBe('playwright-curation')
+        ->and($curation->doi)->toBeNull()
+        ->and(Resource::query()->where('doi', 'like', '10.5880/testdata.%')->exists())->toBeTrue();
+});
+
+it('repairs legacy and incomplete Playwright fixtures idempotently', function (): void {
+    $published = Resource::factory()->withDoi(PLAYWRIGHT_PUBLISHED_DOI)->create();
+    Title::factory()->create([
+        'resource_id' => $published->id,
+        'value' => 'Playwright: Published Resource',
+    ]);
+    ResourceCreator::factory()->create([
+        'resource_id' => $published->id,
+        'position' => 1,
+    ]);
+    LandingPage::create([
+        'resource_id' => $published->id,
+        'slug' => 'playwright-published',
+        'template' => 'default_gfz',
+        'is_published' => true,
+        'published_at' => now(),
+        'doi_prefix' => 'stale-prefix',
+    ]);
+
+    $legacyReview = Resource::factory()->withDoi(PLAYWRIGHT_LEGACY_REVIEW_DOI)->create();
+    Title::factory()->create([
+        'resource_id' => $legacyReview->id,
+        'value' => 'Playwright: Review Resource',
+    ]);
+    ResourceCreator::factory()->create([
+        'resource_id' => $legacyReview->id,
+        'position' => 1,
+    ]);
+    LandingPage::create([
+        'resource_id' => $legacyReview->id,
+        'slug' => 'playwright-review',
+        'template' => 'default_gfz',
+        'is_published' => false,
+        'published_at' => null,
+        'preview_token' => Str::random(64),
+    ]);
+
+    $noLandingPage = Resource::factory()->create(['doi' => null]);
+    Title::factory()->create([
+        'resource_id' => $noLandingPage->id,
+        'value' => 'Playwright: Curation Resource (no landing page)',
+    ]);
+    ResourceCreator::factory()->create([
+        'resource_id' => $noLandingPage->id,
+        'position' => 1,
+    ]);
+
+    $curation = Resource::factory()->create(['doi' => null]);
+    Title::factory()->create([
+        'resource_id' => $curation->id,
+        'value' => 'Playwright: Curation Resource (no DOI)',
+    ]);
+    ResourceCreator::factory()->create([
+        'resource_id' => $curation->id,
+        'position' => 1,
+    ]);
+    LandingPage::create([
+        'resource_id' => $curation->id,
+        'slug' => 'playwright-curation',
+        'template' => 'default_gfz',
+        'is_published' => true,
+        'published_at' => now(),
+        'preview_token' => Str::random(64),
+    ]);
+
+    test()->seed(PlaywrightTestSeeder::class);
+    test()->seed(PlaywrightTestSeeder::class);
+
+    $repairedPublished = loadPlaywrightResourceByDoi(PLAYWRIGHT_PUBLISHED_DOI);
+    $repairedReview = loadPlaywrightResourceByDoi(PLAYWRIGHT_REVIEW_DOI);
+    $repairedNoLandingPage = loadPlaywrightResourceByTitle('Playwright: Curation Resource (no landing page)');
+    $repairedCuration = loadPlaywrightResourceByTitle('Playwright: Curation Resource (no DOI)');
+
+    expect($repairedPublished->id)->toBe($published->id)
+        ->and($repairedPublished->landingPage?->doi_prefix)->toBe(PLAYWRIGHT_PUBLISHED_DOI);
+    expectPlaywrightFixtureToBeComplete($repairedPublished, 'published');
+
+    expect($repairedReview->id)->toBe($legacyReview->id)
+        ->and(Resource::query()->where('doi', PLAYWRIGHT_LEGACY_REVIEW_DOI)->exists())->toBeFalse()
+        ->and($repairedReview->titles->contains(fn ($title) => $title->value === 'Playwright: QA Resource'))->toBeTrue();
+    expectPlaywrightFixtureToBeComplete($repairedReview, 'review');
+
+    expect($repairedNoLandingPage->id)->toBe($noLandingPage->id);
+    expectPlaywrightFixtureToBeComplete($repairedNoLandingPage, 'curation');
+
+    expect($repairedCuration->id)->toBe($curation->id)
+        ->and($repairedCuration->landingPage?->slug)->toBe('playwright-curation');
+    expectPlaywrightFixtureToBeComplete($repairedCuration, 'curation');
+
+    expect(User::query()->whereIn('email', [
+        'test@example.com',
+        'admin@example.com',
+        'groupleader@example.com',
+        'curator@example.com',
+        'beginner@example.com',
+    ])->count())->toBe(5)
+        ->and(LandingPage::query()->whereIn('slug', [
+            'playwright-published',
+            'playwright-review',
+            'playwright-curation',
+        ])->count())->toBe(3)
+        ->and(Resource::query()->where('doi', PLAYWRIGHT_PUBLISHED_DOI)->count())->toBe(1)
+        ->and(Resource::query()->where('doi', PLAYWRIGHT_REVIEW_DOI)->count())->toBe(1);
+});

--- a/tests/playwright/workflows/09-doi-registration.spec.ts
+++ b/tests/playwright/workflows/09-doi-registration.spec.ts
@@ -30,8 +30,9 @@ test.describe('DOI Registration Workflow', () => {
         // Wait for table body to have at least one row
         await expect(resourceTable.locator('tbody tr').first()).toBeVisible({ timeout: 10000 });
         
-        // Find the Published resource row (has a DOI badge)
-        const resourceRow = page.locator('tbody tr').filter({ hasText: /Published/ }).first();
+        // Target the deterministic Playwright fixture instead of matching the
+        // word "Published" anywhere in the row text.
+        const resourceRow = page.locator('tbody tr').filter({ hasText: /10\.1234\/playwright-published/ }).first();
         await expect(resourceRow).toBeVisible();
 
         // Click DataCite button - use data-testid for reliable selection
@@ -45,7 +46,7 @@ test.describe('DOI Registration Workflow', () => {
         await expect(dialog).toBeVisible({ timeout: 15000 });
         
         // Wait for modal content to be loaded
-        await expect(page.getByText(/update doi metadata/i)).toBeVisible({ timeout: 5000 });
+        await expect(page.getByRole('heading', { name: /update metadata/i })).toBeVisible({ timeout: 5000 });
 
         // Should show existing DOI (use first() to avoid strict mode violation with 2 matches)
         await expect(page.getByText(/existing doi/i).first()).toBeVisible();

--- a/tests/playwright/workflows/igsn-workflow.spec.ts
+++ b/tests/playwright/workflows/igsn-workflow.spec.ts
@@ -25,6 +25,28 @@ function resolveDatasetExample(filename: string): string {
     return path.resolve(__dirname, '..', '..', 'pest', 'dataset-examples', filename);
 }
 
+async function exportIgsnJsonThroughUi(page: Parameters<typeof test>[0]['page'], exportButton: ReturnType<Parameters<typeof test>[0]['page']['getByRole']>) {
+    const exportResponsePromise = page.waitForResponse(
+        (response) => {
+            const url = new URL(response.url());
+            return response.request().method() === 'GET' && /\/igsns\/\d+\/export\/json$/.test(url.pathname);
+        },
+        { timeout: 30000 },
+    );
+
+    await exportButton.click();
+
+    const exportResponse = await exportResponsePromise;
+    const responseText = await exportResponse.text();
+
+    expect(exportResponse.ok(), `Expected successful IGSN JSON export, got ${exportResponse.status()}: ${responseText}`).toBeTruthy();
+
+    return {
+        exportResponse,
+        jsonData: JSON.parse(responseText),
+    };
+}
+
 // Test data from the CSV files for verification
 const DOVE_CSV_DATA = {
     filename: '20260116_TEST_ICDP5068-DOVE-v2-Parent-Boreholes.csv',
@@ -266,31 +288,15 @@ test.describe('IGSN Workflow', () => {
         const exportButton = row.getByRole('button', { name: 'Export as DataCite JSON' });
         await expect(exportButton).toBeVisible();
 
-        // Step 4: Set up download listener BEFORE clicking
-        const downloadPromise = page.waitForEvent('download', { timeout: 30000 });
+        // Step 4: Export through the UI and validate the HTTP response directly.
+        // The page triggers the download via Axios + Blob URL, which is less stable
+        // to observe via Playwright's browser download event in CI.
+        const { exportResponse, jsonData } = await exportIgsnJsonThroughUi(page, exportButton);
 
-        // Click the export button
-        await exportButton.click();
-
-        // Step 5: Wait for download to complete
-        const download = await downloadPromise;
-        
-        // Verify the download was successful
-        expect(download).toBeTruthy();
-        
-        // Verify filename contains the IGSN
-        const filename = download.suggestedFilename();
-        expect(filename).toContain('.json');
-        expect(filename.toLowerCase()).toContain('igsn');
-
-        // Step 6: Read and validate the downloaded JSON content
-        const downloadPath = await download.path();
-        expect(downloadPath).toBeTruthy();
-        
-        // Read the file content
-        const fs = await import('fs/promises');
-        const jsonContent = await fs.readFile(downloadPath!, 'utf-8');
-        const jsonData = JSON.parse(jsonContent);
+        // Verify filename metadata from the response header
+        const contentDisposition = exportResponse.headers()['content-disposition'];
+        expect(contentDisposition).toContain('.json');
+        expect(contentDisposition?.toLowerCase()).toContain('igsn');
 
         // Verify basic DataCite JSON structure
         expect(jsonData).toHaveProperty('data');
@@ -341,14 +347,7 @@ test.describe('IGSN Workflow', () => {
         const row = page.locator('tr').filter({ has: igsnCell }).first();
         const exportButton = row.getByRole('button', { name: 'Export as DataCite JSON' });
 
-        // Set up listeners for both download (success) and dialog (validation error)
-        const downloadPromise = page.waitForEvent('download', { timeout: 15000 }).catch(() => null);
-        
-        // Click export
-        await exportButton.click();
-
-        // Wait a moment for either download or validation modal
-        await page.waitForTimeout(2000);
+        const { jsonData } = await exportIgsnJsonThroughUi(page, exportButton);
 
         // Check if validation error modal appeared (this would indicate our fix didn't work)
         const validationModal = page.locator('[role="dialog"]').filter({ hasText: /JSON Export Failed/i });
@@ -360,32 +359,21 @@ test.describe('IGSN Workflow', () => {
             throw new Error(`DataCite JSON validation failed! Validation errors detected:\n${errorText}`);
         }
 
-        // Download should have succeeded
-        const download = await downloadPromise;
-        expect(download).toBeTruthy();
-        
-        // Additional verification: read the JSON and check specific fields that were fixed
-        if (download) {
-            const downloadPath = await download.path();
-            const fs = await import('fs/promises');
-            const jsonContent = await fs.readFile(downloadPath!, 'utf-8');
-            const jsonData = JSON.parse(jsonContent);
-            const attributes = jsonData.data.attributes;
+        const attributes = jsonData.data.attributes;
 
-            // Verify contributors have correct contributorType format (PascalCase, no spaces)
-            if (attributes.contributors) {
-                for (const contributor of attributes.contributors) {
-                    expect(contributor.contributorType).toMatch(/^[A-Z][a-zA-Z]+$/);
-                    expect(contributor.contributorType).not.toContain(' ');
-                }
+        // Verify contributors have correct contributorType format (PascalCase, no spaces)
+        if (attributes.contributors) {
+            for (const contributor of attributes.contributors) {
+                expect(contributor.contributorType).toMatch(/^[A-Z][a-zA-Z]+$/);
+                expect(contributor.contributorType).not.toContain(' ');
             }
+        }
 
-            // Verify relatedIdentifiers have correct relationType format (PascalCase, no spaces)
-            if (attributes.relatedIdentifiers) {
-                for (const ri of attributes.relatedIdentifiers) {
-                    expect(ri.relationType).toMatch(/^[A-Z][a-zA-Z]+$/);
-                    expect(ri.relationType).not.toContain(' ');
-                }
+        // Verify relatedIdentifiers have correct relationType format (PascalCase, no spaces)
+        if (attributes.relatedIdentifiers) {
+            for (const ri of attributes.relatedIdentifiers) {
+                expect(ri.relationType).toMatch(/^[A-Z][a-zA-Z]+$/);
+                expect(ri.relationType).not.toContain(' ');
             }
 
             // Verify geoLocations have numeric coordinates (not strings)

--- a/tests/playwright/workflows/igsn-workflow.spec.ts
+++ b/tests/playwright/workflows/igsn-workflow.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -25,7 +25,7 @@ function resolveDatasetExample(filename: string): string {
     return path.resolve(__dirname, '..', '..', 'pest', 'dataset-examples', filename);
 }
 
-async function exportIgsnJsonThroughUi(page: Parameters<typeof test>[0]['page'], exportButton: ReturnType<Parameters<typeof test>[0]['page']['getByRole']>) {
+async function exportIgsnJsonThroughUi(page: Page, exportButton: Locator) {
     const exportResponsePromise = page.waitForResponse(
         (response) => {
             const url = new URL(response.url());

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -514,7 +514,7 @@ describe('DataCiteForm', () => {
         const datacenterBadge = screen.getByText(longDatacenterName).closest('[data-slot="badge"]');
         expect(datacenterBadge).toHaveClass('max-w-full');
         expect(datacenterBadge).toHaveClass('whitespace-normal');
-        expect(datacenterBadge).toHaveClass('break-words');
+        expect(datacenterBadge).toHaveClass('wrap-break-word');
     });
 
     it('announces available author roles for accessible guidance', async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -483,6 +483,40 @@ describe('DataCiteForm', () => {
         ).toHaveLength(1);
     });
 
+    it('gives the datacenter field more grid width and keeps long selected datacenter badges wrapped', () => {
+        const longDatacenterName = 'DEKORP - German Continental Seismic Reflection Program';
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                availableDatacenters={[{ id: 1, name: longDatacenterName }]}
+                initialDatacenters={[1]}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const datacenterField = screen.getByTestId('datacenter-select').parentElement;
+        expect(datacenterField).toHaveClass('min-w-0');
+        expect(datacenterField).toHaveClass('md:col-span-3');
+
+        const versionField = screen.getByLabelText('Version').parentElement;
+        expect(versionField).toHaveClass('min-w-0');
+        expect(versionField).toHaveClass('md:col-span-1');
+
+        const datacenterBadge = screen.getByText(longDatacenterName).closest('[data-slot="badge"]');
+        expect(datacenterBadge).toHaveClass('max-w-full');
+        expect(datacenterBadge).toHaveClass('whitespace-normal');
+        expect(datacenterBadge).toHaveClass('break-words');
+    });
+
     it('announces available author roles for accessible guidance', async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
         render(

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -50,6 +50,7 @@ describe('RegisterDoiModal', () => {
         id: 1,
         title: 'Test Resource',
         doi: null,
+        publicstatus: 'draft',
         landingPage: {
             id: 1,
             status: 'draft',
@@ -60,6 +61,21 @@ describe('RegisterDoiModal', () => {
     const mockResourceWithDoi = {
         ...mockResource,
         doi: '10.83279/existing-doi',
+        publicstatus: 'published',
+        landingPage: {
+            ...mockResource.landingPage,
+            status: 'published',
+        },
+    };
+
+    const mockResourceWithReviewDoi = {
+        ...mockResource,
+        doi: '10.83279/review-doi',
+        publicstatus: 'review',
+        landingPage: {
+            ...mockResource.landingPage,
+            status: 'draft',
+        },
     };
 
     const mockPrefixConfig = {
@@ -87,18 +103,27 @@ describe('RegisterDoiModal', () => {
     it('renders modal with correct title for new DOI registration', async () => {
         render(<RegisterDoiModal {...defaultProps} />);
 
-        expect(screen.getByText('Register DOI with DataCite')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Register DOI' })).toBeInTheDocument();
         await waitFor(() => {
             expect(screen.getByText(/register a new doi/i)).toBeInTheDocument();
         });
     });
 
-    it('renders modal with correct title for DOI update', async () => {
+    it('renders modal with update title only for published DOI records', async () => {
         render(<RegisterDoiModal {...defaultProps} resource={mockResourceWithDoi} />);
 
-        expect(screen.getByText('Update DOI Metadata')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Update metadata' })).toBeInTheDocument();
         await waitFor(() => {
-            expect(screen.getByText(/update metadata for existing doi/i)).toBeInTheDocument();
+            expect(screen.getByText(/update metadata for registered doi/i)).toBeInTheDocument();
+        });
+    });
+
+    it('keeps the register title for review records that already have a DOI', async () => {
+        render(<RegisterDoiModal {...defaultProps} resource={mockResourceWithReviewDoi} />);
+
+        expect(screen.getByRole('heading', { name: 'Register DOI' })).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/continue to sync the record with datacite/i)).toBeInTheDocument();
         });
     });
 
@@ -297,11 +322,19 @@ describe('RegisterDoiModal', () => {
         });
     });
 
-    it('changes button text to "Update Metadata" for existing DOI', async () => {
+    it('changes button text to "Update metadata" for published DOI records', async () => {
         render(<RegisterDoiModal {...defaultProps} resource={mockResourceWithDoi} />);
 
         await waitFor(() => {
             expect(screen.getByRole('button', { name: /update metadata/i })).toBeInTheDocument();
+        });
+    });
+
+    it('keeps the button text at "Register DOI" for review DOI records', async () => {
+        render(<RegisterDoiModal {...defaultProps} resource={mockResourceWithReviewDoi} />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /register doi/i })).toBeInTheDocument();
         });
     });
 
@@ -509,7 +542,7 @@ describe('RegisterDoiModal', () => {
             });
         });
 
-        it('labels the override button "Update anyway" when the resource already has a DOI', async () => {
+        it('labels the override button "Update anyway" for published DOI records', async () => {
             const user = userEvent.setup();
 
             mockPost.mockRejectedValueOnce(
@@ -541,6 +574,40 @@ describe('RegisterDoiModal', () => {
             const overrideButton = await screen.findByTestId('orcid-preflight-override');
             expect(overrideButton).toHaveTextContent(/update anyway/i);
             expect(overrideButton).not.toHaveTextContent(/register anyway/i);
+        });
+
+        it('keeps the override button as "Register anyway" for review DOI records', async () => {
+            const user = userEvent.setup();
+
+            mockPost.mockRejectedValueOnce(
+                makeAxiosError(409, {
+                    error: 'orcid_validation_warning',
+                    message: 'ORCID service unavailable',
+                    invalid: [],
+                    warnings: [
+                        {
+                            severity: 'warning',
+                            reason: 'timeout',
+                            role: 'creator',
+                            position: 0,
+                            orcid: '0000-0002-3333-4444',
+                            displayName: 'Alex Creator',
+                        },
+                    ],
+                }),
+            );
+
+            render(<RegisterDoiModal {...defaultProps} resource={mockResourceWithReviewDoi} />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /register doi/i })).not.toBeDisabled();
+            });
+
+            await user.click(screen.getByRole('button', { name: /register doi/i }));
+
+            const overrideButton = await screen.findByTestId('orcid-preflight-override');
+            expect(overrideButton).toHaveTextContent(/register anyway/i);
+            expect(overrideButton).not.toHaveTextContent(/update anyway/i);
         });
 
         it('renders plural identifier count when multiple ORCIDs are invalid', async () => {

--- a/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
+++ b/tests/vitest/components/resources/modals/RegisterDoiModal.test.tsx
@@ -53,7 +53,7 @@ describe('RegisterDoiModal', () => {
         publicstatus: 'draft',
         landingPage: {
             id: 1,
-            status: 'draft',
+            is_published: false,
             public_url: 'https://example.com/preview/123',
         },
     };
@@ -64,7 +64,7 @@ describe('RegisterDoiModal', () => {
         publicstatus: 'published',
         landingPage: {
             ...mockResource.landingPage,
-            status: 'published',
+            is_published: true,
         },
     };
 
@@ -74,7 +74,17 @@ describe('RegisterDoiModal', () => {
         publicstatus: 'review',
         landingPage: {
             ...mockResource.landingPage,
-            status: 'draft',
+            is_published: false,
+        },
+    };
+
+    const mockDraftStatusResourceWithPublishedLandingPage = {
+        ...mockResource,
+        doi: '10.83279/published-landing-page-doi',
+        publicstatus: 'draft',
+        landingPage: {
+            ...mockResource.landingPage,
+            is_published: true,
         },
     };
 
@@ -124,6 +134,15 @@ describe('RegisterDoiModal', () => {
         expect(screen.getByRole('heading', { name: 'Register DOI' })).toBeInTheDocument();
         await waitFor(() => {
             expect(screen.getByText(/continue to sync the record with datacite/i)).toBeInTheDocument();
+        });
+    });
+
+    it('uses the published landing page flag when the resource status is not published', async () => {
+        render(<RegisterDoiModal {...defaultProps} resource={mockDraftStatusResourceWithPublishedLandingPage} />);
+
+        expect(screen.getByRole('heading', { name: 'Update metadata' })).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/update metadata for registered doi/i)).toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/pages/__tests__/dashboard.test.tsx
+++ b/tests/vitest/pages/__tests__/dashboard.test.tsx
@@ -174,17 +174,11 @@ describe('Dashboard', () => {
         expect(screen.getByRole('link', { name: /create resource/i })).toHaveAttribute('data-variant', 'default');
     });
 
-    it('scrolls to the import hub when the upload metadata action is clicked', () => {
-        const originalScrollIntoView = Element.prototype.scrollIntoView;
-        const scrollSpy = vi.fn();
-        Element.prototype.scrollIntoView = scrollSpy;
-
+    it('does not render a redundant upload metadata quick action', () => {
         render(<Dashboard />);
-        fireEvent.click(screen.getByRole('button', { name: /upload metadata/i }));
 
-        expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
-
-        Element.prototype.scrollIntoView = originalScrollIntoView;
+        expect(screen.queryByRole('button', { name: /upload metadata/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /upload metadata/i })).not.toBeInTheDocument();
     });
 
     it('renders an actionable empty state when there are no drafts', () => {

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -210,6 +210,25 @@ describe('Docs page', () => {
         expect(screen.getByText('Creating Landing Pages')).toBeInTheDocument();
     });
 
+    it('documents the update metadata DOI action label in the ORCID pre-flight section', async () => {
+        const user = userEvent.setup();
+        render(<Docs userRole="curator" editorSettings={defaultEditorSettings} />);
+
+        await user.click(screen.getByRole('tab', { name: /Datasets/i }));
+
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return text.includes('when you press Register DOI or Update metadata.');
+            }),
+        ).toBeInTheDocument();
+    });
+
     it('shows thesaurus update actions for admin in editor settings', () => {
         render(<Docs userRole="admin" editorSettings={defaultEditorSettings} />);
         expect(screen.getByText('Check for updates by comparing local vs. remote counts')).toBeInTheDocument();

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -389,6 +389,33 @@ describe('ResourcesPage – extended', () => {
             renderPage({ resources: [makeResource({ landingPage: null })] });
             expect(screen.queryByTestId('datacite-button')).not.toBeInTheDocument();
         });
+
+        it('uses update wording only for published resources', () => {
+            renderPage({
+                resources: [
+                    makeResource({
+                        publicstatus: 'published',
+                        landingPage: { id: 1, status: 'published', public_url: 'https://example.com' },
+                    }),
+                ],
+            });
+
+            expect(screen.getByRole('button', { name: /update metadata for resource/i })).toHaveAttribute('title', 'Update metadata');
+        });
+
+        it('uses register wording for review resources even when a DOI already exists', () => {
+            renderPage({
+                resources: [
+                    makeResource({
+                        publicstatus: 'review',
+                        doi: '10.5880/test.2024.001',
+                        landingPage: { id: 1, status: 'draft', public_url: 'https://example.com' },
+                    }),
+                ],
+            });
+
+            expect(screen.getByRole('button', { name: /register doi for resource/i })).toHaveAttribute('title', 'Register DOI');
+        });
     });
 
     // ── Action buttons ───────────────────────────────────────────────

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -86,7 +86,7 @@ interface TestResource {
     resourcetypegeneral?: string;
     title?: string;
     first_author?: { givenName?: string | null; familyName?: string | null; name?: string } | null;
-    landingPage?: { id: number; status: string; public_url: string } | null;
+    landingPage?: { id: number; is_published: boolean; public_url: string } | null;
 }
 
 function makeResource(overrides: Partial<TestResource> = {}): TestResource {
@@ -322,7 +322,7 @@ describe('ResourcesPage – extended', () => {
                 resources: [
                     makeResource({
                         publicstatus: 'review',
-                        landingPage: { id: 1, status: 'active', public_url: 'https://example.com/preview' },
+                        landingPage: { id: 1, is_published: false, public_url: 'https://example.com/preview' },
                     }),
                 ],
             });
@@ -379,7 +379,7 @@ describe('ResourcesPage – extended', () => {
         it('shows DataCite button when resource has a landing page', () => {
             renderPage({
                 resources: [
-                    makeResource({ landingPage: { id: 1, status: 'active', public_url: 'https://example.com' } }),
+                    makeResource({ landingPage: { id: 1, is_published: false, public_url: 'https://example.com' } }),
                 ],
             });
             expect(screen.getByTestId('datacite-button')).toBeInTheDocument();
@@ -395,7 +395,7 @@ describe('ResourcesPage – extended', () => {
                 resources: [
                     makeResource({
                         publicstatus: 'published',
-                        landingPage: { id: 1, status: 'published', public_url: 'https://example.com' },
+                        landingPage: { id: 1, is_published: true, public_url: 'https://example.com' },
                     }),
                 ],
             });
@@ -409,7 +409,7 @@ describe('ResourcesPage – extended', () => {
                     makeResource({
                         publicstatus: 'review',
                         doi: '10.5880/test.2024.001',
-                        landingPage: { id: 1, status: 'draft', public_url: 'https://example.com' },
+                        landingPage: { id: 1, is_published: false, public_url: 'https://example.com' },
                     }),
                 ],
             });

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -416,6 +416,20 @@ describe('ResourcesPage – extended', () => {
 
             expect(screen.getByRole('button', { name: /register doi for resource/i })).toHaveAttribute('title', 'Register DOI');
         });
+
+        it('uses update wording when a published landing page exists for an incomplete resource with DOI', () => {
+            renderPage({
+                resources: [
+                    makeResource({
+                        publicstatus: 'draft',
+                        doi: '10.5880/test.2024.001',
+                        landingPage: { id: 1, is_published: true, public_url: 'https://example.com' },
+                    }),
+                ],
+            });
+
+            expect(screen.getByRole('button', { name: /update metadata for resource/i })).toHaveAttribute('title', 'Update metadata');
+        });
     });
 
     // ── Action buttons ───────────────────────────────────────────────


### PR DESCRIPTION
This pull request introduces several improvements to the Playwright E2E test data seeding, user interface clarity for DOI actions, and the layout of metadata entry forms. The most significant changes ensure that test resources are consistently seeded with required metadata, clarify DOI registration/update actions to better match resource states, and improve the usability of datacenter selection in the DataCite metadata editor. Additionally, the dashboard is decluttered by removing a redundant upload action.

**Playwright E2E Test Data Improvements:**
- Added a new `ensureCompleteFixture` method in `PlaywrightTestSeeder.php` to guarantee that each seeded resource has at least one license (right) and an abstract description, making test fixtures more robust and realistic. This method is now called for all E2E test resources. [[1]](diffhunk://#diff-217f6198b2bbb231669c919d96e2bed5361bc54feb4dbd2425bcf47de4575209R216-R217) [[2]](diffhunk://#diff-217f6198b2bbb231669c919d96e2bed5361bc54feb4dbd2425bcf47de4575209R270-R293) [[3]](diffhunk://#diff-217f6198b2bbb231669c919d96e2bed5361bc54feb4dbd2425bcf47de4575209R319-R345) [[4]](diffhunk://#diff-217f6198b2bbb231669c919d96e2bed5361bc54feb4dbd2425bcf47de4575209R6-R10)

**DOI Action Labeling and Modal Clarity:**
- Updated the logic and UI in `RegisterDoiModal.tsx` so that the primary action label and description dynamically reflect whether the resource is being registered for the first time or updated, using a new `shouldUseUpdateMetadataLabel` helper. This ensures users see 'Register DOI' for unpublished resources and 'Update metadata' for already published DOI records, improving clarity and reducing confusion. [[1]](diffhunk://#diff-585e2e4de35bc3085b1b322516de571c762e29cb3336e20436759cdd9f7fc3d6L15-R15) [[2]](diffhunk://#diff-585e2e4de35bc3085b1b322516de571c762e29cb3336e20436759cdd9f7fc3d6R129-R137) [[3]](diffhunk://#diff-585e2e4de35bc3085b1b322516de571c762e29cb3336e20436759cdd9f7fc3d6L299-R297) [[4]](diffhunk://#diff-585e2e4de35bc3085b1b322516de571c762e29cb3336e20436759cdd9f7fc3d6L350-R344) [[5]](diffhunk://#diff-585e2e4de35bc3085b1b322516de571c762e29cb3336e20436759cdd9f7fc3d6L479-R473) [[6]](diffhunk://#diff-585e2e4de35bc3085b1b322516de571c762e29cb3336e20436759cdd9f7fc3d6L494-R488)

**Metadata Entry Form Usability:**
- Improved the layout of the datacenter selection field in the DataCite metadata editor (`datacenter-field.tsx` and `datacite-form.tsx`) by allowing selected datacenter badges to wrap and preventing long names from overlapping adjacent fields. Adjusted grid classes to allocate more space for the datacenter field. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2242-R2242) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2256-R2256) [[3]](diffhunk://#diff-aa77e752069782001360162abb148c045cf2e2a339f1c067c0487d63f276665eL41-R60) [[4]](diffhunk://#diff-aa77e752069782001360162abb148c045cf2e2a339f1c067c0487d63f276665eL73-R78)

**Dashboard Decluttering:**
- Removed the redundant 'Upload metadata' quick action from the dashboard, as the upload dropzone is already present on the page, reducing visual clutter and potential user confusion. [[1]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL11) [[2]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL231) [[3]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL241-L244) [[4]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL265-L270) [[5]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL308-R296) [[6]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL521-R509)

**Changelog and Documentation:**
- Updated the changelog to reflect the new release date, merged duplicate entries, and added an entry describing the improved clarity of DOI actions and the less cluttered metadata entry UI. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-L15) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR96-R99)