### PR TITLE
Feature: Better UX for Related Work

### DIFF
--- a/app/Console/Commands/HydrateRelatedIdentifierCitationLabels.php
+++ b/app/Console/Commands/HydrateRelatedIdentifierCitationLabels.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\IdentifierType;
+use App\Models\RelatedIdentifier;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Description('Hydrate missing citation labels for existing DOI related identifiers.')]
+#[Signature('related-identifiers:hydrate-citation-labels
+                            {--limit=0 : Maximum number of missing DOI related identifiers to process (0 = all)}')]
+class HydrateRelatedIdentifierCitationLabels extends Command
+{
+    public function __construct(
+        private readonly RelatedIdentifierCitationLabelService $citationLabelService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $doiTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+
+        if (! is_int($doiTypeId)) {
+            $this->error('DOI identifier type not found. Seed identifier types before running this command.');
+
+            return self::FAILURE;
+        }
+
+        $baseQuery = RelatedIdentifier::query()
+            ->where('identifier_type_id', $doiTypeId)
+            ->where(function ($query): void {
+                $query->whereNull('citation_label')
+                    ->orWhere('citation_label', '');
+            })
+            ->whereNotNull('identifier')
+            ->where('identifier', '!=', '');
+
+        $limit = max(0, (int) $this->option('limit'));
+
+        $query = clone $baseQuery;
+
+        if ($limit > 0) {
+            $query = RelatedIdentifier::query()->whereKey(
+                (clone $baseQuery)
+                    ->orderBy('id')
+                    ->limit($limit)
+                    ->pluck('id'),
+            );
+        }
+
+        $total = (clone $query)->count();
+
+        if ($total === 0) {
+            $this->info('No missing DOI citation labels found.');
+
+            return self::SUCCESS;
+        }
+
+        $processed = 0;
+        $updated = 0;
+
+        $this->info("Hydrating missing citation labels for {$total} DOI related identifier(s)...");
+
+        $query->orderBy('id')->chunkById(100, function ($relatedIdentifiers) use (&$processed, &$updated): void {
+            foreach ($relatedIdentifiers as $relatedIdentifier) {
+                $processed++;
+
+                $citationLabel = $this->citationLabelService->resolve($relatedIdentifier->identifier, 'DOI');
+
+                if (! is_string($citationLabel) || trim($citationLabel) === '') {
+                    continue;
+                }
+
+                $relatedIdentifier->forceFill([
+                    'citation_label' => trim($citationLabel),
+                ])->save();
+
+                $updated++;
+            }
+        });
+
+        $this->info("Processed {$processed} missing DOI related identifier(s).");
+        $this->info("Hydrated {$updated} citation label(s).");
+
+        if ($updated < $processed) {
+            $remaining = $processed - $updated;
+            $this->warn("{$remaining} DOI related identifier(s) remain without a citation label.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/UploadJsonController.php
+++ b/app/Http/Controllers/UploadJsonController.php
@@ -889,6 +889,7 @@ class UploadJsonController extends Controller
     {
         $relatedWorks = [];
         $instruments = [];
+        $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
 
         foreach ($relatedIdentifiers as $index => $ri) {
             $identifier = $ri['relatedIdentifier'] ?? '';
@@ -931,7 +932,7 @@ class UploadJsonController extends Controller
                 'identifier_type' => $identifierType,
                 'relation_type' => $relationType,
                 'relation_type_information' => is_string($relationTypeInformation) && trim($relationTypeInformation) !== '' ? trim($relationTypeInformation) : null,
-                'citation_label' => $this->citationLabelService->resolve($identifier, $identifierType),
+                'citation_label' => $this->citationLabelService->resolveBestEffort($identifier, $identifierType, $citationResolutionDeadline),
                 'position' => count($relatedWorks),
             ];
         }

--- a/app/Http/Controllers/UploadJsonController.php
+++ b/app/Http/Controllers/UploadJsonController.php
@@ -8,8 +8,10 @@ use App\Enums\UploadErrorCode;
 use App\Exceptions\JsonLdConversionException;
 use App\Http\Requests\UploadJsonRequest;
 use App\Models\ResourceType;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\DataCiteJsonLdToJsonConverterService;
 use App\Services\JsonSchemaValidator;
+use App\Services\RelatedIdentifierTypeResolverService;
 use App\Services\UploadLogService;
 use App\Support\GcmdUriHelper;
 use App\Support\UploadError;
@@ -20,39 +22,6 @@ use Illuminate\Support\Str;
 
 class UploadJsonController extends Controller
 {
-    /**
-     * Canonical DataCite related identifier types supported by ERNIE editor.
-     *
-     * @var string[]
-     */
-    private const RELATED_IDENTIFIER_TYPES = [
-        'DOI', 'URL', 'Handle', 'IGSN', 'URN', 'ISBN', 'ISSN', 'PURL', 'ARK',
-        'arXiv', 'bibcode', 'CSTR', 'EAN13', 'EISSN', 'ISTC', 'LISSN', 'LSID',
-        'PMID', 'RAiD', 'RRID', 'SWHID', 'UPC', 'w3id',
-    ];
-
-    /**
-     * Canonical DataCite relation types supported by ERNIE editor.
-     *
-     * @var string[]
-     */
-    private const RELATED_RELATION_TYPES = [
-        'Cites', 'IsCitedBy', 'References', 'IsReferencedBy',
-        'Documents', 'IsDocumentedBy', 'Describes', 'IsDescribedBy',
-        'IsNewVersionOf', 'IsPreviousVersionOf', 'HasVersion', 'IsVersionOf',
-        'HasTranslation', 'IsTranslationOf',
-        'Continues', 'IsContinuedBy', 'Obsoletes', 'IsObsoletedBy',
-        'IsVariantFormOf', 'IsOriginalFormOf', 'IsIdenticalTo',
-        'HasPart', 'IsPartOf', 'Compiles', 'IsCompiledBy',
-        'IsSourceOf', 'IsDerivedFrom',
-        'IsSupplementTo', 'IsSupplementedBy',
-        'Requires', 'IsRequiredBy',
-        'HasMetadata', 'IsMetadataFor',
-        'Reviews', 'IsReviewedBy',
-        'IsPublishedIn', 'Collects', 'IsCollectedBy',
-        'Other',
-    ];
-
     /**
      * Contributor role labels mapped from lowercased keys.
      *
@@ -109,6 +78,8 @@ class UploadJsonController extends Controller
         private readonly UploadLogService $uploadLogService,
         private readonly JsonSchemaValidator $jsonSchemaValidator,
         private readonly DataCiteJsonLdToJsonConverterService $jsonLdConverter,
+        private readonly RelatedIdentifierTypeResolverService $relatedIdentifierTypeResolver,
+        private readonly RelatedIdentifierCitationLabelService $citationLabelService,
     ) {}
 
     public function __invoke(UploadJsonRequest $request): JsonResponse
@@ -916,18 +887,6 @@ class UploadJsonController extends Controller
      */
     private function extractRelatedWorksAndInstruments(array $relatedIdentifiers, string $filename): array
     {
-        /** @var array<string, string> $identifierTypeLookup */
-        $identifierTypeLookup = [];
-        foreach (self::RELATED_IDENTIFIER_TYPES as $name) {
-            $identifierTypeLookup[mb_strtolower($name)] = $name;
-        }
-
-        /** @var array<string, string> $relationTypeLookup */
-        $relationTypeLookup = [];
-        foreach (self::RELATED_RELATION_TYPES as $name) {
-            $relationTypeLookup[mb_strtolower($name)] = $name;
-        }
-
         $relatedWorks = [];
         $instruments = [];
 
@@ -941,12 +900,8 @@ class UploadJsonController extends Controller
                 continue;
             }
 
-            $identifierType = is_string($identifierTypeRaw)
-                ? ($identifierTypeLookup[mb_strtolower(trim($identifierTypeRaw))] ?? null)
-                : null;
-            $relationType = is_string($relationTypeRaw)
-                ? ($relationTypeLookup[mb_strtolower(trim($relationTypeRaw))] ?? null)
-                : null;
+            $identifierType = $this->relatedIdentifierTypeResolver->resolveIdentifierType($identifierTypeRaw);
+            $relationType = $this->relatedIdentifierTypeResolver->resolveRelationType($relationTypeRaw);
 
             if ($identifierType === null || $relationType === null) {
                 Log::warning('Skipping related identifier with unsupported type values during JSON upload', [
@@ -976,6 +931,7 @@ class UploadJsonController extends Controller
                 'identifier_type' => $identifierType,
                 'relation_type' => $relationType,
                 'relation_type_information' => is_string($relationTypeInformation) && trim($relationTypeInformation) !== '' ? trim($relationTypeInformation) : null,
+                'citation_label' => $this->citationLabelService->resolve($identifier, $identifierType),
                 'position' => count($relatedWorks),
             ];
         }

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -161,6 +161,7 @@ class StoreDraftResourceRequest extends FormRequest
                 ]),
             ],
             'relatedIdentifiers.*.relationTypeInformation' => ['nullable', 'string', 'max:255'],
+            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string'],
             'fundingReferences' => ['nullable', 'array', 'max:99'],
             'fundingReferences.*.funderName' => ['required', 'string', 'max:500'],
             'fundingReferences.*.funderIdentifier' => ['nullable', 'string', 'max:500'],
@@ -660,11 +661,16 @@ class StoreDraftResourceRequest extends FormRequest
                 ? trim((string) $relatedIdentifier['relationTypeInformation'])
                 : '';
 
+            $citationLabel = isset($relatedIdentifier['citationLabel'])
+                ? trim((string) $relatedIdentifier['citationLabel'])
+                : '';
+
             $relatedIdentifiers[] = [
                 'identifier' => $identifier,
                 'identifierType' => $identifierType,
                 'relationType' => $relationType,
                 ...($relationTypeInformation !== '' ? ['relationTypeInformation' => $relationTypeInformation] : []),
+                ...($citationLabel !== '' ? ['citationLabel' => $citationLabel] : []),
             ];
         }
 

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -161,7 +161,7 @@ class StoreDraftResourceRequest extends FormRequest
                 ]),
             ],
             'relatedIdentifiers.*.relationTypeInformation' => ['nullable', 'string', 'max:255'],
-            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string'],
+            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string', 'max:65535'],
             'fundingReferences' => ['nullable', 'array', 'max:99'],
             'fundingReferences.*.funderName' => ['required', 'string', 'max:500'],
             'fundingReferences.*.funderIdentifier' => ['nullable', 'string', 'max:500'],

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\RelatedIdentifier;
 use App\Models\TitleType;
 use App\Services\DoiSuggestionService;
 use App\Support\BooleanNormalizer;
@@ -161,7 +162,7 @@ class StoreDraftResourceRequest extends FormRequest
                 ]),
             ],
             'relatedIdentifiers.*.relationTypeInformation' => ['nullable', 'string', 'max:255'],
-            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string', 'max:65535'],
+            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string', 'max:'.RelatedIdentifier::MAX_CITATION_LABEL_CHARACTERS],
             'fundingReferences' => ['nullable', 'array', 'max:99'],
             'fundingReferences.*.funderName' => ['required', 'string', 'max:500'],
             'fundingReferences.*.funderIdentifier' => ['nullable', 'string', 'max:500'],

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests;
 
 use App\Models\ContributorType;
+use App\Models\RelatedIdentifier;
 use App\Models\RelatedItem;
 use App\Models\ResourceType;
 use App\Models\TitleType;
@@ -156,7 +157,7 @@ class StoreResourceRequest extends FormRequest
                 ]),
             ],
             'relatedIdentifiers.*.relationTypeInformation' => ['nullable', 'string', 'max:255'],
-            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string', 'max:65535'],
+            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string', 'max:'.RelatedIdentifier::MAX_CITATION_LABEL_CHARACTERS],
 
             // Citation Manager: inline <relatedItem> metadata (DataCite 4.7).
             'relatedItems' => ['nullable', 'array'],

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -156,6 +156,7 @@ class StoreResourceRequest extends FormRequest
                 ]),
             ],
             'relatedIdentifiers.*.relationTypeInformation' => ['nullable', 'string', 'max:255'],
+            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string'],
 
             // Citation Manager: inline <relatedItem> metadata (DataCite 4.7).
             'relatedItems' => ['nullable', 'array'],
@@ -763,11 +764,16 @@ class StoreResourceRequest extends FormRequest
                 ? trim((string) $relatedIdentifier['relationTypeInformation'])
                 : '';
 
+            $citationLabel = isset($relatedIdentifier['citationLabel'])
+                ? trim((string) $relatedIdentifier['citationLabel'])
+                : '';
+
             $relatedIdentifiers[] = [
                 'identifier' => $identifier,
                 'identifierType' => $identifierType,
                 'relationType' => $relationType,
                 ...($relationTypeInformation !== '' ? ['relationTypeInformation' => $relationTypeInformation] : []),
+                ...($citationLabel !== '' ? ['citationLabel' => $citationLabel] : []),
             ];
         }
 

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -156,7 +156,7 @@ class StoreResourceRequest extends FormRequest
                 ]),
             ],
             'relatedIdentifiers.*.relationTypeInformation' => ['nullable', 'string', 'max:255'],
-            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string'],
+            'relatedIdentifiers.*.citationLabel' => ['nullable', 'string', 'max:65535'],
 
             // Citation Manager: inline <relatedItem> metadata (DataCite 4.7).
             'relatedItems' => ['nullable', 'array'],

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -356,6 +356,17 @@ class ImportFromDataCiteJob implements ShouldQueue
         bool $shouldLookupMetaworks = true,
     ): array {
         try {
+            if (Resource::where('doi', $doi)->exists()) {
+                Log::debug('Skipping existing DOI', ['doi' => $doi]);
+
+                return [
+                    'status' => 'skipped',
+                    'metaworks_unavailable' => false,
+                ];
+            }
+
+            $preparedDoiRecord = $transformer->prepareDoiData($doiRecord);
+
             // Use database transaction to ensure atomicity of the check-then-insert operation.
             //
             // Design decision: We use SELECT + INSERT rather than INSERT IGNORE because:
@@ -363,12 +374,12 @@ class ImportFromDataCiteJob implements ShouldQueue
             // 2. INSERT IGNORE would silently succeed, making it impossible to track skips
             // 3. The unique constraint on DOI provides protection against race conditions
             // 4. Most imports won't have many duplicates, so the SELECT overhead is minimal
-            $result = DB::transaction(function () use ($transformer, $doiRecord, $doi) {
+            $result = DB::transaction(function () use ($transformer, $preparedDoiRecord, $doi) {
                 if (Resource::where('doi', $doi)->exists()) {
                     return ['status' => 'skipped', 'resource' => null];
                 }
 
-                $resource = $transformer->transform($doiRecord, $this->userId);
+                $resource = $transformer->transform($preparedDoiRecord, $this->userId);
 
                 return ['status' => 'imported', 'resource' => $resource];
             });

--- a/app/Models/RelatedIdentifier.php
+++ b/app/Models/RelatedIdentifier.php
@@ -37,6 +37,14 @@ class RelatedIdentifier extends Model
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
     use HasFactory;
 
+    /**
+     * Upper bound advertised to form requests for manual citation labels.
+     *
+     * The backing column uses MEDIUMTEXT so this character limit remains safe
+     * under utf8mb4 multibyte storage.
+     */
+    public const MAX_CITATION_LABEL_CHARACTERS = 65535;
+
     protected $casts = [
         'position' => 'integer',
     ];

--- a/app/Models/RelatedIdentifier.php
+++ b/app/Models/RelatedIdentifier.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $identifier_type_id
  * @property int $relation_type_id
  * @property string|null $relation_type_information
+ * @property string|null $citation_label
  * @property string|null $resource_type_general
  * @property int $position
  * @property \Illuminate\Support\Carbon|null $created_at
@@ -30,7 +31,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @see https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/relatedidentifier/
  */
-#[Fillable(['resource_id', 'identifier', 'identifier_type_id', 'relation_type_id', 'relation_type_information', 'resource_type_general', 'position'])]
+#[Fillable(['resource_id', 'identifier', 'identifier_type_id', 'relation_type_id', 'relation_type_information', 'citation_label', 'resource_type_general', 'position'])]
 class RelatedIdentifier extends Model
 {
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */

--- a/app/Services/Citations/RelatedIdentifierCitationLabelService.php
+++ b/app/Services/Citations/RelatedIdentifierCitationLabelService.php
@@ -8,11 +8,17 @@ use App\Services\DataCiteApiService;
 
 class RelatedIdentifierCitationLabelService
 {
+    public const DEFAULT_AGGREGATE_TIMEOUT_SECONDS = 2.0;
+
+    public const DEFAULT_PER_REQUEST_TIMEOUT_SECONDS = 0.75;
+
+    private const MIN_REQUEST_TIMEOUT_SECONDS = 0.1;
+
     public function __construct(
         private readonly DataCiteApiService $dataCite,
     ) {}
 
-    public function resolve(string $identifier, string $identifierType): ?string
+    public function resolve(string $identifier, string $identifierType, ?float $timeoutSeconds = null): ?string
     {
         $doi = $this->extractResolvableDoi($identifier, $identifierType);
 
@@ -20,7 +26,9 @@ class RelatedIdentifierCitationLabelService
             return null;
         }
 
-        $metadata = $this->dataCite->getMetadata($doi);
+        $metadata = $timeoutSeconds === null
+            ? $this->dataCite->getMetadata($doi)
+            : $this->dataCite->getMetadata($doi, $timeoutSeconds, false);
 
         if (! is_array($metadata)) {
             return null;
@@ -29,6 +37,23 @@ class RelatedIdentifierCitationLabelService
         $citation = trim($this->dataCite->buildCitationFromMetadata($metadata));
 
         return $citation !== '' ? $citation : null;
+    }
+
+    public function resolveBestEffort(string $identifier, string $identifierType, float $deadline): ?string
+    {
+        $remainingBudget = $deadline - microtime(true);
+
+        if ($remainingBudget <= 0) {
+            return null;
+        }
+
+        $timeoutSeconds = min(self::DEFAULT_PER_REQUEST_TIMEOUT_SECONDS, $remainingBudget);
+
+        if ($timeoutSeconds < self::MIN_REQUEST_TIMEOUT_SECONDS) {
+            return null;
+        }
+
+        return $this->resolve($identifier, $identifierType, $timeoutSeconds);
     }
 
     private function extractResolvableDoi(string $identifier, string $identifierType): ?string

--- a/app/Services/Citations/RelatedIdentifierCitationLabelService.php
+++ b/app/Services/Citations/RelatedIdentifierCitationLabelService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Citations;
+
+use App\Services\DataCiteApiService;
+
+class RelatedIdentifierCitationLabelService
+{
+    public function __construct(
+        private readonly DataCiteApiService $dataCite,
+    ) {}
+
+    public function resolve(string $identifier, string $identifierType): ?string
+    {
+        $doi = $this->extractResolvableDoi($identifier, $identifierType);
+
+        if ($doi === null) {
+            return null;
+        }
+
+        $metadata = $this->dataCite->getMetadata($doi);
+
+        if (! is_array($metadata)) {
+            return null;
+        }
+
+        $citation = trim($this->dataCite->buildCitationFromMetadata($metadata));
+
+        return $citation !== '' ? $citation : null;
+    }
+
+    private function extractResolvableDoi(string $identifier, string $identifierType): ?string
+    {
+        $identifier = trim($identifier);
+        if ($identifier === '') {
+            return null;
+        }
+
+        $normalizedType = trim($identifierType);
+        if ($normalizedType !== 'DOI' && $normalizedType !== 'URL') {
+            return null;
+        }
+
+        $doi = $this->dataCite->normalizeDoi($identifier);
+
+        if ($doi === null || ! preg_match('#^10\.\d{4,9}/.+$#', $doi)) {
+            return null;
+        }
+
+        return $doi;
+    }
+}

--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -21,6 +21,8 @@ class DataCiteApiService
 {
     use ChecksCacheTagging;
 
+    private const DEFAULT_TIMEOUT_SECONDS = 10.0;
+
     /** Sentinel value stored in cache to represent a confirmed 404. */
     private const CACHE_NULL_SENTINEL = '__NULL__';
 
@@ -60,7 +62,7 @@ class DataCiteApiService
      * @param  string  $doi  Die DOI, für die Metadaten abgerufen werden sollen
      * @return array<string, mixed>|null Die Metadaten als Array oder null bei Fehler
      */
-    public function getMetadata(string $doi): ?array
+    public function getMetadata(string $doi, ?float $timeoutSeconds = null, bool $cacheTransientFailure = true): ?array
     {
         $cleanDoi = $this->normalizeDoi($doi);
 
@@ -81,14 +83,14 @@ class DataCiteApiService
             return $cached;
         }
 
-        $result = $this->fetchMetadataFromApi($cleanDoi, $doi);
+        $result = $this->fetchMetadataFromApi($cleanDoi, $doi, $timeoutSeconds ?? self::DEFAULT_TIMEOUT_SECONDS);
 
         if (is_array($result)) {
             $cache->put($cacheKey, $result, CacheKey::DOI_CITATION->ttl());
         } elseif ($result === self::CACHE_NULL_SENTINEL) {
             // Confirmed 404 — cache for full TTL
             $cache->put($cacheKey, self::CACHE_NULL_SENTINEL, CacheKey::DOI_CITATION->ttl());
-        } else {
+        } elseif ($cacheTransientFailure) {
             // Transient failure — cache for 5 minutes to avoid hammering the API
             $cache->put($cacheKey, self::CACHE_TRANSIENT_FAILURE, 300);
         }
@@ -104,12 +106,12 @@ class DataCiteApiService
      *
      * @return array<string, mixed>|string
      */
-    private function fetchMetadataFromApi(string $cleanDoi, string $originalDoi): array|string
+    private function fetchMetadataFromApi(string $cleanDoi, string $originalDoi, float $timeoutSeconds): array|string
     {
         try {
             $url = "https://doi.org/{$cleanDoi}";
 
-            $response = Http::timeout(10)
+            $response = Http::timeout($timeoutSeconds)
                 ->withHeaders([
                     'Accept' => 'application/vnd.citationstyles.csl+json',
                 ])

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -141,6 +141,8 @@ class DataCiteToResourceTransformer
             return $attributes;
         }
 
+        $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
+
         foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
             if (! is_array($relatedIdentifier)) {
                 continue;
@@ -168,9 +170,10 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
-            $resolvedCitationLabel = $this->citationLabelService()->resolve(
+            $resolvedCitationLabel = $this->citationLabelService()->resolveBestEffort(
                 $identifier,
                 (string) ($relatedIdentifier['relatedIdentifierType'] ?? ''),
+                $citationResolutionDeadline,
             );
 
             if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -36,6 +36,7 @@ use App\Models\Size;
 use App\Models\Subject;
 use App\Models\Title;
 use App\Models\TitleType;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -49,6 +50,12 @@ use Illuminate\Support\Facades\Log;
  */
 class DataCiteToResourceTransformer
 {
+    private const PREPARED_MARKER = '__citation_labels_prepared';
+
+    public function __construct(
+        private ?RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService = null,
+    ) {}
+
     /**
      * Cached lookup tables for performance.
      *
@@ -67,7 +74,14 @@ class DataCiteToResourceTransformer
      */
     public function transform(array $doiData, int $userId): Resource
     {
-        $attributes = $doiData['attributes'] ?? $doiData;
+        $preparedDoiData = $this->prepareDoiData($doiData);
+
+        /** @var array<string, mixed> $attributes */
+        $attributes = is_array($preparedDoiData['attributes'] ?? null)
+            ? $preparedDoiData['attributes']
+            : $preparedDoiData;
+
+        unset($attributes[self::PREPARED_MARKER]);
 
         return DB::transaction(function () use ($attributes, $userId) {
             // Create the main Resource
@@ -90,6 +104,88 @@ class DataCiteToResourceTransformer
 
             return $resource;
         });
+    }
+
+    /**
+     * @param  array<string, mixed>  $doiData
+     * @return array<string, mixed>
+     */
+    public function prepareDoiData(array $doiData): array
+    {
+        if (($doiData[self::PREPARED_MARKER] ?? false) === true) {
+            return $doiData;
+        }
+
+        if (is_array($doiData['attributes'] ?? null)) {
+            $doiData['attributes'] = $this->prepareAttributes($doiData['attributes']);
+            $doiData[self::PREPARED_MARKER] = true;
+
+            return $doiData;
+        }
+
+        $preparedAttributes = $this->prepareAttributes($doiData);
+        $preparedAttributes[self::PREPARED_MARKER] = true;
+
+        return $preparedAttributes;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    private function prepareAttributes(array $attributes): array
+    {
+        $relatedIdentifiers = $attributes['relatedIdentifiers'] ?? null;
+
+        if (! is_array($relatedIdentifiers)) {
+            return $attributes;
+        }
+
+        foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
+            if (! is_array($relatedIdentifier)) {
+                continue;
+            }
+
+            $identifier = isset($relatedIdentifier['relatedIdentifier'])
+                ? trim((string) $relatedIdentifier['relatedIdentifier'])
+                : '';
+
+            if ($identifier === '') {
+                unset($relatedIdentifiers[$index]['citationLabel']);
+
+                continue;
+            }
+
+            $relatedIdentifiers[$index]['relatedIdentifier'] = $identifier;
+
+            $citationLabel = isset($relatedIdentifier['citationLabel'])
+                ? trim((string) $relatedIdentifier['citationLabel'])
+                : '';
+
+            if ($citationLabel !== '') {
+                $relatedIdentifiers[$index]['citationLabel'] = $citationLabel;
+
+                continue;
+            }
+
+            $resolvedCitationLabel = $this->citationLabelService()->resolve(
+                $identifier,
+                (string) ($relatedIdentifier['relatedIdentifierType'] ?? ''),
+            );
+
+            if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
+                $relatedIdentifiers[$index]['citationLabel'] = trim($resolvedCitationLabel);
+            }
+        }
+
+        $attributes['relatedIdentifiers'] = $relatedIdentifiers;
+
+        return $attributes;
+    }
+
+    private function citationLabelService(): RelatedIdentifierCitationLabelService
+    {
+        return $this->relatedIdentifierCitationLabelService ??= app(RelatedIdentifierCitationLabelService::class);
     }
 
     /**
@@ -996,6 +1092,9 @@ class DataCiteToResourceTransformer
                 'identifier_type_id' => $identifierTypeId,
                 'relation_type_id' => $relationTypeId,
                 'relation_type_information' => $relIdData['relationTypeInformation'] ?? null,
+                'citation_label' => isset($relIdData['citationLabel']) && trim((string) $relIdData['citationLabel']) !== ''
+                    ? trim((string) $relIdData['citationLabel'])
+                    : null,
                 'related_metadata_scheme' => $relIdData['relatedMetadataScheme'] ?? null,
                 'scheme_uri' => $relIdData['schemeUri'] ?? null,
                 'scheme_type' => $relIdData['schemeType'] ?? null,

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -476,7 +476,7 @@ class EditorDataTransformer
     /**
      * Transform related identifiers to frontend format.
      *
-     * @return array<int, array{identifier: string, identifier_type: string, relation_type: string, relation_type_information: string|null}>
+     * @return array<int, array{identifier: string, identifier_type: string, relation_type: string, relation_type_information: string|null, citation_label: string|null}>
      */
     public function transformRelatedIdentifiers(Resource $resource): array
     {
@@ -484,9 +484,10 @@ class EditorDataTransformer
             ->sortBy('position')
             ->map(fn (\App\Models\RelatedIdentifier $relatedId): array => [
                 'identifier' => $relatedId->identifier,
-                'identifier_type' => $relatedId->identifierType->name,
-                'relation_type' => $relatedId->relationType->name,
+                'identifier_type' => $relatedId->identifierType->slug,
+                'relation_type' => $relatedId->relationType->slug,
                 'relation_type_information' => $relatedId->relation_type_information,
+                'citation_label' => $relatedId->citation_label,
             ])
             ->values()
             ->toArray();

--- a/app/Services/LandingPageResourceTransformer.php
+++ b/app/Services/LandingPageResourceTransformer.php
@@ -90,8 +90,9 @@ final class LandingPageResourceTransformer
                 return [
                     'id' => $relatedId->id,
                     'identifier' => $relatedId->identifier,
-                    'identifier_type' => $identifierType !== null ? $identifierType->name : null,
-                    'relation_type' => $relationType !== null ? $relationType->name : null,
+                    'identifier_type' => $identifierType !== null ? $identifierType->slug : null,
+                    'relation_type' => $relationType !== null ? $relationType->slug : null,
+                    'citation_label' => $relatedId->citation_label,
                     'position' => $relatedId->position,
                 ];
             })

--- a/app/Services/RelatedIdentifierTypeResolverService.php
+++ b/app/Services/RelatedIdentifierTypeResolverService.php
@@ -89,7 +89,7 @@ class RelatedIdentifierTypeResolverService
     /** @var array<string, string>|null */
     private ?array $relationTypeLookup = null;
 
-    public function resolveIdentifierType(?string $value): ?string
+    public function resolveIdentifierType(mixed $value): ?string
     {
         if (! is_string($value)) {
             return null;
@@ -98,7 +98,7 @@ class RelatedIdentifierTypeResolverService
         return $this->identifierTypeLookup()[$this->normalizeKey($value)] ?? null;
     }
 
-    public function resolveRelationType(?string $value): ?string
+    public function resolveRelationType(mixed $value): ?string
     {
         if (! is_string($value)) {
             return null;

--- a/app/Services/RelatedIdentifierTypeResolverService.php
+++ b/app/Services/RelatedIdentifierTypeResolverService.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\IdentifierType;
+use App\Models\RelationType;
+
+class RelatedIdentifierTypeResolverService
+{
+    /**
+     * @var array<int, array{name: string, slug: string}>
+     */
+    private const DEFAULT_IDENTIFIER_TYPES = [
+        ['name' => 'ARK', 'slug' => 'ARK'],
+        ['name' => 'arXiv', 'slug' => 'arXiv'],
+        ['name' => 'bibcode', 'slug' => 'bibcode'],
+        ['name' => 'CSTR', 'slug' => 'CSTR'],
+        ['name' => 'DOI', 'slug' => 'DOI'],
+        ['name' => 'EAN13', 'slug' => 'EAN13'],
+        ['name' => 'EISSN', 'slug' => 'EISSN'],
+        ['name' => 'Handle', 'slug' => 'Handle'],
+        ['name' => 'IGSN', 'slug' => 'IGSN'],
+        ['name' => 'ISBN', 'slug' => 'ISBN'],
+        ['name' => 'ISSN', 'slug' => 'ISSN'],
+        ['name' => 'ISTC', 'slug' => 'ISTC'],
+        ['name' => 'LISSN', 'slug' => 'LISSN'],
+        ['name' => 'LSID', 'slug' => 'LSID'],
+        ['name' => 'PMID', 'slug' => 'PMID'],
+        ['name' => 'PURL', 'slug' => 'PURL'],
+        ['name' => 'RAiD', 'slug' => 'RAiD'],
+        ['name' => 'RRID', 'slug' => 'RRID'],
+        ['name' => 'SWHID', 'slug' => 'SWHID'],
+        ['name' => 'UPC', 'slug' => 'UPC'],
+        ['name' => 'URL', 'slug' => 'URL'],
+        ['name' => 'URN', 'slug' => 'URN'],
+        ['name' => 'w3id', 'slug' => 'w3id'],
+    ];
+
+    /**
+     * @var array<int, array{name: string, slug: string}>
+     */
+    private const DEFAULT_RELATION_TYPES = [
+        ['name' => 'Is Cited By', 'slug' => 'IsCitedBy'],
+        ['name' => 'Cites', 'slug' => 'Cites'],
+        ['name' => 'Is Supplement To', 'slug' => 'IsSupplementTo'],
+        ['name' => 'Is Supplemented By', 'slug' => 'IsSupplementedBy'],
+        ['name' => 'Is Translation Of', 'slug' => 'IsTranslationOf'],
+        ['name' => 'Has Translation', 'slug' => 'HasTranslation'],
+        ['name' => 'Is Continued By', 'slug' => 'IsContinuedBy'],
+        ['name' => 'Continues', 'slug' => 'Continues'],
+        ['name' => 'Is Described By', 'slug' => 'IsDescribedBy'],
+        ['name' => 'Describes', 'slug' => 'Describes'],
+        ['name' => 'Has Metadata', 'slug' => 'HasMetadata'],
+        ['name' => 'Is Metadata For', 'slug' => 'IsMetadataFor'],
+        ['name' => 'Has Version', 'slug' => 'HasVersion'],
+        ['name' => 'Is Version Of', 'slug' => 'IsVersionOf'],
+        ['name' => 'Is New Version Of', 'slug' => 'IsNewVersionOf'],
+        ['name' => 'Is Previous Version Of', 'slug' => 'IsPreviousVersionOf'],
+        ['name' => 'Is Part Of', 'slug' => 'IsPartOf'],
+        ['name' => 'Has Part', 'slug' => 'HasPart'],
+        ['name' => 'Is Published In', 'slug' => 'IsPublishedIn'],
+        ['name' => 'Is Referenced By', 'slug' => 'IsReferencedBy'],
+        ['name' => 'References', 'slug' => 'References'],
+        ['name' => 'Is Documented By', 'slug' => 'IsDocumentedBy'],
+        ['name' => 'Documents', 'slug' => 'Documents'],
+        ['name' => 'Is Compiled By', 'slug' => 'IsCompiledBy'],
+        ['name' => 'Compiles', 'slug' => 'Compiles'],
+        ['name' => 'Is Variant Form Of', 'slug' => 'IsVariantFormOf'],
+        ['name' => 'Is Original Form Of', 'slug' => 'IsOriginalFormOf'],
+        ['name' => 'Is Identical To', 'slug' => 'IsIdenticalTo'],
+        ['name' => 'Is Reviewed By', 'slug' => 'IsReviewedBy'],
+        ['name' => 'Reviews', 'slug' => 'Reviews'],
+        ['name' => 'Is Derived From', 'slug' => 'IsDerivedFrom'],
+        ['name' => 'Is Source Of', 'slug' => 'IsSourceOf'],
+        ['name' => 'Is Required By', 'slug' => 'IsRequiredBy'],
+        ['name' => 'Requires', 'slug' => 'Requires'],
+        ['name' => 'Is Obsoleted By', 'slug' => 'IsObsoletedBy'],
+        ['name' => 'Obsoletes', 'slug' => 'Obsoletes'],
+        ['name' => 'Is Collected By', 'slug' => 'IsCollectedBy'],
+        ['name' => 'Collects', 'slug' => 'Collects'],
+        ['name' => 'Other', 'slug' => 'Other'],
+    ];
+
+    /** @var array<string, string>|null */
+    private ?array $identifierTypeLookup = null;
+
+    /** @var array<string, string>|null */
+    private ?array $relationTypeLookup = null;
+
+    public function resolveIdentifierType(?string $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        return $this->identifierTypeLookup()[$this->normalizeKey($value)] ?? null;
+    }
+
+    public function resolveRelationType(?string $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        return $this->relationTypeLookup()[$this->normalizeKey($value)] ?? null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function identifierTypeLookup(): array
+    {
+        if ($this->identifierTypeLookup !== null) {
+            return $this->identifierTypeLookup;
+        }
+
+        /** @var array<int, array{name: string, slug: string}> $databaseValues */
+        $databaseValues = IdentifierType::query()
+            ->get(['name', 'slug'])
+            ->map(fn (IdentifierType $type): array => [
+                'name' => (string) $type->name,
+                'slug' => (string) $type->slug,
+            ])
+            ->all();
+
+        return $this->identifierTypeLookup = $this->buildLookup(
+            array_merge(self::DEFAULT_IDENTIFIER_TYPES, $databaseValues)
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function relationTypeLookup(): array
+    {
+        if ($this->relationTypeLookup !== null) {
+            return $this->relationTypeLookup;
+        }
+
+        /** @var array<int, array{name: string, slug: string}> $databaseValues */
+        $databaseValues = RelationType::query()
+            ->get(['name', 'slug'])
+            ->map(fn (RelationType $type): array => [
+                'name' => (string) $type->name,
+                'slug' => (string) $type->slug,
+            ])
+            ->all();
+
+        return $this->relationTypeLookup = $this->buildLookup(
+            array_merge(self::DEFAULT_RELATION_TYPES, $databaseValues)
+        );
+    }
+
+    /**
+     * @param  array<int, array{name: string, slug: string}>  $values
+     * @return array<string, string>
+     */
+    private function buildLookup(array $values): array
+    {
+        $lookup = [];
+
+        foreach ($values as $value) {
+            $canonical = trim($value['slug']);
+
+            if ($canonical === '') {
+                continue;
+            }
+
+            $this->addLookupValue($lookup, $value['slug'], $canonical);
+            $this->addLookupValue($lookup, $value['name'], $canonical);
+        }
+
+        return $lookup;
+    }
+
+    /**
+     * @param  array<string, string>  $lookup
+     */
+    private function addLookupValue(array &$lookup, string $rawValue, string $canonical): void
+    {
+        $key = $this->normalizeKey($rawValue);
+
+        if ($key === '') {
+            return;
+        }
+
+        $lookup[$key] = $canonical;
+    }
+
+    private function normalizeKey(string $value): string
+    {
+        $normalized = preg_replace('/[^[:alnum:]]+/u', '', trim($value)) ?? '';
+
+        return mb_strtolower($normalized);
+    }
+}

--- a/app/Services/RelationDiscoveryService.php
+++ b/app/Services/RelationDiscoveryService.php
@@ -236,15 +236,23 @@ class RelationDiscoveryService
     /**
      * Accept a suggested relation: creates a RelatedIdentifier and syncs to DataCite.
      *
-     * Uses a DB transaction for atomicity and firstOrCreate for idempotency.
+    * Uses a DB transaction for atomicity and re-checks duplicates under lock.
      *
      * @return array{success: bool, datacite_synced: bool, message: string}
      */
     public function acceptRelation(SuggestedRelation $suggestion): array
     {
         $resource = $suggestion->resource;
+        $alreadyExists = RelatedIdentifier::where('resource_id', $resource->id)
+            ->where('identifier', $suggestion->identifier)
+            ->where('relation_type_id', $suggestion->relation_type_id)
+            ->exists();
 
-        DB::transaction(function () use ($suggestion, $resource) {
+        $citationLabel = $alreadyExists
+            ? null
+            : $this->resolveAcceptedSuggestionCitationLabel($suggestion);
+
+        DB::transaction(function () use ($suggestion, $resource, $citationLabel) {
             $existingRelation = RelatedIdentifier::where('resource_id', $resource->id)
                 ->where('identifier', $suggestion->identifier)
                 ->where('relation_type_id', $suggestion->relation_type_id)
@@ -260,8 +268,6 @@ class RelationDiscoveryService
             $maxPosition = RelatedIdentifier::where('resource_id', $resource->id)
                 ->lockForUpdate()
                 ->max('position') ?? -1;
-
-            $citationLabel = $this->resolveAcceptedSuggestionCitationLabel($suggestion);
 
             RelatedIdentifier::create([
                 'resource_id' => $resource->id,

--- a/app/Services/RelationDiscoveryService.php
+++ b/app/Services/RelationDiscoveryService.php
@@ -243,27 +243,34 @@ class RelationDiscoveryService
     public function acceptRelation(SuggestedRelation $suggestion): array
     {
         $resource = $suggestion->resource;
-        $citationLabel = $this->resolveAcceptedSuggestionCitationLabel($suggestion);
 
-        DB::transaction(function () use ($suggestion, $resource, $citationLabel) {
-            // Lock existing rows to prevent concurrent inserts from reading the same max
+        DB::transaction(function () use ($suggestion, $resource) {
+            $existingRelation = RelatedIdentifier::where('resource_id', $resource->id)
+                ->where('identifier', $suggestion->identifier)
+                ->where('relation_type_id', $suggestion->relation_type_id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existingRelation !== null) {
+                $suggestion->delete();
+
+                return;
+            }
+
             $maxPosition = RelatedIdentifier::where('resource_id', $resource->id)
                 ->lockForUpdate()
                 ->max('position') ?? -1;
 
-            // Create the new RelatedIdentifier (idempotent via firstOrCreate)
-            RelatedIdentifier::firstOrCreate(
-                [
-                    'resource_id' => $resource->id,
-                    'identifier' => $suggestion->identifier,
-                    'relation_type_id' => $suggestion->relation_type_id,
-                ],
-                [
-                    'identifier_type_id' => $suggestion->identifier_type_id,
-                    'citation_label' => $citationLabel,
-                    'position' => $maxPosition + 1,
-                ],
-            );
+            $citationLabel = $this->resolveAcceptedSuggestionCitationLabel($suggestion);
+
+            RelatedIdentifier::create([
+                'resource_id' => $resource->id,
+                'identifier' => $suggestion->identifier,
+                'identifier_type_id' => $suggestion->identifier_type_id,
+                'relation_type_id' => $suggestion->relation_type_id,
+                'citation_label' => $citationLabel,
+                'position' => $maxPosition + 1,
+            ]);
 
             // Delete the suggestion
             $suggestion->delete();

--- a/app/Services/RelationDiscoveryService.php
+++ b/app/Services/RelationDiscoveryService.php
@@ -12,6 +12,7 @@ use App\Models\RelationType;
 use App\Models\Resource;
 use App\Models\SuggestedRelation;
 use App\Models\User;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -28,6 +29,7 @@ class RelationDiscoveryService
         private readonly ScholExplorerService $scholExplorerService,
         private readonly DataCiteEventDataService $dataCiteEventDataService,
         private readonly DataCiteSyncService $dataCiteSyncService,
+        private readonly RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService,
     ) {}
 
     /**
@@ -241,8 +243,9 @@ class RelationDiscoveryService
     public function acceptRelation(SuggestedRelation $suggestion): array
     {
         $resource = $suggestion->resource;
+        $citationLabel = $this->resolveAcceptedSuggestionCitationLabel($suggestion);
 
-        DB::transaction(function () use ($suggestion, $resource) {
+        DB::transaction(function () use ($suggestion, $resource, $citationLabel) {
             // Lock existing rows to prevent concurrent inserts from reading the same max
             $maxPosition = RelatedIdentifier::where('resource_id', $resource->id)
                 ->lockForUpdate()
@@ -257,6 +260,7 @@ class RelationDiscoveryService
                 ],
                 [
                     'identifier_type_id' => $suggestion->identifier_type_id,
+                    'citation_label' => $citationLabel,
                     'position' => $maxPosition + 1,
                 ],
             );
@@ -292,6 +296,58 @@ class RelationDiscoveryService
             'datacite_synced' => false,
             'message' => 'Relation accepted but DataCite sync failed: ' . ($syncResult->errorMessage ?? 'Unknown error'),
         ];
+    }
+
+    private function resolveAcceptedSuggestionCitationLabel(SuggestedRelation $suggestion): ?string
+    {
+        $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolveBestEffort(
+            $suggestion->identifier,
+            (string) ($suggestion->identifierType->slug ?? ''),
+            microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS,
+        );
+
+        if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
+            return trim($resolvedCitationLabel);
+        }
+
+        return $this->buildCitationLabelFromSuggestionMetadata($suggestion);
+    }
+
+    private function buildCitationLabelFromSuggestionMetadata(SuggestedRelation $suggestion): ?string
+    {
+        $title = is_string($suggestion->source_title) ? trim($suggestion->source_title) : '';
+
+        if ($title === '') {
+            return null;
+        }
+
+        $label = $title;
+        $year = $this->extractPublicationYear($suggestion->source_publication_date);
+
+        if ($year !== null) {
+            $label .= " ({$year})";
+        }
+
+        $publisher = is_string($suggestion->source_publisher) ? trim($suggestion->source_publisher) : '';
+
+        if ($publisher !== '') {
+            $label .= ". {$publisher}";
+        }
+
+        return rtrim($label, ". ") . '.';
+    }
+
+    private function extractPublicationYear(?string $publicationDate): ?string
+    {
+        if ($publicationDate === null) {
+            return null;
+        }
+
+        if (preg_match('/\b(\d{4})\b/', $publicationDate, $matches) !== 1) {
+            return null;
+        }
+
+        return $matches[1];
     }
 
     /**

--- a/app/Services/RelationDiscoveryService.php
+++ b/app/Services/RelationDiscoveryService.php
@@ -236,7 +236,8 @@ class RelationDiscoveryService
     /**
      * Accept a suggested relation: creates a RelatedIdentifier and syncs to DataCite.
      *
-    * Uses a DB transaction for atomicity and re-checks duplicates under lock.
+    * Uses a DB transaction for atomicity and re-checks duplicates under a
+    * resource-level lock before assigning the next position.
      *
      * @return array{success: bool, datacite_synced: bool, message: string}
      */
@@ -253,6 +254,11 @@ class RelationDiscoveryService
             : $this->resolveAcceptedSuggestionCitationLabel($suggestion);
 
         DB::transaction(function () use ($suggestion, $resource, $citationLabel) {
+            Resource::query()
+                ->whereKey($resource->getKey())
+                ->lockForUpdate()
+                ->first();
+
             $existingRelation = RelatedIdentifier::where('resource_id', $resource->id)
                 ->where('identifier', $suggestion->identifier)
                 ->where('relation_type_id', $suggestion->relation_type_id)

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -149,6 +149,8 @@ class ResourceStorageService
             return $data;
         }
 
+        $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
+
         foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
             if (! is_array($relatedIdentifier)) {
                 continue;
@@ -176,9 +178,10 @@ class ResourceStorageService
                 continue;
             }
 
-            $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolve(
+            $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolveBestEffort(
                 $identifier,
                 (string) ($relatedIdentifier['identifierType'] ?? ''),
+                $citationResolutionDeadline,
             );
 
             if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -56,6 +56,8 @@ class ResourceStorageService
     #[\NoDiscard('Stored resource and update flag must be used')]
     public function store(array $data, ?int $userId = null): array
     {
+        $data = $this->prepareDataForStorage($data);
+
         return DB::transaction(function () use ($data, $userId): array {
             $languageId = null;
 
@@ -133,6 +135,64 @@ class ResourceStorageService
                 $isUpdate,
             ];
         });
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function prepareDataForStorage(array $data): array
+    {
+        $relatedIdentifiers = $data['relatedIdentifiers'] ?? null;
+
+        if (! is_array($relatedIdentifiers)) {
+            return $data;
+        }
+
+        foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
+            if (! is_array($relatedIdentifier)) {
+                continue;
+            }
+
+            $identifier = isset($relatedIdentifier['identifier'])
+                ? trim((string) $relatedIdentifier['identifier'])
+                : '';
+
+            if ($identifier === '') {
+                unset($relatedIdentifiers[$index]['citationLabel']);
+
+                continue;
+            }
+
+            $relatedIdentifiers[$index]['identifier'] = $identifier;
+
+            $citationLabel = isset($relatedIdentifier['citationLabel'])
+                ? trim((string) $relatedIdentifier['citationLabel'])
+                : '';
+
+            if ($citationLabel !== '') {
+                $relatedIdentifiers[$index]['citationLabel'] = $citationLabel;
+
+                continue;
+            }
+
+            $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolve(
+                $identifier,
+                (string) ($relatedIdentifier['identifierType'] ?? ''),
+            );
+
+            if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
+                $relatedIdentifiers[$index]['citationLabel'] = trim($resolvedCitationLabel);
+
+                continue;
+            }
+
+            unset($relatedIdentifiers[$index]['citationLabel']);
+        }
+
+        $data['relatedIdentifiers'] = $relatedIdentifiers;
+
+        return $data;
     }
 
     /**
@@ -977,10 +1037,7 @@ class ResourceStorageService
             if (! empty(trim($relatedIdentifier['identifier']))) {
                 $citationLabel = isset($relatedIdentifier['citationLabel']) && trim($relatedIdentifier['citationLabel']) !== ''
                     ? trim($relatedIdentifier['citationLabel'])
-                    : $this->relatedIdentifierCitationLabelService->resolve(
-                        trim($relatedIdentifier['identifier']),
-                        (string) ($relatedIdentifier['identifierType'] ?? ''),
-                    );
+                    : null;
 
                 $resource->relatedIdentifiers()->create([
                     'identifier' => trim($relatedIdentifier['identifier']),

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -22,6 +22,7 @@ use App\Models\TitleType;
 use App\Services\Entities\AffiliationService;
 use App\Services\Entities\InstitutionService;
 use App\Services\Entities\PersonService;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\Citations\RelatedItemStorageService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -39,6 +40,7 @@ class ResourceStorageService
         protected InstitutionService $institutionService,
         protected AffiliationService $affiliationService,
         protected RorLookupService $rorLookupService,
+        protected RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService,
         protected RelatedItemStorageService $relatedItemStorage,
     ) {}
 
@@ -973,11 +975,19 @@ class ResourceStorageService
         foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
             // Only save if identifier is not empty
             if (! empty(trim($relatedIdentifier['identifier']))) {
+                $citationLabel = isset($relatedIdentifier['citationLabel']) && trim($relatedIdentifier['citationLabel']) !== ''
+                    ? trim($relatedIdentifier['citationLabel'])
+                    : $this->relatedIdentifierCitationLabelService->resolve(
+                        trim($relatedIdentifier['identifier']),
+                        (string) ($relatedIdentifier['identifierType'] ?? ''),
+                    );
+
                 $resource->relatedIdentifiers()->create([
                     'identifier' => trim($relatedIdentifier['identifier']),
                     'identifier_type_id' => $relatedIdTypeLookup[$relatedIdentifier['identifierType']] ?? null,
                     'relation_type_id' => $relationTypeLookup[$relatedIdentifier['relationType']] ?? null,
                     'relation_type_information' => isset($relatedIdentifier['relationTypeInformation']) && trim($relatedIdentifier['relationTypeInformation']) !== '' ? trim($relatedIdentifier['relationTypeInformation']) : null,
+                    'citation_label' => $citationLabel,
                     'position' => $index,
                 ]);
             }

--- a/app/Services/Xml/Sections/RelatedWorkAndInstrumentSectionParser.php
+++ b/app/Services/Xml/Sections/RelatedWorkAndInstrumentSectionParser.php
@@ -37,6 +37,7 @@ final readonly class RelatedWorkAndInstrumentSectionParser
 
         $relatedWorks = [];
         $instruments = [];
+        $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
 
         foreach ($relatedIdentifierElements as $index => $element) {
             $identifier = XmlElementHelpers::stringValue($element);
@@ -78,7 +79,7 @@ final readonly class RelatedWorkAndInstrumentSectionParser
                 'identifier_type' => $identifierType,
                 'relation_type' => $relationType,
                 'relation_type_information' => is_string($relationTypeInformationRaw) && trim($relationTypeInformationRaw) !== '' ? trim($relationTypeInformationRaw) : null,
-                'citation_label' => $this->citationLabelService->resolve($identifier, $identifierType),
+                'citation_label' => $this->citationLabelService->resolveBestEffort($identifier, $identifierType, $citationResolutionDeadline),
                 'position' => count($relatedWorks),
             ];
         }

--- a/app/Services/Xml/Sections/RelatedWorkAndInstrumentSectionParser.php
+++ b/app/Services/Xml/Sections/RelatedWorkAndInstrumentSectionParser.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Xml\Sections;
 
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\RelatedIdentifierTypeResolverService;
 use App\Support\Xml\XmlElementHelpers;
 use Illuminate\Support\Facades\Log;
 use Saloon\XmlWrangler\XmlReader;
@@ -16,38 +18,10 @@ use Saloon\XmlWrangler\XmlReader;
  */
 final readonly class RelatedWorkAndInstrumentSectionParser
 {
-    /**
-     * Canonical DataCite related identifier types supported by ERNIE editor.
-     *
-     * @var string[]
-     */
-    private const RELATED_IDENTIFIER_TYPES = [
-        'DOI', 'URL', 'Handle', 'IGSN', 'URN', 'ISBN', 'ISSN', 'PURL', 'ARK',
-        'arXiv', 'bibcode', 'CSTR', 'EAN13', 'EISSN', 'ISTC', 'LISSN', 'LSID',
-        'PMID', 'RAiD', 'RRID', 'SWHID', 'UPC', 'w3id',
-    ];
-
-    /**
-     * Canonical DataCite relation types supported by ERNIE editor.
-     *
-     * @var string[]
-     */
-    private const RELATED_RELATION_TYPES = [
-        'Cites', 'IsCitedBy', 'References', 'IsReferencedBy',
-        'Documents', 'IsDocumentedBy', 'Describes', 'IsDescribedBy',
-        'IsNewVersionOf', 'IsPreviousVersionOf', 'HasVersion', 'IsVersionOf',
-        'HasTranslation', 'IsTranslationOf',
-        'Continues', 'IsContinuedBy', 'Obsoletes', 'IsObsoletedBy',
-        'IsVariantFormOf', 'IsOriginalFormOf', 'IsIdenticalTo',
-        'HasPart', 'IsPartOf', 'Compiles', 'IsCompiledBy',
-        'IsSourceOf', 'IsDerivedFrom',
-        'IsSupplementTo', 'IsSupplementedBy',
-        'Requires', 'IsRequiredBy',
-        'HasMetadata', 'IsMetadataFor',
-        'Reviews', 'IsReviewedBy',
-        'IsPublishedIn', 'Collects', 'IsCollectedBy',
-        'Other',
-    ];
+    public function __construct(
+        private RelatedIdentifierTypeResolverService $typeResolver,
+        private RelatedIdentifierCitationLabelService $citationLabelService,
+    ) {}
 
     /**
      * @return array{
@@ -60,18 +34,6 @@ final readonly class RelatedWorkAndInstrumentSectionParser
         $relatedIdentifierElements = $reader
             ->xpathElement('//*[local-name()="resource"]/*[local-name()="relatedIdentifiers"]/*[local-name()="relatedIdentifier"]')
             ->get();
-
-        /** @var array<string, string> $identifierTypeLookup */
-        $identifierTypeLookup = [];
-        foreach (self::RELATED_IDENTIFIER_TYPES as $name) {
-            $identifierTypeLookup[mb_strtolower($name)] = $name;
-        }
-
-        /** @var array<string, string> $relationTypeLookup */
-        $relationTypeLookup = [];
-        foreach (self::RELATED_RELATION_TYPES as $name) {
-            $relationTypeLookup[mb_strtolower($name)] = $name;
-        }
 
         $relatedWorks = [];
         $instruments = [];
@@ -86,12 +48,8 @@ final readonly class RelatedWorkAndInstrumentSectionParser
                 continue;
             }
 
-            $identifierType = is_string($identifierTypeRaw)
-                ? ($identifierTypeLookup[mb_strtolower(trim($identifierTypeRaw))] ?? null)
-                : null;
-            $relationType = is_string($relationTypeRaw)
-                ? ($relationTypeLookup[mb_strtolower(trim($relationTypeRaw))] ?? null)
-                : null;
+            $identifierType = $this->typeResolver->resolveIdentifierType($identifierTypeRaw);
+            $relationType = $this->typeResolver->resolveRelationType($relationTypeRaw);
 
             if ($identifierType === null || $relationType === null) {
                 Log::warning('Skipping related identifier with unsupported type values during XML upload', [
@@ -120,6 +78,7 @@ final readonly class RelatedWorkAndInstrumentSectionParser
                 'identifier_type' => $identifierType,
                 'relation_type' => $relationType,
                 'relation_type_information' => is_string($relationTypeInformationRaw) && trim($relationTypeInformationRaw) !== '' ? trim($relationTypeInformationRaw) : null,
+                'citation_label' => $this->citationLabelService->resolve($identifier, $identifierType),
                 'position' => count($relatedWorks),
             ];
         }

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -402,6 +402,7 @@ entity "related_identifiers" as related_identifiers {
     * identifier_type_id : BIGINT <<FK>>
     * relation_type_id : BIGINT <<FK>>
     relation_type_information : VARCHAR //DataCite 4.7//
+    citation_label : TEXT
     related_metadata_scheme : VARCHAR
     scheme_uri : VARCHAR(512)
     scheme_type : VARCHAR(100)

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -402,7 +402,7 @@ entity "related_identifiers" as related_identifiers {
     * identifier_type_id : BIGINT <<FK>>
     * relation_type_id : BIGINT <<FK>>
     relation_type_information : VARCHAR //DataCite 4.7//
-    citation_label : TEXT
+    citation_label : MEDIUMTEXT
     related_metadata_scheme : VARCHAR
     scheme_uri : VARCHAR(512)
     scheme_type : VARCHAR(100)

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -361,7 +361,7 @@ erDiagram
         bigint identifier_type_id FK
         bigint relation_type_id FK
         varchar relation_type_information "nullable, DataCite 4.7"
-        text citation_label "nullable"
+        mediumtext citation_label "nullable"
         varchar related_metadata_scheme
         varchar scheme_uri
         varchar scheme_type

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -361,6 +361,7 @@ erDiagram
         bigint identifier_type_id FK
         bigint relation_type_id FK
         varchar relation_type_information "nullable, DataCite 4.7"
+        text citation_label "nullable"
         varchar related_metadata_scheme
         varchar scheme_uri
         varchar scheme_type

--- a/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
+++ b/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -13,6 +14,14 @@ return new class extends Migration
         Schema::table('related_identifiers', function (Blueprint $table): void {
             $table->text('citation_label')->nullable()->after('relation_type_information');
         });
+
+        DB::table('related_identifiers')
+            ->whereNull('citation_label')
+            ->whereNotNull('identifier')
+            ->where('identifier', '!=', '')
+            ->update([
+                'citation_label' => DB::raw('identifier'),
+            ]);
     }
 
     public function down(): void

--- a/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
+++ b/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
@@ -11,7 +11,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('related_identifiers', function (Blueprint $table): void {
-            $table->text('citation_label')->nullable()->after('relation_type_information');
+            // MEDIUMTEXT keeps the 65,535-character validation ceiling safe
+            // under utf8mb4, where TEXT would otherwise cap at 65,535 bytes.
+            $table->mediumText('citation_label')->nullable()->after('relation_type_information');
         });
     }
 

--- a/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
+++ b/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('related_identifiers', function (Blueprint $table): void {
+            $table->text('citation_label')->nullable()->after('relation_type_information');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('related_identifiers', function (Blueprint $table): void {
+            $table->dropColumn('citation_label');
+        });
+    }
+};

--- a/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
+++ b/database/migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,14 +13,6 @@ return new class extends Migration
         Schema::table('related_identifiers', function (Blueprint $table): void {
             $table->text('citation_label')->nullable()->after('relation_type_information');
         });
-
-        DB::table('related_identifiers')
-            ->whereNull('citation_label')
-            ->whereNotNull('identifier')
-            ->where('identifier', '!=', '')
-            ->update([
-                'citation_label' => DB::raw('identifier'),
-            ]);
     }
 
     public function down(): void

--- a/package-lock.json
+++ b/package-lock.json
@@ -12583,9 +12583,9 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.0.tgz",
-      "integrity": "sha512-lrEXo5wFPsq5LTcayelM3BPueD00v7zbdipAY+EIdPcseVykYwkOWx4Ujn/EtbBvpnp8ZPUHol17HXH6kVbZoA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
@@ -12599,7 +12599,13 @@
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8.0",
         "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-debounce-input": {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-12",
+        "date": "2026-05-15",
         "features": [
             {
                 "title": "Single DOI Import for GFZ Legacy Resources",
@@ -93,6 +93,10 @@
             }
         ],
         "improvements": [
+            {
+                "title": "Related Work editor, import, and landing-page citation flow",
+                "description": "Related Work now uses a single inline add form with auto-detected identifier types, a pinned 'Most used' relation-type block, editable cards, and drag-and-drop reordering. DOI-based related identifiers now resolve and persist citation labels during add, save, and import, while XML/JSON import also normalizes human-readable relation-type variants to the canonical DataCite values. Landing pages and the relation browser now reuse these persisted citation labels instead of fetching third-party citation data at runtime, reducing traffic and keeping related-work output stable even when external APIs are unavailable."
+            },
             {
                 "title": "Clearer DOI Actions and Less Cluttered Metadata Entry",
                 "description": "The Dashboard no longer shows a redundant 'Upload metadata' quick action because the upload dropzone is already available on the same page. On the Resources page, the DataCite action now reads 'Register DOI' for records that are not yet published and only switches to 'Update metadata' for already published DOI records, matching the visible publication state more closely. In the Data Editor, the Datacenter field now takes more horizontal space and selected datacenter badges can wrap cleanly, preventing long names such as 'DEKORP - German Continental Seismic Reflection Program' from overlapping the adjacent Version field."

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -1714,6 +1714,7 @@ export default function DataCiteForm({
                 identifierType: string;
                 relationType: string;
                 relationTypeInformation?: string;
+                citationLabel?: string;
             }[];
             fundingReferences: {
                 funderName: string;
@@ -1793,6 +1794,7 @@ export default function DataCiteForm({
                 identifierType: rw.identifier_type,
                 relationType: rw.relation_type,
                 ...(rw.relation_type_information ? { relationTypeInformation: rw.relation_type_information } : {}),
+                ...(rw.citation_label ? { citationLabel: rw.citation_label } : {}),
             })),
             // Pass-through for XML-imported inline citations; the backend
             // persists these on first save, after which the REST-based

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2582,7 +2582,7 @@ export default function DataCiteForm({
                         <SectionHeader
                             label="Related Work"
                             description="Links to related publications and datasets."
-                            tooltip="DOIs, URLs, and Handles supported. Use Quick Add for common relation types."
+                            tooltip="DOIs, URLs, Handles, and other DataCite identifier types are supported. Add entries, refine citation labels, and drag cards to reorder them."
                             counter={{ current: relatedWorks.length, max: 100 }}
                         />
                         <RelatedWorkField

--- a/resources/js/components/curation/fields/related-work/related-work-field.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-field.tsx
@@ -69,6 +69,7 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
     // Shared form state - persisted across mode switches
     const [identifier, setIdentifier] = useState('');
     const [identifierType, setIdentifierType] = useState<IdentifierType>('DOI');
+    const [identifierTypeWasManuallySelected, setIdentifierTypeWasManuallySelected] = useState(false);
     const [relationType, setRelationType] = useState<RelationType>('Cites');
 
     useEffect(() => {
@@ -145,9 +146,19 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
     // Update identifierType when identifier changes in simple mode (auto-detection)
     const handleIdentifierChange = (value: string, autoDetect: boolean = false) => {
         setIdentifier(value);
-        if (autoDetect) {
+
+        if (value.trim() === '') {
+            setIdentifierTypeWasManuallySelected(false);
+        }
+
+        if (autoDetect && !identifierTypeWasManuallySelected) {
             setIdentifierType(detectIdentifierType(value));
         }
+    };
+
+    const handleIdentifierTypeChange = (value: IdentifierType) => {
+        setIdentifierType(value);
+        setIdentifierTypeWasManuallySelected(true);
     };
 
     const handleAdd = (data: RelatedIdentifierFormData) => {
@@ -185,6 +196,7 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
         // Reset form after successful add
         setIdentifier('');
         setIdentifierType('DOI');
+        setIdentifierTypeWasManuallySelected(false);
         setRelationType('Cites');
     };
 
@@ -288,7 +300,7 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
                         identifier={identifier}
                         onIdentifierChange={(value) => handleIdentifierChange(value, true)}
                         identifierType={identifierType}
-                        onIdentifierTypeChange={setIdentifierType}
+                        onIdentifierTypeChange={handleIdentifierTypeChange}
                         relationType={relationType}
                         onRelationTypeChange={setRelationType}
                         activeRelationTypes={activeRelationTypes}

--- a/resources/js/components/curation/fields/related-work/related-work-field.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-field.tsx
@@ -1,12 +1,13 @@
 import { FileUp } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
+import { getCitation } from '@/actions/App/Http/Controllers/Api/DataCiteController';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { normalizeDOI } from '@/lib/doi-validation';
 import { detectIdentifierType } from '@/lib/identifier-type-detection';
 import type { IdentifierType, RelatedIdentifier, RelatedIdentifierFormData, RelationType } from '@/types';
 
-import RelatedWorkAdvancedAdd from './related-work-advanced-add';
 import RelatedWorkCsvImport from './related-work-csv-import';
 import RelatedWorkList from './related-work-list';
 import RelatedWorkQuickAdd from './related-work-quick-add';
@@ -61,15 +62,85 @@ function isDuplicate(identifier: string, identifierType: string, relationType: s
 }
 
 export default function RelatedWorkField({ relatedWorks, onChange, activeRelationTypes, activeIdentifierTypes }: RelatedWorkFieldProps) {
-    const [showAdvanced, setShowAdvanced] = useState(false);
     const [showCsvImport, setShowCsvImport] = useState(false);
     const [duplicateError, setDuplicateError] = useState<string | null>(null);
+    const relatedWorksRef = useRef(relatedWorks);
 
     // Shared form state - persisted across mode switches
     const [identifier, setIdentifier] = useState('');
     const [identifierType, setIdentifierType] = useState<IdentifierType>('DOI');
     const [relationType, setRelationType] = useState<RelationType>('Cites');
-    const [relationTypeInformation, setRelationTypeInformation] = useState('');
+
+    useEffect(() => {
+        relatedWorksRef.current = relatedWorks;
+    }, [relatedWorks]);
+
+    const assignPositions = (items: RelatedIdentifier[]) =>
+        items.map((item, index) => ({
+            ...item,
+            position: index,
+        }));
+
+    const hydrateCitationLabel = async (identifier: string, itemIdentifierType: string, itemRelationType: string) => {
+        if (itemIdentifierType !== 'DOI') {
+            return;
+        }
+
+        try {
+            const response = await fetch(
+                getCitation.url({
+                    query: {
+                        doi: normalizeDOI(identifier),
+                    },
+                }),
+                {
+                    headers: {
+                        Accept: 'application/json',
+                    },
+                },
+            );
+
+            if (!response.ok) {
+                return;
+            }
+
+            const payload = (await response.json()) as { citation?: unknown };
+            const citationLabel = typeof payload.citation === 'string' ? payload.citation.trim() : '';
+
+            if (!citationLabel) {
+                return;
+            }
+
+            let didUpdate = false;
+
+            const updated = relatedWorksRef.current.map((item) => {
+                if (
+                    item.identifier === identifier
+                    && item.identifier_type === itemIdentifierType
+                    && item.relation_type === itemRelationType
+                    && !item.citation_label?.trim()
+                ) {
+                    didUpdate = true;
+
+                    return {
+                        ...item,
+                        citation_label: citationLabel,
+                    };
+                }
+
+                return item;
+            });
+
+            if (!didUpdate) {
+                return;
+            }
+
+            relatedWorksRef.current = updated;
+            onChange(updated);
+        } catch {
+            // Saving will backfill citation labels server-side when client-side lookup fails.
+        }
+    };
 
     // Update identifierType when identifier changes in simple mode (auto-detection)
     const handleIdentifierChange = (value: string, autoDetect: boolean = false) => {
@@ -99,16 +170,22 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
             identifier_type: data.identifierType,
             relation_type: data.relationType,
             ...(data.relationTypeInformation ? { relation_type_information: data.relationTypeInformation } : {}),
+            ...(data.citationLabel ? { citation_label: data.citationLabel } : {}),
             position: relatedWorks.length,
         };
 
-        onChange([...relatedWorks, newItem]);
+        const updated = [...relatedWorks, newItem];
+        relatedWorksRef.current = updated;
+        onChange(updated);
+
+        if (!newItem.citation_label?.trim()) {
+            void hydrateCitationLabel(newItem.identifier, newItem.identifier_type, newItem.relation_type);
+        }
 
         // Reset form after successful add
         setIdentifier('');
         setIdentifierType('DOI');
         setRelationType('Cites');
-        setRelationTypeInformation('');
     };
 
     const handleBulkImport = (data: RelatedIdentifierFormData[]) => {
@@ -125,13 +202,21 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
                     identifier_type: item.identifierType,
                     relation_type: item.relationType,
                     ...(item.relationTypeInformation ? { relation_type_information: item.relationTypeInformation } : {}),
+                    ...(item.citationLabel ? { citation_label: item.citationLabel } : {}),
                     position: combinedList.length,
                 });
             }
         });
 
+        relatedWorksRef.current = combinedList;
         onChange(combinedList);
         setShowCsvImport(false);
+
+        combinedList.forEach((item) => {
+            if (!item.citation_label?.trim()) {
+                void hydrateCitationLabel(item.identifier, item.identifier_type, item.relation_type);
+            }
+        });
 
         // Show warning if duplicates were skipped
         if (skippedDuplicates.length > 0) {
@@ -143,19 +228,38 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
     };
 
     const handleRemove = (index: number) => {
-        const updated = relatedWorks.filter((_, i) => i !== index);
+        const reindexed = assignPositions(relatedWorks.filter((_, i) => i !== index));
 
-        // Re-assign positions after removal
-        const reindexed = updated.map((item, i) => ({
-            ...item,
-            position: i,
-        }));
-
+        relatedWorksRef.current = reindexed;
         onChange(reindexed);
     };
 
-    const handleToggleAdvanced = () => {
-        setShowAdvanced(!showAdvanced);
+    const handleItemChange = (index: number, updatedItem: RelatedIdentifier) => {
+        const previousItem = relatedWorks[index];
+        const identifierChanged =
+            previousItem.identifier !== updatedItem.identifier || previousItem.identifier_type !== updatedItem.identifier_type;
+
+        const updated = relatedWorks.map((item, itemIndex) => {
+            if (itemIndex !== index) {
+                return item;
+            }
+
+            return {
+                ...updatedItem,
+                citation_label: identifierChanged ? null : updatedItem.citation_label ?? null,
+                position: itemIndex,
+            };
+        });
+
+        relatedWorksRef.current = updated;
+        onChange(updated);
+    };
+
+    const handleReorder = (items: RelatedIdentifier[]) => {
+        const reindexed = assignPositions(items);
+
+        relatedWorksRef.current = reindexed;
+        onChange(reindexed);
     };
 
     return (
@@ -179,45 +283,17 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
                 </div>
             ) : (
                 <>
-                    {/* Quick or Advanced Mode */}
-                    {!showAdvanced ? (
-                        <RelatedWorkQuickAdd
-                            onAdd={handleAdd}
-                            showAdvancedMode={showAdvanced}
-                            onToggleAdvanced={handleToggleAdvanced}
-                            identifier={identifier}
-                            onIdentifierChange={(value) => handleIdentifierChange(value, true)}
-                            identifierType={identifierType}
-                            relationType={relationType}
-                            onRelationTypeChange={setRelationType}
-                            activeRelationTypes={activeRelationTypes}
-                        />
-                    ) : (
-                        <>
-                            <RelatedWorkAdvancedAdd
-                                onAdd={handleAdd}
-                                identifier={identifier}
-                                onIdentifierChange={(value) => handleIdentifierChange(value, false)}
-                                identifierType={identifierType}
-                                onIdentifierTypeChange={setIdentifierType}
-                                relationType={relationType}
-                                onRelationTypeChange={setRelationType}
-                                relationTypeInformation={relationTypeInformation}
-                                onRelationTypeInformationChange={setRelationTypeInformation}
-                                activeRelationTypes={activeRelationTypes}
-                                activeIdentifierTypes={activeIdentifierTypes}
-                            />
-                            <div className="pt-2">
-                                <button
-                                    type="button"
-                                    onClick={handleToggleAdvanced}
-                                    className="text-xs text-muted-foreground underline hover:text-foreground"
-                                >
-                                    ← Switch to simple mode
-                                </button>
-                            </div>
-                        </>
-                    )}
+                    <RelatedWorkQuickAdd
+                        onAdd={handleAdd}
+                        identifier={identifier}
+                        onIdentifierChange={(value) => handleIdentifierChange(value, true)}
+                        identifierType={identifierType}
+                        onIdentifierTypeChange={setIdentifierType}
+                        relationType={relationType}
+                        onRelationTypeChange={setRelationType}
+                        activeRelationTypes={activeRelationTypes}
+                        activeIdentifierTypes={activeIdentifierTypes}
+                    />
 
                     {/* CSV Import Button */}
                     <div className="flex justify-end">
@@ -230,7 +306,16 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
             )}
 
             {/* List of Added Items */}
-            {relatedWorks.length > 0 && <RelatedWorkList items={relatedWorks} onRemove={handleRemove} />}
+            {relatedWorks.length > 0 && (
+                <RelatedWorkList
+                    items={relatedWorks}
+                    onItemChange={handleItemChange}
+                    onRemove={handleRemove}
+                    onReorder={handleReorder}
+                    activeRelationTypes={activeRelationTypes}
+                    activeIdentifierTypes={activeIdentifierTypes}
+                />
+            )}
         </div>
     );
 }

--- a/resources/js/components/curation/fields/related-work/related-work-field.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-field.tsx
@@ -259,6 +259,19 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
     };
 
     const handleItemChange = (index: number, updatedItem: RelatedIdentifier) => {
+        const otherItems = relatedWorks.filter((_, itemIndex) => itemIndex !== index);
+
+        if (isDuplicate(updatedItem.identifier, updatedItem.identifier_type, updatedItem.relation_type, otherItems)) {
+            setDuplicateError(
+                `This exact relation already exists in the list (same identifier and relation type). Note: You can add the same identifier with a different relation type.`,
+            );
+            setTimeout(() => setDuplicateError(null), 5000);
+
+            return;
+        }
+
+        setDuplicateError(null);
+
         const previousItem = relatedWorks[index];
         const identifierChanged =
             previousItem.identifier !== updatedItem.identifier || previousItem.identifier_type !== updatedItem.identifier_type;

--- a/resources/js/components/curation/fields/related-work/related-work-field.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-field.tsx
@@ -19,6 +19,8 @@ interface RelatedWorkFieldProps {
     activeIdentifierTypes?: string[];
 }
 
+const BULK_IMPORT_CITATION_HYDRATION_CONCURRENCY = 3;
+
 /**
  * RelatedWorkField Component
  *
@@ -143,6 +145,16 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
         }
     };
 
+    const hydrateCitationLabelsForImportedItems = async (items: RelatedIdentifier[]) => {
+        const itemsNeedingHydration = items.filter((item) => item.identifier_type === 'DOI' && !item.citation_label?.trim());
+
+        for (let index = 0; index < itemsNeedingHydration.length; index += BULK_IMPORT_CITATION_HYDRATION_CONCURRENCY) {
+            const chunk = itemsNeedingHydration.slice(index, index + BULK_IMPORT_CITATION_HYDRATION_CONCURRENCY);
+
+            await Promise.all(chunk.map((item) => hydrateCitationLabel(item.identifier, item.identifier_type, item.relation_type)));
+        }
+    };
+
     // Update identifierType when identifier changes in simple mode (auto-detection)
     const handleIdentifierChange = (value: string, autoDetect: boolean = false) => {
         setIdentifier(value);
@@ -203,20 +215,24 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
     const handleBulkImport = (data: RelatedIdentifierFormData[]) => {
         // Filter out duplicates from CSV import
         const combinedList = [...relatedWorks];
+        const importedItems: RelatedIdentifier[] = [];
         const skippedDuplicates: string[] = [];
 
         data.forEach((item) => {
             if (isDuplicate(item.identifier, item.identifierType, item.relationType, combinedList)) {
                 skippedDuplicates.push(`${item.identifier} (${item.relationType})`);
             } else {
-                combinedList.push({
+                const importedItem: RelatedIdentifier = {
                     identifier: item.identifier,
                     identifier_type: item.identifierType,
                     relation_type: item.relationType,
                     ...(item.relationTypeInformation ? { relation_type_information: item.relationTypeInformation } : {}),
                     ...(item.citationLabel ? { citation_label: item.citationLabel } : {}),
                     position: combinedList.length,
-                });
+                };
+
+                combinedList.push(importedItem);
+                importedItems.push(importedItem);
             }
         });
 
@@ -224,11 +240,7 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
         onChange(combinedList);
         setShowCsvImport(false);
 
-        combinedList.forEach((item) => {
-            if (!item.citation_label?.trim()) {
-                void hydrateCitationLabel(item.identifier, item.identifier_type, item.relation_type);
-            }
-        });
+        void hydrateCitationLabelsForImportedItems(importedItems);
 
         // Show warning if duplicates were skipped
         if (skippedDuplicates.length > 0) {
@@ -259,6 +271,8 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
             return {
                 ...updatedItem,
                 citation_label: identifierChanged ? null : updatedItem.citation_label ?? null,
+                related_title: identifierChanged ? null : updatedItem.related_title ?? null,
+                related_metadata: identifierChanged ? null : updatedItem.related_metadata ?? null,
                 position: itemIndex,
             };
         });

--- a/resources/js/components/curation/fields/related-work/related-work-field.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-field.tsx
@@ -63,20 +63,53 @@ function isDuplicate(identifier: string, identifierType: string, relationType: s
     });
 }
 
+function isActiveOption(value: string, activeOptions?: string[]): boolean {
+    return activeOptions === undefined || activeOptions.includes(value);
+}
+
+function getPreferredActiveOption<T extends string>(preferred: T, activeOptions?: string[]): T | null {
+    if (activeOptions === undefined) {
+        return preferred;
+    }
+
+    if (activeOptions.includes(preferred)) {
+        return preferred;
+    }
+
+    const firstActive = activeOptions.find((value) => value.trim() !== '');
+
+    return firstActive ? (firstActive as T) : null;
+}
+
 export default function RelatedWorkField({ relatedWorks, onChange, activeRelationTypes, activeIdentifierTypes }: RelatedWorkFieldProps) {
     const [showCsvImport, setShowCsvImport] = useState(false);
     const [duplicateError, setDuplicateError] = useState<string | null>(null);
     const relatedWorksRef = useRef(relatedWorks);
+    const defaultIdentifierType = getPreferredActiveOption<IdentifierType>('DOI', activeIdentifierTypes);
+    const defaultRelationType = getPreferredActiveOption<RelationType>('Cites', activeRelationTypes);
 
     // Shared form state - persisted across mode switches
     const [identifier, setIdentifier] = useState('');
-    const [identifierType, setIdentifierType] = useState<IdentifierType>('DOI');
+    const [identifierType, setIdentifierType] = useState<IdentifierType>(() => defaultIdentifierType ?? 'DOI');
     const [identifierTypeWasManuallySelected, setIdentifierTypeWasManuallySelected] = useState(false);
-    const [relationType, setRelationType] = useState<RelationType>('Cites');
+    const [relationType, setRelationType] = useState<RelationType>(() => defaultRelationType ?? 'Cites');
 
     useEffect(() => {
         relatedWorksRef.current = relatedWorks;
     }, [relatedWorks]);
+
+    useEffect(() => {
+        if (defaultIdentifierType !== null && !isActiveOption(identifierType, activeIdentifierTypes)) {
+            setIdentifierType(defaultIdentifierType);
+            setIdentifierTypeWasManuallySelected(false);
+        }
+    }, [activeIdentifierTypes, defaultIdentifierType, identifierType]);
+
+    useEffect(() => {
+        if (defaultRelationType !== null && !isActiveOption(relationType, activeRelationTypes)) {
+            setRelationType(defaultRelationType);
+        }
+    }, [activeRelationTypes, defaultRelationType, relationType]);
 
     const assignPositions = (items: RelatedIdentifier[]) =>
         items.map((item, index) => ({
@@ -164,7 +197,12 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
         }
 
         if (autoDetect && !identifierTypeWasManuallySelected) {
-            setIdentifierType(detectIdentifierType(value));
+            const detectedIdentifierType = detectIdentifierType(value);
+            const nextIdentifierType = getPreferredActiveOption<IdentifierType>(detectedIdentifierType, activeIdentifierTypes);
+
+            if (nextIdentifierType !== null) {
+                setIdentifierType(nextIdentifierType);
+            }
         }
     };
 
@@ -174,6 +212,10 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
     };
 
     const handleAdd = (data: RelatedIdentifierFormData) => {
+        if (!isActiveOption(data.identifierType, activeIdentifierTypes) || !isActiveOption(data.relationType, activeRelationTypes)) {
+            return;
+        }
+
         // Check for duplicates (same identifier AND same relation type)
         if (isDuplicate(data.identifier, data.identifierType, data.relationType, relatedWorks)) {
             setDuplicateError(
@@ -207,9 +249,9 @@ export default function RelatedWorkField({ relatedWorks, onChange, activeRelatio
 
         // Reset form after successful add
         setIdentifier('');
-        setIdentifierType('DOI');
+        setIdentifierType(defaultIdentifierType ?? 'DOI');
         setIdentifierTypeWasManuallySelected(false);
-        setRelationType('Cites');
+        setRelationType(defaultRelationType ?? 'Cites');
     };
 
     const handleBulkImport = (data: RelatedIdentifierFormData[]) => {

--- a/resources/js/components/curation/fields/related-work/related-work-item.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-item.tsx
@@ -277,9 +277,12 @@ export default function RelatedWorkItem({
                     </div>
 
                     <div className="md:col-span-4">
-                        <Label htmlFor={`related-work-${index}-resolved-title`}>Resolved title</Label>
+                        <p id={`related-work-${index}-resolved-title-label`} className="text-sm font-medium leading-none">
+                            Resolved title
+                        </p>
                         <div
                             id={`related-work-${index}-resolved-title`}
+                            aria-labelledby={`related-work-${index}-resolved-title-label`}
                             className="min-h-24 rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
                         >
                             {item.related_title?.trim() ? item.related_title : 'No resolved title available yet.'}

--- a/resources/js/components/curation/fields/related-work/related-work-item.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-item.tsx
@@ -16,6 +16,7 @@ import {
     MOST_USED_RELATION_TYPES,
     RELATION_TYPE_DESCRIPTIONS,
 } from '@/lib/related-identifiers';
+import { resolveIdentifierUrl } from '@/pages/LandingPages/lib/resolveIdentifierUrl';
 import { identifierTypes } from '@/schemas/related-work.schema';
 import type { RelatedIdentifier, RelationType } from '@/types';
 
@@ -63,13 +64,11 @@ export default function RelatedWorkItem({
         ? identifierTypes.filter((type) => activeIdentifierTypes.includes(type))
         : [...identifierTypes];
 
-    const isClickable = item.identifier_type === 'DOI' || item.identifier_type === 'URL' || item.identifier_type === 'Handle';
-    const linkUrl =
-        item.identifier_type === 'DOI'
-            ? `https://doi.org/${item.identifier}`
-            : item.identifier_type === 'Handle'
-              ? `https://hdl.handle.net/${item.identifier}`
-              : item.identifier;
+    const previewLinkIdentifierTypes = new Set(['DOI', 'URL', 'Handle']);
+    const linkUrl = previewLinkIdentifierTypes.has(item.identifier_type)
+        ? resolveIdentifierUrl(item.identifier, item.identifier_type)
+        : null;
+    const isClickable = linkUrl !== null;
     const style = {
         transform: CSS.Transform.toString(transform),
         transition,

--- a/resources/js/components/curation/fields/related-work/related-work-item.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-item.tsx
@@ -1,16 +1,32 @@
-import { AlertCircle, CheckCircle2, ExternalLink, Trash2 } from 'lucide-react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { AlertCircle, CheckCircle2, ExternalLink, GripVertical, Trash2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { RELATION_TYPE_DESCRIPTIONS } from '@/lib/related-identifiers';
+import {
+    formatRelationTypeLabel,
+    getAllRelationTypes,
+    MOST_USED_RELATION_TYPES,
+    RELATION_TYPE_DESCRIPTIONS,
+} from '@/lib/related-identifiers';
+import { identifierTypes } from '@/schemas/related-work.schema';
 import type { RelatedIdentifier, RelationType } from '@/types';
 
 interface RelatedWorkItemProps {
+    sortableId: string;
     item: RelatedIdentifier;
     index: number;
+    onChange: (item: RelatedIdentifier) => void;
     onRemove: (index: number) => void;
+    activeRelationTypes?: string[];
+    activeIdentifierTypes?: string[];
     validationStatus?: 'validating' | 'valid' | 'invalid' | 'warning';
     validationMessage?: string;
 }
@@ -19,19 +35,54 @@ interface RelatedWorkItemProps {
  * RelatedWorkItem Component
  *
  * Displays a single related work item with:
- * - Identifier with external link (if URL or DOI)
- * - Relation type with description tooltip
- * - Identifier type badge
+ * - Editable identifier, type, relation type, and citation label fields
+ * - External link preview for DOI, URL, and Handle identifiers
+ * - Drag handle for ordering
  * - Validation status indicator
  * - Remove button
  */
-export default function RelatedWorkItem({ item, index, onRemove, validationStatus, validationMessage }: RelatedWorkItemProps) {
-    // Determine if identifier is a clickable link
-    const isClickable = item.identifier_type === 'DOI' || item.identifier_type === 'URL';
-    const linkUrl = item.identifier_type === 'DOI' ? `https://doi.org/${item.identifier}` : item.identifier;
+export default function RelatedWorkItem({
+    sortableId,
+    item,
+    index,
+    onChange,
+    onRemove,
+    activeRelationTypes,
+    activeIdentifierTypes,
+    validationStatus,
+    validationMessage,
+}: RelatedWorkItemProps) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: sortableId });
+
+    const filteredRelationTypes = activeRelationTypes
+        ? getAllRelationTypes().filter((type) => activeRelationTypes.includes(type))
+        : getAllRelationTypes();
+    const filteredMostUsedRelationTypes = MOST_USED_RELATION_TYPES.filter((type) => filteredRelationTypes.includes(type));
+    const additionalRelationTypes = filteredRelationTypes.filter((type) => !filteredMostUsedRelationTypes.includes(type));
+    const filteredIdentifierTypes = activeIdentifierTypes
+        ? identifierTypes.filter((type) => activeIdentifierTypes.includes(type))
+        : [...identifierTypes];
+
+    const isClickable = item.identifier_type === 'DOI' || item.identifier_type === 'URL' || item.identifier_type === 'Handle';
+    const linkUrl =
+        item.identifier_type === 'DOI'
+            ? `https://doi.org/${item.identifier}`
+            : item.identifier_type === 'Handle'
+              ? `https://hdl.handle.net/${item.identifier}`
+              : item.identifier;
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
 
     // Get relation type description
     const description = RELATION_TYPE_DESCRIPTIONS[item.relation_type as RelationType] || '';
+    const updateItem = (patch: Partial<RelatedIdentifier>) => {
+        onChange({
+            ...item,
+            ...patch,
+        });
+    };
 
     // Validation icon
     const ValidationIcon = () => {
@@ -76,65 +127,179 @@ export default function RelatedWorkItem({ item, index, onRemove, validationStatu
     };
 
     return (
-        <Card className="p-4">
-            <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 space-y-2">
-                    {/* Relation Type with Tooltip */}
-                    <div className="flex items-center gap-2">
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <span className="text-sm font-semibold text-foreground">{item.relation_type}</span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p className="max-w-xs text-sm">{description}</p>
-                            </TooltipContent>
-                        </Tooltip>
-                        <Badge variant="secondary" className="text-xs" data-testid="identifier-type-badge">
-                            {item.identifier_type}
-                        </Badge>
+        <div ref={setNodeRef} style={style} role="listitem">
+            <Card className={`p-4 ${isDragging ? 'border-primary/50 shadow-lg' : ''}`}>
+                <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 items-start gap-3">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="mt-0.5 h-8 w-8 flex-shrink-0 cursor-grab text-muted-foreground"
+                            aria-label={`Reorder related work ${index + 1}`}
+                            {...attributes}
+                            {...listeners}
+                        >
+                            <GripVertical className="h-4 w-4" />
+                        </Button>
+
+                        <div className="space-y-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="text-sm font-semibold text-foreground">Related Work {index + 1}</h4>
+                                <Badge variant="outline" className="text-xs">
+                                    {formatRelationTypeLabel(item.relation_type)}
+                                </Badge>
+                                <Badge variant="secondary" className="text-xs" data-testid="identifier-type-badge">
+                                    {item.identifier_type}
+                                </Badge>
+                                <ValidationIcon />
+                            </div>
+                            <p className="text-xs text-muted-foreground">Edit the identifier, relation type, and landing-page citation label in one place.</p>
+                        </div>
                     </div>
 
-                    {/* Identifier with optional link */}
-                    <div className="flex items-center gap-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => onRemove(index)}
+                        aria-label="Remove related work"
+                        className="h-8 w-8 flex-shrink-0"
+                    >
+                        <Trash2 className="h-4 w-4" />
+                    </Button>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-12">
+                    <div className="md:col-span-5">
+                        <Label htmlFor={`related-work-${index}-identifier`}>Identifier</Label>
+                        <Input
+                            id={`related-work-${index}-identifier`}
+                            type="text"
+                            value={item.identifier}
+                            onChange={(event) => updateItem({ identifier: event.target.value })}
+                            placeholder="e.g., 10.5194/nhess-15-1463-2015"
+                            className="font-mono text-sm"
+                        />
+                    </div>
+
+                    <div className="md:col-span-2">
+                        <Label htmlFor={`related-work-${index}-identifier-type`}>Type</Label>
+                        <Select value={item.identifier_type} onValueChange={(value) => updateItem({ identifier_type: value })}>
+                            <SelectTrigger id={`related-work-${index}-identifier-type`}>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {filteredIdentifierTypes.map((type) => (
+                                    <SelectItem key={type} value={type}>
+                                        {type}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="md:col-span-5">
+                        <Label htmlFor={`related-work-${index}-relation-type`}>Relation type</Label>
+                        <Select
+                            value={item.relation_type}
+                            onValueChange={(value) =>
+                                updateItem({
+                                    relation_type: value,
+                                    relation_type_information: value === 'Other' ? item.relation_type_information ?? '' : null,
+                                })
+                            }
+                        >
+                            <SelectTrigger id={`related-work-${index}-relation-type`}>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent className="max-h-[400px]">
+                                {filteredMostUsedRelationTypes.length > 0 && (
+                                    <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Most Used</div>
+                                )}
+                                {filteredMostUsedRelationTypes.map((type) => (
+                                    <SelectItem key={type} value={type}>
+                                        <div className="flex flex-col items-start">
+                                            <span className="font-medium">{formatRelationTypeLabel(type)}</span>
+                                            <span className="text-xs text-muted-foreground">{RELATION_TYPE_DESCRIPTIONS[type]}</span>
+                                        </div>
+                                    </SelectItem>
+                                ))}
+                                {additionalRelationTypes.length > 0 && (
+                                    <div className="px-2 pt-3 pb-1.5 text-xs font-semibold text-muted-foreground">All relation types</div>
+                                )}
+                                {additionalRelationTypes.map((type) => (
+                                    <SelectItem key={type} value={type}>
+                                        <div className="flex flex-col items-start">
+                                            <span className="font-medium">{formatRelationTypeLabel(type)}</span>
+                                            <span className="text-xs text-muted-foreground">{RELATION_TYPE_DESCRIPTIONS[type]}</span>
+                                        </div>
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2 text-sm">
+                        <span className="font-medium text-foreground">Preview</span>
                         {isClickable ? (
                             <a
                                 href={linkUrl}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="group flex items-center gap-1 text-sm text-primary hover:underline"
+                                className="group inline-flex min-w-0 items-center gap-1 text-primary hover:underline"
                             >
                                 <span className="break-all">{item.identifier}</span>
                                 <ExternalLink className="h-3 w-3 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
                             </a>
                         ) : (
-                            <span className="text-sm break-all text-muted-foreground">{item.identifier}</span>
+                            <span className="break-all text-muted-foreground">{item.identifier}</span>
                         )}
-                        <ValidationIcon />
                     </div>
-
-                    {/* Optional: Related title from API */}
-                    {item.related_title && <p className="text-xs text-muted-foreground italic">{item.related_title}</p>}
-
-                    {/* Relation Type Information (for "Other" relation type) */}
-                    {item.relation_type_information && (
-                        <p className="text-xs text-muted-foreground">
-                            <span className="font-medium">Info:</span> {item.relation_type_information}
-                        </p>
-                    )}
+                    <p className="text-xs text-muted-foreground">{description}</p>
                 </div>
 
-                {/* Remove Button */}
-                <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => onRemove(index)}
-                    aria-label="Remove related work"
-                    className="h-8 w-8 flex-shrink-0"
-                >
-                    <Trash2 className="h-4 w-4" />
-                </Button>
-            </div>
-        </Card>
+                <div className="mt-4 grid gap-4 md:grid-cols-12">
+                    <div className="md:col-span-8">
+                        <Label htmlFor={`related-work-${index}-citation-label`}>Citation label</Label>
+                        <Textarea
+                            id={`related-work-${index}-citation-label`}
+                            value={item.citation_label ?? ''}
+                            onChange={(event) => updateItem({ citation_label: event.target.value })}
+                            rows={3}
+                            placeholder="Optional formatted citation shown on landing pages"
+                        />
+                        <p className="mt-1 text-xs text-muted-foreground">
+                            This text is preferred on landing pages and in relation graphs. Leave it empty to let the backend resolve a DOI citation.
+                        </p>
+                    </div>
+
+                    <div className="md:col-span-4">
+                        <Label htmlFor={`related-work-${index}-resolved-title`}>Resolved title</Label>
+                        <div
+                            id={`related-work-${index}-resolved-title`}
+                            className="min-h-24 rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+                        >
+                            {item.related_title?.trim() ? item.related_title : 'No resolved title available yet.'}
+                        </div>
+                    </div>
+                </div>
+
+                {item.relation_type === 'Other' && (
+                    <div className="mt-4 space-y-1">
+                        <Label htmlFor={`related-work-${index}-relation-type-information`}>Relation type information</Label>
+                        <Input
+                            id={`related-work-${index}-relation-type-information`}
+                            type="text"
+                            value={item.relation_type_information ?? ''}
+                            onChange={(event) => updateItem({ relation_type_information: event.target.value })}
+                            placeholder="Describe the custom relationship"
+                        />
+                    </div>
+                )}
+            </Card>
+        </div>
     );
 }

--- a/resources/js/components/curation/fields/related-work/related-work-list.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-list.tsx
@@ -1,10 +1,17 @@
+import { closestCenter, DndContext, type DragEndEvent, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
+
 import type { RelatedIdentifier } from '@/types';
 
 import RelatedWorkItem from './related-work-item';
 
 interface RelatedWorkListProps {
     items: RelatedIdentifier[];
+    onItemChange: (index: number, item: RelatedIdentifier) => void;
     onRemove: (index: number) => void;
+    onReorder: (items: RelatedIdentifier[]) => void;
+    activeRelationTypes?: string[];
+    activeIdentifierTypes?: string[];
     validationStatuses?: Map<
         number,
         {
@@ -17,38 +24,78 @@ interface RelatedWorkListProps {
 /**
  * RelatedWorkList Component
  *
- * Displays a list of related work items.
- * Items are shown in the order they were added (by position).
+ * Displays editable related work cards with drag-and-drop ordering.
  */
-export default function RelatedWorkList({ items, onRemove, validationStatuses }: RelatedWorkListProps) {
+export default function RelatedWorkList({
+    items,
+    onItemChange,
+    onRemove,
+    onReorder,
+    activeRelationTypes,
+    activeIdentifierTypes,
+    validationStatuses,
+}: RelatedWorkListProps) {
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+        }),
+    );
+
     if (items.length === 0) {
         return null;
     }
+
+    const getSortableId = (index: number) => `related-work-${index}`;
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+
+        if (!over || active.id === over.id) {
+            return;
+        }
+
+        const oldIndex = items.findIndex((_, index) => getSortableId(index) === active.id);
+        const newIndex = items.findIndex((_, index) => getSortableId(index) === over.id);
+
+        if (oldIndex === -1 || newIndex === -1) {
+            return;
+        }
+
+        onReorder(arrayMove(items, oldIndex, newIndex));
+    };
 
     return (
         <div className="space-y-3">
             <div className="flex items-center justify-between">
                 <h4 className="text-sm font-medium text-foreground">Added Relations ({items.length})</h4>
-                {items.length > 0 && <span className="text-xs text-muted-foreground">Ordered by addition</span>}
+                {items.length > 1 && <span className="text-xs text-muted-foreground">Drag cards to reorder them</span>}
             </div>
 
-            <div className="space-y-2" role="list" aria-label="Related works">
-                {items.map((item, index) => {
-                    const validation = validationStatuses?.get(index);
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <SortableContext items={items.map((_, index) => getSortableId(index))} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-3" role="list" aria-label="Related works">
+                        {items.map((item, index) => {
+                            const validation = validationStatuses?.get(index);
 
-                    return (
-                        <div key={`${item.identifier}-${index}`} role="listitem">
-                            <RelatedWorkItem
-                                item={item}
-                                index={index}
-                                onRemove={onRemove}
-                                validationStatus={validation?.status}
-                                validationMessage={validation?.message}
-                            />
-                        </div>
-                    );
-                })}
-            </div>
+                            return (
+                                <RelatedWorkItem
+                                    key={getSortableId(index)}
+                                    sortableId={getSortableId(index)}
+                                    item={item}
+                                    index={index}
+                                    onChange={(updatedItem) => onItemChange(index, updatedItem)}
+                                    onRemove={onRemove}
+                                    activeRelationTypes={activeRelationTypes}
+                                    activeIdentifierTypes={activeIdentifierTypes}
+                                    validationStatus={validation?.status}
+                                    validationMessage={validation?.message}
+                                />
+                            );
+                        })}
+                    </div>
+                </SortableContext>
+            </DndContext>
         </div>
     );
 }

--- a/resources/js/components/curation/fields/related-work/related-work-quick-add.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-quick-add.tsx
@@ -8,19 +8,26 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import { useIdentifierValidation } from '@/hooks/use-identifier-validation';
-import { getOppositeRelationType, MOST_USED_RELATION_TYPES, RELATION_TYPE_DESCRIPTIONS } from '@/lib/related-identifiers';
+import {
+    formatRelationTypeLabel,
+    getAllRelationTypes,
+    getOppositeRelationType,
+    MOST_USED_RELATION_TYPES,
+    RELATION_TYPE_DESCRIPTIONS,
+} from '@/lib/related-identifiers';
+import { identifierTypes } from '@/schemas/related-work.schema';
 import type { IdentifierType, RelatedIdentifierFormData, RelationType } from '@/types';
 
 interface RelatedWorkQuickAddProps {
     onAdd: (data: RelatedIdentifierFormData) => void;
-    showAdvancedMode?: boolean;
-    onToggleAdvanced?: () => void;
     identifier: string;
     onIdentifierChange: (value: string) => void;
     identifierType: IdentifierType;
+    onIdentifierTypeChange: (value: IdentifierType) => void;
     relationType: RelationType;
     onRelationTypeChange: (value: RelationType) => void;
     activeRelationTypes?: string[];
+    activeIdentifierTypes?: string[];
 }
 
 /**
@@ -35,24 +42,44 @@ interface RelatedWorkQuickAddProps {
  */
 export default function RelatedWorkQuickAdd({
     onAdd,
-    showAdvancedMode = false,
-    onToggleAdvanced,
     identifier,
     onIdentifierChange,
     identifierType,
+    onIdentifierTypeChange,
     relationType,
     onRelationTypeChange,
     activeRelationTypes,
+    activeIdentifierTypes,
 }: RelatedWorkQuickAddProps) {
     const [showSuggestion, setShowSuggestion] = useState(false);
 
-    // Filter most-used relation types to only show active ones
-    const filteredRelationTypes = useMemo(
+    const filteredMostUsedRelationTypes = useMemo(
         () =>
             activeRelationTypes
                 ? MOST_USED_RELATION_TYPES.filter((t) => activeRelationTypes.includes(t))
                 : MOST_USED_RELATION_TYPES,
         [activeRelationTypes],
+    );
+
+    const filteredRelationTypes = useMemo(
+        () =>
+            activeRelationTypes
+                ? getAllRelationTypes().filter((t) => activeRelationTypes.includes(t))
+                : getAllRelationTypes(),
+        [activeRelationTypes],
+    );
+
+    const additionalRelationTypes = useMemo(
+        () => filteredRelationTypes.filter((type) => !filteredMostUsedRelationTypes.includes(type)),
+        [filteredMostUsedRelationTypes, filteredRelationTypes],
+    );
+
+    const filteredIdentifierTypes = useMemo(
+        () =>
+            activeIdentifierTypes
+                ? identifierTypes.filter((type) => activeIdentifierTypes.includes(type))
+                : [...identifierTypes],
+        [activeIdentifierTypes],
     );
 
     // Validate identifier with API
@@ -120,15 +147,15 @@ export default function RelatedWorkQuickAdd({
             <div className="flex items-start gap-2 text-sm text-muted-foreground">
                 <Info className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
                 <p>
-                    Add relationships to other datasets, publications, or resources. Enter a DOI, URL, or other identifier and select the relationship
-                    type.
+                    Add relationships to other datasets, publications, or resources. Identifier types are auto-detected, and you can fine-tune citation
+                    labels directly in the cards below after adding an entry.
                 </p>
             </div>
 
             {/* Quick Add Form */}
             <div className="grid gap-4 md:grid-cols-12">
                 {/* Identifier Input */}
-                <div className="md:col-span-6">
+                <div className="md:col-span-5">
                     <Label htmlFor="related-identifier" className="sr-only">
                         Identifier (DOI, URL, etc.)
                     </Label>
@@ -171,12 +198,30 @@ export default function RelatedWorkQuickAdd({
                         <p className="mt-1 text-xs text-green-600">✓ {validation.metadata.title}</p>
                     )}
                     {validation.status === 'idle' && (
-                        <p className="mt-1 text-xs text-muted-foreground">Type will be auto-detected (DOI, URL, Handle)</p>
+                        <p className="mt-1 text-xs text-muted-foreground">Type will be auto-detected. You can still override it manually.</p>
                     )}
                 </div>
 
+                <div className="md:col-span-2">
+                    <Label htmlFor="related-identifier-type" className="sr-only">
+                        Identifier Type
+                    </Label>
+                    <Select value={identifierType} onValueChange={(value) => onIdentifierTypeChange(value as IdentifierType)}>
+                        <SelectTrigger id="related-identifier-type">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {filteredIdentifierTypes.map((type) => (
+                                <SelectItem key={type} value={type}>
+                                    {type}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
                 {/* Relation Type Select */}
-                <div className="md:col-span-5">
+                <div className="md:col-span-4">
                     <Label htmlFor="relation-type" className="sr-only">
                         Relation Type
                     </Label>
@@ -185,12 +230,25 @@ export default function RelatedWorkQuickAdd({
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                            <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Most Used</div>
-                            {filteredRelationTypes.map((type) => (
+                            {filteredMostUsedRelationTypes.length > 0 && (
+                                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Most Used</div>
+                            )}
+                            {filteredMostUsedRelationTypes.map((type) => (
                                 <SelectItem key={type} value={type}>
                                     <div className="flex flex-col items-start">
-                                        <span>{type}</span>
+                                        <span>{formatRelationTypeLabel(type)}</span>
                                         <span className="text-xs text-muted-foreground">{RELATION_TYPE_DESCRIPTIONS[type].substring(0, 50)}...</span>
+                                    </div>
+                                </SelectItem>
+                            ))}
+                            {additionalRelationTypes.length > 0 && (
+                                <div className="px-2 pt-3 pb-1.5 text-xs font-semibold text-muted-foreground">All relation types</div>
+                            )}
+                            {additionalRelationTypes.map((type) => (
+                                <SelectItem key={type} value={type}>
+                                    <div className="flex flex-col items-start">
+                                        <span>{formatRelationTypeLabel(type)}</span>
+                                        <span className="text-xs text-muted-foreground">{RELATION_TYPE_DESCRIPTIONS[type]}</span>
                                     </div>
                                 </SelectItem>
                             ))}
@@ -227,15 +285,6 @@ export default function RelatedWorkQuickAdd({
                         </Button>
                     </AlertDescription>
                 </Alert>
-            )}
-
-            {/* Advanced Mode Toggle */}
-            {onToggleAdvanced && (
-                <div className="pt-2">
-                    <Button type="button" variant="ghost" size="sm" onClick={onToggleAdvanced} className="text-xs">
-                        {showAdvancedMode ? '← Simple mode' : 'Show all relation types →'}
-                    </Button>
-                </div>
             )}
         </div>
     );

--- a/resources/js/lib/related-identifiers.ts
+++ b/resources/js/lib/related-identifiers.ts
@@ -45,8 +45,8 @@ export const RELATION_TYPES_GROUPED: Record<string, RelationType[]> = {
  * - IsCitedBy: 0.6%
  * - IsVariantFormOf: 0.6%
  *
- * Version relations (IsNewVersionOf, IsPreviousVersionOf) added for easy access
- * in simple mode as they are commonly needed for dataset version management.
+ * Version relations (IsNewVersionOf, IsPreviousVersionOf) stay surfaced in the
+ * add form because they are commonly needed for dataset version management.
  */
 export const MOST_USED_RELATION_TYPES: RelationType[] = [
     'Cites',
@@ -119,6 +119,10 @@ export function getOppositeRelationType(relationType: RelationType): RelationTyp
  */
 export function getAllRelationTypes(): RelationType[] {
     return Object.values(RELATION_TYPES_GROUPED).flat();
+}
+
+export function formatRelationTypeLabel(relationType: string): string {
+    return relationType.replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim();
 }
 
 /**

--- a/resources/js/pages/LandingPages/components/ModelDescriptionSection.tsx
+++ b/resources/js/pages/LandingPages/components/ModelDescriptionSection.tsx
@@ -1,7 +1,5 @@
 import { ExternalLink } from 'lucide-react';
-import { useEffect, useState } from 'react';
 
-import { Skeleton } from '@/components/ui/skeleton';
 import type { LandingPageRelatedIdentifier } from '@/types/landing-page';
 
 import { resolveIdentifierUrl } from '../lib/resolveIdentifierUrl';
@@ -14,57 +12,11 @@ interface ModelDescriptionSectionProps {
 /**
  * Model Description Section
  *
- * Displays the IsSupplementTo relation with citation fetched from the DOI.
+ * Displays the IsSupplementTo relation using persisted citation labels.
  */
 export function ModelDescriptionSection({ relatedIdentifiers }: ModelDescriptionSectionProps) {
-    const [citation, setCitation] = useState<string | null>(null);
-    const [doi, setDoi] = useState<string | null>(null);
-    const [loading, setLoading] = useState(false);
-
     // Find the IsSupplementTo relation
     const supplementTo = relatedIdentifiers.find((rel) => rel.relation_type === 'IsSupplementTo');
-
-    useEffect(() => {
-        if (!supplementTo || supplementTo.identifier_type !== 'DOI' || !supplementTo.identifier.trim()) {
-            // Reset state when switching from a valid DOI to a non-DOI/empty value
-            setCitation(null);
-            setDoi(null);
-            setLoading(false);
-            return;
-        }
-
-        const controller = new AbortController();
-
-        const fetchCitation = async () => {
-            setLoading(true);
-            try {
-                const url = `/api/datacite/citation?doi=${encodeURIComponent(supplementTo.identifier)}`;
-                const response = await fetch(url, { signal: controller.signal });
-
-                if (response.ok) {
-                    const data = await response.json();
-                    setCitation(data.citation);
-                    setDoi(supplementTo.identifier);
-                }
-            } catch (err: unknown) {
-                if (err instanceof Error && err.name === 'AbortError') {
-                    return;
-                }
-            } finally {
-                if (!controller.signal.aborted) {
-                    setLoading(false);
-                }
-            }
-        };
-
-        fetchCitation();
-
-        return () => {
-            controller.abort();
-            // Ensure loading is cleared so the next effect run won't find stuck state
-            setLoading(false);
-        };
-    }, [supplementTo]);
 
     if (!supplementTo) {
         return null;
@@ -76,6 +28,10 @@ export function ModelDescriptionSection({ relatedIdentifiers }: ModelDescription
         return null;
     }
 
+    const displayLabel = supplementTo.citation_label?.trim()
+        || supplementTo.related_title?.trim()
+        || supplementTo.identifier;
+
     return (
         <LandingPageCard
             aria-labelledby="heading-model-description"
@@ -83,38 +39,15 @@ export function ModelDescriptionSection({ relatedIdentifiers }: ModelDescription
             <h2 id="heading-model-description" className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">Model Description</h2>
 
             <div className="space-y-3">
-                {loading && (
-                    <div className="space-y-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700" aria-busy="true">
-                        <Skeleton className="h-4 w-3/4" />
-                        <Skeleton className="h-4 w-1/2" />
-                    </div>
-                )}
-
-                {!loading && citation && doi && resolvedUrl && (
-                    <a
-                        href={resolvedUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="group flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-sm text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700/50"
-                    >
-                        <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" aria-hidden="true" />
-                        <span className="flex-1">{citation}</span>
-                    </a>
-                )}
-
-                {!loading && !citation && resolvedUrl && (
-                    <a
-                        href={resolvedUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="group flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-sm text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700/50"
-                    >
-                        <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" aria-hidden="true" />
-                        <span className="flex-1">
-                            {supplementTo.related_title || supplementTo.identifier}
-                        </span>
-                    </a>
-                )}
+                <a
+                    href={resolvedUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-sm text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700/50"
+                >
+                    <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" aria-hidden="true" />
+                    <span className="flex-1">{displayLabel}</span>
+                </a>
             </div>
         </LandingPageCard>
     );

--- a/resources/js/pages/LandingPages/components/RelatedWorkSection.tsx
+++ b/resources/js/pages/LandingPages/components/RelatedWorkSection.tsx
@@ -1,9 +1,8 @@
 import { ChevronDown, ChevronUp, ExternalLink, Network, Quote } from 'lucide-react';
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useMemo, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
 import type { LandingPageRelatedIdentifier, LandingPageRelatedItem, LandingPageResource } from '@/types/landing-page';
 
 import { normalizeDoiKey, resolveIdentifierUrl } from '../lib/resolveIdentifierUrl';
@@ -18,18 +17,32 @@ interface RelatedWorkSectionProps {
     resource: LandingPageResource;
 }
 
-interface Citation {
-    citation: string;
-    loading: boolean;
-    error: boolean;
-}
-
 /**
  * Converts CamelCase to readable text with spaces.
  * e.g. "IsDocumentedBy" -> "Is Documented By"
  */
 function formatRelationType(type: string): string {
     return type.replace(/([A-Z])/g, ' $1').trim();
+}
+
+function getRelatedIdentifierLabel(relatedIdentifier: LandingPageRelatedIdentifier): string {
+    const citationLabel = relatedIdentifier.citation_label?.trim();
+
+    if (citationLabel) {
+        return citationLabel;
+    }
+
+    const relatedTitle = relatedIdentifier.related_title?.trim();
+
+    if (relatedTitle) {
+        return relatedTitle;
+    }
+
+    if (relatedIdentifier.identifier_type === 'DOI') {
+        return `DOI: ${normalizeDoiKey(relatedIdentifier.identifier) ?? relatedIdentifier.identifier}`;
+    }
+
+    return relatedIdentifier.identifier;
 }
 
 /** Number of renderable relations before collapsing on mobile */
@@ -42,7 +55,6 @@ const COLLAPSE_THRESHOLD = 9;
  * The first IsSupplementTo relation is excluded (shown in Model Description).
  */
 export function RelatedWorkSection({ relatedIdentifiers, relatedItems = [], resource }: RelatedWorkSectionProps) {
-    const [citations, setCitations] = useState<Map<string, Citation>>(new Map());
     const [browserOpen, setBrowserOpen] = useState(false);
     const [expanded, setExpanded] = useState(false);
 
@@ -76,77 +88,23 @@ export function RelatedWorkSection({ relatedIdentifiers, relatedItems = [], reso
     // Sort groups alphabetically
     const sortedTypes = useMemo(() => Object.keys(groupedByType).sort(), [groupedByType]);
 
-    useEffect(() => {
-        const controller = new AbortController();
-
-        // Deduplicate: only fetch DOIs that have a resolvable URL
-        const doisToFetch = new Set<string>();
-        filteredRelations.forEach((rel) => {
-            if (rel.identifier_type === 'DOI') {
-                const doi = normalizeDoiKey(rel.identifier);
-                if (doi && resolveIdentifierUrl(rel.identifier, rel.identifier_type)) {
-                    doisToFetch.add(doi);
-                }
-            }
-        });
-
-        // Fetch DOIs that are not yet successfully loaded.
-        // Includes loading entries so that a prop-change after abort can retry.
-        const newDois = new Set<string>();
-        doisToFetch.forEach((doi) => {
-            const existing = citations.get(doi);
-            if (!existing || existing.loading || existing.error) {
-                newDois.add(doi);
-            }
-        });
-
-        if (newDois.size === 0) {
-            return;
-        }
-
-        // Batch-initialize new DOIs as loading in a single state update
-        setCitations((prev) => {
-            const next = new Map(prev);
-            newDois.forEach((doi) => {
-                next.set(doi, { citation: '', loading: true, error: false });
-            });
-            return next;
-        });
-
-        // Fetch each new DOI citation, updating individually on resolve
-        newDois.forEach((doi) => {
-            fetch(`/api/datacite/citation?doi=${encodeURIComponent(doi)}`, { signal: controller.signal })
-                .then((response) => {
-                    if (response.ok) {
-                        return response.json();
-                    }
-                    throw new Error('Citation not found');
-                })
-                .then((data) => {
-                    setCitations((prev) => new Map(prev).set(doi, { citation: data.citation, loading: false, error: false }));
-                })
-                .catch((err: unknown) => {
-                    if (err instanceof Error && err.name === 'AbortError') {
-                        return;
-                    }
-                    setCitations((prev) => new Map(prev).set(doi, { citation: '', loading: false, error: true }));
-                });
-        });
-
-        return () => controller.abort();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [relatedIdentifiers]);
-
-    // Provide fully-loaded citation texts for the relation browser to avoid duplicate fetches
+    // Provide persisted citation texts for the relation browser.
     const citationTexts = useMemo(() => {
         const map = new Map<string, string>();
-        citations.forEach((v, k) => {
-            if (!v.loading && !v.error && v.citation) {
-                map.set(k, v.citation);
+        filteredRelations.forEach((relatedIdentifier) => {
+            if (relatedIdentifier.identifier_type !== 'DOI') {
+                return;
+            }
+
+            const citationLabel = relatedIdentifier.citation_label?.trim();
+            const doi = normalizeDoiKey(relatedIdentifier.identifier);
+
+            if (citationLabel && doi) {
+                map.set(doi, citationLabel);
             }
         });
         return map;
-    }, [citations]);
+    }, [filteredRelations]);
 
     // Only render if at least one relation has a resolvable URL
     const renderableRelations = useMemo(
@@ -241,49 +199,6 @@ export function RelatedWorkSection({ relatedIdentifiers, relatedItems = [], reso
 
                                     const isHiddenOnMobile = hiddenItemIds.has(rel.id);
 
-                                    // DOI: show citation (fetched async)
-                                    if (rel.identifier_type === 'DOI') {
-                                        const doiKey = normalizeDoiKey(rel.identifier);
-                                        const citationData = citations.get(doiKey);
-                                        const isLoading = !citationData || citationData.loading;
-
-                                        return (
-                                            <li key={rel.id} className={isHiddenOnMobile ? 'collapsible-print-only hidden md:list-item' : ''}>
-                                                {isLoading && (
-                                                    <div className="space-y-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700" aria-busy="true">
-                                                        <Skeleton className="h-4 w-3/4" />
-                                                        <Skeleton className="h-4 w-1/2" />
-                                                    </div>
-                                                )}
-
-                                                {!isLoading && citationData?.citation && (
-                                                    <a
-                                                        href={url}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="group flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-sm text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700/50"
-                                                    >
-                                                        <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" aria-hidden="true" />
-                                                        <span className="flex-1">{citationData.citation}</span>
-                                                    </a>
-                                                )}
-
-                                                {!isLoading && citationData?.error && (
-                                                    <a
-                                                        href={url}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="group flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-sm text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700/50"
-                                                    >
-                                                        <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" aria-hidden="true" />
-                                                        <span className="flex-1">DOI: {doiKey}</span>
-                                                    </a>
-                                                )}
-                                            </li>
-                                        );
-                                    }
-
-                                    // Non-DOI: show identifier as link directly
                                     return (
                                         <li key={rel.id} className={isHiddenOnMobile ? 'collapsible-print-only hidden md:list-item' : ''}>
                                             <a
@@ -293,7 +208,7 @@ export function RelatedWorkSection({ relatedIdentifiers, relatedItems = [], reso
                                                 className="group flex items-start gap-2 rounded-lg border border-gray-200 p-3 text-sm text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-700/50"
                                             >
                                                 <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300" aria-hidden="true" />
-                                                <span className="flex-1">{rel.identifier}</span>
+                                                <span className="flex-1">{getRelatedIdentifierLabel(rel)}</span>
                                             </a>
                                         </li>
                                     );

--- a/resources/js/pages/LandingPages/components/relation-browser/use-citation-labels.ts
+++ b/resources/js/pages/LandingPages/components/relation-browser/use-citation-labels.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useMemo } from 'react';
 
 import { normalizeDoiKey } from '../../lib/resolveIdentifierUrl';
 import type { CitationLabel } from './graph-types';
@@ -6,6 +6,7 @@ import type { CitationLabel } from './graph-types';
 interface IdentifierInput {
     identifier: string;
     identifier_type: string;
+    citation_label?: string | null;
 }
 
 /**
@@ -45,99 +46,48 @@ export function useCitationLabels(
     identifiers: IdentifierInput[],
     citationTexts?: Map<string, string>,
 ): Map<string, CitationLabel> {
-    const [labels, setLabels] = useState<Map<string, CitationLabel>>(new Map());
-    const controllerRef = useRef<AbortController | null>(null);
-
-    useEffect(() => {
-        controllerRef.current?.abort();
-        const controller = new AbortController();
-        controllerRef.current = controller;
-
-        const newLabels = new Map<string, CitationLabel>();
-
-        const doisToFetch: string[] = [];
+    return useMemo(() => {
+        const labels = new Map<string, CitationLabel>();
 
         for (const item of identifiers) {
+            const persistedCitation = item.citation_label?.trim();
+
             if (item.identifier_type === 'DOI') {
                 const doi = normalizeDoiKey(item.identifier);
-                if (doi && !newLabels.has(doi)) {
-                    const provided = citationTexts?.get(doi);
-                    if (provided) {
-                        newLabels.set(doi, {
-                            shortLabel: extractAuthorYear(provided),
-                            fullCitation: provided,
-                            loading: false,
-                        });
-                    } else {
-                        newLabels.set(doi, {
-                            shortLabel: doi.length > 20 ? shortenIdentifier(doi) : doi,
-                            fullCitation: doi,
-                            loading: true,
-                        });
-                        doisToFetch.push(doi);
-                    }
+
+                if (!doi || labels.has(doi)) {
+                    continue;
+                }
+
+                const provided = persistedCitation || citationTexts?.get(doi);
+
+                if (provided) {
+                    labels.set(doi, {
+                        shortLabel: extractAuthorYear(provided),
+                        fullCitation: provided,
+                        loading: false,
+                    });
+                } else {
+                    labels.set(doi, {
+                        shortLabel: doi.length > 20 ? shortenIdentifier(doi) : doi,
+                        fullCitation: doi,
+                        loading: false,
+                    });
                 }
             } else {
                 const key = `${item.identifier_type}:${item.identifier}`;
-                if (!newLabels.has(key)) {
-                    newLabels.set(key, {
-                        shortLabel: `${item.identifier_type}: ${shortenIdentifier(item.identifier)}`,
-                        fullCitation: item.identifier,
+                if (!labels.has(key)) {
+                    labels.set(key, {
+                        shortLabel: persistedCitation ? extractAuthorYear(persistedCitation) : `${item.identifier_type}: ${shortenIdentifier(item.identifier)}`,
+                        fullCitation: persistedCitation || item.identifier,
                         loading: false,
                     });
                 }
             }
         }
 
-        setLabels(new Map(newLabels));
-
-        if (doisToFetch.length === 0) {
-            return () => controller.abort();
-        }
-
-        for (const doi of doisToFetch) {
-            fetch(`/api/datacite/citation?doi=${encodeURIComponent(doi)}`, {
-                signal: controller.signal,
-            })
-                .then((response) => {
-                    if (!response.ok) {
-                        throw new Error('Citation not found');
-                    }
-                    return response.json();
-                })
-                .then((data) => {
-                    const shortLabel = extractAuthorYear(data.citation);
-                    setLabels((prev) => {
-                        const next = new Map(prev);
-                        next.set(doi, {
-                            shortLabel,
-                            fullCitation: data.citation,
-                            loading: false,
-                        });
-                        return next;
-                    });
-                })
-                .catch((err: unknown) => {
-                    if (err instanceof Error && err.name === 'AbortError') {
-                        return;
-                    }
-                    setLabels((prev) => {
-                        const next = new Map(prev);
-                        const existing = next.get(doi);
-                        next.set(doi, {
-                            shortLabel: existing?.shortLabel ?? doi,
-                            fullCitation: doi,
-                            loading: false,
-                        });
-                        return next;
-                    });
-                });
-        }
-
-        return () => controller.abort();
+        return labels;
     }, [identifiers, citationTexts]);
-
-    return labels;
 }
 
 export function getCitationKey(identifierType: string, identifier: string): string {

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1155,16 +1155,26 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <h4>Adding Related Identifiers</h4>
                         <WorkflowSteps>
-                            <WorkflowSteps.Step number={1} title="Select Identifier Type">
-                                <p>Choose the type: DOI, URL, Handle, IGSN, URN, etc.</p>
+                            <WorkflowSteps.Step number={1} title="Enter the Identifier">
+                                <p>Paste a DOI, URL, Handle, IGSN, URN, or another supported identifier. ERNIE auto-detects the type and still lets you override it manually when needed.</p>
                             </WorkflowSteps.Step>
-                            <WorkflowSteps.Step number={2} title="Enter Identifier">
-                                <p>Enter the identifier value (e.g., 10.1234/example for DOI).</p>
+                            <WorkflowSteps.Step number={2} title="Pick the Relation Type">
+                                <p>The relation menu keeps the most frequently used DataCite relation types in a dedicated <em>Most used</em> block, with the full schema available below it.</p>
                             </WorkflowSteps.Step>
-                            <WorkflowSteps.Step number={3} title="Select Relation Type">
-                                <p>Choose how this resource relates: Cites, IsSupplementTo, IsPartOf, etc.</p>
+                            <WorkflowSteps.Step number={3} title="Refine the Card">
+                                <p>After adding an entry, edit the related-work card directly. You can adjust the identifier, change the relation type, add a custom citation label for landing pages, and review any resolved title metadata.</p>
+                            </WorkflowSteps.Step>
+                            <WorkflowSteps.Step number={4} title="Reorder the List">
+                                <p>Drag related-work cards into the order you want. This order is preserved in the editor and reused on the landing page.</p>
                             </WorkflowSteps.Step>
                         </WorkflowSteps>
+
+                        <h4>DOI Citation Labels</h4>
+                        <p>
+                            When you add a DOI, ERNIE tries to resolve a formatted citation label immediately and stores it with the related identifier.
+                            The same citation label is reused on landing pages and in the relation browser, so no third-party citation lookup is needed at page-load time.
+                            You can overwrite the label manually whenever you need a curated citation string.
+                        </p>
 
                         <h4>Common Relation Types</h4>
                         <ul className="list-inside list-disc space-y-1">

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -443,6 +443,19 @@ export default function Docs({ userRole, editorSettings }: DocsProps) {
                         <h4>Update MSL Keywords</h4>
                         <DocsCodeBlock code="php artisan get-msl-keywords" />
 
+                        <h4>Backfill Related Work Citation Labels</h4>
+                        <DocsCodeBlock code="php artisan related-identifiers:hydrate-citation-labels" />
+                        <p className="text-sm text-muted-foreground">
+                            Run this once after deploying the citation-label update to an existing installation. It hydrates missing
+                            citation labels for already stored DOI-based related identifiers without overwriting labels that were curated
+                            manually.
+                        </p>
+                        <DocsCodeBlock code="php artisan related-identifiers:hydrate-citation-labels --limit=500" />
+                        <p className="text-sm text-muted-foreground">
+                            Use <code>--limit</code> to process large installations in smaller batches during low-traffic maintenance
+                            windows.
+                        </p>
+
                         <h4>DataCite Configuration</h4>
                         <p>
                             Configure DataCite API credentials in your <code>.env</code> file:

--- a/resources/js/schemas/related-work.schema.ts
+++ b/resources/js/schemas/related-work.schema.ts
@@ -111,6 +111,7 @@ export const relatedIdentifierSchema = z.object({
     identifier_type: identifierTypeSchema,
     relation_type: relationTypeSchema,
     relation_type_information: z.string().max(255).optional().nullable(),
+    citation_label: z.string().optional().nullable(),
     position: z.number().optional(),
     related_title: z.string().optional().nullable(),
     related_metadata: z.record(z.string(), z.unknown()).optional().nullable(),
@@ -135,6 +136,7 @@ export const relatedWorkFormSchema = z.object({
     identifierType: identifierTypeSchema,
     relationType: relationTypeSchema,
     relationTypeInformation: z.string().max(255).optional().nullable(),
+    citationLabel: z.string().optional().nullable(),
 });
 
 export type RelatedWorkFormData = z.infer<typeof relatedWorkFormSchema>;

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -167,6 +167,7 @@ export interface RelatedIdentifier {
     identifier_type: string;
     relation_type: string;
     relation_type_information?: string | null;
+    citation_label?: string | null;
     position?: number;
     related_title?: string | null;
     related_metadata?: Record<string, unknown> | null;
@@ -177,6 +178,7 @@ export interface RelatedIdentifierFormData {
     identifierType: string;
     relationType: string;
     relationTypeInformation?: string | null;
+    citationLabel?: string | null;
 }
 
 export type IdentifierType =

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -326,6 +326,8 @@ export interface LandingPageRelatedIdentifier {
     identifier_type: string;
     /** Relation type (e.g., 'IsSupplementTo', 'References') */
     relation_type: string;
+    /** Persisted citation label for display without runtime DOI lookups */
+    citation_label?: string | null;
     /** General resource type (e.g., 'Dataset', 'Text') */
     resource_type_general?: string | null;
     /** Legacy: identifier value */

--- a/tests/pest/Feature/Console/Commands/HydrateRelatedIdentifierCitationLabelsTest.php
+++ b/tests/pest/Feature/Console/Commands/HydrateRelatedIdentifierCitationLabelsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\HydrateRelatedIdentifierCitationLabels;
+use App\Models\IdentifierType;
+use App\Models\RelatedIdentifier;
+use App\Models\RelationType;
+use App\Models\Resource;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\RelationTypeSeeder;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+covers(HydrateRelatedIdentifierCitationLabels::class);
+
+beforeEach(function (): void {
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+    Cache::flush();
+});
+
+it('hydrates missing citation labels only for DOI related identifiers', function (): void {
+    $resource = Resource::factory()->create();
+    $doiTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+    $urlTypeId = IdentifierType::query()->where('slug', 'URL')->value('id');
+    $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+    expect($doiTypeId)->toBeInt()
+        ->and($urlTypeId)->toBeInt()
+        ->and($relationTypeId)->toBeInt();
+
+    $missingDoi = RelatedIdentifier::query()->create([
+        'resource_id' => $resource->id,
+        'identifier' => '10.5880/legacy.2026.010',
+        'identifier_type_id' => $doiTypeId,
+        'relation_type_id' => $relationTypeId,
+        'position' => 0,
+    ]);
+
+    $existingLabel = RelatedIdentifier::query()->create([
+        'resource_id' => $resource->id,
+        'identifier' => '10.5880/legacy.2026.011',
+        'identifier_type_id' => $doiTypeId,
+        'relation_type_id' => $relationTypeId,
+        'citation_label' => 'Existing curated citation label',
+        'position' => 1,
+    ]);
+
+    $urlRelation = RelatedIdentifier::query()->create([
+        'resource_id' => $resource->id,
+        'identifier' => 'https://example.com/legacy',
+        'identifier_type_id' => $urlTypeId,
+        'relation_type_id' => $relationTypeId,
+        'position' => 2,
+    ]);
+
+    Http::fake([
+        'https://doi.org/*' => Http::response([
+            'DOI' => '10.5880/legacy.2026.010',
+            'title' => 'Hydrated citation',
+            'publisher' => 'GFZ',
+            'author' => [
+                [
+                    'family' => 'Doe',
+                    'given' => 'Jane',
+                ],
+            ],
+            'issued' => [
+                'date-parts' => [[2026]],
+            ],
+        ], 200),
+    ]);
+
+    test()->artisan('related-identifiers:hydrate-citation-labels')
+        ->assertExitCode(Command::SUCCESS)
+        ->expectsOutputToContain('Processed 1 missing DOI related identifier');
+
+    expect($missingDoi->fresh()?->citation_label)->toBe('Doe, J. (2026): Hydrated citation. GFZ. https://doi.org/10.5880/legacy.2026.010')
+        ->and($existingLabel->fresh()?->citation_label)->toBe('Existing curated citation label')
+        ->and($urlRelation->fresh()?->citation_label)->toBeNull();
+});
+
+it('reports success when no missing DOI citation labels need hydration', function (): void {
+    $resource = Resource::factory()->create();
+    $doiTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+    $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+    expect($doiTypeId)->toBeInt()
+        ->and($relationTypeId)->toBeInt();
+
+    RelatedIdentifier::query()->create([
+        'resource_id' => $resource->id,
+        'identifier' => '10.5880/already-hydrated',
+        'identifier_type_id' => $doiTypeId,
+        'relation_type_id' => $relationTypeId,
+        'citation_label' => 'Already hydrated',
+        'position' => 0,
+    ]);
+
+    test()->artisan('related-identifiers:hydrate-citation-labels')
+        ->assertExitCode(Command::SUCCESS)
+        ->expectsOutputToContain('No missing DOI citation labels found.');
+});

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -23,6 +23,10 @@ beforeEach(function () {
 
     // Mock the transformer for isolated job testing
     $this->transformer = Mockery::mock(DataCiteToResourceTransformer::class);
+    $this->transformer
+        ->shouldReceive('prepareDoiData')
+        ->zeroOrMoreTimes()
+        ->andReturnUsing(fn (array $doiRecord): array => $doiRecord);
     $this->app->instance(DataCiteToResourceTransformer::class, $this->transformer);
 
     // Mock the metaworks service (returns empty result by default)

--- a/tests/pest/Feature/Database/AddCitationLabelToRelatedIdentifiersMigrationTest.php
+++ b/tests/pest/Feature/Database/AddCitationLabelToRelatedIdentifiersMigrationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class)->group('database');
+
+function loadAddCitationLabelMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_05_15_000001_add_citation_label_to_related_identifiers.php');
+
+    return $migration;
+}
+
+it('drops and re-adds the citation_label column on related_identifiers', function (): void {
+    $migration = loadAddCitationLabelMigration();
+
+    expect(Schema::hasColumn('related_identifiers', 'citation_label'))->toBeTrue();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    expect(Schema::hasColumn('related_identifiers', 'citation_label'))->toBeFalse();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Schema::hasColumn('related_identifiers', 'citation_label'))->toBeTrue();
+});

--- a/tests/pest/Feature/Database/AddCitationLabelToRelatedIdentifiersMigrationTest.php
+++ b/tests/pest/Feature/Database/AddCitationLabelToRelatedIdentifiersMigrationTest.php
@@ -38,7 +38,7 @@ it('drops and re-adds the citation_label column on related_identifiers', functio
     expect(Schema::hasColumn('related_identifiers', 'citation_label'))->toBeTrue();
 });
 
-it('backfills existing related identifiers with their identifier value when reapplying the migration', function (): void {
+it('leaves legacy related identifiers unresolved when reapplying the migration', function (): void {
     test()->seed(IdentifierTypeSeeder::class);
     test()->seed(RelationTypeSeeder::class);
 
@@ -68,5 +68,5 @@ it('backfills existing related identifiers with their identifier value when reap
     $migration->up();
 
     expect(DB::table('related_identifiers')->where('resource_id', $resource->id)->value('citation_label'))
-        ->toBe('10.5880/legacy.2026.001');
+        ->toBeNull();
 });

--- a/tests/pest/Feature/Database/AddCitationLabelToRelatedIdentifiersMigrationTest.php
+++ b/tests/pest/Feature/Database/AddCitationLabelToRelatedIdentifiersMigrationTest.php
@@ -2,8 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Models\IdentifierType;
+use App\Models\RelationType;
+use App\Models\Resource;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\RelationTypeSeeder;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 uses(RefreshDatabase::class)->group('database');
@@ -30,4 +36,37 @@ it('drops and re-adds the citation_label column on related_identifiers', functio
     $migration->up();
 
     expect(Schema::hasColumn('related_identifiers', 'citation_label'))->toBeTrue();
+});
+
+it('backfills existing related identifiers with their identifier value when reapplying the migration', function (): void {
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+
+    $resource = Resource::factory()->create();
+    $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+    $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+    expect($identifierTypeId)->toBeInt()
+        ->and($relationTypeId)->toBeInt();
+
+    DB::table('related_identifiers')->insert([
+        'resource_id' => $resource->id,
+        'identifier' => '10.5880/legacy.2026.001',
+        'identifier_type_id' => $identifierTypeId,
+        'relation_type_id' => $relationTypeId,
+        'position' => 0,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $migration = loadAddCitationLabelMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(DB::table('related_identifiers')->where('resource_id', $resource->id)->value('citation_label'))
+        ->toBe('10.5880/legacy.2026.001');
 });

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -398,9 +398,9 @@ describe('related identifiers validation', function () {
 
     it('auto-fills a missing citation label during save', function () {
         $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
-        $mock->shouldReceive('resolve')
+        $mock->shouldReceive('resolveBestEffort')
             ->once()
-            ->with('10.1234/test', 'DOI')
+            ->with('10.1234/test', 'DOI', Mockery::type('float'))
             ->andReturn('Doe, J. (2026): Auto-filled. Publisher.');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 
@@ -425,7 +425,7 @@ describe('related identifiers validation', function () {
 
     it('preserves a manually provided citation label during save', function () {
         $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
-        $mock->shouldNotReceive('resolve');
+        $mock->shouldNotReceive('resolveBestEffort');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 
         $data = validResourcePayload($this->resourceType->id, $this->right->identifier);

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 use App\Http\Requests\StoreResourceRequest;
 use App\Models\ContributorType;
 use App\Models\Datacenter;
+use App\Models\DescriptionType;
+use App\Models\IdentifierType;
+use App\Models\RelatedIdentifier;
+use App\Models\RelationType;
 use App\Models\ResourceType;
 use App\Models\Right;
 use App\Models\TitleType;
 use App\Models\User;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 
 covers(StoreResourceRequest::class);
 
@@ -47,6 +52,22 @@ function validResourcePayload(int $resourceTypeId, string $licenseIdentifier): a
 beforeEach(function () {
     $this->user = User::factory()->create();
     TitleType::factory()->count(5)->create();
+    TitleType::firstOrCreate(
+        ['slug' => 'MainTitle'],
+        ['name' => 'MainTitle'],
+    );
+    DescriptionType::firstOrCreate(
+        ['slug' => 'Abstract'],
+        ['name' => 'Abstract'],
+    );
+    IdentifierType::firstOrCreate(
+        ['slug' => 'DOI'],
+        ['name' => 'DOI', 'is_active' => true],
+    );
+    RelationType::firstOrCreate(
+        ['slug' => 'Cites'],
+        ['name' => 'Cites', 'is_active' => true],
+    );
     $this->resourceType = ResourceType::factory()->create();
     $this->right = Right::factory()->create();
 
@@ -344,7 +365,7 @@ describe('related identifiers validation', function () {
     it('accepts valid related identifier', function () {
         $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
         $data['relatedIdentifiers'] = [
-            ['identifier' => '10.1234/test', 'identifierType' => 'DOI', 'relationType' => 'Cites'],
+            ['identifier' => '10.1234/test', 'identifierType' => 'DOI', 'relationType' => 'Cites', 'citationLabel' => 'Doe, J. (2026): Example. Publisher.'],
         ];
 
         $response = $this->actingAs($this->user)
@@ -354,7 +375,57 @@ describe('related identifiers validation', function () {
             'relatedIdentifiers.0.identifier',
             'relatedIdentifiers.0.identifierType',
             'relatedIdentifiers.0.relationType',
+            'relatedIdentifiers.0.citationLabel',
         ]);
+    });
+
+    it('auto-fills a missing citation label during save', function () {
+        $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock->shouldReceive('resolve')
+            ->once()
+            ->with('10.1234/test', 'DOI')
+            ->andReturn('Doe, J. (2026): Auto-filled. Publisher.');
+        $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['relatedIdentifiers'] = [
+            ['identifier' => '10.1234/test', 'identifierType' => 'DOI', 'relationType' => 'Cites'],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data)
+            ->assertCreated();
+
+        $resourceId = $response->json('resource.id');
+
+        expect($resourceId)->toBeInt();
+
+        $related = RelatedIdentifier::query()->where('resource_id', $resourceId)->first();
+
+        expect($related)->not->toBeNull()
+            ->and($related?->citation_label)->toBe('Doe, J. (2026): Auto-filled. Publisher.');
+    });
+
+    it('preserves a manually provided citation label during save', function () {
+        $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock->shouldNotReceive('resolve');
+        $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['relatedIdentifiers'] = [
+            ['identifier' => '10.1234/test', 'identifierType' => 'DOI', 'relationType' => 'Cites', 'citationLabel' => 'Manual citation text'],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data)
+            ->assertCreated();
+
+        $resourceId = $response->json('resource.id');
+
+        $related = RelatedIdentifier::query()->where('resource_id', $resourceId)->first();
+
+        expect($related)->not->toBeNull()
+            ->and($related?->citation_label)->toBe('Manual citation text');
     });
 });
 

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -379,6 +379,23 @@ describe('related identifiers validation', function () {
         ]);
     });
 
+    it('rejects related identifier citation labels that exceed the text-safe maximum', function () {
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['relatedIdentifiers'] = [
+            [
+                'identifier' => '10.1234/test',
+                'identifierType' => 'DOI',
+                'relationType' => 'Cites',
+                'citationLabel' => str_repeat('a', 65536),
+            ],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data);
+
+        $response->assertJsonValidationErrors(['relatedIdentifiers.0.citationLabel']);
+    });
+
     it('auto-fills a missing citation label during save', function () {
         $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
         $mock->shouldReceive('resolve')

--- a/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
+++ b/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
@@ -292,9 +292,9 @@ describe('JSON Upload - DataCite JSON format', function () {
         $this->actingAs(User::factory()->create());
 
         $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
-        $mock->shouldReceive('resolve')
+        $mock->shouldReceive('resolveBestEffort')
             ->once()
-            ->with('10.1234/related', 'DOI')
+            ->with('10.1234/related', 'DOI', Mockery::type('float'))
             ->andReturn('Doe, J. (2026): Imported citation. Publisher.');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 

--- a/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
+++ b/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Models\ResourceType;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -290,6 +291,13 @@ describe('JSON Upload - DataCite JSON format', function () {
     test('extracts related identifiers and instruments', function () {
         $this->actingAs(User::factory()->create());
 
+        $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock->shouldReceive('resolve')
+            ->once()
+            ->with('10.1234/related', 'DOI')
+            ->andReturn('Doe, J. (2026): Imported citation. Publisher.');
+        $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
         $json = dataCiteJson(minimalAttributes([
             'relatedIdentifiers' => [
                 [
@@ -314,6 +322,7 @@ describe('JSON Upload - DataCite JSON format', function () {
         expect($data['relatedWorks'][0]['identifier'])->toBe('10.1234/related');
         expect($data['relatedWorks'][0]['identifier_type'])->toBe('DOI');
         expect($data['relatedWorks'][0]['relation_type'])->toBe('Cites');
+        expect($data['relatedWorks'][0]['citation_label'])->toBe('Doe, J. (2026): Imported citation. Publisher.');
 
         expect($data['instruments'])->toHaveCount(1);
         expect($data['instruments'][0]['pid'])->toBe('http://hdl.handle.net/123/456');

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -109,9 +109,9 @@ describe('DataCiteToResourceTransformer', function (): void {
             $user = User::factory()->create();
 
             $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
-            $mock->shouldReceive('resolve')
+            $mock->shouldReceive('resolveBestEffort')
                 ->once()
-                ->with('10.5880/import.related.2024.001', 'DOI')
+                ->with('10.5880/import.related.2024.001', 'DOI', Mockery::type('float'))
                 ->andReturn('Doe, J. (2024): Imported related work. GFZ. https://doi.org/10.5880/import.related.2024.001');
             $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -10,11 +10,14 @@ use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\TitleType;
 use App\Models\User;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\DataCiteToResourceTransformer;
 use Database\Seeders\ContributorTypeSeeder;
 use Database\Seeders\DescriptionTypeSeeder;
+use Database\Seeders\IdentifierTypeSeeder;
 use Database\Seeders\LanguageSeeder;
 use Database\Seeders\PublisherSeeder;
+use Database\Seeders\RelationTypeSeeder;
 use Database\Seeders\ResourceTypeSeeder;
 use Database\Seeders\TitleTypeSeeder;
 
@@ -24,8 +27,14 @@ beforeEach(function (): void {
     test()->seed(TitleTypeSeeder::class);
     test()->seed(DescriptionTypeSeeder::class);
     test()->seed(ContributorTypeSeeder::class);
+    test()->seed(IdentifierTypeSeeder::class);
     test()->seed(LanguageSeeder::class);
     test()->seed(PublisherSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+});
+
+afterEach(function (): void {
+    Mockery::close();
 });
 
 describe('DataCiteToResourceTransformer', function (): void {
@@ -94,6 +103,53 @@ describe('DataCiteToResourceTransformer', function (): void {
                 ->and($resource->version)->toBe('1.0.0')
                 ->and($resource->language_id)->not->toBeNull()
                 ->and($resource->resource_type_id)->not->toBeNull();
+        });
+
+        it('persists related identifiers with resolved citation labels during import', function (): void {
+            $user = User::factory()->create();
+
+            $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+            $mock->shouldReceive('resolve')
+                ->once()
+                ->with('10.5880/import.related.2024.001', 'DOI')
+                ->andReturn('Doe, J. (2024): Imported related work. GFZ. https://doi.org/10.5880/import.related.2024.001');
+            $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+            $transformer = new DataCiteToResourceTransformer;
+
+            $doiData = [
+                'attributes' => [
+                    'doi' => '10.5880/import.main.2024.001',
+                    'publicationYear' => 2024,
+                    'titles' => [
+                        ['title' => 'Imported dataset'],
+                    ],
+                    'creators' => [
+                        [
+                            'familyName' => 'Importer',
+                            'givenName' => 'Test',
+                            'nameType' => 'Personal',
+                        ],
+                    ],
+                    'relatedIdentifiers' => [
+                        [
+                            'relatedIdentifier' => '10.5880/import.related.2024.001',
+                            'relatedIdentifierType' => 'DOI',
+                            'relationType' => 'Cites',
+                            'relationTypeInformation' => 'Supporting publication',
+                        ],
+                    ],
+                ],
+            ];
+
+            $resource = $transformer->transform($doiData, $user->id);
+            $relatedIdentifier = $resource->relatedIdentifiers()->with('identifierType', 'relationType')->sole();
+
+            expect($relatedIdentifier->identifier)->toBe('10.5880/import.related.2024.001')
+                ->and($relatedIdentifier->identifierType?->slug)->toBe('DOI')
+                ->and($relatedIdentifier->relationType?->slug)->toBe('Cites')
+                ->and($relatedIdentifier->relation_type_information)->toBe('Supporting publication')
+                ->and($relatedIdentifier->citation_label)->toBe('Doe, J. (2024): Imported related work. GFZ. https://doi.org/10.5880/import.related.2024.001');
         });
 
     });

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -1042,11 +1042,11 @@ describe('transformCoverages', function (): void {
 describe('transformRelatedIdentifiers', function (): void {
     it('transforms related identifiers sorted by position', function (): void {
         $identifierType = IdentifierType::firstOrCreate(
-            ['slug' => 'doi'],
+            ['slug' => 'DOI'],
             ['name' => 'DOI', 'is_active' => true]
         );
         $relationType = RelationType::firstOrCreate(
-            ['slug' => 'cites'],
+            ['slug' => 'Cites'],
             ['name' => 'Cites', 'is_active' => true]
         );
 
@@ -1055,6 +1055,7 @@ describe('transformRelatedIdentifiers', function (): void {
             'identifier' => '10.5880/test.2024.002',
             'identifier_type_id' => $identifierType->id,
             'relation_type_id' => $relationType->id,
+            'citation_label' => 'Doe, J. (2024): Second item. GFZ.',
             'position' => 2,
         ]);
         RelatedIdentifier::create([
@@ -1062,6 +1063,7 @@ describe('transformRelatedIdentifiers', function (): void {
             'identifier' => '10.5880/test.2024.001',
             'identifier_type_id' => $identifierType->id,
             'relation_type_id' => $relationType->id,
+            'citation_label' => 'Doe, J. (2024): First item. GFZ.',
             'position' => 1,
         ]);
 
@@ -1073,7 +1075,8 @@ describe('transformRelatedIdentifiers', function (): void {
             ->and($result[0]['identifier'])->toBe('10.5880/test.2024.001')
             ->and($result[1]['identifier'])->toBe('10.5880/test.2024.002')
             ->and($result[0]['identifier_type'])->toBe('DOI')
-            ->and($result[0]['relation_type'])->toBe('Cites');
+            ->and($result[0]['relation_type'])->toBe('Cites')
+            ->and($result[0]['citation_label'])->toBe('Doe, J. (2024): First item. GFZ.');
     });
 });
 

--- a/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
@@ -124,4 +124,61 @@ describe('RelationDiscoveryService', function (): void {
         expect($relatedIdentifier)->not->toBeNull()
             ->and($relatedIdentifier?->citation_label)->toBe('Fallback related work (2024). GFZ Data Services.');
     });
+
+    it('preserves an existing curated citation label when accepting a duplicate suggestion', function (): void {
+        $resource = Resource::factory()->create();
+        $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+        $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+        expect($identifierTypeId)->toBeInt()
+            ->and($relationTypeId)->toBeInt();
+
+        RelatedIdentifier::query()->create([
+            'resource_id' => $resource->id,
+            'identifier' => '10.5880/related.2026.003',
+            'identifier_type_id' => $identifierTypeId,
+            'relation_type_id' => $relationTypeId,
+            'citation_label' => 'Manual curated citation label',
+            'position' => 0,
+        ]);
+
+        $suggestion = SuggestedRelation::query()->create([
+            'resource_id' => $resource->id,
+            'identifier' => '10.5880/related.2026.003',
+            'identifier_type_id' => $identifierTypeId,
+            'relation_type_id' => $relationTypeId,
+            'source' => 'scholexplorer',
+            'source_title' => 'Duplicate related work',
+            'source_publisher' => 'GFZ',
+            'source_publication_date' => '2026-05-15',
+            'discovered_at' => now(),
+        ]);
+
+        $syncService = Mockery::mock(DataCiteSyncService::class);
+        $syncService->shouldReceive('syncIfRegistered')
+            ->once()
+            ->with(Mockery::on(fn (Resource $candidate): bool => $candidate->is($resource)))
+            ->andReturn(DataCiteSyncResult::notRequired());
+
+        $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $citationLabelService->shouldReceive('resolveBestEffort')
+            ->once()
+            ->with('10.5880/related.2026.003', 'DOI', Mockery::type('float'))
+            ->andReturn('Resolved replacement that must not overwrite manual label');
+
+        $service = new RelationDiscoveryService(
+            Mockery::mock(ScholExplorerService::class),
+            Mockery::mock(DataCiteEventDataService::class),
+            $syncService,
+            $citationLabelService,
+        );
+
+        $service->acceptRelation($suggestion);
+
+        $relatedIdentifiers = RelatedIdentifier::query()->where('resource_id', $resource->id)->get();
+
+        expect($relatedIdentifiers)->toHaveCount(1)
+            ->and($relatedIdentifiers->first()?->citation_label)->toBe('Manual curated citation label')
+            ->and(SuggestedRelation::query()->find($suggestion->id))->toBeNull();
+    });
 });

--- a/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\IdentifierType;
+use App\Models\RelatedIdentifier;
+use App\Models\RelationType;
+use App\Models\Resource;
+use App\Models\SuggestedRelation;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\DataCiteEventDataService;
+use App\Services\DataCiteSyncResult;
+use App\Services\DataCiteSyncService;
+use App\Services\RelationDiscoveryService;
+use App\Services\ScholExplorerService;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\RelationTypeSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+});
+
+afterEach(function (): void {
+    Mockery::close();
+});
+
+describe('RelationDiscoveryService', function (): void {
+    it('stores a resolved citation label when accepting a suggested relation', function (): void {
+        $resource = Resource::factory()->create();
+        $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+        $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+        expect($identifierTypeId)->toBeInt()
+            ->and($relationTypeId)->toBeInt();
+
+        $suggestion = SuggestedRelation::query()->create([
+            'resource_id' => $resource->id,
+            'identifier' => '10.5880/related.2026.001',
+            'identifier_type_id' => $identifierTypeId,
+            'relation_type_id' => $relationTypeId,
+            'source' => 'scholexplorer',
+            'source_title' => 'Suggested related work',
+            'source_publisher' => 'GFZ',
+            'source_publication_date' => '2026-05-15',
+            'discovered_at' => now(),
+        ]);
+
+        $syncService = Mockery::mock(DataCiteSyncService::class);
+        $syncService->shouldReceive('syncIfRegistered')
+            ->once()
+            ->with(Mockery::on(fn (Resource $candidate): bool => $candidate->is($resource)))
+            ->andReturn(DataCiteSyncResult::notRequired());
+
+        $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $citationLabelService->shouldReceive('resolveBestEffort')
+            ->once()
+            ->with('10.5880/related.2026.001', 'DOI', Mockery::type('float'))
+            ->andReturn('Doe, J. (2026): Suggested related work. GFZ.');
+
+        $service = new RelationDiscoveryService(
+            Mockery::mock(ScholExplorerService::class),
+            Mockery::mock(DataCiteEventDataService::class),
+            $syncService,
+            $citationLabelService,
+        );
+
+        $result = $service->acceptRelation($suggestion);
+
+        $relatedIdentifier = RelatedIdentifier::query()->where('resource_id', $resource->id)->first();
+
+        expect($result['success'])->toBeTrue()
+            ->and($relatedIdentifier)->not->toBeNull()
+            ->and($relatedIdentifier?->citation_label)->toBe('Doe, J. (2026): Suggested related work. GFZ.')
+            ->and(SuggestedRelation::query()->find($suggestion->id))->toBeNull();
+    });
+
+    it('falls back to suggestion metadata when citation resolution does not produce a label', function (): void {
+        $resource = Resource::factory()->create();
+        $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+        $relationTypeId = RelationType::query()->where('slug', 'References')->value('id');
+
+        expect($identifierTypeId)->toBeInt()
+            ->and($relationTypeId)->toBeInt();
+
+        $suggestion = SuggestedRelation::query()->create([
+            'resource_id' => $resource->id,
+            'identifier' => '10.5880/related.2024.002',
+            'identifier_type_id' => $identifierTypeId,
+            'relation_type_id' => $relationTypeId,
+            'source' => 'scholexplorer',
+            'source_title' => 'Fallback related work',
+            'source_publisher' => 'GFZ Data Services',
+            'source_publication_date' => '2024-03-11',
+            'discovered_at' => now(),
+        ]);
+
+        $syncService = Mockery::mock(DataCiteSyncService::class);
+        $syncService->shouldReceive('syncIfRegistered')
+            ->once()
+            ->with(Mockery::on(fn (Resource $candidate): bool => $candidate->is($resource)))
+            ->andReturn(DataCiteSyncResult::notRequired());
+
+        $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $citationLabelService->shouldReceive('resolveBestEffort')
+            ->once()
+            ->with('10.5880/related.2024.002', 'DOI', Mockery::type('float'))
+            ->andReturnNull();
+
+        $service = new RelationDiscoveryService(
+            Mockery::mock(ScholExplorerService::class),
+            Mockery::mock(DataCiteEventDataService::class),
+            $syncService,
+            $citationLabelService,
+        );
+
+        $service->acceptRelation($suggestion);
+
+        $relatedIdentifier = RelatedIdentifier::query()->where('resource_id', $resource->id)->first();
+
+        expect($relatedIdentifier)->not->toBeNull()
+            ->and($relatedIdentifier?->citation_label)->toBe('Fallback related work (2024). GFZ Data Services.');
+    });
+});

--- a/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
@@ -161,10 +161,7 @@ describe('RelationDiscoveryService', function (): void {
             ->andReturn(DataCiteSyncResult::notRequired());
 
         $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
-        $citationLabelService->shouldReceive('resolveBestEffort')
-            ->once()
-            ->with('10.5880/related.2026.003', 'DOI', Mockery::type('float'))
-            ->andReturn('Resolved replacement that must not overwrite manual label');
+        $citationLabelService->shouldNotReceive('resolveBestEffort');
 
         $service = new RelationDiscoveryService(
             Mockery::mock(ScholExplorerService::class),

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Models\IdentifierType;
+use App\Models\RelationType;
 use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\TitleType;
 use App\Models\User;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\ResourceStorageService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -20,6 +25,12 @@ describe('ResourceStorageService', function () {
         }
         if (ResourceType::count() === 0) {
             $this->artisan('db:seed', ['--class' => 'ResourceTypeSeeder']);
+        }
+        if (IdentifierType::count() === 0) {
+            $this->artisan('db:seed', ['--class' => 'IdentifierTypeSeeder']);
+        }
+        if (RelationType::count() === 0) {
+            $this->artisan('db:seed', ['--class' => 'RelationTypeSeeder']);
         }
         // Seed DescriptionType for descriptions tests
         $this->artisan('db:seed', ['--class' => 'DescriptionTypeSeeder']);
@@ -243,6 +254,125 @@ describe('ResourceStorageService', function () {
         expect($resource->subjects()->count())->toBe(3);
         $keywords = $resource->subjects->pluck('value')->all();
         expect($keywords)->toContain('keyword1', 'keyword2', 'keyword3');
+    });
+
+    it('stores related identifiers with resolved citation labels and trimmed relation details', function () {
+        $resourceType = ResourceType::first();
+
+        $mock = \Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock->shouldReceive('resolve')
+            ->once()
+            ->with('10.5880/test.related', 'DOI')
+            ->andReturn('Doe, J. (2026): Auto-resolved citation.');
+        $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+        $service = app(ResourceStorageService::class);
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Test Resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'John',
+                    'lastName' => 'Doe',
+                    'position' => 0,
+                ],
+            ],
+            'descriptions' => [
+                [
+                    'descriptionType' => 'Abstract',
+                    'description' => 'Test abstract.',
+                ],
+            ],
+            'relatedIdentifiers' => [
+                [
+                    'identifier' => ' 10.5880/test.related ',
+                    'identifierType' => 'DOI',
+                    'relationType' => 'Cites',
+                    'relationTypeInformation' => '  Supplemental context  ',
+                ],
+                [
+                    'identifier' => '   ',
+                    'identifierType' => 'URL',
+                    'relationType' => 'References',
+                ],
+            ],
+        ];
+
+        [$resource] = $service->store($data, $this->user->id);
+
+        $resource->refresh()->load('relatedIdentifiers.identifierType', 'relatedIdentifiers.relationType');
+
+        expect($resource->relatedIdentifiers)->toHaveCount(1);
+
+        $related = $resource->relatedIdentifiers->sole();
+
+        expect($related->identifier)->toBe('10.5880/test.related')
+            ->and($related->identifierType?->slug)->toBe('DOI')
+            ->and($related->relationType?->slug)->toBe('Cites')
+            ->and($related->relation_type_information)->toBe('Supplemental context')
+            ->and($related->citation_label)->toBe('Doe, J. (2026): Auto-resolved citation.')
+            ->and($related->position)->toBe(0);
+    });
+
+    it('preserves manual related identifier citation labels without calling the resolver', function () {
+        $resourceType = ResourceType::first();
+
+        $mock = \Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock->shouldNotReceive('resolve');
+        $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+        $service = app(ResourceStorageService::class);
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Test Resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'John',
+                    'lastName' => 'Doe',
+                    'position' => 0,
+                ],
+            ],
+            'descriptions' => [
+                [
+                    'descriptionType' => 'Abstract',
+                    'description' => 'Test abstract.',
+                ],
+            ],
+            'relatedIdentifiers' => [
+                [
+                    'identifier' => '10.5880/test.manual',
+                    'identifierType' => 'DOI',
+                    'relationType' => 'References',
+                    'relationTypeInformation' => '   ',
+                    'citationLabel' => '  Manual citation label  ',
+                ],
+            ],
+        ];
+
+        [$resource] = $service->store($data, $this->user->id);
+
+        $related = $resource->fresh()->relatedIdentifiers()->sole();
+
+        expect($related->citation_label)->toBe('Manual citation label')
+            ->and($related->relation_type_information)->toBeNull();
     });
 
     it('stores controlled GCMD keywords', function () {

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -260,9 +260,9 @@ describe('ResourceStorageService', function () {
         $resourceType = ResourceType::first();
 
         $mock = \Mockery::mock(RelatedIdentifierCitationLabelService::class);
-        $mock->shouldReceive('resolve')
+        $mock->shouldReceive('resolveBestEffort')
             ->once()
-            ->with('10.5880/test.related', 'DOI')
+            ->with('10.5880/test.related', 'DOI', \Mockery::type('float'))
             ->andReturn('Doe, J. (2026): Auto-resolved citation.');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 
@@ -327,7 +327,7 @@ describe('ResourceStorageService', function () {
         $resourceType = ResourceType::first();
 
         $mock = \Mockery::mock(RelatedIdentifierCitationLabelService::class);
-        $mock->shouldNotReceive('resolve');
+        $mock->shouldNotReceive('resolveBestEffort');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 
         $service = app(ResourceStorageService::class);

--- a/tests/pest/Feature/XmlUpload/XmlUploadRelatedWorksRegressionTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadRelatedWorksRegressionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
@@ -120,5 +121,48 @@ XML;
             ->where('relatedWorks.1.identifier', '10.1000/original.1')
             ->where('relatedWorks.1.identifier_type', 'DOI')
             ->where('relatedWorks.1.relation_type', 'IsTranslationOf')
+        );
+});
+
+test('xml upload canonicalizes human readable related work type values', function () {
+    $this->actingAs(User::factory()->create());
+    withoutVite();
+
+    $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $mock->shouldReceive('resolve')
+        ->once()
+        ->with('10.1000/readable.1', 'DOI')
+        ->andReturn('Doe, J. (2026): XML imported citation. Publisher.');
+    $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+    <titles>
+        <title>Test</title>
+    </titles>
+    <publicationYear>2026</publicationYear>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="doi" relationType="Is Cited By">10.1000/readable.1</relatedIdentifier>
+    </relatedIdentifiers>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('human-readable-related-types.xml', $xml);
+
+    $uploadResponse = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $sessionKey = $uploadResponse->json('sessionKey');
+
+    $this->get(route('editor', ['xmlSession' => $sessionKey]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('editor')
+            ->has('relatedWorks', 1)
+            ->where('relatedWorks.0.identifier', '10.1000/readable.1')
+            ->where('relatedWorks.0.identifier_type', 'DOI')
+            ->where('relatedWorks.0.relation_type', 'IsCitedBy')
+            ->where('relatedWorks.0.citation_label', 'Doe, J. (2026): XML imported citation. Publisher.')
         );
 });

--- a/tests/pest/Feature/XmlUpload/XmlUploadRelatedWorksRegressionTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadRelatedWorksRegressionTest.php
@@ -129,9 +129,9 @@ test('xml upload canonicalizes human readable related work type values', functio
     withoutVite();
 
     $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
-    $mock->shouldReceive('resolve')
+    $mock->shouldReceive('resolveBestEffort')
         ->once()
-        ->with('10.1000/readable.1', 'DOI')
+        ->with('10.1000/readable.1', 'DOI', Mockery::type('float'))
         ->andReturn('Doe, J. (2026): XML imported citation. Publisher.');
     $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 

--- a/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Http\Requests\StoreDraftResourceRequest;
+use App\Http\Requests\StoreResourceRequest;
+use App\Models\RelatedIdentifier;
 
 covers(StoreDraftResourceRequest::class);
 
@@ -64,8 +66,12 @@ it('normalizes related identifiers and keeps optional related-work fields only w
     ]);
 });
 
-it('limits related-work citation labels to the text-safe validation maximum', function (): void {
-    $request = new StoreDraftResourceRequest;
+it('keeps related-work citation label limits aligned between draft and store requests', function (): void {
+    $draftRequest = new StoreDraftResourceRequest;
+    $storeRequest = new StoreResourceRequest;
 
-    expect($request->rules()['relatedIdentifiers.*.citationLabel'])->toContain('max:65535');
+    expect($draftRequest->rules()['relatedIdentifiers.*.citationLabel'])
+        ->toContain('max:'.RelatedIdentifier::MAX_CITATION_LABEL_CHARACTERS)
+        ->and($storeRequest->rules()['relatedIdentifiers.*.citationLabel'])
+        ->toContain('max:'.RelatedIdentifier::MAX_CITATION_LABEL_CHARACTERS);
 });

--- a/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Requests\StoreDraftResourceRequest;
+
+covers(StoreDraftResourceRequest::class);
+
+/**
+ * @param  array<int, mixed>  $arguments
+ */
+function invokeDraftRequestMethod(StoreDraftResourceRequest $request, string $method, array $arguments = []): mixed
+{
+    $reflection = new ReflectionMethod($request, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invokeArgs($request, $arguments);
+}
+
+it('normalizes related identifiers and keeps optional related-work fields only when non-empty', function (): void {
+    $request = StoreDraftResourceRequest::create('/editor/resources/draft', 'POST', [
+        'titles' => [
+            ['title' => 'Draft Resource', 'titleType' => 'main-title'],
+        ],
+        'relatedIdentifiers' => [
+            [
+                'identifier' => ' 10.5880/test.2026.001 ',
+                'identifierType' => ' DOI ',
+                'relationType' => ' Other ',
+                'relationTypeInformation' => '  Custom relationship  ',
+                'citationLabel' => '  Doe, J. (2026): Example citation.  ',
+            ],
+            [
+                'identifier' => ' https://example.org/resource ',
+                'identifierType' => 'URL',
+                'relationType' => 'References',
+                'relationTypeInformation' => '   ',
+                'citationLabel' => '   ',
+            ],
+            [
+                'identifier' => '   ',
+                'identifierType' => 'DOI',
+                'relationType' => 'Cites',
+            ],
+            'not-an-array',
+        ],
+    ]);
+
+    invokeDraftRequestMethod($request, 'prepareForValidation');
+
+    expect($request->input('relatedIdentifiers'))->toBe([
+        [
+            'identifier' => '10.5880/test.2026.001',
+            'identifierType' => 'DOI',
+            'relationType' => 'Other',
+            'relationTypeInformation' => 'Custom relationship',
+            'citationLabel' => 'Doe, J. (2026): Example citation.',
+        ],
+        [
+            'identifier' => 'https://example.org/resource',
+            'identifierType' => 'URL',
+            'relationType' => 'References',
+        ],
+    ]);
+});

--- a/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
@@ -63,3 +63,9 @@ it('normalizes related identifiers and keeps optional related-work fields only w
         ],
     ]);
 });
+
+it('limits related-work citation labels to the text-safe validation maximum', function (): void {
+    $request = new StoreDraftResourceRequest;
+
+    expect($request->rules()['relatedIdentifiers.*.citationLabel'])->toContain('max:65535');
+});

--- a/tests/pest/Unit/Services/Citations/RelatedIdentifierCitationLabelServiceTest.php
+++ b/tests/pest/Unit/Services/Citations/RelatedIdentifierCitationLabelServiceTest.php
@@ -61,3 +61,25 @@ it('returns null when metadata lookup fails', function () {
 
     expect($service->resolve('10.1234/missing', 'DOI'))->toBeNull();
 });
+
+it('uses the provided timeout for best-effort resolution without caching transient failures', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldReceive('normalizeDoi')->once()->with('10.1234/example')->andReturn('10.1234/example');
+    $dataCite->shouldReceive('getMetadata')->once()->with('10.1234/example', 0.5, false)->andReturn(['title' => 'Example']);
+    $dataCite->shouldReceive('buildCitationFromMetadata')->once()->with(['title' => 'Example'])->andReturn('Doe, J. (2026): Example. Publisher.');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolve('10.1234/example', 'DOI', 0.5))->toBe('Doe, J. (2026): Example. Publisher.');
+});
+
+it('skips best-effort resolution when the aggregate budget is exhausted', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldNotReceive('normalizeDoi');
+    $dataCite->shouldNotReceive('getMetadata');
+    $dataCite->shouldNotReceive('buildCitationFromMetadata');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolveBestEffort('10.1234/example', 'DOI', microtime(true) - 1))->toBeNull();
+});

--- a/tests/pest/Unit/Services/Citations/RelatedIdentifierCitationLabelServiceTest.php
+++ b/tests/pest/Unit/Services/Citations/RelatedIdentifierCitationLabelServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\DataCiteApiService;
+
+covers(RelatedIdentifierCitationLabelService::class);
+
+it('resolves a citation label for DOI identifiers', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldReceive('normalizeDoi')->once()->with('10.1234/example')->andReturn('10.1234/example');
+    $dataCite->shouldReceive('getMetadata')->once()->with('10.1234/example')->andReturn(['title' => 'Example']);
+    $dataCite->shouldReceive('buildCitationFromMetadata')->once()->with(['title' => 'Example'])->andReturn('Doe, J. (2026): Example. Publisher.');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolve('10.1234/example', 'DOI'))->toBe('Doe, J. (2026): Example. Publisher.');
+});
+
+it('resolves a citation label for DOI resolver URLs stored as URL', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldReceive('normalizeDoi')->once()->with('https://doi.org/10.1234/example')->andReturn('10.1234/example');
+    $dataCite->shouldReceive('getMetadata')->once()->with('10.1234/example')->andReturn(['title' => 'Example']);
+    $dataCite->shouldReceive('buildCitationFromMetadata')->once()->with(['title' => 'Example'])->andReturn('Doe, J. (2026): Example. Publisher.');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolve('https://doi.org/10.1234/example', 'URL'))->toBe('Doe, J. (2026): Example. Publisher.');
+});
+
+it('returns null for non DOI-like URL identifiers', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldReceive('normalizeDoi')->once()->with('https://example.org/page')->andReturn('https://example.org/page');
+    $dataCite->shouldNotReceive('getMetadata');
+    $dataCite->shouldNotReceive('buildCitationFromMetadata');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolve('https://example.org/page', 'URL'))->toBeNull();
+});
+
+it('returns null for unsupported identifier types', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldNotReceive('normalizeDoi');
+    $dataCite->shouldNotReceive('getMetadata');
+    $dataCite->shouldNotReceive('buildCitationFromMetadata');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolve('1234/5678', 'Handle'))->toBeNull();
+});
+
+it('returns null when metadata lookup fails', function () {
+    $dataCite = Mockery::mock(DataCiteApiService::class);
+    $dataCite->shouldReceive('normalizeDoi')->once()->with('10.1234/missing')->andReturn('10.1234/missing');
+    $dataCite->shouldReceive('getMetadata')->once()->with('10.1234/missing')->andReturnNull();
+    $dataCite->shouldNotReceive('buildCitationFromMetadata');
+
+    $service = new RelatedIdentifierCitationLabelService($dataCite);
+
+    expect($service->resolve('10.1234/missing', 'DOI'))->toBeNull();
+});

--- a/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
+++ b/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
@@ -159,6 +159,55 @@ test('transformation is null-safe for optional relationships', function () {
         ->and($data['contributors'][0]['contributor_types'])->toBeArray();
 });
 
+test('transforms related identifier slugs and citation label for landing pages', function () {
+    $transformer = new LandingPageResourceTransformer;
+
+    $resource = new Resource;
+
+    $identifierType = new \App\Models\IdentifierType;
+    $identifierType->forceFill([
+        'id' => 1,
+        'name' => 'DOI',
+        'slug' => 'DOI',
+    ]);
+
+    $relationType = new RelationType;
+    $relationType->forceFill([
+        'id' => 1,
+        'name' => 'Is Supplement To',
+        'slug' => 'IsSupplementTo',
+    ]);
+
+    $related = new RelatedIdentifier;
+    $related->forceFill([
+        'id' => 1,
+        'identifier' => '10.1234/example',
+        'citation_label' => 'Doe, J. (2026): Example. GFZ.',
+        'position' => 1,
+    ]);
+    $related->setRelation('identifierType', $identifierType);
+    $related->setRelation('relationType', $relationType);
+
+    $resource->setRelation('titles', new EloquentCollection);
+    $resource->setRelation('creators', new EloquentCollection);
+    $resource->setRelation('contributors', new EloquentCollection);
+    $resource->setRelation('relatedIdentifiers', new EloquentCollection([$related]));
+    $resource->setRelation('descriptions', new EloquentCollection);
+    $resource->setRelation('fundingReferences', new EloquentCollection);
+    $resource->setRelation('subjects', new EloquentCollection);
+    $resource->setRelation('geoLocations', new EloquentCollection);
+    $resource->setRelation('rights', new EloquentCollection);
+
+    $data = $transformer->transform($resource);
+
+    expect($data['related_identifiers'][0])->toMatchArray([
+        'identifier' => '10.1234/example',
+        'identifier_type' => 'DOI',
+        'relation_type' => 'IsSupplementTo',
+        'citation_label' => 'Doe, J. (2026): Example. GFZ.',
+    ]);
+});
+
 test('transforms rights to licenses with correct field mapping', function () {
     $transformer = new LandingPageResourceTransformer;
 

--- a/tests/pest/Unit/Services/RelatedIdentifierTypeResolverServiceTest.php
+++ b/tests/pest/Unit/Services/RelatedIdentifierTypeResolverServiceTest.php
@@ -38,11 +38,13 @@ it('resolves database-backed display names to canonical slugs', function () {
         ->and($service->resolveRelationType('My Relation Type'))->toBe('MyRelationType');
 });
 
-it('returns null for null, blank, and unresolvable inputs', function () {
+it('returns null for null, blank, non-string, and unresolvable inputs', function () {
     $service = app(RelatedIdentifierTypeResolverService::class);
 
     expect($service->resolveIdentifierType(null))->toBeNull()
         ->and($service->resolveRelationType(null))->toBeNull()
+    ->and($service->resolveIdentifierType(['DOI']))->toBeNull()
+    ->and($service->resolveRelationType(123))->toBeNull()
         ->and($service->resolveIdentifierType('   '))->toBeNull()
         ->and($service->resolveRelationType('@@@'))->toBeNull();
 });

--- a/tests/pest/Unit/Services/RelatedIdentifierTypeResolverServiceTest.php
+++ b/tests/pest/Unit/Services/RelatedIdentifierTypeResolverServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\IdentifierType;
+use App\Models\RelationType;
+use App\Services\RelatedIdentifierTypeResolverService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+covers(RelatedIdentifierTypeResolverService::class);
+
+it('resolves fallback identifier and relation type variants to canonical slugs', function () {
+    $service = app(RelatedIdentifierTypeResolverService::class);
+
+    expect($service->resolveIdentifierType('doi'))->toBe('DOI')
+        ->and($service->resolveRelationType('Is Cited By'))->toBe('IsCitedBy')
+        ->and($service->resolveRelationType('is-cited-by'))->toBe('IsCitedBy');
+});
+
+it('resolves database-backed display names to canonical slugs', function () {
+    IdentifierType::query()->create([
+        'name' => 'My Identifier',
+        'slug' => 'MyIdentifier',
+        'is_active' => true,
+    ]);
+
+    RelationType::query()->create([
+        'name' => 'My Relation Type',
+        'slug' => 'MyRelationType',
+        'is_active' => true,
+    ]);
+
+    $service = app(RelatedIdentifierTypeResolverService::class);
+
+    expect($service->resolveIdentifierType('my identifier'))->toBe('MyIdentifier')
+        ->and($service->resolveRelationType('My Relation Type'))->toBe('MyRelationType');
+});

--- a/tests/pest/Unit/Services/RelatedIdentifierTypeResolverServiceTest.php
+++ b/tests/pest/Unit/Services/RelatedIdentifierTypeResolverServiceTest.php
@@ -37,3 +37,12 @@ it('resolves database-backed display names to canonical slugs', function () {
     expect($service->resolveIdentifierType('my identifier'))->toBe('MyIdentifier')
         ->and($service->resolveRelationType('My Relation Type'))->toBe('MyRelationType');
 });
+
+it('returns null for null, blank, and unresolvable inputs', function () {
+    $service = app(RelatedIdentifierTypeResolverService::class);
+
+    expect($service->resolveIdentifierType(null))->toBeNull()
+        ->and($service->resolveRelationType(null))->toBeNull()
+        ->and($service->resolveIdentifierType('   '))->toBeNull()
+        ->and($service->resolveRelationType('@@@'))->toBeNull();
+});

--- a/tests/playwright/critical/landing-pages.spec.ts
+++ b/tests/playwright/critical/landing-pages.spec.ts
@@ -214,7 +214,7 @@ test.describe('Landing Page - GeoLocations', () => {
 });
 
 test.describe('Landing Page - Related Identifiers', () => {
-  test('displays related works with real DOIs', async ({ page }) => {
+  test('displays related identifier DOIs in related work and model description', async ({ page }) => {
     const landingPage = new LandingPage(page);
     await landingPage.goto('many-related-identifiers');
     await landingPage.verifyPageLoaded();
@@ -222,9 +222,10 @@ test.describe('Landing Page - Related Identifiers', () => {
     // Verify related works section
     await expect(landingPage.relatedWorksSection).toBeVisible();
 
-    // Verify real DOIs are displayed
+    // Verify real DOIs are displayed in the correct sections.
+    // The first IsSupplementTo entry is rendered as Model Description.
     await landingPage.verifyRelatedWorkDoi('10.5880/igets.su.l1.001');
-    await landingPage.verifyRelatedWorkDoi('10.1007/978-3-642-20338-1_37');
+    await landingPage.verifyModelDescriptionDoi('10.1007/978-3-642-20338-1_37');
     await landingPage.verifyRelatedWorkDoi('10.1016/j.jog.2009.09.009');
   });
 

--- a/tests/playwright/helpers/page-objects/LandingPage.ts
+++ b/tests/playwright/helpers/page-objects/LandingPage.ts
@@ -27,6 +27,9 @@ export class LandingPage {
   readonly abstractSection: Locator;
   readonly abstractText: Locator;
 
+  // Model Description section
+  readonly modelDescriptionSection: Locator;
+
   // Creators section
   readonly creatorsSection: Locator;
   readonly creatorsList: Locator;
@@ -72,6 +75,9 @@ export class LandingPage {
     // Abstract section
     this.abstractSection = page.locator('[data-testid="abstract-section"]').or(page.locator('section[aria-labelledby="heading-abstract"]'));
     this.abstractText = this.abstractSection.locator('p, [data-testid="abstract-text"]').first();
+
+    // Model Description section
+    this.modelDescriptionSection = page.locator('section[aria-labelledby="heading-model-description"]');
 
     // Creators section
     this.creatorsSection = page.locator('[data-testid="creators-section"]');
@@ -300,6 +306,15 @@ export class LandingPage {
    */
   async verifyRelatedWorkDoi(doi: string) {
     const doiLink = this.relatedWorksSection.locator(`a[href*="${doi}"]`);
+    await expect(doiLink).toBeVisible();
+  }
+
+  /**
+   * Verify a model description DOI is displayed and clickable
+   */
+  async verifyModelDescriptionDoi(doi: string) {
+    await expect(this.modelDescriptionSection).toBeVisible();
+    const doiLink = this.modelDescriptionSection.locator(`a[href*="${doi}"]`);
     await expect(doiLink).toBeVisible();
   }
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4339,5 +4339,64 @@ describe('DataCiteForm', () => {
                 }));
             });
         });
+
+        it('includes related work citation labels in the save payload', { timeout: 60000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({
+                data: { message: 'Resource stored!' },
+                status: 200,
+            });
+
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    dateTypes={dateTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    initialYear="2024"
+                    initialResourceType="1"
+                    initialTitles={[{ title: 'First Title', titleType: 'main-title' }]}
+                    initialLicenses={['MIT']}
+                    availableDatacenters={availableDatacenters}
+                    initialDatacenters={[1]}
+                    initialRelatedWorks={[
+                        {
+                            identifier: '10.1234/example',
+                            identifier_type: 'DOI',
+                            relation_type: 'IsReferencedBy',
+                            relation_type_information: null,
+                            citation_label: 'Doe, J. (2024): Manual citation. Publisher.',
+                        },
+                    ]}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
+
+            await fillRequiredAuthor(user);
+            await fillRequiredContributor(user);
+            await fillRequiredAbstract(user);
+
+            const saveButton = screen.getByRole('button', { name: /save & validate/i });
+            await user.click(saveButton);
+
+            const saveCall = getSaveAxiosCall();
+            expect(saveCall).toBeDefined();
+
+            const body = JSON.parse((saveCall![1] as RequestInit).body as string);
+            expect(body.relatedIdentifiers).toEqual([
+                {
+                    identifier: '10.1234/example',
+                    identifierType: 'DOI',
+                    relationType: 'IsReferencedBy',
+                    citationLabel: 'Doe, J. (2024): Manual citation. Publisher.',
+                },
+            ]);
+        });
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
@@ -214,6 +214,34 @@ describe('RelatedWorkField', () => {
         expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
     });
 
+    it('preserves a manually overridden identifier type while the field continues to change', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        mockDetectIdentifierType.mockReturnValue('DOI');
+
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+
+        await user.click(screen.getByTestId('set-url-type'));
+        await user.type(screen.getByTestId('identifier-input'), 'ambiguous-identifier');
+
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
+    });
+
+    it('re-enables identifier auto-detection after the shared field is reset', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        mockDetectIdentifierType
+            .mockReturnValueOnce('DOI')
+            .mockReturnValue('URL');
+
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+
+        await user.click(screen.getByTestId('set-url-type'));
+        await user.type(screen.getByTestId('identifier-input'), 'ambiguous-identifier');
+        await user.clear(screen.getByTestId('identifier-input'));
+        await user.type(screen.getByTestId('identifier-input'), 'https://example.org/resource');
+
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
+    });
+
     it('hydrates a citation label after adding a DOI when lookup succeeds', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         global.fetch = vi.fn().mockResolvedValue({

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
@@ -132,19 +132,34 @@ vi.mock('@/components/curation/fields/related-work/related-work-list', () => ({
                 </>
             )}
             {items.length > 1 && (
-                <button
-                    data-testid="reorder-items"
-                    onClick={() =>
-                        onReorder(
-                            [...items].reverse().map((item, index) => ({
-                                ...item,
-                                position: index,
-                            })),
-                        )
-                    }
-                >
-                    Reorder
-                </button>
+                <>
+                    <button
+                        data-testid="edit-first-item-to-duplicate"
+                        onClick={() =>
+                            onItemChange(0, {
+                                ...items[0],
+                                identifier: items[1].identifier,
+                                identifier_type: items[1].identifier_type,
+                                relation_type: items[1].relation_type,
+                            })
+                        }
+                    >
+                        Edit first to duplicate
+                    </button>
+                    <button
+                        data-testid="reorder-items"
+                        onClick={() =>
+                            onReorder(
+                                [...items].reverse().map((item, index) => ({
+                                    ...item,
+                                    position: index,
+                                })),
+                            )
+                        }
+                    >
+                        Reorder
+                    </button>
+                </>
             )}
         </div>
     ),
@@ -528,6 +543,34 @@ describe('RelatedWorkField', () => {
             expect.objectContaining({ identifier: '10.1234/updated', citation_label: null, position: 0 }),
             { identifier: '10.1234/untouched', identifier_type: 'DOI', relation_type: 'References', position: 1 },
         ]);
+    });
+
+    it('rejects edits that would duplicate another related work entry', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    {
+                        identifier: '10.1234/original',
+                        identifier_type: 'DOI',
+                        relation_type: 'Cites',
+                        position: 0,
+                    },
+                    {
+                        identifier: '10.1234/duplicate',
+                        identifier_type: 'DOI',
+                        relation_type: 'References',
+                        position: 1,
+                    },
+                ]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByTestId('edit-first-item-to-duplicate'));
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(screen.getByText(/this exact relation already exists/i)).toBeInTheDocument();
     });
 
     it('preserves citation labels when editing an item without changing its identifier', async () => {

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
@@ -123,6 +123,12 @@ vi.mock('@/components/curation/fields/related-work/related-work-list', () => ({
                     >
                         Edit first label only
                     </button>
+                    <button
+                        data-testid="edit-first-item-type"
+                        onClick={() => onItemChange(0, { ...items[0], identifier_type: 'URL', citation_label: 'Old citation' })}
+                    >
+                        Edit first type
+                    </button>
                 </>
             )}
             {items.length > 1 && (
@@ -429,7 +435,7 @@ describe('RelatedWorkField', () => {
         ]);
     });
 
-    it('clears stale citation labels when an item identifier changes', async () => {
+    it('clears stale citation labels and resolved metadata when an item identifier changes', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         render(
             <RelatedWorkField
@@ -439,6 +445,8 @@ describe('RelatedWorkField', () => {
                         identifier_type: 'DOI',
                         relation_type: 'Cites',
                         citation_label: 'Old citation',
+                        related_title: 'Resolved title for old DOI',
+                        related_metadata: { publisher: 'GFZ' },
                         position: 0,
                     },
                 ]}
@@ -452,6 +460,40 @@ describe('RelatedWorkField', () => {
             expect.objectContaining({
                 identifier: '10.1234/updated',
                 citation_label: null,
+                related_title: null,
+                related_metadata: null,
+                position: 0,
+            }),
+        ]);
+    });
+
+    it('clears stale resolved metadata when only the identifier type changes', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    {
+                        identifier: '10.1234/original',
+                        identifier_type: 'DOI',
+                        relation_type: 'Cites',
+                        citation_label: 'Old citation',
+                        related_title: 'Resolved title for old DOI',
+                        related_metadata: { publisher: 'GFZ' },
+                        position: 0,
+                    },
+                ]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByTestId('edit-first-item-type'));
+
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({
+                identifier_type: 'URL',
+                citation_label: null,
+                related_title: null,
+                related_metadata: null,
                 position: 0,
             }),
         ]);
@@ -596,6 +638,33 @@ describe('RelatedWorkField', () => {
             }),
         ]);
         expect(screen.getByText(/skipped 1 duplicate/i)).toBeInTheDocument();
+    });
+
+    it('hydrates citation labels only for newly imported DOI rows', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            json: vi.fn().mockResolvedValue({}),
+        }) as unknown as typeof fetch;
+
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    {
+                        identifier: '10.1234/csv1',
+                        identifier_type: 'DOI',
+                        relation_type: 'Cites',
+                        position: 0,
+                    },
+                ]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /import from csv/i }));
+        await user.click(screen.getByTestId('csv-import-submit'));
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('clears CSV duplicate warnings after eight seconds', async () => {

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
@@ -263,6 +263,48 @@ describe('RelatedWorkField', () => {
         expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
     });
 
+    it('initializes and resets add-form selections from active options when defaults are inactive', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+        render(
+            <RelatedWorkField
+                relatedWorks={[]}
+                onChange={onChange}
+                activeIdentifierTypes={['URL']}
+                activeRelationTypes={['References']}
+            />,
+        );
+
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
+        expect(screen.getByTestId('relation-type')).toHaveTextContent('References');
+
+        await user.type(screen.getByTestId('identifier-input'), 'https://example.org/reference');
+        await user.click(screen.getByTestId('add-button'));
+
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({
+                identifier: 'https://example.org/reference',
+                identifier_type: 'URL',
+                relation_type: 'References',
+                position: 0,
+            }),
+        ]);
+        expect(screen.getByTestId('identifier-input')).toHaveValue('');
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
+        expect(screen.getByTestId('relation-type')).toHaveTextContent('References');
+    });
+
+    it('keeps auto-detected identifier types within the active options', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        mockDetectIdentifierType.mockReturnValue('DOI');
+
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} activeIdentifierTypes={['URL']} />);
+
+        await user.type(screen.getByTestId('identifier-input'), '10.5880/inactive-doi');
+
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
+    });
+
     it('hydrates a citation label after adding a DOI when lookup succeeds', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         global.fetch = vi.fn().mockResolvedValue({

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
@@ -7,56 +7,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import RelatedWorkField from '@/components/curation/fields/related-work/related-work-field';
 import type { RelatedIdentifier } from '@/types';
 
-// Mock child components to isolate RelatedWorkField logic
+vi.mock('@/actions/App/Http/Controllers/Api/DataCiteController', () => ({
+    getCitation: {
+        url: vi.fn(() => '/api/datacite/citation'),
+    },
+}));
+
 vi.mock('@/components/curation/fields/related-work/related-work-quick-add', () => ({
     default: ({
         onAdd,
         identifier,
         onIdentifierChange,
-        relationType,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        onRelationTypeChange,
-        onToggleAdvanced,
-    }: {
-        onAdd: (data: { identifier: string; identifierType: string; relationType: string }) => void;
-        identifier: string;
-        onIdentifierChange: (val: string) => void;
-        relationType: string;
-        onRelationTypeChange: (val: string) => void;
-        onToggleAdvanced: () => void;
-    }) => (
-        <div data-testid="quick-add">
-            <input
-                data-testid="identifier-input"
-                value={identifier}
-                onChange={(e) => onIdentifierChange(e.target.value)}
-            />
-            <button
-                data-testid="add-button"
-                onClick={() =>
-                    onAdd({ identifier, identifierType: 'DOI', relationType })
-                }
-            >
-                Add
-            </button>
-            <button data-testid="toggle-advanced" onClick={onToggleAdvanced}>
-                Advanced
-            </button>
-            <span data-testid="relation-type">{relationType}</span>
-        </div>
-    ),
-}));
-
-vi.mock('@/components/curation/fields/related-work/related-work-advanced-add', () => ({
-    default: ({
-        onAdd,
-        identifier,
-        onIdentifierChange,
         identifierType,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onIdentifierTypeChange,
         relationType,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         onRelationTypeChange,
     }: {
         onAdd: (data: { identifier: string; identifierType: string; relationType: string }) => void;
@@ -67,20 +31,19 @@ vi.mock('@/components/curation/fields/related-work/related-work-advanced-add', (
         relationType: string;
         onRelationTypeChange: (val: string) => void;
     }) => (
-        <div data-testid="advanced-add">
-            <input
-                data-testid="adv-identifier-input"
-                value={identifier}
-                onChange={(e) => onIdentifierChange(e.target.value)}
-            />
-            <button
-                data-testid="adv-add-button"
-                onClick={() =>
-                    onAdd({ identifier, identifierType, relationType })
-                }
-            >
+        <div data-testid="quick-add">
+            <input data-testid="identifier-input" value={identifier} onChange={(event) => onIdentifierChange(event.target.value)} />
+            <button data-testid="set-url-type" onClick={() => onIdentifierTypeChange('URL')}>
+                Set URL type
+            </button>
+            <button data-testid="set-references" onClick={() => onRelationTypeChange('References')}>
+                Set References
+            </button>
+            <button data-testid="add-button" onClick={() => onAdd({ identifier, identifierType, relationType })}>
                 Add
             </button>
+            <span data-testid="identifier-type">{identifierType}</span>
+            <span data-testid="relation-type">{relationType}</span>
         </div>
     ),
 }));
@@ -116,20 +79,48 @@ vi.mock('@/components/curation/fields/related-work/related-work-list', () => ({
     default: ({
         items,
         onRemove,
+        onItemChange,
+        onReorder,
     }: {
         items: RelatedIdentifier[];
         onRemove: (index: number) => void;
+        onItemChange: (index: number, item: RelatedIdentifier) => void;
+        onReorder: (items: RelatedIdentifier[]) => void;
     }) => (
         <div data-testid="related-work-list">
             {items.map((item, index) => (
                 <div key={`${item.identifier}-${item.relation_type}`} data-testid={`item-${index}`}>
                     <span>{item.identifier}</span>
                     <span>{item.relation_type}</span>
+                    <span>{item.citation_label ?? ''}</span>
                     <button data-testid={`remove-${index}`} onClick={() => onRemove(index)}>
                         Remove
                     </button>
                 </div>
             ))}
+            {items[0] && (
+                <button
+                    data-testid="edit-first-item"
+                    onClick={() => onItemChange(0, { ...items[0], identifier: '10.1234/updated', citation_label: 'Old citation' })}
+                >
+                    Edit first
+                </button>
+            )}
+            {items.length > 1 && (
+                <button
+                    data-testid="reorder-items"
+                    onClick={() =>
+                        onReorder(
+                            [...items].reverse().map((item, index) => ({
+                                ...item,
+                                position: index,
+                            })),
+                        )
+                    }
+                >
+                    Reorder
+                </button>
+            )}
         </div>
     ),
 }));
@@ -144,49 +135,40 @@ describe('RelatedWorkField', () => {
     beforeEach(() => {
         onChange = vi.fn<(relatedWorks: RelatedIdentifier[]) => void>();
         vi.useFakeTimers({ shouldAdvanceTime: true });
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            json: vi.fn().mockResolvedValue({}),
+        }) as unknown as typeof fetch;
     });
 
     afterEach(() => {
         vi.useRealTimers();
     });
 
-    it('renders quick-add mode by default', () => {
+    it('renders the add form by default', () => {
         render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
 
         expect(screen.getByTestId('quick-add')).toBeInTheDocument();
-        expect(screen.queryByTestId('advanced-add')).not.toBeInTheDocument();
-    });
-
-    it('shows the Import from CSV button', () => {
-        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
-
         expect(screen.getByRole('button', { name: /import from csv/i })).toBeInTheDocument();
     });
 
-    it('does not render the list when there are no related works', () => {
-        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
-
-        expect(screen.queryByTestId('related-work-list')).not.toBeInTheDocument();
-    });
-
     it('renders the list when related works are provided', () => {
-        const works: RelatedIdentifier[] = [
-            { identifier: '10.1234/test', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
-
-        render(<RelatedWorkField relatedWorks={works} onChange={onChange} />);
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/test', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
 
         expect(screen.getByTestId('related-work-list')).toBeInTheDocument();
         expect(screen.getByText('10.1234/test')).toBeInTheDocument();
     });
 
-    it('adds a new related work via quick-add', async () => {
+    it('adds a new related work via the add form', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-
         render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
 
-        const input = screen.getByTestId('identifier-input');
-        await user.type(input, '10.1234/new');
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/new');
         await user.click(screen.getByTestId('add-button'));
 
         expect(onChange).toHaveBeenCalledWith([
@@ -199,52 +181,58 @@ describe('RelatedWorkField', () => {
         ]);
     });
 
-    it('prevents adding duplicate identifiers with the same relation type', async () => {
+    it('hydrates a citation label after adding a DOI when lookup succeeds', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const existing: RelatedIdentifier[] = [
-            { identifier: '10.1234/dup', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ citation: 'Doe, J. (2024). Fetched Citation.' }),
+        }) as unknown as typeof fetch;
 
-        render(<RelatedWorkField relatedWorks={existing} onChange={onChange} />);
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
 
-        const input = screen.getByTestId('identifier-input');
-        await user.type(input, '10.1234/dup');
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/new');
+        await user.click(screen.getByTestId('add-button'));
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(onChange).toHaveBeenLastCalledWith([
+            expect.objectContaining({
+                identifier: '10.1234/new',
+                citation_label: 'Doe, J. (2024). Fetched Citation.',
+            }),
+        ]);
+    });
+
+    it('prevents duplicates with the same relation type', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/dup', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/dup');
         await user.click(screen.getByTestId('add-button'));
 
         expect(onChange).not.toHaveBeenCalled();
         expect(screen.getByText(/this exact relation already exists/i)).toBeInTheDocument();
     });
 
-    it('detects DOI URL form as duplicate', async () => {
+    it('clears duplicate errors after five seconds', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const existing: RelatedIdentifier[] = [
-            { identifier: 'https://doi.org/10.1234/dup', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/dup', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
 
-        // The quick-add mock sends the raw identifier; normalizeIdentifier strips URLs
-        render(<RelatedWorkField relatedWorks={existing} onChange={onChange} />);
-
-        const input = screen.getByTestId('identifier-input');
-        await user.type(input, '10.1234/dup');
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/dup');
         await user.click(screen.getByTestId('add-button'));
-
-        expect(onChange).not.toHaveBeenCalled();
-        expect(screen.getByText(/this exact relation already exists/i)).toBeInTheDocument();
-    });
-
-    it('clears the duplicate error after 5 seconds', async () => {
-        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const existing: RelatedIdentifier[] = [
-            { identifier: '10.1234/dup', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
-
-        render(<RelatedWorkField relatedWorks={existing} onChange={onChange} />);
-
-        const input = screen.getByTestId('identifier-input');
-        await user.type(input, '10.1234/dup');
-        await user.click(screen.getByTestId('add-button'));
-
-        expect(screen.getByText(/this exact relation already exists/i)).toBeInTheDocument();
 
         act(() => {
             vi.advanceTimersByTime(5000);
@@ -253,30 +241,31 @@ describe('RelatedWorkField', () => {
         expect(screen.queryByText(/this exact relation already exists/i)).not.toBeInTheDocument();
     });
 
-    it('resets the form state after a successful add', async () => {
+    it('resets the add-form state after a successful add', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-
         render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
 
-        const input = screen.getByTestId('identifier-input');
-        await user.type(input, '10.1234/new');
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/new');
+        await user.click(screen.getByTestId('set-references'));
         await user.click(screen.getByTestId('add-button'));
 
-        // After adding, identifier should be reset to empty
-        expect(input).toHaveValue('');
-        // Relation type should reset to Cites
+        expect(screen.getByTestId('identifier-input')).toHaveValue('');
         expect(screen.getByTestId('relation-type')).toHaveTextContent('Cites');
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('DOI');
     });
 
-    it('removes a related work and re-indexes positions', async () => {
+    it('removes a related work and reindexes positions', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const works: RelatedIdentifier[] = [
-            { identifier: '10.1234/a', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-            { identifier: '10.1234/b', identifier_type: 'DOI', relation_type: 'References', position: 1 },
-            { identifier: '10.1234/c', identifier_type: 'DOI', relation_type: 'Describes', position: 2 },
-        ];
-
-        render(<RelatedWorkField relatedWorks={works} onChange={onChange} />);
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    { identifier: '10.1234/a', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
+                    { identifier: '10.1234/b', identifier_type: 'DOI', relation_type: 'References', position: 1 },
+                    { identifier: '10.1234/c', identifier_type: 'DOI', relation_type: 'Describes', position: 2 },
+                ]}
+                onChange={onChange}
+            />,
+        );
 
         await user.click(screen.getByTestId('remove-1'));
 
@@ -286,98 +275,78 @@ describe('RelatedWorkField', () => {
         ]);
     });
 
-    it('switches to advanced mode when toggled', async () => {
+    it('clears stale citation labels when an item identifier changes', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    {
+                        identifier: '10.1234/original',
+                        identifier_type: 'DOI',
+                        relation_type: 'Cites',
+                        citation_label: 'Old citation',
+                        position: 0,
+                    },
+                ]}
+                onChange={onChange}
+            />,
+        );
 
-        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+        await user.click(screen.getByTestId('edit-first-item'));
 
-        await user.click(screen.getByTestId('toggle-advanced'));
-
-        expect(screen.getByTestId('advanced-add')).toBeInTheDocument();
-        expect(screen.queryByTestId('quick-add')).not.toBeInTheDocument();
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({
+                identifier: '10.1234/updated',
+                citation_label: null,
+                position: 0,
+            }),
+        ]);
     });
 
-    it('switches back to simple mode from advanced', async () => {
+    it('applies reordered items from the list callback', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    { identifier: '10.1234/a', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
+                    { identifier: '10.1234/b', identifier_type: 'DOI', relation_type: 'References', position: 1 },
+                ]}
+                onChange={onChange}
+            />,
+        );
 
-        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+        await user.click(screen.getByTestId('reorder-items'));
 
-        // Go to advanced
-        await user.click(screen.getByTestId('toggle-advanced'));
-        expect(screen.getByTestId('advanced-add')).toBeInTheDocument();
-
-        // Switch back via the "← Switch to simple mode" button
-        const switchButton = screen.getByText(/switch to simple mode/i);
-        await user.click(switchButton);
-
-        expect(screen.getByTestId('quick-add')).toBeInTheDocument();
-        expect(screen.queryByTestId('advanced-add')).not.toBeInTheDocument();
+        expect(onChange).toHaveBeenCalledWith([
+            { identifier: '10.1234/b', identifier_type: 'DOI', relation_type: 'References', position: 0 },
+            { identifier: '10.1234/a', identifier_type: 'DOI', relation_type: 'Cites', position: 1 },
+        ]);
     });
 
-    it('opens CSV import when the Import from CSV button is clicked', async () => {
+    it('opens and closes the CSV import flow', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-
         render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
 
         await user.click(screen.getByRole('button', { name: /import from csv/i }));
-
         expect(screen.getByTestId('csv-import')).toBeInTheDocument();
-        // Quick-add and CSV button should be hidden
-        expect(screen.queryByTestId('quick-add')).not.toBeInTheDocument();
-    });
 
-    it('closes CSV import and returns to quick-add mode', async () => {
-        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-
-        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
-
-        await user.click(screen.getByRole('button', { name: /import from csv/i }));
         await user.click(screen.getByTestId('csv-import-close'));
-
         expect(screen.queryByTestId('csv-import')).not.toBeInTheDocument();
         expect(screen.getByTestId('quick-add')).toBeInTheDocument();
     });
 
-    it('handles bulk CSV import and appends items', async () => {
+    it('appends non-duplicate CSV imports and skips duplicates', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const existing: RelatedIdentifier[] = [
-            { identifier: '10.1234/existing', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
-
-        render(<RelatedWorkField relatedWorks={existing} onChange={onChange} />);
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/csv1', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
 
         await user.click(screen.getByRole('button', { name: /import from csv/i }));
         await user.click(screen.getByTestId('csv-import-submit'));
 
-        expect(onChange).toHaveBeenCalledWith([
-            { identifier: '10.1234/existing', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-            expect.objectContaining({
-                identifier: '10.1234/csv1',
-                identifier_type: 'DOI',
-                relation_type: 'Cites',
-                position: 1,
-            }),
-            expect.objectContaining({
-                identifier: '10.1234/csv2',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-                position: 2,
-            }),
-        ]);
-    });
-
-    it('skips duplicates during CSV import and shows a warning', async () => {
-        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const existing: RelatedIdentifier[] = [
-            { identifier: '10.1234/csv1', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
-
-        render(<RelatedWorkField relatedWorks={existing} onChange={onChange} />);
-
-        await user.click(screen.getByRole('button', { name: /import from csv/i }));
-        await user.click(screen.getByTestId('csv-import-submit'));
-
-        // Should skip csv1 (duplicate) and add csv2
         expect(onChange).toHaveBeenCalledWith([
             { identifier: '10.1234/csv1', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
             expect.objectContaining({
@@ -386,28 +355,6 @@ describe('RelatedWorkField', () => {
                 position: 1,
             }),
         ]);
-
-        // Should show duplicate warning
         expect(screen.getByText(/skipped 1 duplicate/i)).toBeInTheDocument();
-    });
-
-    it('clears duplicate warning from CSV import after 8 seconds', async () => {
-        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-        const existing: RelatedIdentifier[] = [
-            { identifier: '10.1234/csv1', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
-        ];
-
-        render(<RelatedWorkField relatedWorks={existing} onChange={onChange} />);
-
-        await user.click(screen.getByRole('button', { name: /import from csv/i }));
-        await user.click(screen.getByTestId('csv-import-submit'));
-
-        expect(screen.getByText(/skipped 1 duplicate/i)).toBeInTheDocument();
-
-        act(() => {
-            vi.advanceTimersByTime(8000);
-        });
-
-        expect(screen.queryByText(/skipped 1 duplicate/i)).not.toBeInTheDocument();
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-field.test.tsx
@@ -2,9 +2,11 @@ import '@testing-library/jest-dom/vitest';
 
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RelatedWorkField from '@/components/curation/fields/related-work/related-work-field';
+import { detectIdentifierType } from '@/lib/identifier-type-detection';
 import type { RelatedIdentifier } from '@/types';
 
 vi.mock('@/actions/App/Http/Controllers/Api/DataCiteController', () => ({
@@ -23,7 +25,7 @@ vi.mock('@/components/curation/fields/related-work/related-work-quick-add', () =
         relationType,
         onRelationTypeChange,
     }: {
-        onAdd: (data: { identifier: string; identifierType: string; relationType: string }) => void;
+        onAdd: (data: { identifier: string; identifierType: string; relationType: string; citationLabel?: string }) => void;
         identifier: string;
         onIdentifierChange: (val: string) => void;
         identifierType: string;
@@ -39,8 +41,17 @@ vi.mock('@/components/curation/fields/related-work/related-work-quick-add', () =
             <button data-testid="set-references" onClick={() => onRelationTypeChange('References')}>
                 Set References
             </button>
+            <button data-testid="set-cites" onClick={() => onRelationTypeChange('Cites')}>
+                Set Cites
+            </button>
             <button data-testid="add-button" onClick={() => onAdd({ identifier, identifierType, relationType })}>
                 Add
+            </button>
+            <button
+                data-testid="add-with-manual-citation"
+                onClick={() => onAdd({ identifier, identifierType, relationType, citationLabel: 'Manual citation from add form' })}
+            >
+                Add with citation
             </button>
             <span data-testid="identifier-type">{identifierType}</span>
             <span data-testid="relation-type">{relationType}</span>
@@ -99,12 +110,20 @@ vi.mock('@/components/curation/fields/related-work/related-work-list', () => ({
                 </div>
             ))}
             {items[0] && (
-                <button
-                    data-testid="edit-first-item"
-                    onClick={() => onItemChange(0, { ...items[0], identifier: '10.1234/updated', citation_label: 'Old citation' })}
-                >
-                    Edit first
-                </button>
+                <>
+                    <button
+                        data-testid="edit-first-item"
+                        onClick={() => onItemChange(0, { ...items[0], identifier: '10.1234/updated', citation_label: 'Old citation' })}
+                    >
+                        Edit first
+                    </button>
+                    <button
+                        data-testid="edit-first-item-preserve-label"
+                        onClick={() => onItemChange(0, { ...items[0], citation_label: 'Updated citation without identifier change' })}
+                    >
+                        Edit first label only
+                    </button>
+                </>
             )}
             {items.length > 1 && (
                 <button
@@ -129,11 +148,14 @@ vi.mock('@/lib/identifier-type-detection', () => ({
     detectIdentifierType: vi.fn(() => 'DOI'),
 }));
 
+const mockDetectIdentifierType = vi.mocked(detectIdentifierType);
+
 describe('RelatedWorkField', () => {
     let onChange = vi.fn<(relatedWorks: RelatedIdentifier[]) => void>();
 
     beforeEach(() => {
         onChange = vi.fn<(relatedWorks: RelatedIdentifier[]) => void>();
+        mockDetectIdentifierType.mockReturnValue('DOI');
         vi.useFakeTimers({ shouldAdvanceTime: true });
         global.fetch = vi.fn().mockResolvedValue({
             ok: false,
@@ -181,6 +203,17 @@ describe('RelatedWorkField', () => {
         ]);
     });
 
+    it('auto-detects the identifier type while typing into the shared form', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        mockDetectIdentifierType.mockReturnValue('URL');
+
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+
+        await user.type(screen.getByTestId('identifier-input'), 'https://example.org/resource');
+
+        expect(screen.getByTestId('identifier-type')).toHaveTextContent('URL');
+    });
+
     it('hydrates a citation label after adding a DOI when lookup succeeds', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         global.fetch = vi.fn().mockResolvedValue({
@@ -206,6 +239,59 @@ describe('RelatedWorkField', () => {
         ]);
     });
 
+    it('ignores empty citation payloads from the lookup endpoint', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ citation: '   ' }),
+        }) as unknown as typeof fetch;
+
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/new');
+        await user.click(screen.getByTestId('add-button'));
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('hydrates newly added citations without mutating unrelated existing items', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({ citation: 'Doe, J. (2024). Fetched Citation.' }),
+        }) as unknown as typeof fetch;
+
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/existing', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/new');
+        await user.click(screen.getByTestId('set-references'));
+        await user.click(screen.getByTestId('add-button'));
+
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(onChange).toHaveBeenLastCalledWith([
+            { identifier: '10.1234/existing', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
+            expect.objectContaining({
+                identifier: '10.1234/new',
+                relation_type: 'References',
+                citation_label: 'Doe, J. (2024). Fetched Citation.',
+            }),
+        ]);
+    });
+
     it('prevents duplicates with the same relation type', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         render(
@@ -220,6 +306,46 @@ describe('RelatedWorkField', () => {
 
         expect(onChange).not.toHaveBeenCalled();
         expect(screen.getByText(/this exact relation already exists/i)).toBeInTheDocument();
+    });
+
+    it('treats DOI URLs as duplicates of their normalized bare DOI', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/dup', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.type(screen.getByTestId('identifier-input'), 'https://doi.org/10.1234/dup');
+        await user.click(screen.getByTestId('add-button'));
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(screen.getByText(/this exact relation already exists/i)).toBeInTheDocument();
+    });
+
+    it('allows the same identifier when the relation type differs', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/shared', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/shared');
+        await user.click(screen.getByTestId('set-references'));
+        await user.click(screen.getByTestId('add-button'));
+
+        expect(onChange).toHaveBeenCalledWith([
+            { identifier: '10.1234/shared', identifier_type: 'DOI', relation_type: 'Cites', position: 0 },
+            expect.objectContaining({
+                identifier: '10.1234/shared',
+                identifier_type: 'DOI',
+                relation_type: 'References',
+                position: 1,
+            }),
+        ]);
     });
 
     it('clears duplicate errors after five seconds', async () => {
@@ -303,6 +429,65 @@ describe('RelatedWorkField', () => {
         ]);
     });
 
+    it('keeps untouched sibling items unchanged when editing one related work entry', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    {
+                        identifier: '10.1234/original',
+                        identifier_type: 'DOI',
+                        relation_type: 'Cites',
+                        citation_label: 'Old citation',
+                        position: 0,
+                    },
+                    {
+                        identifier: '10.1234/untouched',
+                        identifier_type: 'DOI',
+                        relation_type: 'References',
+                        position: 1,
+                    },
+                ]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByTestId('edit-first-item'));
+
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({ identifier: '10.1234/updated', citation_label: null, position: 0 }),
+            { identifier: '10.1234/untouched', identifier_type: 'DOI', relation_type: 'References', position: 1 },
+        ]);
+    });
+
+    it('preserves citation labels when editing an item without changing its identifier', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[
+                    {
+                        identifier: '10.1234/original',
+                        identifier_type: 'DOI',
+                        relation_type: 'Cites',
+                        citation_label: 'Existing citation',
+                        position: 0,
+                    },
+                ]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByTestId('edit-first-item-preserve-label'));
+
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({
+                identifier: '10.1234/original',
+                citation_label: 'Updated citation without identifier change',
+                position: 0,
+            }),
+        ]);
+    });
+
     it('applies reordered items from the list callback', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         render(
@@ -335,6 +520,33 @@ describe('RelatedWorkField', () => {
         expect(screen.getByTestId('quick-add')).toBeInTheDocument();
     });
 
+    it('skips client-side citation lookups for non-DOI entries', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+
+        await user.type(screen.getByTestId('identifier-input'), 'https://example.org/documentation');
+        await user.click(screen.getByTestId('set-url-type'));
+        await user.click(screen.getByTestId('add-button'));
+
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch a citation label when the add form already provides one', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(<RelatedWorkField relatedWorks={[]} onChange={onChange} />);
+
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/manual-citation');
+        await user.click(screen.getByTestId('add-with-manual-citation'));
+
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({
+                identifier: '10.1234/manual-citation',
+                citation_label: 'Manual citation from add form',
+            }),
+        ]);
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it('appends non-duplicate CSV imports and skips duplicates', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         render(
@@ -356,5 +568,62 @@ describe('RelatedWorkField', () => {
             }),
         ]);
         expect(screen.getByText(/skipped 1 duplicate/i)).toBeInTheDocument();
+    });
+
+    it('clears CSV duplicate warnings after eight seconds', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        render(
+            <RelatedWorkField
+                relatedWorks={[{ identifier: '10.1234/csv1', identifier_type: 'DOI', relation_type: 'Cites', position: 0 }]}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /import from csv/i }));
+        await user.click(screen.getByTestId('csv-import-submit'));
+
+        expect(screen.getByText(/skipped 1 duplicate/i)).toBeInTheDocument();
+
+        act(() => {
+            vi.advanceTimersByTime(8000);
+        });
+
+        expect(screen.queryByText(/skipped 1 duplicate/i)).not.toBeInTheDocument();
+    });
+
+    it('does not apply a fetched citation label after the related work was removed', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        let resolveCitation: ((value: { citation: string }) => void) | undefined;
+
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn(
+                () =>
+                    new Promise<{ citation: string }>((resolve) => {
+                        resolveCitation = resolve;
+                    }),
+            ),
+        }) as unknown as typeof fetch;
+
+        function StatefulField() {
+            const [items, setItems] = useState<RelatedIdentifier[]>([]);
+
+            return <RelatedWorkField relatedWorks={items} onChange={setItems} />;
+        }
+
+        render(<StatefulField />);
+
+        await user.type(screen.getByTestId('identifier-input'), '10.1234/pending');
+        await user.click(screen.getByTestId('add-button'));
+        await user.click(screen.getByTestId('remove-0'));
+
+        await act(async () => {
+            resolveCitation?.({ citation: 'Deferred citation' });
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(screen.queryByTestId('related-work-list')).not.toBeInTheDocument();
+        expect(screen.queryByText('Deferred citation')).not.toBeInTheDocument();
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
@@ -100,6 +100,20 @@ describe('RelatedWorkItem', () => {
         );
     });
 
+    it('calls onChange when the identifier type is edited', async () => {
+        const user = userEvent.setup();
+        render(<RelatedWorkItem {...defaultProps} />);
+
+        await user.click(screen.getByRole('combobox', { name: /^type$/i }));
+        await user.click(screen.getByRole('option', { name: 'URL' }));
+
+        expect(mockOnChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                identifier_type: 'URL',
+            }),
+        );
+    });
+
     it('calls onChange when the citation label is edited', async () => {
         render(<RelatedWorkItem {...defaultProps} />);
 
@@ -111,6 +125,12 @@ describe('RelatedWorkItem', () => {
                 citation_label: 'Smith, J. (2024). Test Dataset.',
             }),
         );
+    });
+
+    it('shows a fallback message when no resolved title is available', () => {
+        render(<RelatedWorkItem {...defaultProps} />);
+
+        expect(screen.getByText('No resolved title available yet.')).toBeInTheDocument();
     });
 
     it('renders validation tooltips for valid items', async () => {
@@ -131,6 +151,16 @@ describe('RelatedWorkItem', () => {
         await user.hover(invalidIcon);
 
         expect((await screen.findAllByText('DOI not found')).length).toBeGreaterThan(0);
+    });
+
+    it('renders warning tooltips with the default message when no warning text is provided', async () => {
+        const user = userEvent.setup();
+        render(<RelatedWorkItem {...defaultProps} validationStatus="warning" />);
+
+        const warningIcon = screen.getByLabelText('Warning');
+        await user.hover(warningIcon);
+
+        expect((await screen.findAllByText('Validation warning')).length).toBeGreaterThan(0);
     });
 
     it('shows the resolved title helper when related_title is available', () => {
@@ -160,5 +190,55 @@ describe('RelatedWorkItem', () => {
         );
 
         expect(screen.getByLabelText('Relation type information')).toHaveValue('Custom relation');
+    });
+
+    it('clears relation type information when switching away from Other', async () => {
+        const user = userEvent.setup();
+        render(
+            <RelatedWorkItem
+                {...defaultProps}
+                item={{
+                    ...defaultItem,
+                    relation_type: 'Other',
+                    relation_type_information: 'Custom relation',
+                }}
+            />,
+        );
+
+        await user.click(screen.getByRole('combobox', { name: /relation type/i }));
+        await user.click(screen.getByRole('option', { name: /cites/i }));
+
+        expect(mockOnChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                relation_type: 'Cites',
+                relation_type_information: null,
+            }),
+        );
+    });
+
+    it('filters identifier and relation type options when active sets are provided', async () => {
+        const user = userEvent.setup();
+        render(
+            <RelatedWorkItem
+                {...defaultProps}
+                activeIdentifierTypes={['DOI', 'URL']}
+                activeRelationTypes={['Cites', 'Documents']}
+            />,
+        );
+
+        await user.click(screen.getByRole('combobox', { name: /^type$/i }));
+
+        expect(screen.getByRole('option', { name: 'DOI' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'URL' })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Handle' })).not.toBeInTheDocument();
+
+        await user.keyboard('{Escape}');
+        await user.click(screen.getByRole('combobox', { name: /relation type/i }));
+
+        expect(screen.getByText('Most Used')).toBeInTheDocument();
+        expect(screen.getByText('All relation types')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /cites/i })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /documents/i })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: /references/i })).not.toBeInTheDocument();
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
@@ -62,6 +62,22 @@ describe('RelatedWorkItem', () => {
         expect(screen.getByRole('combobox', { name: /relation type/i })).toHaveTextContent('Is Cited By');
     });
 
+    it('suppresses clickable preview links for non-http URL identifiers', () => {
+        render(
+            <RelatedWorkItem
+                {...defaultProps}
+                item={{
+                    identifier: 'javascript:alert(1)',
+                    identifier_type: 'URL',
+                    relation_type: 'IsCitedBy',
+                }}
+            />,
+        );
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+    });
+
     it('renders non-clickable identifier types as plain preview text', () => {
         render(
             <RelatedWorkItem

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@tests/vitest/utils/render';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -6,6 +7,7 @@ import RelatedWorkItem from '@/components/curation/fields/related-work/related-w
 import type { RelatedIdentifier } from '@/types';
 
 describe('RelatedWorkItem', () => {
+    const mockOnChange = vi.fn();
     const mockOnRemove = vi.fn();
 
     const defaultItem: RelatedIdentifier = {
@@ -15,8 +17,10 @@ describe('RelatedWorkItem', () => {
     };
 
     const defaultProps = {
+        sortableId: 'related-work-0',
         item: defaultItem,
         index: 0,
+        onChange: mockOnChange,
         onRemove: mockOnRemove,
     };
 
@@ -24,57 +28,57 @@ describe('RelatedWorkItem', () => {
         vi.clearAllMocks();
     });
 
-    it('renders the relation type', () => {
+    it('renders the card heading and current select values', () => {
         render(<RelatedWorkItem {...defaultProps} />);
 
-        expect(screen.getByText('References')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /related work 1/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /relation type/i })).toHaveTextContent('References');
+        expect(screen.getByTestId('identifier-type-badge')).toHaveTextContent('DOI');
     });
 
-    it('renders the identifier', () => {
-        render(<RelatedWorkItem {...defaultProps} />);
-
-        expect(screen.getByText('10.5880/test.2024.001')).toBeInTheDocument();
-    });
-
-    it('renders the identifier type badge', () => {
-        render(<RelatedWorkItem {...defaultProps} />);
-
-        expect(screen.getByText('DOI')).toBeInTheDocument();
-    });
-
-    it('renders DOI as clickable link with correct href', () => {
+    it('renders DOI identifiers as clickable preview links', () => {
         render(<RelatedWorkItem {...defaultProps} />);
 
         const link = screen.getByRole('link', { name: /10\.5880\/test\.2024\.001/i });
         expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/test.2024.001');
         expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    it('renders URL as clickable link with correct href', () => {
-        const urlItem: RelatedIdentifier = {
-            identifier: 'https://example.com/resource',
-            identifier_type: 'URL',
-            relation_type: 'IsCitedBy',
-        };
-        render(<RelatedWorkItem {...defaultProps} item={urlItem} />);
+    it('renders URL identifiers as clickable preview links', () => {
+        render(
+            <RelatedWorkItem
+                {...defaultProps}
+                item={{
+                    identifier: 'https://example.com/resource',
+                    identifier_type: 'URL',
+                    relation_type: 'IsCitedBy',
+                }}
+            />,
+        );
 
         const link = screen.getByRole('link', { name: /https:\/\/example\.com\/resource/i });
         expect(link).toHaveAttribute('href', 'https://example.com/resource');
+        expect(screen.getByRole('combobox', { name: /relation type/i })).toHaveTextContent('Is Cited By');
     });
 
-    it('renders non-URL/DOI identifiers as plain text', () => {
-        const isbnItem: RelatedIdentifier = {
-            identifier: '978-3-16-148410-0',
-            identifier_type: 'ISBN',
-            relation_type: 'IsPartOf',
-        };
-        render(<RelatedWorkItem {...defaultProps} item={isbnItem} />);
+    it('renders non-clickable identifier types as plain preview text', () => {
+        render(
+            <RelatedWorkItem
+                {...defaultProps}
+                item={{
+                    identifier: '978-3-16-148410-0',
+                    identifier_type: 'ISBN',
+                    relation_type: 'IsPartOf',
+                }}
+            />,
+        );
 
-        expect(screen.getByText('978-3-16-148410-0')).toBeInTheDocument();
         expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        expect(screen.getByDisplayValue('978-3-16-148410-0')).toBeInTheDocument();
     });
 
-    it('calls onRemove with index when remove button is clicked', async () => {
+    it('calls onRemove with the item index', async () => {
         const user = userEvent.setup();
         render(<RelatedWorkItem {...defaultProps} index={2} />);
 
@@ -83,122 +87,78 @@ describe('RelatedWorkItem', () => {
         expect(mockOnRemove).toHaveBeenCalledWith(2);
     });
 
-    it('displays valid icon when validationStatus is valid', async () => {
+    it('calls onChange when the identifier is edited', async () => {
+        render(<RelatedWorkItem {...defaultProps} />);
+
+        const identifierInput = screen.getByLabelText('Identifier');
+        fireEvent.change(identifierInput, { target: { value: '10.5880/updated.2024.001' } });
+
+        expect(mockOnChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                identifier: '10.5880/updated.2024.001',
+            }),
+        );
+    });
+
+    it('calls onChange when the citation label is edited', async () => {
+        render(<RelatedWorkItem {...defaultProps} />);
+
+        const citationLabel = screen.getByLabelText('Citation label');
+        fireEvent.change(citationLabel, { target: { value: 'Smith, J. (2024). Test Dataset.' } });
+
+        expect(mockOnChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                citation_label: 'Smith, J. (2024). Test Dataset.',
+            }),
+        );
+    });
+
+    it('renders validation tooltips for valid items', async () => {
         const user = userEvent.setup();
         render(<RelatedWorkItem {...defaultProps} validationStatus="valid" />);
 
         const validIcon = screen.getByLabelText('Valid');
-        expect(validIcon).toBeInTheDocument();
-
-        // Hover to show tooltip
         await user.hover(validIcon);
-        const tooltipTexts = await screen.findAllByText('Identifier validated successfully');
-        expect(tooltipTexts.length).toBeGreaterThan(0);
+
+        expect((await screen.findAllByText('Identifier validated successfully')).length).toBeGreaterThan(0);
     });
 
-    it('displays invalid icon with message when validationStatus is invalid', async () => {
+    it('renders validation tooltips for invalid items', async () => {
         const user = userEvent.setup();
-        render(
-            <RelatedWorkItem
-                {...defaultProps}
-                validationStatus="invalid"
-                validationMessage="DOI not found"
-            />,
-        );
+        render(<RelatedWorkItem {...defaultProps} validationStatus="invalid" validationMessage="DOI not found" />);
 
         const invalidIcon = screen.getByLabelText('Invalid');
-        expect(invalidIcon).toBeInTheDocument();
-
         await user.hover(invalidIcon);
-        const tooltipTexts = await screen.findAllByText('DOI not found');
-        expect(tooltipTexts.length).toBeGreaterThan(0);
+
+        expect((await screen.findAllByText('DOI not found')).length).toBeGreaterThan(0);
     });
 
-    it('displays warning icon with message when validationStatus is warning', async () => {
-        const user = userEvent.setup();
+    it('shows the resolved title helper when related_title is available', () => {
         render(
             <RelatedWorkItem
                 {...defaultProps}
-                validationStatus="warning"
-                validationMessage="DOI may be incorrect"
+                item={{
+                    ...defaultItem,
+                    related_title: 'Related Research Paper Title',
+                }}
             />,
         );
-
-        const warningIcon = screen.getByLabelText('Warning');
-        expect(warningIcon).toBeInTheDocument();
-
-        await user.hover(warningIcon);
-        const tooltipTexts = await screen.findAllByText('DOI may be incorrect');
-        expect(tooltipTexts.length).toBeGreaterThan(0);
-    });
-
-    it('does not display validation icon when status is validating', () => {
-        render(<RelatedWorkItem {...defaultProps} validationStatus="validating" />);
-
-        expect(screen.queryByLabelText('Valid')).not.toBeInTheDocument();
-        expect(screen.queryByLabelText('Invalid')).not.toBeInTheDocument();
-        expect(screen.queryByLabelText('Warning')).not.toBeInTheDocument();
-    });
-
-    it('does not display validation icon when no status provided', () => {
-        render(<RelatedWorkItem {...defaultProps} />);
-
-        expect(screen.queryByLabelText('Valid')).not.toBeInTheDocument();
-        expect(screen.queryByLabelText('Invalid')).not.toBeInTheDocument();
-        expect(screen.queryByLabelText('Warning')).not.toBeInTheDocument();
-    });
-
-    it('displays related_title when provided', () => {
-        const itemWithTitle: RelatedIdentifier = {
-            ...defaultItem,
-            related_title: 'Related Research Paper Title',
-        };
-        render(<RelatedWorkItem {...defaultProps} item={itemWithTitle} />);
 
         expect(screen.getByText('Related Research Paper Title')).toBeInTheDocument();
     });
 
-    it('renders different relation types correctly', () => {
-        const citedByItem: RelatedIdentifier = {
-            identifier: '10.5880/test.2024.002',
-            identifier_type: 'DOI',
-            relation_type: 'IsCitedBy',
-        };
-        render(<RelatedWorkItem {...defaultProps} item={citedByItem} />);
+    it('shows the relation type information field for Other', () => {
+        render(
+            <RelatedWorkItem
+                {...defaultProps}
+                item={{
+                    ...defaultItem,
+                    relation_type: 'Other',
+                    relation_type_information: 'Custom relation',
+                }}
+            />,
+        );
 
-        expect(screen.getByText('IsCitedBy')).toBeInTheDocument();
-    });
-
-    it('handles ARK identifier type', () => {
-        const arkItem: RelatedIdentifier = {
-            identifier: 'ark:/12345/abc123',
-            identifier_type: 'ARK',
-            relation_type: 'References',
-        };
-        render(<RelatedWorkItem {...defaultProps} item={arkItem} />);
-
-        expect(screen.getByText('ARK')).toBeInTheDocument();
-        expect(screen.getByText('ark:/12345/abc123')).toBeInTheDocument();
-        expect(screen.queryByRole('link')).not.toBeInTheDocument();
-    });
-
-    it('displays default message when validation fails without custom message', async () => {
-        const user = userEvent.setup();
-        render(<RelatedWorkItem {...defaultProps} validationStatus="invalid" />);
-
-        const invalidIcon = screen.getByLabelText('Invalid');
-        await user.hover(invalidIcon);
-        const tooltipTexts = await screen.findAllByText('Validation failed');
-        expect(tooltipTexts.length).toBeGreaterThan(0);
-    });
-
-    it('displays default message when warning without custom message', async () => {
-        const user = userEvent.setup();
-        render(<RelatedWorkItem {...defaultProps} validationStatus="warning" />);
-
-        const warningIcon = screen.getByLabelText('Warning');
-        await user.hover(warningIcon);
-        const tooltipTexts = await screen.findAllByText('Validation warning');
-        expect(tooltipTexts.length).toBeGreaterThan(0);
+        expect(screen.getByLabelText('Relation type information')).toHaveValue('Custom relation');
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
@@ -177,6 +177,13 @@ describe('RelatedWorkItem', () => {
         expect(screen.getByText('Related Research Paper Title')).toBeInTheDocument();
     });
 
+    it('associates the resolved title content with its visible heading', () => {
+        render(<RelatedWorkItem {...defaultProps} />);
+
+        expect(screen.getByText('Resolved title')).toBeInTheDocument();
+        expect(screen.getByText('No resolved title available yet.')).toHaveAttribute('aria-labelledby', 'related-work-0-resolved-title-label');
+    });
+
     it('shows the relation type information field for Other', () => {
         render(
             <RelatedWorkItem

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-quick-add.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-quick-add.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RelatedWorkQuickAdd from '@/components/curation/fields/related-work/related-work-quick-add';
 
-// Mock the identifier validation hook
 vi.mock('@/hooks/use-identifier-validation', () => ({
     useIdentifierValidation: vi.fn(() => ({
         status: 'idle',
@@ -19,14 +18,15 @@ const mockUseIdentifierValidation = vi.mocked(useIdentifierValidation);
 describe('RelatedWorkQuickAdd', () => {
     const mockOnAdd = vi.fn();
     const mockOnIdentifierChange = vi.fn();
+    const mockOnIdentifierTypeChange = vi.fn();
     const mockOnRelationTypeChange = vi.fn();
-    const mockOnToggleAdvanced = vi.fn();
 
     const defaultProps = {
         onAdd: mockOnAdd,
         identifier: '',
         onIdentifierChange: mockOnIdentifierChange,
         identifierType: 'DOI' as const,
+        onIdentifierTypeChange: mockOnIdentifierTypeChange,
         relationType: 'References' as const,
         onRelationTypeChange: mockOnRelationTypeChange,
     };
@@ -39,42 +39,38 @@ describe('RelatedWorkQuickAdd', () => {
         });
     });
 
-    it('renders the info text', () => {
+    it('renders the info text and core controls', () => {
         render(<RelatedWorkQuickAdd {...defaultProps} />);
 
-        expect(screen.getByText(/Add relationships to other datasets, publications, or resources/)).toBeInTheDocument();
+        expect(screen.getByText(/add relationships to other datasets, publications, or resources/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/10\.5194\/nhess/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /identifier type/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /relation type/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /add related work/i })).toBeInTheDocument();
     });
 
-    it('renders the identifier input', () => {
+    it('does not render the removed simple mode toggle', () => {
         render(<RelatedWorkQuickAdd {...defaultProps} />);
 
-        expect(screen.getByPlaceholderText(/10\.5194\/nhess/)).toBeInTheDocument();
-    });
-
-    it('renders the add button', () => {
-        render(<RelatedWorkQuickAdd {...defaultProps} />);
-
-        expect(screen.getByRole('button', { name: /Add/i })).toBeInTheDocument();
+        expect(screen.queryByText(/simple mode/i)).not.toBeInTheDocument();
     });
 
     it('calls onIdentifierChange when typing', async () => {
         const user = userEvent.setup();
         render(<RelatedWorkQuickAdd {...defaultProps} />);
 
-        const input = screen.getByPlaceholderText(/10\.5194\/nhess/);
-        await user.type(input, '10.5880/test');
+        await user.type(screen.getByPlaceholderText(/10\.5194\/nhess/i), '10.5880/test');
 
         expect(mockOnIdentifierChange).toHaveBeenCalled();
     });
 
-    it('disables add button when identifier is empty', () => {
+    it('disables the add button when identifier is empty', () => {
         render(<RelatedWorkQuickAdd {...defaultProps} identifier="" />);
 
-        const addButton = screen.getByRole('button', { name: /Add/i });
-        expect(addButton).toBeDisabled();
+        expect(screen.getByRole('button', { name: /add related work/i })).toBeDisabled();
     });
 
-    it('enables add button when identifier is valid', () => {
+    it('enables the add button when the identifier validates', () => {
         mockUseIdentifierValidation.mockReturnValue({
             status: 'valid',
             metadata: { title: 'Test Title' },
@@ -82,11 +78,10 @@ describe('RelatedWorkQuickAdd', () => {
 
         render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test.2024.001" />);
 
-        const addButton = screen.getByRole('button', { name: /Add/i });
-        expect(addButton).not.toBeDisabled();
+        expect(screen.getByRole('button', { name: /add related work/i })).not.toBeDisabled();
     });
 
-    it('calls onAdd when clicking add button with valid identifier', async () => {
+    it('calls onAdd when clicking add with a valid identifier', async () => {
         const user = userEvent.setup();
         mockUseIdentifierValidation.mockReturnValue({
             status: 'valid',
@@ -95,7 +90,7 @@ describe('RelatedWorkQuickAdd', () => {
 
         render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test.2024.001" />);
 
-        await user.click(screen.getByRole('button', { name: /Add/i }));
+        await user.click(screen.getByRole('button', { name: /add related work/i }));
 
         expect(mockOnAdd).toHaveBeenCalledWith({
             identifier: '10.5880/test.2024.001',
@@ -104,7 +99,7 @@ describe('RelatedWorkQuickAdd', () => {
         });
     });
 
-    it('normalizes DOI URL to just the DOI', async () => {
+    it('normalizes DOI URLs before calling onAdd', async () => {
         const user = userEvent.setup();
         mockUseIdentifierValidation.mockReturnValue({
             status: 'valid',
@@ -113,7 +108,7 @@ describe('RelatedWorkQuickAdd', () => {
 
         render(<RelatedWorkQuickAdd {...defaultProps} identifier="https://doi.org/10.5880/test.2024.001" />);
 
-        await user.click(screen.getByRole('button', { name: /Add/i }));
+        await user.click(screen.getByRole('button', { name: /add related work/i }));
 
         expect(mockOnAdd).toHaveBeenCalledWith({
             identifier: '10.5880/test.2024.001',
@@ -122,67 +117,61 @@ describe('RelatedWorkQuickAdd', () => {
         });
     });
 
-    it('shows validation error when status is invalid', () => {
-        mockUseIdentifierValidation.mockReturnValue({
+    it('shows validation messages for invalid, warning, and valid states', () => {
+        mockUseIdentifierValidation.mockReturnValueOnce({
             status: 'invalid',
             metadata: undefined,
         });
+        const { rerender } = render(<RelatedWorkQuickAdd {...defaultProps} identifier="invalid-doi" />);
+        expect(screen.getByText(/invalid doi format/i)).toBeInTheDocument();
 
-        render(<RelatedWorkQuickAdd {...defaultProps} identifier="invalid-doi" />);
-
-        expect(screen.getByText(/Invalid DOI format/)).toBeInTheDocument();
-    });
-
-    it('shows warning message when status is warning', () => {
-        mockUseIdentifierValidation.mockReturnValue({
+        mockUseIdentifierValidation.mockReturnValueOnce({
             status: 'warning',
             metadata: undefined,
         });
+        rerender(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test" />);
+        expect(screen.getByText(/could not verify via api/i)).toBeInTheDocument();
 
-        render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test" />);
-
-        expect(screen.getByText(/Could not verify via API/)).toBeInTheDocument();
-    });
-
-    it('shows validated title when status is valid with metadata', () => {
-        mockUseIdentifierValidation.mockReturnValue({
+        mockUseIdentifierValidation.mockReturnValueOnce({
             status: 'valid',
             metadata: { title: 'Validated Resource Title' },
         });
-
-        render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test" />);
-
-        expect(screen.getByText(/Validated Resource Title/)).toBeInTheDocument();
+        rerender(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test" />);
+        expect(screen.getByText(/validated resource title/i)).toBeInTheDocument();
     });
 
-    it('shows loading spinner when validating', () => {
+    it('shows a loading spinner while validating', () => {
         mockUseIdentifierValidation.mockReturnValue({
             status: 'validating',
             metadata: undefined,
         });
 
-        render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test" />);
-
-        const spinner = document.querySelector('.animate-spin');
-        expect(spinner).toBeInTheDocument();
+        const { container } = render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test" />);
+        expect(container.querySelector('.animate-spin')).toBeInTheDocument();
     });
 
-    it('renders simple mode toggle when in advanced mode', () => {
-        render(<RelatedWorkQuickAdd {...defaultProps} showAdvancedMode={true} onToggleAdvanced={mockOnToggleAdvanced} />);
-
-        expect(screen.getByText(/Simple mode/)).toBeInTheDocument();
-    });
-
-    it('calls onToggleAdvanced when clicking simple mode toggle', async () => {
+    it('renders Most Used and All relation types in the relation select', async () => {
         const user = userEvent.setup();
-        render(<RelatedWorkQuickAdd {...defaultProps} showAdvancedMode={true} onToggleAdvanced={mockOnToggleAdvanced} />);
+        render(<RelatedWorkQuickAdd {...defaultProps} />);
 
-        await user.click(screen.getByText(/Simple mode/));
+        await user.click(screen.getByRole('combobox', { name: /relation type/i }));
 
-        expect(mockOnToggleAdvanced).toHaveBeenCalled();
+        expect(screen.getByText('Most Used')).toBeInTheDocument();
+        expect(screen.getByText('All relation types')).toBeInTheDocument();
+        expect(screen.getByText('Is Derived From')).toBeInTheDocument();
     });
 
-    it('handles Enter key press to add', async () => {
+    it('calls onIdentifierTypeChange when selecting a different identifier type', async () => {
+        const user = userEvent.setup();
+        render(<RelatedWorkQuickAdd {...defaultProps} />);
+
+        await user.click(screen.getByRole('combobox', { name: /identifier type/i }));
+        await user.click(screen.getByRole('option', { name: 'URL' }));
+
+        expect(mockOnIdentifierTypeChange).toHaveBeenCalledWith('URL');
+    });
+
+    it('handles Enter to add a valid identifier', async () => {
         const user = userEvent.setup();
         mockUseIdentifierValidation.mockReturnValue({
             status: 'valid',
@@ -191,24 +180,8 @@ describe('RelatedWorkQuickAdd', () => {
 
         render(<RelatedWorkQuickAdd {...defaultProps} identifier="10.5880/test.2024.001" />);
 
-        const input = screen.getByPlaceholderText(/10\.5194\/nhess/);
-        await user.type(input, '{Enter}');
+        await user.type(screen.getByPlaceholderText(/10\.5194\/nhess/i), '{Enter}');
 
         expect(mockOnAdd).toHaveBeenCalled();
-    });
-
-    it('does not add when identifier is invalid on Enter', async () => {
-        const user = userEvent.setup();
-        mockUseIdentifierValidation.mockReturnValue({
-            status: 'invalid',
-            metadata: undefined,
-        });
-
-        render(<RelatedWorkQuickAdd {...defaultProps} identifier="invalid" />);
-
-        const input = screen.getByPlaceholderText(/10\.5194\/nhess/);
-        await user.type(input, '{Enter}');
-
-        expect(mockOnAdd).not.toHaveBeenCalled();
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-quick-add.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-quick-add.test.tsx
@@ -117,6 +117,40 @@ describe('RelatedWorkQuickAdd', () => {
         });
     });
 
+    it('normalizes dx.doi.org URLs before calling onAdd', async () => {
+        const user = userEvent.setup();
+        mockUseIdentifierValidation.mockReturnValue({
+            status: 'valid',
+            metadata: undefined,
+        });
+
+        render(<RelatedWorkQuickAdd {...defaultProps} identifier="https://dx.doi.org/10.5880/test.2024.002" />);
+
+        await user.click(screen.getByRole('button', { name: /add related work/i }));
+
+        expect(mockOnAdd).toHaveBeenCalledWith({
+            identifier: '10.5880/test.2024.002',
+            identifierType: 'DOI',
+            relationType: 'References',
+        });
+    });
+
+    it('does not submit invalid identifiers when Enter is pressed', async () => {
+        const user = userEvent.setup();
+        mockUseIdentifierValidation.mockReturnValue({
+            status: 'invalid',
+            metadata: undefined,
+        });
+
+        render(<RelatedWorkQuickAdd {...defaultProps} identifier="invalid-doi" />);
+
+        const input = screen.getByPlaceholderText(/10\.5194\/nhess/i);
+        input.focus();
+        await user.keyboard('{Enter}');
+
+        expect(mockOnAdd).not.toHaveBeenCalled();
+    });
+
     it('shows validation messages for invalid, warning, and valid states', () => {
         mockUseIdentifierValidation.mockReturnValueOnce({
             status: 'invalid',
@@ -169,6 +203,72 @@ describe('RelatedWorkQuickAdd', () => {
         await user.click(screen.getByRole('option', { name: 'URL' }));
 
         expect(mockOnIdentifierTypeChange).toHaveBeenCalledWith('URL');
+    });
+
+    it('shows and applies the opposite relation suggestion when available', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(<RelatedWorkQuickAdd {...defaultProps} relationType="References" />);
+
+        await user.click(screen.getByRole('combobox', { name: /relation type/i }));
+        await user.click(screen.getByRole('option', { name: /cites/i }));
+
+        expect(mockOnRelationTypeChange).toHaveBeenCalledWith('Cites');
+
+        rerender(<RelatedWorkQuickAdd {...defaultProps} relationType="Cites" />);
+
+        expect(screen.getByText(/did you mean/i)).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /use iscitedby/i }));
+
+        expect(mockOnRelationTypeChange).toHaveBeenLastCalledWith('IsCitedBy');
+    });
+
+    it('suppresses opposite relation suggestions when the opposite type is filtered out', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <RelatedWorkQuickAdd
+                {...defaultProps}
+                relationType="References"
+                activeRelationTypes={['Cites']}
+            />,
+        );
+
+        await user.click(screen.getByRole('combobox', { name: /relation type/i }));
+        await user.click(screen.getByRole('option', { name: /cites/i }));
+
+        rerender(
+            <RelatedWorkQuickAdd
+                {...defaultProps}
+                relationType="Cites"
+                activeRelationTypes={['Cites']}
+            />,
+        );
+
+        expect(screen.queryByText(/did you mean/i)).not.toBeInTheDocument();
+    });
+
+    it('filters identifier types and relation groups when active options are constrained', async () => {
+        const user = userEvent.setup();
+        render(
+            <RelatedWorkQuickAdd
+                {...defaultProps}
+                activeIdentifierTypes={['DOI', 'URL']}
+                activeRelationTypes={['Documents']}
+            />,
+        );
+
+        await user.click(screen.getByRole('combobox', { name: /identifier type/i }));
+
+        expect(screen.getByRole('option', { name: 'DOI' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'URL' })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Handle' })).not.toBeInTheDocument();
+
+        await user.keyboard('{Escape}');
+        await user.click(screen.getByRole('combobox', { name: /relation type/i }));
+
+        expect(screen.queryByText('Most Used')).not.toBeInTheDocument();
+        expect(screen.getByText('All relation types')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /documents/i })).toBeInTheDocument();
     });
 
     it('handles Enter to add a valid identifier', async () => {

--- a/tests/vitest/components/curation/fields/related-work/related-work-item.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/related-work-item.test.tsx
@@ -1,11 +1,12 @@
-import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
 import { render, screen } from '@tests/vitest/utils/render';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RelatedWorkItem from '@/components/curation/fields/related-work/related-work-item';
 import type { RelatedIdentifier } from '@/types';
 
-describe('RelatedWorkItem', () => {
+describe('RelatedWorkItem variants', () => {
+    const mockOnChange = vi.fn();
     const mockOnRemove = vi.fn();
 
     const createItem = (overrides: Partial<RelatedIdentifier> = {}): RelatedIdentifier => ({
@@ -15,177 +16,87 @@ describe('RelatedWorkItem', () => {
         ...overrides,
     });
 
-    const defaultProps = {
-        item: createItem(),
-        index: 0,
-        onRemove: mockOnRemove,
-    };
+    const renderItem = (item: RelatedIdentifier) =>
+        render(
+            <RelatedWorkItem
+                sortableId="related-work-0"
+                item={item}
+                index={0}
+                onChange={mockOnChange}
+                onRemove={mockOnRemove}
+            />,
+        );
 
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    describe('rendering', () => {
-        it('renders the relation type', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
+    it('renders Handle identifiers as clickable preview links', () => {
+        renderItem(
+            createItem({
+                identifier: '10013/epic.12345',
+                identifier_type: 'Handle',
+            }),
+        );
 
-            expect(screen.getByText('Cites')).toBeInTheDocument();
-        });
-
-        it('renders the identifier type badge', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
-
-            expect(screen.getByText('DOI')).toBeInTheDocument();
-        });
-
-        it('renders the identifier', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
-
-            expect(screen.getByText('10.5880/test.2024.001')).toBeInTheDocument();
-        });
-
-        it('renders related title when provided', () => {
-            const item = createItem({ related_title: 'Test Dataset Title' });
-
-            render(<RelatedWorkItem {...defaultProps} item={item} />);
-
-            expect(screen.getByText('Test Dataset Title')).toBeInTheDocument();
-        });
-
-        it('does not render related title when not provided', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
-
-            expect(screen.queryByText(/test dataset title/i)).not.toBeInTheDocument();
-        });
+        const link = screen.getByRole('link', { name: /10013\/epic\.12345/i });
+        expect(link).toHaveAttribute('href', 'https://hdl.handle.net/10013/epic.12345');
     });
 
-    describe('link handling', () => {
-        it('renders DOI as clickable link with doi.org URL', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
-
-            const link = screen.getByRole('link');
-            expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/test.2024.001');
-            expect(link).toHaveAttribute('target', '_blank');
-            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-        });
-
-        it('renders URL as clickable link with original URL', () => {
-            const item = createItem({
-                identifier: 'https://example.com/dataset',
-                identifier_type: 'URL',
-            });
-
-            render(<RelatedWorkItem {...defaultProps} item={item} />);
-
-            const link = screen.getByRole('link');
-            expect(link).toHaveAttribute('href', 'https://example.com/dataset');
-        });
-
-        it('renders non-clickable identifier types as plain text', () => {
-            const item = createItem({
-                identifier: 'ISBN-1234567890',
-                identifier_type: 'ISBN',
-            });
-
-            render(<RelatedWorkItem {...defaultProps} item={item} />);
-
-            expect(screen.queryByRole('link')).not.toBeInTheDocument();
-            expect(screen.getByText('ISBN-1234567890')).toBeInTheDocument();
-        });
-
-        it('renders ARK identifier as plain text', () => {
-            const item = createItem({
+    it('renders ARK identifiers without a preview link', () => {
+        renderItem(
+            createItem({
                 identifier: 'ark:/12345/example',
                 identifier_type: 'ARK',
-            });
+            }),
+        );
 
-            render(<RelatedWorkItem {...defaultProps} item={item} />);
-
-            expect(screen.queryByRole('link')).not.toBeInTheDocument();
-            expect(screen.getByText('ark:/12345/example')).toBeInTheDocument();
-        });
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+        expect(screen.getByDisplayValue('ark:/12345/example')).toBeInTheDocument();
     });
 
-    describe('validation status', () => {
-        it('shows valid icon for valid status', () => {
-            render(<RelatedWorkItem {...defaultProps} validationStatus="valid" />);
+    it('formats CamelCase relation types for the visible label', () => {
+        renderItem(
+            createItem({
+                relation_type: 'IsDocumentedBy',
+            }),
+        );
 
-            expect(screen.getByLabelText('Valid')).toBeInTheDocument();
-        });
-
-        it('shows warning icon for warning status', () => {
-            render(<RelatedWorkItem {...defaultProps} validationStatus="warning" validationMessage="Could not verify" />);
-
-            expect(screen.getByLabelText('Warning')).toBeInTheDocument();
-        });
-
-        it('shows invalid icon for invalid status', () => {
-            render(<RelatedWorkItem {...defaultProps} validationStatus="invalid" validationMessage="DOI not found" />);
-
-            expect(screen.getByLabelText('Invalid')).toBeInTheDocument();
-        });
-
-        it('does not show validation icon when status is validating', () => {
-            render(<RelatedWorkItem {...defaultProps} validationStatus="validating" />);
-
-            expect(screen.queryByLabelText('Valid')).not.toBeInTheDocument();
-            expect(screen.queryByLabelText('Warning')).not.toBeInTheDocument();
-            expect(screen.queryByLabelText('Invalid')).not.toBeInTheDocument();
-        });
-
-        it('does not show validation icon when no status provided', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
-
-            expect(screen.queryByLabelText('Valid')).not.toBeInTheDocument();
-            expect(screen.queryByLabelText('Warning')).not.toBeInTheDocument();
-            expect(screen.queryByLabelText('Invalid')).not.toBeInTheDocument();
-        });
+        expect(screen.getByRole('combobox', { name: /relation type/i })).toHaveTextContent('Is Documented By');
     });
 
-    describe('remove button', () => {
-        it('renders remove button with accessible label', () => {
-            render(<RelatedWorkItem {...defaultProps} />);
+    it('calls onChange when editing relation type information', async () => {
+        renderItem(
+            createItem({
+                relation_type: 'Other',
+                relation_type_information: '',
+            }),
+        );
 
-            expect(screen.getByRole('button', { name: /remove related work/i })).toBeInTheDocument();
-        });
+        const infoInput = screen.getByLabelText('Relation type information');
+        fireEvent.change(infoInput, { target: { value: 'Custom relationship' } });
 
-        it('calls onRemove with correct index when clicked', async () => {
-            const user = userEvent.setup();
-
-            render(<RelatedWorkItem {...defaultProps} index={2} />);
-
-            await user.click(screen.getByRole('button', { name: /remove related work/i }));
-
-            expect(mockOnRemove).toHaveBeenCalledTimes(1);
-            expect(mockOnRemove).toHaveBeenCalledWith(2);
-        });
+        expect(mockOnChange).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                relation_type_information: 'Custom relationship',
+            }),
+        );
     });
 
-    describe('relation types', () => {
-        it('displays different relation types correctly', () => {
-            const relationTypes = ['References', 'IsDocumentedBy', 'IsDerivedFrom', 'HasPart'] as const;
+    it('keeps validation icons hidden when status is validating', () => {
+        render(
+            <RelatedWorkItem
+                sortableId="related-work-0"
+                item={createItem()}
+                index={0}
+                onChange={mockOnChange}
+                onRemove={mockOnRemove}
+                validationStatus="validating"
+            />,
+        );
 
-            relationTypes.forEach((relationType) => {
-                const item = createItem({ relation_type: relationType });
-                const { unmount } = render(<RelatedWorkItem {...defaultProps} item={item} />);
-
-                expect(screen.getByText(relationType)).toBeInTheDocument();
-                unmount();
-            });
-        });
-    });
-
-    describe('identifier types', () => {
-        it('displays different identifier type badges', () => {
-            const identifierTypes = ['DOI', 'URL', 'ISBN', 'ISSN', 'Handle', 'URN', 'ARK'] as const;
-
-            identifierTypes.forEach((identifierType) => {
-                const item = createItem({ identifier_type: identifierType });
-                const { unmount } = render(<RelatedWorkItem {...defaultProps} item={item} />);
-
-                expect(screen.getByText(identifierType)).toBeInTheDocument();
-                unmount();
-            });
-        });
+        expect(screen.queryByLabelText('Valid')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Warning')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Invalid')).not.toBeInTheDocument();
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/related-work-list.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/related-work-list.test.tsx
@@ -6,11 +6,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import RelatedWorkList from '@/components/curation/fields/related-work/related-work-list';
 import type { RelatedIdentifier } from '@/types';
 
+const dndState = vi.hoisted(() => ({
+    event: {
+        active: { id: 'related-work-0' },
+        over: { id: 'related-work-1' } as { id: string } | null,
+    },
+}));
+
 vi.mock('@dnd-kit/core', () => ({
     closestCenter: vi.fn(),
-    DndContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (event: { active: { id: string }; over: { id: string } }) => void }) => (
+    DndContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (event: { active: { id: string }; over: { id: string } | null }) => void }) => (
         <div>
-            <button data-testid="trigger-drag" onClick={() => onDragEnd({ active: { id: 'related-work-0' }, over: { id: 'related-work-1' } })}>
+            <button data-testid="trigger-drag" onClick={() => onDragEnd(dndState.event)}>
                 Trigger drag
             </button>
             {children}
@@ -75,6 +82,10 @@ describe('RelatedWorkList', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        dndState.event = {
+            active: { id: 'related-work-0' },
+            over: { id: 'related-work-1' },
+        };
     });
 
     it('returns null when no items are present', () => {
@@ -99,6 +110,19 @@ describe('RelatedWorkList', () => {
         expect(screen.getByText('Drag cards to reorder them')).toBeInTheDocument();
         expect(screen.getByRole('list', { name: /related works/i })).toBeInTheDocument();
         expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    });
+
+    it('hides the reorder hint when only one item is present', () => {
+        render(
+            <RelatedWorkList
+                items={[createItem()]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
+
+        expect(screen.queryByText('Drag cards to reorder them')).not.toBeInTheDocument();
     });
 
     it('passes validation status and messages to items', () => {
@@ -174,5 +198,68 @@ describe('RelatedWorkList', () => {
             expect.objectContaining({ identifier: '10.5880/test.2024.002' }),
             expect.objectContaining({ identifier: '10.5880/test.2024.001' }),
         ]);
+    });
+
+    it('does not call onReorder when the drop target is missing', async () => {
+        const user = userEvent.setup();
+        dndState.event = {
+            active: { id: 'related-work-0' },
+            over: null,
+        };
+
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockOnReorder).not.toHaveBeenCalled();
+    });
+
+    it('does not call onReorder when an item is dropped onto itself', async () => {
+        const user = userEvent.setup();
+        dndState.event = {
+            active: { id: 'related-work-0' },
+            over: { id: 'related-work-0' },
+        };
+
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockOnReorder).not.toHaveBeenCalled();
+    });
+
+    it('does not call onReorder when sortable ids cannot be resolved', async () => {
+        const user = userEvent.setup();
+        dndState.event = {
+            active: { id: 'related-work-99' },
+            over: { id: 'related-work-1' },
+        };
+
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockOnReorder).not.toHaveBeenCalled();
     });
 });

--- a/tests/vitest/components/curation/fields/related-work/related-work-list.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/related-work-list.test.tsx
@@ -1,31 +1,75 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import RelatedWorkList from '@/components/curation/fields/related-work/related-work-list';
 import type { RelatedIdentifier } from '@/types';
 
-// Mock RelatedWorkItem component
+vi.mock('@dnd-kit/core', () => ({
+    closestCenter: vi.fn(),
+    DndContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (event: { active: { id: string }; over: { id: string } }) => void }) => (
+        <div>
+            <button data-testid="trigger-drag" onClick={() => onDragEnd({ active: { id: 'related-work-0' }, over: { id: 'related-work-1' } })}>
+                Trigger drag
+            </button>
+            {children}
+        </div>
+    ),
+    KeyboardSensor: vi.fn(),
+    PointerSensor: vi.fn(),
+    useSensor: vi.fn(() => ({})),
+    useSensors: vi.fn(() => []),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+    arrayMove: <T,>(items: T[], oldIndex: number, newIndex: number) => {
+        const next = [...items];
+        const [moved] = next.splice(oldIndex, 1);
+        next.splice(newIndex, 0, moved);
+        return next;
+    },
+    SortableContext: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    sortableKeyboardCoordinates: vi.fn(),
+    verticalListSortingStrategy: vi.fn(),
+}));
+
 vi.mock('@/components/curation/fields/related-work/related-work-item', () => ({
-    default: vi.fn(({ item, index, onRemove, validationStatus, validationMessage }) => (
-        <div data-testid={`related-work-item-${index}`}>
+    default: ({
+        item,
+        index,
+        onRemove,
+        onChange,
+        validationStatus,
+        validationMessage,
+    }: {
+        item: RelatedIdentifier;
+        index: number;
+        onRemove: (index: number) => void;
+        onChange: (item: RelatedIdentifier) => void;
+        validationStatus?: string;
+        validationMessage?: string;
+    }) => (
+        <div data-testid={`related-work-item-${index}`} role="listitem">
             <span>{item.identifier}</span>
-            <span>{item.relation_type}</span>
-            <span>{item.identifier_type}</span>
-            {validationStatus && <span data-testid="validation-status">{validationStatus}</span>}
-            {validationMessage && <span data-testid="validation-message">{validationMessage}</span>}
+            {validationStatus && <span data-testid={`validation-status-${index}`}>{validationStatus}</span>}
+            {validationMessage && <span data-testid={`validation-message-${index}`}>{validationMessage}</span>}
+            <button onClick={() => onChange({ ...item, identifier: `${item.identifier}-edited` })}>Edit</button>
             <button onClick={() => onRemove(index)}>Remove</button>
         </div>
-    )),
+    ),
 }));
 
 describe('RelatedWorkList', () => {
+    const mockOnItemChange = vi.fn();
     const mockOnRemove = vi.fn();
+    const mockOnReorder = vi.fn();
 
     const createItem = (overrides: Partial<RelatedIdentifier> = {}): RelatedIdentifier => ({
         identifier: '10.5880/test.2024.001',
         identifier_type: 'DOI',
         relation_type: 'Cites',
+        position: 0,
         ...overrides,
     });
 
@@ -33,114 +77,102 @@ describe('RelatedWorkList', () => {
         vi.clearAllMocks();
     });
 
-    describe('rendering', () => {
-        it('returns null when items array is empty', () => {
-            const { container } = render(<RelatedWorkList items={[]} onRemove={mockOnRemove} />);
+    it('returns null when no items are present', () => {
+        const { container } = render(
+            <RelatedWorkList items={[]} onItemChange={mockOnItemChange} onRemove={mockOnRemove} onReorder={mockOnReorder} />,
+        );
 
-            expect(container.firstChild).toBeNull();
-        });
-
-        it('renders the list when items are present', () => {
-            const items = [createItem()];
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.getByRole('list', { name: /related works/i })).toBeInTheDocument();
-        });
-
-        it('displays the correct count of items in header', () => {
-            const items = [createItem(), createItem({ identifier: '10.5880/test.2024.002' })];
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.getByText('Added Relations (2)')).toBeInTheDocument();
-        });
-
-        it('shows ordering hint when items are present', () => {
-            const items = [createItem()];
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.getByText('Ordered by addition')).toBeInTheDocument();
-        });
-
-        it('renders all items in the list', () => {
-            const items = [
-                createItem({ identifier: '10.5880/test.001' }),
-                createItem({ identifier: '10.5880/test.002' }),
-                createItem({ identifier: '10.5880/test.003' }),
-            ];
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.getByTestId('related-work-item-0')).toBeInTheDocument();
-            expect(screen.getByTestId('related-work-item-1')).toBeInTheDocument();
-            expect(screen.getByTestId('related-work-item-2')).toBeInTheDocument();
-        });
+        expect(container.firstChild).toBeNull();
     });
 
-    describe('accessibility', () => {
-        it('has accessible list with aria-label', () => {
-            const items = [createItem()];
+    it('renders the list header and accessibility roles', () => {
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
 
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.getByRole('list', { name: /related works/i })).toBeInTheDocument();
-        });
-
-        it('renders items as listitems', () => {
-            const items = [createItem()];
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.getByRole('listitem')).toBeInTheDocument();
-        });
+        expect(screen.getByText('Added Relations (2)')).toBeInTheDocument();
+        expect(screen.getByText('Drag cards to reorder them')).toBeInTheDocument();
+        expect(screen.getByRole('list', { name: /related works/i })).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem')).toHaveLength(2);
     });
 
-    describe('validation statuses', () => {
-        it('passes validation status to items', () => {
-            const items = [createItem(), createItem({ identifier: '10.5880/test.002' })];
-            const validationStatuses = new Map([
-                [0, { status: 'valid' as const }],
-                [1, { status: 'invalid' as const, message: 'Not found' }],
-            ]);
+    it('passes validation status and messages to items', () => {
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+                validationStatuses={new Map([
+                    [0, { status: 'valid', message: 'Looks good' }],
+                    [1, { status: 'invalid', message: 'Not found' }],
+                ])}
+            />,
+        );
 
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} validationStatuses={validationStatuses} />);
-
-            const statuses = screen.getAllByTestId('validation-status');
-            expect(statuses[0]).toHaveTextContent('valid');
-            expect(statuses[1]).toHaveTextContent('invalid');
-        });
-
-        it('passes validation message to items', () => {
-            const items = [createItem()];
-            const validationStatuses = new Map([[0, { status: 'warning' as const, message: 'Could not verify' }]]);
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} validationStatuses={validationStatuses} />);
-
-            expect(screen.getByTestId('validation-message')).toHaveTextContent('Could not verify');
-        });
-
-        it('works without validation statuses', () => {
-            const items = [createItem()];
-
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
-
-            expect(screen.queryByTestId('validation-status')).not.toBeInTheDocument();
-        });
+        expect(screen.getByTestId('validation-status-0')).toHaveTextContent('valid');
+        expect(screen.getByTestId('validation-message-1')).toHaveTextContent('Not found');
     });
 
-    describe('remove functionality', () => {
-        it('calls onRemove with correct index when remove button is clicked', async () => {
-            const user = userEvent.setup();
-            const items = [createItem({ identifier: 'first' }), createItem({ identifier: 'second' })];
+    it('forwards child edits to onItemChange', async () => {
+        const user = userEvent.setup();
+        render(
+            <RelatedWorkList
+                items={[createItem()]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
 
-            render(<RelatedWorkList items={items} onRemove={mockOnRemove} />);
+        await user.click(screen.getByRole('button', { name: 'Edit' }));
 
-            const removeButtons = screen.getAllByRole('button', { name: /remove/i });
-            await user.click(removeButtons[1]);
+        expect(mockOnItemChange).toHaveBeenCalledWith(
+            0,
+            expect.objectContaining({
+                identifier: '10.5880/test.2024.001-edited',
+            }),
+        );
+    });
 
-            expect(mockOnRemove).toHaveBeenCalledWith(1);
-        });
+    it('forwards remove actions to onRemove', async () => {
+        const user = userEvent.setup();
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
+
+        const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+        await user.click(removeButtons[1]);
+
+        expect(mockOnRemove).toHaveBeenCalledWith(1);
+    });
+
+    it('calls onReorder when drag end moves an item', async () => {
+        const user = userEvent.setup();
+        render(
+            <RelatedWorkList
+                items={[createItem(), createItem({ identifier: '10.5880/test.2024.002', position: 1 })]}
+                onItemChange={mockOnItemChange}
+                onRemove={mockOnRemove}
+                onReorder={mockOnReorder}
+            />,
+        );
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockOnReorder).toHaveBeenCalledWith([
+            expect.objectContaining({ identifier: '10.5880/test.2024.002' }),
+            expect.objectContaining({ identifier: '10.5880/test.2024.001' }),
+        ]);
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/ModelDescriptionSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ModelDescriptionSection.test.tsx
@@ -1,412 +1,146 @@
-import { render, screen, waitFor } from '@tests/vitest/utils/render';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@tests/vitest/utils/render';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ModelDescriptionSection } from '@/pages/LandingPages/components/ModelDescriptionSection';
 
 describe('ModelDescriptionSection', () => {
     beforeEach(() => {
         vi.resetAllMocks();
+        global.fetch = vi.fn();
     });
 
     it('returns null when no IsSupplementTo relation exists', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
         const { container } = render(
-            <ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />,
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '10.5880/test',
+                    identifier_type: 'DOI',
+                    relation_type: 'References',
+                },
+            ]} />,
         );
 
         expect(container.firstChild).toBeNull();
     });
 
-    it('returns null when relatedIdentifiers is empty', () => {
-        const { container } = render(
-            <ModelDescriptionSection relatedIdentifiers={[]} />,
+    it('renders the section title and persisted citation label', () => {
+        render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '10.5880/test',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                    citation_label: 'Smith, J. (2024). Test Model.',
+                },
+            ]} />,
         );
-
-        expect(container.firstChild).toBeNull();
-    });
-
-    it('renders the section title', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
 
         expect(screen.getByRole('heading', { name: 'Model Description' })).toBeInTheDocument();
-    });
-
-    it('shows loading skeleton while fetching citation', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        // Never resolve to keep loading state
-        global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        // Loading state now uses Skeleton components with aria-busy
-        const busyEl = document.querySelector('[aria-busy="true"]');
-        expect(busyEl).toBeInTheDocument();
-    });
-
-    it('displays citation after successful fetch', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Smith, J. (2024). Test Model.' }),
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Smith, J. (2024). Test Model.')).toBeInTheDocument();
-        });
-    });
-
-    it('renders link with correct href to DOI', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/my-dataset',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            const link = screen.getByRole('link');
-            expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/my-dataset');
-            expect(link).toHaveAttribute('target', '_blank');
-            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-        });
-    });
-
-    it('shows related_title when citation fetch fails', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-                related_title: 'Fallback Model Title',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: false,
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Fallback Model Title')).toBeInTheDocument();
-        });
-    });
-
-    it('does not fetch citation for non-DOI identifier types', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: 'http://example.com/model',
-                identifier_type: 'URL',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        // Fetch should not be called for non-DOI types
+        expect(screen.getByText('Smith, J. (2024). Test Model.')).toBeInTheDocument();
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('only considers the first IsSupplementTo relation', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/first',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-            {
-                id: 2,
-                identifier: '10.5880/second',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'First Model Citation' }),
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        // Should only fetch the first IsSupplementTo
-        expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringContaining('10.5880%2Ffirst'),
-            expect.objectContaining({ signal: expect.any(AbortSignal) }),
-        );
-        expect(global.fetch).toHaveBeenCalledTimes(1);
-    });
-
-    it('encodes DOI identifier in the API URL', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/special/chars',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledWith(
-                '/api/datacite/citation?doi=10.5880%2Fspecial%2Fchars',
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
-            );
-        });
-    });
-
-    it('renders fallback link when fetch fails but related_title exists', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-                related_title: 'Model Title',
-            },
-        ];
-
-        // Simulate fetch returning an error response (not a network error)
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: false,
-            status: 500,
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            const link = screen.getByRole('link');
-            expect(link).toHaveTextContent('Model Title');
-            expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/test');
-        });
-    });
-
-    it('returns null when identifier is empty (unresolvable URL)', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        const { container } = render(
-            <ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />,
+    it('falls back to related_title when no citation label exists', () => {
+        render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '10.5880/test',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                    related_title: 'Fallback Model Title',
+                },
+            ]} />,
         );
 
-        expect(container.firstChild).toBeNull();
-        expect(global.fetch).not.toHaveBeenCalled();
+        expect(screen.getByText('Fallback Model Title')).toBeInTheDocument();
     });
 
-    it('returns null when URL identifier uses dangerous scheme', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: 'javascript:alert(1)',
-                identifier_type: 'URL',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        const { container } = render(
-            <ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />,
+    it('falls back to the identifier when no citation label or related title exists', () => {
+        render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '10.5880/test',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                },
+            ]} />,
         );
 
-        expect(container.firstChild).toBeNull();
+        expect(screen.getByText('10.5880/test')).toBeInTheDocument();
     });
 
-    it('renders identifier as fallback when fetch fails and no related_title exists', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
+    it('uses the first IsSupplementTo relation only', () => {
+        render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '10.5880/first',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                    citation_label: 'First citation',
+                },
+                {
+                    id: 2,
+                    identifier: '10.5880/second',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                    citation_label: 'Second citation',
+                },
+            ]} />,
+        );
 
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: false,
-            status: 404,
-        });
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            const link = screen.getByRole('link');
-            expect(link).toHaveTextContent('10.5880/test');
-            expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/test');
-        });
+        expect(screen.getByText('First citation')).toBeInTheDocument();
+        expect(screen.queryByText('Second citation')).not.toBeInTheDocument();
     });
 
-    it('handles network errors gracefully', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-                related_title: 'Fallback Title',
-            },
-        ];
-
-        global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            const link = screen.getByRole('link');
-            expect(link).toHaveTextContent('Fallback Title');
-        });
-    });
-
-    it('renders non-DOI supplementTo with related_title as link', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: 'http://example.com/model',
-                identifier_type: 'URL',
-                relation_type: 'IsSupplementTo',
-                related_title: 'External Model Documentation',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
+    it('renders the resolved DOI link', () => {
+        render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '10.5880/my-dataset',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                    citation_label: 'Test Citation',
+                },
+            ]} />,
+        );
 
         const link = screen.getByRole('link');
-        expect(link).toHaveTextContent('External Model Documentation');
-        expect(link).toHaveAttribute('href', 'http://example.com/model');
-        expect(global.fetch).not.toHaveBeenCalled();
+        expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/my-dataset');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    it('renders non-DOI supplementTo with identifier as fallback when no related_title', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: 'http://example.com/model',
-                identifier_type: 'URL',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        render(<ModelDescriptionSection relatedIdentifiers={relatedIdentifiers} />);
-
-        const link = screen.getByRole('link');
-        expect(link).toHaveTextContent('http://example.com/model');
-        expect(link).toHaveAttribute('href', 'http://example.com/model');
-        expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it('resets stale citation state when supplementTo changes to non-DOI', async () => {
-        const doiRelation = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Old Citation' }),
-        });
-
-        const { rerender } = render(
-            <ModelDescriptionSection relatedIdentifiers={doiRelation} />,
+    it('returns null when the identifier is empty or unsafe', () => {
+        const { container: emptyContainer } = render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 1,
+                    identifier: '',
+                    identifier_type: 'DOI',
+                    relation_type: 'IsSupplementTo',
+                },
+            ]} />,
         );
 
-        await waitFor(() => {
-            expect(screen.getByText('Old Citation')).toBeInTheDocument();
-        });
+        const { container: unsafeContainer } = render(
+            <ModelDescriptionSection relatedIdentifiers={[
+                {
+                    id: 2,
+                    identifier: 'javascript:alert(1)',
+                    identifier_type: 'URL',
+                    relation_type: 'IsSupplementTo',
+                },
+            ]} />,
+        );
 
-        // Switch to non-DOI supplementTo
-        const urlRelation = [
-            {
-                id: 2,
-                identifier: 'http://example.com/new-model',
-                identifier_type: 'URL',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
-
-        rerender(<ModelDescriptionSection relatedIdentifiers={urlRelation} />);
-
-        await waitFor(() => {
-            // Old citation should be cleared, show identifier instead
-            expect(screen.queryByText('Old Citation')).not.toBeInTheDocument();
-            const link = screen.getByRole('link');
-            expect(link).toHaveTextContent('http://example.com/new-model');
-        });
+        expect(emptyContainer.firstChild).toBeNull();
+        expect(unsafeContainer.firstChild).toBeNull();
+        expect(global.fetch).not.toHaveBeenCalled();
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/RelatedWorkSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/RelatedWorkSection.test.tsx
@@ -1,12 +1,16 @@
-﻿import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen, waitFor } from '@tests/vitest/utils/render';
+import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@tests/vitest/utils/render';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RelatedWorkSection } from '@/pages/LandingPages/components/RelatedWorkSection';
-import type { LandingPageResource } from '@/types/landing-page';
+import type { LandingPageRelatedIdentifier, LandingPageResource } from '@/types/landing-page';
 
+vi.mock('@/pages/LandingPages/components/relation-browser/RelationBrowserGraph', () => ({
+    RelationBrowserGraph: ({ relatedIdentifiers }: { relatedIdentifiers: LandingPageRelatedIdentifier[] }) => (
+        <div data-testid="relation-browser-graph">{relatedIdentifiers.length}</div>
+    ),
+}));
 
-// Mock matchMedia for prefers-reduced-motion
 Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({
@@ -43,14 +47,25 @@ const mockResource: LandingPageResource = {
             },
         },
     ],
-    titles: [
-        { id: 1, title: 'Test Dataset', title_type: null },
-    ],
+    titles: [{ id: 1, title: 'Test Dataset', title_type: null }],
 };
+
+function makeRelatedIdentifier(overrides: Partial<LandingPageRelatedIdentifier> = {}): LandingPageRelatedIdentifier {
+    return {
+        id: 1,
+        identifier: '10.5880/test',
+        identifier_type: 'DOI',
+        relation_type: 'References',
+        citation_label: null,
+        related_title: null,
+        ...overrides,
+    };
+}
 
 describe('RelatedWorkSection', () => {
     beforeEach(() => {
         vi.resetAllMocks();
+        global.fetch = vi.fn();
 
         Object.defineProperty(window, 'matchMedia', {
             writable: true,
@@ -67,728 +82,198 @@ describe('RelatedWorkSection', () => {
         });
     });
 
-    it('returns null when no related identifiers', () => {
+    it('returns null when there are no renderable related identifiers or related items', () => {
         const { container } = render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={[]} />);
+
         expect(container.firstChild).toBeNull();
     });
 
-    it('renders inline relatedItems with Inline metadata badge', () => {
-        const relatedItems = [
-            {
-                id: 10,
-                related_item_type: 'JournalArticle',
-                relation_type: 'IsCitedBy',
-                relation_type_slug: 'iscitedby',
-                publication_year: 2024,
-                volume: '42',
-                issue: '3',
-                number: null,
-                number_type: null,
-                first_page: '1',
-                last_page: '20',
-                publisher: 'Acme Press',
-                edition: null,
-                identifier: '10.1234/cited',
-                identifier_type: 'DOI',
-                related_metadata_scheme: null,
-                scheme_uri: null,
-                scheme_type: null,
-                position: 1,
-                titles: [
-                    { id: 1, title: 'Cited Paper Title', title_type: 'MainTitle', language: 'en' },
-                ],
-                creators: [
-                    {
-                        id: 1,
-                        name_type: 'Personal' as const,
-                        name: 'Doe, Jane',
-                        given_name: 'Jane',
-                        family_name: 'Doe',
-                        name_identifier: null,
-                        name_identifier_scheme: null,
-                        scheme_uri: null,
-                        position: 1,
-                        affiliations: [],
-                    },
-                ],
-                contributors: [],
-            },
-        ];
-
+    it('renders inline related items with the metadata badge', () => {
         render(
             <RelatedWorkSection
                 resource={mockResource}
                 relatedIdentifiers={[]}
-                relatedItems={relatedItems}
+                relatedItems={[
+                    {
+                        id: 10,
+                        related_item_type: 'JournalArticle',
+                        relation_type: 'IsCitedBy',
+                        relation_type_slug: 'iscitedby',
+                        publication_year: 2024,
+                        volume: '42',
+                        issue: '3',
+                        number: null,
+                        number_type: null,
+                        first_page: '1',
+                        last_page: '20',
+                        publisher: 'Acme Press',
+                        edition: null,
+                        identifier: '10.1234/cited',
+                        identifier_type: 'DOI',
+                        related_metadata_scheme: null,
+                        scheme_uri: null,
+                        scheme_type: null,
+                        position: 1,
+                        titles: [{ id: 1, title: 'Cited Paper Title', title_type: 'MainTitle', language: 'en' }],
+                        creators: [{
+                            id: 1,
+                            name_type: 'Personal',
+                            name: 'Doe, Jane',
+                            given_name: 'Jane',
+                            family_name: 'Doe',
+                            name_identifier: null,
+                            name_identifier_scheme: null,
+                            scheme_uri: null,
+                            position: 1,
+                            affiliations: [],
+                        }],
+                        contributors: [],
+                    },
+                ]}
             />,
         );
 
         expect(screen.getByTestId('related-items-list')).toBeInTheDocument();
         expect(screen.getByText('Inline metadata')).toBeInTheDocument();
         expect(screen.getByText('Cited Paper Title')).toBeInTheDocument();
-        expect(screen.getByTestId('related-item-10')).toBeInTheDocument();
-        // Descriptor combines author, year, publisher, volume/issue/pages
         expect(screen.getByText(/Doe/)).toBeInTheDocument();
-        expect(screen.getByText(/2024/)).toBeInTheDocument();
     });
 
-    it('returns null when all identifiers have unsupported types', () => {
-        const relatedIdentifiers = [
-            { id: 1, identifier: '12345', identifier_type: 'PMID', relation_type: 'References' },
-            { id: 2, identifier: '67890', identifier_type: 'EAN13', relation_type: 'IsCitedBy' },
-        ];
+    it('does not render when all identifiers use unsupported types', () => {
+        const { container } = render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[
+                    makeRelatedIdentifier({ id: 1, identifier_type: 'PMID', identifier: '12345' }),
+                    makeRelatedIdentifier({ id: 2, identifier_type: 'EAN13', identifier: '67890' }),
+                ]}
+            />,
+        );
 
-        const { container } = render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
         expect(container.firstChild).toBeNull();
     });
 
-    it('excludes the first IsSupplementTo relation', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/first-supplement',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-            {
-                id: 2,
-                identifier: '10.5880/second-supplement',
-                identifier_type: 'DOI',
-                relation_type: 'IsSupplementTo',
-            },
-        ];
+    it('excludes the first IsSupplementTo relation from the list', () => {
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[
+                    makeRelatedIdentifier({ id: 1, relation_type: 'IsSupplementTo', citation_label: 'Hidden first supplement' }),
+                    makeRelatedIdentifier({ id: 2, relation_type: 'IsSupplementTo', identifier: '10.5880/second', citation_label: 'Visible supplement' }),
+                ]}
+            />,
+        );
 
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // Should only show the second IsSupplementTo relation
-        expect(screen.getByTestId('related-works-section')).toBeInTheDocument();
+        expect(screen.queryByText('Hidden first supplement')).not.toBeInTheDocument();
+        expect(screen.getByText('Visible supplement')).toBeInTheDocument();
     });
 
-    it('renders the section title', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
+    it('renders headings as region, h2, and alphabetically sorted h3 groups', () => {
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[
+                    makeRelatedIdentifier({ id: 1, relation_type: 'References' }),
+                    makeRelatedIdentifier({ id: 2, relation_type: 'Cites', identifier: '10.5880/cites' }),
+                    makeRelatedIdentifier({ id: 3, relation_type: 'IsDocumentedBy', identifier: 'https://example.com/doc', identifier_type: 'URL' }),
+                ]}
+            />,
+        );
 
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
+        expect(screen.getByRole('region', { name: 'Related Work' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Related Work' })).toBeInTheDocument();
 
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        expect(screen.getByRole('heading', { name: 'Related Work' })).toBeInTheDocument();
+        const headings = screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent);
+        expect(headings).toEqual(['Cites', 'Is Documented By', 'References']);
     });
 
-    it('groups relations by relation type', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/ref1',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-            {
-                id: 2,
-                identifier: '10.5880/cites1',
-                identifier_type: 'DOI',
-                relation_type: 'Cites',
-            },
-            {
-                id: 3,
-                identifier: '10.5880/ref2',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
+    it('renders persisted citation labels for DOI links and synchronous DOI fallbacks when missing', () => {
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[
+                    makeRelatedIdentifier({ id: 1, citation_label: 'Smith, J. (2024). Persisted Citation.' }),
+                    makeRelatedIdentifier({ id: 2, identifier: '10.5880/no-label' }),
+                ]}
+            />,
+        );
 
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // Check for relation type headings
-        expect(screen.getByText('References')).toBeInTheDocument();
-        expect(screen.getByText('Cites')).toBeInTheDocument();
-    });
-
-    it('formats CamelCase relation types with spaces', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'IsDocumentedBy',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        expect(screen.getByText('Is Documented By')).toBeInTheDocument();
-    });
-
-    it('shows loading indicator while fetching citation', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
-        // Never resolve to keep loading state
-        global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // Loading state now uses Skeleton components with aria-busy
-        const busyEl = document.querySelector('[aria-busy="true"]');
-        expect(busyEl).toBeInTheDocument();
-    });
-
-    it('displays citation after successful fetch', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Smith, J. (2024). Test Dataset.' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Smith, J. (2024). Test Dataset.')).toBeInTheDocument();
-        });
-    });
-
-    it('shows DOI identifier when citation fetch fails', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: false,
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(screen.getByText('DOI: 10.5880/test')).toBeInTheDocument();
-        });
-    });
-
-    it('handles network errors gracefully', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(screen.getByText('DOI: 10.5880/test')).toBeInTheDocument();
-        });
-    });
-
-    it('renders external links with correct href', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            const link = screen.getByRole('link');
-            expect(link).toHaveAttribute('href', 'https://doi.org/10.5880/test');
-            expect(link).toHaveAttribute('target', '_blank');
-            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-        });
-    });
-
-    it('renders URL identifier types as direct links', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: 'https://example.com/dataset',
-                identifier_type: 'URL',
-                relation_type: 'IsDocumentedBy',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        const link = screen.getByRole('link');
-        expect(link).toHaveAttribute('href', 'https://example.com/dataset');
-        expect(link).toHaveTextContent('https://example.com/dataset');
-        // No citation fetch for URLs
+        expect(screen.getByText('Smith, J. (2024). Persisted Citation.')).toBeInTheDocument();
+        expect(screen.getByText('DOI: 10.5880/no-label')).toBeInTheDocument();
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('renders Handle identifier types with hdl.handle.net', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10013/epic.12345',
-                identifier_type: 'Handle',
-                relation_type: 'IsPreviousVersionOf',
-            },
-        ];
+    it('renders URL and Handle identifiers as direct links without runtime fetches', () => {
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[
+                    makeRelatedIdentifier({ id: 1, identifier_type: 'URL', identifier: 'https://example.com/dataset' }),
+                    makeRelatedIdentifier({ id: 2, identifier_type: 'Handle', identifier: '10013/epic.12345' }),
+                ]}
+            />,
+        );
 
-        global.fetch = vi.fn();
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        const link = screen.getByRole('link');
-        expect(link).toHaveAttribute('href', 'https://hdl.handle.net/10013/epic.12345');
-        expect(link).toHaveTextContent('10013/epic.12345');
+        const links = screen.getAllByRole('link');
+        expect(links[0]).toHaveAttribute('href', 'https://example.com/dataset');
+        expect(links[1]).toHaveAttribute('href', 'https://hdl.handle.net/10013/epic.12345');
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('renders URN identifier types with nbn-resolving.org', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: 'urn:nbn:de:kobv:b4-200905193913',
-                identifier_type: 'URN',
-                relation_type: 'References',
-            },
-        ];
+    it('renders mixed DOI and non-DOI items within the same relation group', () => {
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[
+                    makeRelatedIdentifier({ id: 1, relation_type: 'IsDocumentedBy', citation_label: 'DOI Citation' }),
+                    makeRelatedIdentifier({ id: 2, relation_type: 'IsDocumentedBy', identifier_type: 'URL', identifier: 'https://docs.example.com/manual' }),
+                ]}
+            />,
+        );
 
-        global.fetch = vi.fn();
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        const link = screen.getByRole('link');
-        expect(link).toHaveAttribute('href', 'https://nbn-resolving.org/urn:nbn:de:kobv:b4-200905193913');
-    });
-
-    it('hides group heading when all items have unsupported identifier types', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '12345',
-                identifier_type: 'EAN13',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn();
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // Section shouldn't render at all since there are no renderable items...
-        // Actually the section DOES render because filteredRelations is non-empty,
-        // but the group heading should not appear
-        expect(screen.queryByText('References')).not.toBeInTheDocument();
-    });
-
-    it('deduplicates citation fetch for same DOI with different relation types', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/same-doi',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-            {
-                id: 2,
-                identifier: '10.5880/same-doi',
-                identifier_type: 'DOI',
-                relation_type: 'Cites',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Shared Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // Should only fetch once for the deduplicated DOI
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    it('fetches citations only for DOI types, not for URL or Handle', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/doi-test',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-            {
-                id: 2,
-                identifier: 'https://example.com',
-                identifier_type: 'URL',
-                relation_type: 'References',
-            },
-            {
-                id: 3,
-                identifier: '10013/epic.55555',
-                identifier_type: 'Handle',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // Only the DOI should trigger a fetch
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledTimes(1);
-            expect(global.fetch).toHaveBeenCalledWith(
-                expect.stringContaining('10.5880%2Fdoi-test'),
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
-            );
-        });
-    });
-
-    it('sorts relation types alphabetically', () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/z',
-                identifier_type: 'DOI',
-                relation_type: 'Cites',
-            },
-            {
-                id: 2,
-                identifier: '10.5880/a',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-            {
-                id: 3,
-                identifier: '10.5880/b',
-                identifier_type: 'DOI',
-                relation_type: 'Documents',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Test Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        const headings = screen.getAllByRole('heading', { level: 3 });
-        const headingTexts = headings.map((h) => h.textContent);
-
-        // Should be sorted alphabetically
-        expect(headingTexts).toEqual(['Cites', 'Documents', 'References']);
-    });
-
-    it('renders multiple entries in same relation type group', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test1',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-            {
-                id: 2,
-                identifier: '10.5880/test2',
-                identifier_type: 'DOI',
-                relation_type: 'References',
-            },
-        ];
-
-        global.fetch = vi.fn()
-            .mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Citation 1' }),
-            })
-            .mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Citation 2' }),
-            });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Citation 1')).toBeInTheDocument();
-            expect(screen.getByText('Citation 2')).toBeInTheDocument();
-        });
-    });
-
-    it('renders mixed DOI and non-DOI items in the same group', async () => {
-        const relatedIdentifiers = [
-            {
-                id: 1,
-                identifier: '10.5880/test-doi',
-                identifier_type: 'DOI',
-                relation_type: 'IsDocumentedBy',
-            },
-            {
-                id: 2,
-                identifier: 'https://docs.example.com/manual',
-                identifier_type: 'URL',
-                relation_type: 'IsDocumentedBy',
-            },
-        ];
-
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'DOI Citation' }),
-        });
-
-        render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-        // URL should render immediately
+        expect(screen.getByText('DOI Citation')).toBeInTheDocument();
         expect(screen.getByText('https://docs.example.com/manual')).toBeInTheDocument();
-
-        // DOI citation should appear after fetch
-        await waitFor(() => {
-            expect(screen.getByText('DOI Citation')).toBeInTheDocument();
-        });
     });
 
-    describe('Relation Browser button', () => {
-        it('renders the Relation Browser icon button', () => {
-            const relatedIdentifiers = [
-                {
-                    id: 1,
-                    identifier: '10.5880/test',
-                    identifier_type: 'DOI',
-                    relation_type: 'References',
-                },
-            ];
+    it('shows the mobile collapse button when more than nine entries exist and toggles it', () => {
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={Array.from({ length: 12 }, (_, index) =>
+                    makeRelatedIdentifier({
+                        id: index + 1,
+                        identifier_type: 'URL',
+                        identifier: `https://example.com/${index}`,
+                    }),
+                )}
+            />,
+        );
 
-            global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Test Citation' }),
-            });
+        const expandButton = screen.getByRole('button', { name: /Show all \(12\)/i });
+        expect(expandButton).toHaveAttribute('aria-expanded', 'false');
 
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
+        fireEvent.click(expandButton);
 
-            expect(screen.getByTestId('relation-browser-button')).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: 'Open Relation Browser' })).toBeInTheDocument();
-        });
-
-        it('opens Relation Browser modal on button click', async () => {
-            const user = userEvent.setup();
-
-            const relatedIdentifiers = [
-                {
-                    id: 1,
-                    identifier: '10.5880/test',
-                    identifier_type: 'DOI',
-                    relation_type: 'References',
-                },
-            ];
-
-            global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Test Citation' }),
-            });
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            const button = screen.getByTestId('relation-browser-button');
-            await user.click(button);
-
-            expect(await screen.findByText('Relation Browser', {}, { timeout: 5000 })).toBeInTheDocument();
-        });
-
-        it('passes resource and filtered identifiers to modal', async () => {
-            const user = userEvent.setup();
-
-            const relatedIdentifiers = [
-                {
-                    id: 1,
-                    identifier: '10.5880/test',
-                    identifier_type: 'DOI',
-                    relation_type: 'References',
-                },
-            ];
-
-            global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Test Citation' }),
-            });
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            const button = screen.getByTestId('relation-browser-button');
-            await user.click(button);
-
-            expect(await screen.findByTestId('relation-browser-modal', {}, { timeout: 5000 })).toBeInTheDocument();
-            expect(await screen.findByTestId('relation-browser-graph', {}, { timeout: 5000 })).toBeInTheDocument();
-        });
+        expect(screen.getByRole('button', { name: /Show less/i })).toHaveAttribute('aria-expanded', 'true');
     });
 
-    describe('accessibility', () => {
-        it('renders as a section element with aria-labelledby', () => {
-            const relatedIdentifiers = [
-                { id: 1, identifier: '10.5880/test', identifier_type: 'DOI', relation_type: 'References' },
-            ];
+    it('opens the relation browser modal from the action button', async () => {
+        const user = userEvent.setup();
 
-            global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Test' }),
-            });
+        render(
+            <RelatedWorkSection
+                resource={mockResource}
+                relatedIdentifiers={[makeRelatedIdentifier({ citation_label: 'Smith, J. (2024). Persisted Citation.' })]}
+            />,
+        );
 
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
+        const button = screen.getByRole('button', { name: 'Open Relation Browser' });
+        expect(button).toHaveClass('min-h-11', 'min-w-11');
 
-            const section = screen.getByRole('region', { name: 'Related Work' });
-            expect(section).toBeInTheDocument();
-        });
+        await user.click(button);
 
-        it('renders heading as h2 and group headings as h3', () => {
-            const relatedIdentifiers = [
-                { id: 1, identifier: '10.5880/test', identifier_type: 'DOI', relation_type: 'References' },
-            ];
-
-            global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Test' }),
-            });
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            expect(screen.getByRole('heading', { level: 2, name: 'Related Work' })).toBeInTheDocument();
-            expect(screen.getByRole('heading', { level: 3, name: 'References' })).toBeInTheDocument();
-        });
-
-        it('renders Skeleton with aria-busy when citations are loading', () => {
-            const relatedIdentifiers = [
-                { id: 1, identifier: '10.5880/test', identifier_type: 'DOI', relation_type: 'References' },
-            ];
-
-            global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            const busyEls = document.querySelectorAll('[aria-busy="true"]');
-            expect(busyEls.length).toBeGreaterThan(0);
-        });
-
-        it('renders Relation Browser button with minimum touch target', () => {
-            const relatedIdentifiers = [
-                { id: 1, identifier: '10.5880/test', identifier_type: 'DOI', relation_type: 'References' },
-            ];
-
-            global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({ citation: 'Test' }),
-            });
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            const button = screen.getByTestId('relation-browser-button');
-            expect(button).toHaveClass('min-h-11', 'min-w-11');
-        });
-    });
-
-    describe('collapsible on mobile', () => {
-        it('does not show expand button when entries <= 9', () => {
-            const relatedIdentifiers = Array.from({ length: 5 }, (_, i) => ({
-                id: i + 1,
-                identifier: `https://example.com/${i}`,
-                identifier_type: 'URL',
-                relation_type: 'References',
-            }));
-
-            global.fetch = vi.fn();
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            expect(screen.queryByRole('button', { name: /Show all/i })).not.toBeInTheDocument();
-        });
-
-        it('shows expand button when entries > 9', () => {
-            const relatedIdentifiers = Array.from({ length: 12 }, (_, i) => ({
-                id: i + 1,
-                identifier: `https://example.com/${i}`,
-                identifier_type: 'URL',
-                relation_type: 'References',
-            }));
-
-            global.fetch = vi.fn();
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            const expandButton = screen.getByRole('button', { name: /Show all \(12\)/i });
-            expect(expandButton).toBeInTheDocument();
-            expect(expandButton).toHaveAttribute('aria-expanded', 'false');
-            expect(expandButton).toHaveAttribute('aria-controls', 'related-work-list');
-        });
-
-        it('toggles expanded state on button click', async () => {
-            const relatedIdentifiers = Array.from({ length: 12 }, (_, i) => ({
-                id: i + 1,
-                identifier: `https://example.com/${i}`,
-                identifier_type: 'URL',
-                relation_type: 'References',
-            }));
-
-            global.fetch = vi.fn();
-
-            render(<RelatedWorkSection resource={mockResource} relatedIdentifiers={relatedIdentifiers} />);
-
-            const expandButton = screen.getByRole('button', { name: /Show all/i });
-            fireEvent.click(expandButton);
-
-            await waitFor(() => {
-                expect(screen.getByRole('button', { name: /Show less/i })).toBeInTheDocument();
-                expect(screen.getByRole('button', { name: /Show less/i })).toHaveAttribute('aria-expanded', 'true');
-            });
-        });
+        expect(await screen.findByText('Relation Browser')).toBeInTheDocument();
+        expect(screen.getByTestId('relation-browser-modal')).toBeInTheDocument();
+        expect(screen.getByTestId('relation-browser-graph')).toHaveTextContent('1');
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/relation-browser/use-citation-labels.test.ts
+++ b/tests/vitest/pages/LandingPages/__tests__/relation-browser/use-citation-labels.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -12,18 +12,8 @@ describe('extractAuthorYear', () => {
         expect(extractAuthorYear('Doe, J., Smith, A. (2024). Title. Publisher.')).toBe('Doe, 2024');
     });
 
-    it('extracts author and year from single-author citation', () => {
-        expect(extractAuthorYear('Mueller, H. (2023). Some Dataset. GFZ.')).toBe('Mueller, 2023');
-    });
-
-    it('returns author only when no year found', () => {
+    it('returns author only when no year is found', () => {
         expect(extractAuthorYear('Doe, J. Title without year.')).toBe('Doe');
-    });
-
-    it('falls back to truncated string when no author pattern', () => {
-        const longCitation = 'A'.repeat(50);
-        // No comma → firstAuthor is the full string, no year → returns firstAuthor
-        expect(extractAuthorYear(longCitation)).toBe('A'.repeat(50));
     });
 });
 
@@ -33,15 +23,15 @@ describe('getCitationKey', () => {
         expect(getCitationKey('DOI', '10.5880/test')).toBe('10.5880/test');
     });
 
-    it('creates composite key for non-DOI identifiers', () => {
+    it('creates composite keys for non-DOI identifiers', () => {
         expect(getCitationKey('URL', 'https://example.com')).toBe('URL:https://example.com');
-        expect(getCitationKey('ISBN', '978-3-06-024')).toBe('ISBN:978-3-06-024');
     });
 });
 
 describe('useCitationLabels', () => {
     beforeEach(() => {
         vi.resetAllMocks();
+        global.fetch = vi.fn();
     });
 
     it('returns immediate labels for non-DOI identifiers', () => {
@@ -57,32 +47,22 @@ describe('useCitationLabels', () => {
             fullCitation: '978-3-06-024810-5',
             loading: false,
         });
-
         expect(result.current.get('URL:https://example.com')).toEqual({
             shortLabel: 'URL: https://example.com',
             fullCitation: 'https://example.com',
             loading: false,
         });
+        expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('fetches citations for DOI identifiers', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Doe, J. (2024). Test Dataset. GFZ.' }),
-        });
-
-        const identifiers = [
-            { identifier: '10.5880/test.2024', identifier_type: 'DOI' },
-        ];
-
-        const { result } = renderHook(() => useCitationLabels(identifiers));
-
-        // Initially loading
-        expect(result.current.get('10.5880/test.2024')?.loading).toBe(true);
-
-        await waitFor(() => {
-            expect(result.current.get('10.5880/test.2024')?.loading).toBe(false);
-        });
+    it('uses persisted citation labels for DOI identifiers', () => {
+        const { result } = renderHook(() => useCitationLabels([
+            {
+                identifier: '10.5880/test.2024',
+                identifier_type: 'DOI',
+                citation_label: 'Doe, J. (2024). Test Dataset. GFZ.',
+            },
+        ]));
 
         expect(result.current.get('10.5880/test.2024')).toEqual({
             shortLabel: 'Doe, 2024',
@@ -91,111 +71,65 @@ describe('useCitationLabels', () => {
         });
     });
 
-    it('handles fetch errors gracefully', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: false,
-        });
-
-        const identifiers = [
+    it('falls back to the DOI when no citation label exists', () => {
+        const { result } = renderHook(() => useCitationLabels([
             { identifier: '10.5880/bad-doi', identifier_type: 'DOI' },
-        ];
+        ]));
 
-        const { result } = renderHook(() => useCitationLabels(identifiers));
-
-        await waitFor(() => {
-            expect(result.current.get('10.5880/bad-doi')?.loading).toBe(false);
-        });
-
-        expect(result.current.get('10.5880/bad-doi')?.fullCitation).toBe('10.5880/bad-doi');
-    });
-
-    it('deduplicates DOI fetches', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Doe, J. (2024). Test. GFZ.' }),
-        });
-
-        const identifiers = [
-            { identifier: '10.5880/test', identifier_type: 'DOI' },
-            { identifier: '10.5880/test', identifier_type: 'DOI' },
-        ];
-
-        renderHook(() => useCitationLabels(identifiers));
-
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(result.current.get('10.5880/bad-doi')).toEqual({
+            shortLabel: '10.5880/bad-doi',
+            fullCitation: '10.5880/bad-doi',
+            loading: false,
         });
     });
 
-    it('normalizes DOI resolver URLs before fetching', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Smith, A. (2023). Title. GFZ.' }),
-        });
-
-        const identifiers = [
+    it('deduplicates repeated DOI entries by normalized key', () => {
+        const { result } = renderHook(() => useCitationLabels([
+            { identifier: '10.5880/test', identifier_type: 'DOI', citation_label: 'Doe, J. (2024). Test. GFZ.' },
             { identifier: 'https://doi.org/10.5880/test', identifier_type: 'DOI' },
-        ];
+        ]));
 
-        renderHook(() => useCitationLabels(identifiers));
-
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledWith(
-                '/api/datacite/citation?doi=10.5880%2Ftest',
-                expect.any(Object),
-            );
-        });
+        expect(result.current.size).toBe(1);
+        expect(result.current.get('10.5880/test')?.fullCitation).toBe('Doe, J. (2024). Test. GFZ.');
     });
 
-    it('uses pre-provided citationTexts instead of fetching', async () => {
-        global.fetch = vi.fn();
-
-        const identifiers = [
-            { identifier: '10.5880/provided', identifier_type: 'DOI' },
-        ];
+    it('uses pre-provided citationTexts when identifier data lacks citation_label', () => {
         const citationTexts = new Map([
             ['10.5880/provided', 'Doe, J. (2024). Provided Citation. GFZ.'],
         ]);
 
-        const { result } = renderHook(() => useCitationLabels(identifiers, citationTexts));
+        const { result } = renderHook(() => useCitationLabels([
+            { identifier: '10.5880/provided', identifier_type: 'DOI' },
+        ], citationTexts));
 
         expect(result.current.get('10.5880/provided')).toEqual({
             shortLabel: 'Doe, 2024',
             fullCitation: 'Doe, J. (2024). Provided Citation. GFZ.',
             loading: false,
         });
-
-        // Should not fetch since citation was pre-provided
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('fetches only DOIs not covered by citationTexts', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ citation: 'Smith, A. (2023). Fetched. GFZ.' }),
-        });
-
-        const identifiers = [
-            { identifier: '10.5880/provided', identifier_type: 'DOI' },
-            { identifier: '10.5880/missing', identifier_type: 'DOI' },
-        ];
+    it('falls back synchronously for DOIs not covered by citationTexts', () => {
         const citationTexts = new Map([
             ['10.5880/provided', 'Doe, J. (2024). Provided. GFZ.'],
         ]);
 
-        const { result } = renderHook(() => useCitationLabels(identifiers, citationTexts));
+        const { result } = renderHook(() => useCitationLabels([
+            { identifier: '10.5880/provided', identifier_type: 'DOI' },
+            { identifier: '10.5880/missing', identifier_type: 'DOI' },
+        ], citationTexts));
 
-        // Provided one is immediately available
-        expect(result.current.get('10.5880/provided')?.loading).toBe(false);
-        // Missing one still fetches
-        expect(result.current.get('10.5880/missing')?.loading).toBe(true);
-
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledTimes(1);
-            expect(global.fetch).toHaveBeenCalledWith(
-                '/api/datacite/citation?doi=10.5880%2Fmissing',
-                expect.any(Object),
-            );
+        expect(result.current.get('10.5880/provided')).toEqual({
+            shortLabel: 'Doe, 2024',
+            fullCitation: 'Doe, J. (2024). Provided. GFZ.',
+            loading: false,
         });
+        expect(result.current.get('10.5880/missing')).toEqual({
+            shortLabel: '10.5880/missing',
+            fullCitation: '10.5880/missing',
+            loading: false,
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
This pull request introduces support for storing and hydrating citation labels for related identifiers, particularly for DOIs, across the application. It adds a new service for resolving citation labels using DataCite, updates controllers and request validation to handle citation labels, and provides a console command to retroactively hydrate missing citation labels. The changes also refactor related identifier type resolution logic and improve the handling of DataCite API timeouts.

**Citation Label Support and Hydration**

* Added a new service, `RelatedIdentifierCitationLabelService`, to resolve and hydrate citation labels for related identifiers (primarily DOIs) using the DataCite API, with built-in timeout and best-effort strategies.
* Introduced a console command `HydrateRelatedIdentifierCitationLabels` to backfill missing citation labels for existing DOI related identifiers in the database.

**API and Request Handling Enhancements**

* Updated `RelatedIdentifier` model to include a `citation_label` property and constant for maximum label length, and made it fillable. [[1]](diffhunk://#diff-0e65a6af847830b4d81d43c48b2656b524693698762030145d1911c99f2f53c4R23) [[2]](diffhunk://#diff-0e65a6af847830b4d81d43c48b2656b524693698762030145d1911c99f2f53c4L33-R47)
* Extended `StoreResourceRequest` and `StoreDraftResourceRequest` to accept and validate an optional `citationLabel` for each related identifier, and to trim and include this field during validation preparation. [[1]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R160) [[2]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R768-R777) [[3]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R165) [[4]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R665-R674)

**Controller and Type Resolution Refactoring**

* Refactored `UploadJsonController` to use `RelatedIdentifierTypeResolverService` for identifier and relation type resolution, and to resolve citation labels for related identifiers during upload, using a time budget for external API calls. [[1]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R11-R14) [[2]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3L23-L55) [[3]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R81-R82) [[4]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3L919-R892) [[5]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3L944-R905) [[6]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R935)

**DataCite API Improvements**

* Enhanced `DataCiteApiService` to support configurable request timeouts and to allow skipping cache on transient failures, improving reliability and responsiveness for citation label lookups. [[1]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9R24-R25) [[2]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L63-R65) [[3]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L84-R93) [[4]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L107-R114)

**Import Process Robustness**

* Updated the DataCite import job to use a pre-transformed DOI record and to skip import if the DOI already exists, ensuring atomicity and clearer status reporting.

These changes collectively improve the system's ability to display, validate, and hydrate citation labels for related identifiers, especially for DOIs, and lay the groundwork for better citation management throughout the application.