### PR TITLE
Fix: ORCID Affiliation Suggestions No Longer Disappear After Selection

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-18",
+        "date": "2026-05-19",
         "features": [
             {
                 "title": "Single DOI Import for GFZ Legacy Resources",
@@ -207,6 +207,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "ORCID Affiliation Suggestions No Longer Disappear After Selection",
+                "description": "In the Data Editor, selecting an ORCID result now keeps affiliation suggestions available for curator review instead of dropping them during the immediate form rerender. ORCID, first name, and last name are still filled as before, while current ORCID affiliations such as 'GFZ Helmholtz Centre for Geosciences' remain accessible through the ORCID Suggestions workflow until the curator accepts or discards them."
+            },
             {
                 "title": "Publication Year Range Filters No Longer Reload Mid-Entry",
                 "description": "The Publication Year range filters on both /resources and /old-datasets now wait for an explicit Apply action instead of refreshing the list on every keystroke. Users can enter both year boundaries first, review the draft range inside the popover, and clear draft values without triggering a premature reload."

--- a/resources/js/hooks/use-orcid-autofill.ts
+++ b/resources/js/hooks/use-orcid-autofill.ts
@@ -425,6 +425,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
     const entryType = entry.type;
     const prevOrcidRef = useRef(orcidValue);
     const prevEntryTypeRef = useRef(entryType);
+    const verifiedOrcidRef = useRef<string | null>(isPersonEntry(entry) && entry.orcidVerified && entry.orcid ? entry.orcid : null);
     const entryRef = useRef(entry);
     const onEntryChangeRef = useRef(onEntryChange);
     // Mirror isVerifying so the auto-verify effect can check it without
@@ -448,9 +449,15 @@ export function useOrcidAutofill<T extends BaseEntry>({
             updatePendingOrcidData(null);
         }
 
+        if (entryTypeChanged) {
+            verifiedOrcidRef.current = null;
+        }
+
         // Reset verified state when the ORCID value actually changes so the new value can be re-verified
         const currentEntry = entryRef.current;
-        if (orcidChanged && isPersonEntry(currentEntry) && currentEntry.orcidVerified) {
+        const hasFreshVerifiedState = isPersonEntry(currentEntry) && verifiedOrcidRef.current === orcidValue;
+        if (orcidChanged && isPersonEntry(currentEntry) && currentEntry.orcidVerified && !hasFreshVerifiedState) {
+            verifiedOrcidRef.current = null;
             onEntryChangeRef.current({ ...currentEntry, orcidVerified: false, orcidVerifiedAt: undefined } as T);
         }
         if (orcidChanged) {
@@ -475,6 +482,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
         clearError();
         // Clear stale data from prior verification runs
         updatePendingOrcidData(null);
+        verifiedOrcidRef.current = null;
         setOrcidSuggestions([]);
         // Reset verified state so the auto-verify effect can run again
         if (entry.orcidVerified) {
@@ -568,6 +576,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
                 // Update ORCID field on the entry for selection
                 const entryWithOrcid = { ...entry, orcid } as T & PersonEntry;
                 const { updatedEntry, pendingData } = await processOrcidData(entryWithOrcid, response.data, includeEmail);
+                verifiedOrcidRef.current = orcid;
                 updatePendingOrcidData(pendingData, orcid);
                 onEntryChange(updatedEntry);
             } catch (error) {
@@ -764,6 +773,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
                 }
 
                 const { updatedEntry, pendingData } = await processOrcidData(personEntry, response.data, includeEmail);
+                verifiedOrcidRef.current = personEntry.orcid;
                 updatePendingOrcidData(pendingData, personEntry.orcid);
                 onEntryChange(updatedEntry);
             } catch (error) {

--- a/resources/js/hooks/use-orcid-autofill.ts
+++ b/resources/js/hooks/use-orcid-autofill.ts
@@ -402,9 +402,15 @@ export function useOrcidAutofill<T extends BaseEntry>({
 
     // Pending ORCID data for curator review
     const [pendingOrcidData, setPendingOrcidData] = useState<PendingOrcidData | null>(null);
+    const pendingDataOrcidRef = useRef<string | null>(null);
 
     // Track retry trigger
     const [retryTrigger, setRetryTrigger] = useState(0);
+
+    const updatePendingOrcidData = useCallback((data: PendingOrcidData | null, sourceOrcid: string | null = null) => {
+        pendingDataOrcidRef.current = data && sourceOrcid ? sourceOrcid : null;
+        setPendingOrcidData(data);
+    }, []);
 
     const clearError = useCallback(() => {
         setVerificationError(null);
@@ -412,12 +418,13 @@ export function useOrcidAutofill<T extends BaseEntry>({
         setCanRetry(false);
     }, []);
     const hideSuggestions = useCallback(() => setShowSuggestions(false), []);
-    const clearPendingOrcidData = useCallback(() => setPendingOrcidData(null), []);
+    const clearPendingOrcidData = useCallback(() => updatePendingOrcidData(null), [updatePendingOrcidData]);
 
     // Clear stale pending data and verification state when ORCID value or entry type changes
     const orcidValue = isPersonEntry(entry) ? entry.orcid : null;
     const entryType = entry.type;
     const prevOrcidRef = useRef(orcidValue);
+    const prevEntryTypeRef = useRef(entryType);
     const entryRef = useRef(entry);
     const onEntryChangeRef = useRef(onEntryChange);
     // Mirror isVerifying so the auto-verify effect can check it without
@@ -434,18 +441,25 @@ export function useOrcidAutofill<T extends BaseEntry>({
     onEntryChangeRef.current = onEntryChange;
     isVerifyingRef.current = isVerifying;
     useEffect(() => {
-        setPendingOrcidData(null);
+        const orcidChanged = prevOrcidRef.current !== orcidValue;
+        const entryTypeChanged = prevEntryTypeRef.current !== entryType;
+
+        if (entryTypeChanged || (orcidChanged && pendingDataOrcidRef.current !== orcidValue)) {
+            updatePendingOrcidData(null);
+        }
+
         // Reset verified state when the ORCID value actually changes so the new value can be re-verified
         const currentEntry = entryRef.current;
-        if (prevOrcidRef.current !== orcidValue && isPersonEntry(currentEntry) && currentEntry.orcidVerified) {
+        if (orcidChanged && isPersonEntry(currentEntry) && currentEntry.orcidVerified) {
             onEntryChangeRef.current({ ...currentEntry, orcidVerified: false, orcidVerifiedAt: undefined } as T);
         }
-        if (prevOrcidRef.current !== orcidValue) {
+        if (orcidChanged) {
             // A fresh ORCID value always deserves a new verification attempt.
             lastAttemptedSignatureRef.current = null;
         }
         prevOrcidRef.current = orcidValue;
-    }, [orcidValue, entryType]);
+        prevEntryTypeRef.current = entryType;
+    }, [orcidValue, entryType, updatePendingOrcidData]);
 
     // Check if current ORCID has valid format and checksum (offline validation)
     const isFormatValid = useMemo(() => {
@@ -460,14 +474,14 @@ export function useOrcidAutofill<T extends BaseEntry>({
         if (!isPersonEntry(entry) || !entry.orcid?.trim()) return;
         clearError();
         // Clear stale data from prior verification runs
-        setPendingOrcidData(null);
+        updatePendingOrcidData(null);
         setOrcidSuggestions([]);
         // Reset verified state so the auto-verify effect can run again
         if (entry.orcidVerified) {
             onEntryChange({ ...entry, orcidVerified: false, orcidVerifiedAt: undefined } as T);
         }
         setRetryTrigger((prev) => prev + 1);
-    }, [entry, clearError, onEntryChange]);
+    }, [entry, clearError, onEntryChange, updatePendingOrcidData]);
 
     /**
      * Apply selected pending data to the entry
@@ -526,9 +540,9 @@ export function useOrcidAutofill<T extends BaseEntry>({
             }
 
             onEntryChange(updatedEntry);
-            setPendingOrcidData(null);
+            updatePendingOrcidData(null);
         },
-        [entry, pendingOrcidData, onEntryChange],
+        [entry, pendingOrcidData, onEntryChange, updatePendingOrcidData],
     );
 
     /**
@@ -538,7 +552,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
         async (orcid: string) => {
             if (!isPersonEntry(entry)) return;
 
-            setPendingOrcidData(null);
+            updatePendingOrcidData(null);
             setVerificationError(null);
             setIsVerifying(true);
 
@@ -554,7 +568,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
                 // Update ORCID field on the entry for selection
                 const entryWithOrcid = { ...entry, orcid } as T & PersonEntry;
                 const { updatedEntry, pendingData } = await processOrcidData(entryWithOrcid, response.data, includeEmail);
-                setPendingOrcidData(pendingData);
+                updatePendingOrcidData(pendingData, orcid);
                 onEntryChange(updatedEntry);
             } catch (error) {
                 console.error('ORCID fetch error:', error);
@@ -563,7 +577,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
                 setIsVerifying(false);
             }
         },
-        [entry, onEntryChange, includeEmail],
+        [entry, onEntryChange, includeEmail, updatePendingOrcidData],
     );
 
     /**
@@ -750,7 +764,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
                 }
 
                 const { updatedEntry, pendingData } = await processOrcidData(personEntry, response.data, includeEmail);
-                setPendingOrcidData(pendingData);
+                updatePendingOrcidData(pendingData, personEntry.orcid);
                 onEntryChange(updatedEntry);
             } catch (error) {
                 console.error('Auto-verify ORCID error:', error);
@@ -766,7 +780,7 @@ export function useOrcidAutofill<T extends BaseEntry>({
         const timeoutId = setTimeout(autoVerifyOrcid, 500);
 
         return () => clearTimeout(timeoutId);
-    }, [entry, onEntryChange, includeEmail, retryTrigger, hasUserInteracted]);
+    }, [entry, onEntryChange, includeEmail, retryTrigger, hasUserInteracted, updatePendingOrcidData]);
 
     return {
         isVerifying,

--- a/tests/vitest/hooks/__tests__/use-orcid-autofill.test.ts
+++ b/tests/vitest/hooks/__tests__/use-orcid-autofill.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type PersonEntry, useOrcidAutofill } from '@/hooks/use-orcid-autofill';
@@ -340,6 +341,51 @@ describe('useOrcidAutofill', () => {
             expect(result.current.pendingOrcidData?.affiliations).toHaveLength(2);
         });
 
+        it('keeps pending affiliations after the parent rerenders with the selected ORCID', async () => {
+            vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
+                success: true,
+                data: {
+                    orcid: '0009-0003-4793-2913',
+                    firstName: 'Tatjana',
+                    lastName: 'Antipanova',
+                    creditName: null,
+                    emails: [],
+                    affiliations: [
+                        {
+                            type: 'employment',
+                            name: 'GFZ Helmholtz Centre for Geosciences',
+                            role: null,
+                            department: '5.1 Data and Information Management',
+                            rorId: 'https://ror.org/04z8jg394',
+                        },
+                    ],
+                    verifiedAt: new Date().toISOString(),
+                },
+            });
+
+            const { result } = renderHook(() => {
+                const [entry, setEntry] = useState(createPersonEntry());
+
+                return useOrcidAutofill({
+                    entry,
+                    onEntryChange: setEntry,
+                    hasUserInteracted: false,
+                });
+            });
+
+            await act(async () => {
+                await result.current.handleOrcidSelect('0009-0003-4793-2913');
+            });
+
+            expect(result.current.pendingOrcidData?.affiliations).toEqual([
+                expect.objectContaining({
+                    value: 'GFZ Helmholtz Centre for Geosciences',
+                    rorId: 'https://ror.org/04z8jg394',
+                    status: 'new',
+                }),
+            ]);
+        });
+
         it('does not add existing affiliations to pending data', async () => {
             vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
                 success: true,
@@ -378,6 +424,61 @@ describe('useOrcidAutofill', () => {
             expect(call.affiliations).toEqual([{ value: 'Same University', rorId: null }]);
 
             // No pending data since affiliation already exists
+            expect(result.current.pendingOrcidData).toBeNull();
+        });
+
+        it('clears pending affiliations when the entry later switches to a different ORCID', async () => {
+            vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
+                success: true,
+                data: {
+                    orcid: '0009-0003-4793-2913',
+                    firstName: 'Tatjana',
+                    lastName: 'Antipanova',
+                    creditName: null,
+                    emails: [],
+                    affiliations: [
+                        {
+                            type: 'employment',
+                            name: 'GFZ Helmholtz Centre for Geosciences',
+                            role: null,
+                            department: '5.1 Data and Information Management',
+                            rorId: 'https://ror.org/04z8jg394',
+                        },
+                    ],
+                    verifiedAt: new Date().toISOString(),
+                },
+            });
+
+            let updateEntry: ((entry: PersonEntry | ((currentEntry: PersonEntry) => PersonEntry)) => void) | null = null;
+
+            const { result } = renderHook(() => {
+                const [entry, setEntry] = useState(createPersonEntry());
+                updateEntry = setEntry;
+
+                return useOrcidAutofill({
+                    entry,
+                    onEntryChange: setEntry,
+                    hasUserInteracted: false,
+                });
+            });
+
+            await act(async () => {
+                await result.current.handleOrcidSelect('0009-0003-4793-2913');
+            });
+
+            expect(result.current.pendingOrcidData?.affiliations).toEqual([
+                expect.objectContaining({
+                    value: 'GFZ Helmholtz Centre for Geosciences',
+                }),
+            ]);
+
+            await act(async () => {
+                updateEntry?.((currentEntry) => ({
+                    ...currentEntry,
+                    orcid: '0000-0002-1825-0097',
+                }));
+            });
+
             expect(result.current.pendingOrcidData).toBeNull();
         });
     });

--- a/tests/vitest/hooks/__tests__/use-orcid-autofill.test.ts
+++ b/tests/vitest/hooks/__tests__/use-orcid-autofill.test.ts
@@ -150,6 +150,40 @@ describe('useOrcidAutofill', () => {
             );
         });
 
+        it('keeps the verified status after the parent rerenders with a selected ORCID', async () => {
+            vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
+                success: true,
+                data: {
+                    orcid: '0000-0001-2345-6789',
+                    firstName: 'Jane',
+                    lastName: 'Smith',
+                    creditName: null,
+                    emails: [],
+                    affiliations: [],
+                    verifiedAt: new Date().toISOString(),
+                },
+            });
+
+            const { result } = renderHook(() => {
+                const [entry, setEntry] = useState(createPersonEntry());
+                const hook = useOrcidAutofill({
+                    entry,
+                    onEntryChange: setEntry,
+                    hasUserInteracted: false,
+                });
+
+                return { ...hook, entry };
+            });
+
+            await act(async () => {
+                await result.current.handleOrcidSelect('0000-0001-2345-6789');
+            });
+
+            expect(result.current.entry.orcid).toBe('0000-0001-2345-6789');
+            expect(result.current.entry.orcidVerified).toBe(true);
+            expect(result.current.entry.orcidVerifiedAt).toBeTruthy();
+        });
+
         it('handles fetch error', async () => {
             vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
                 success: false,
@@ -618,6 +652,46 @@ describe('useOrcidAutofill', () => {
                     lastName: 'Smith',
                 }),
             );
+        });
+
+        it('keeps the verified status after auto-verify updates the parent entry', async () => {
+            vi.mocked(OrcidService.isValidFormat).mockReturnValue(true);
+            vi.mocked(OrcidService.validateChecksum).mockReturnValue(true);
+            vi.mocked(OrcidService.validateOrcid).mockResolvedValue({
+                success: true,
+                data: { valid: true, exists: true, message: 'Valid', errorType: null },
+            });
+            vi.mocked(OrcidService.fetchOrcidRecord).mockResolvedValue({
+                success: true,
+                data: {
+                    orcid: '0000-0001-2345-6789',
+                    firstName: 'Jane',
+                    lastName: 'Smith',
+                    creditName: null,
+                    emails: [],
+                    affiliations: [],
+                    verifiedAt: new Date().toISOString(),
+                },
+            });
+
+            const { result } = renderHook(() => {
+                const [entry, setEntry] = useState(createPersonEntry({ orcid: '0000-0001-2345-6789' }));
+                const hook = useOrcidAutofill({
+                    entry,
+                    onEntryChange: setEntry,
+                    hasUserInteracted: true,
+                });
+
+                return { ...hook, entry };
+            });
+
+            await act(async () => {
+                vi.advanceTimersByTime(600);
+                await vi.runAllTimersAsync();
+            });
+
+            expect(result.current.entry.orcidVerified).toBe(true);
+            expect(result.current.entry.orcidVerifiedAt).toBeTruthy();
         });
 
         it('sets checksum error when checksum validation fails', async () => {


### PR DESCRIPTION
This pull request improves the ORCID autofill workflow in the Data Editor, ensuring that affiliation suggestions from ORCID remain available for curator review after selection, and that verified ORCID status is preserved correctly during form rerenders. It also adds comprehensive tests to cover these behaviors and updates the changelog accordingly.

### ORCID Affiliation Suggestion Handling & Verification

* Refactored the `useOrcidAutofill` hook to track the source ORCID for pending data, ensuring that affiliation suggestions persist after ORCID selection and only clear when the ORCID changes, not on every rerender. Verified ORCID status is now preserved more reliably across rerenders and auto-verification cycles. [[1]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bR405-R428) [[2]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL437-R469) [[3]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL463-R492) [[4]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL529-R553) [[5]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL541-R563) [[6]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL557-R580) [[7]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL566-R589) [[8]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL753-R777) [[9]](diffhunk://#diff-5da5f3bbad7e6d114198576c2f2a20c0f42f2836bc647db26c1981bd6432427bL769-R793)

### Testing Enhancements

* Added new tests to verify that pending affiliations persist after ORCID selection and are only cleared when the ORCID changes, and that verified status is maintained after both manual selection and auto-verification. [[1]](diffhunk://#diff-57b68e6db398a65c7e60f7a6a3d7360421d75b98c0ee88d63e24ac225e928528R153-R186) [[2]](diffhunk://#diff-57b68e6db398a65c7e60f7a6a3d7360421d75b98c0ee88d63e24ac225e928528R378-R422) [[3]](diffhunk://#diff-57b68e6db398a65c7e60f7a6a3d7360421d75b98c0ee88d63e24ac225e928528R463-R517) [[4]](diffhunk://#diff-57b68e6db398a65c7e60f7a6a3d7360421d75b98c0ee88d63e24ac225e928528R657-R696)

### Documentation

* Updated the changelog to document the improved ORCID affiliation suggestion behavior and the fix for suggestions disappearing after selection. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR210-R213)