### PR TITLE
Fix: Allow DataCite-style version numbers

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -262,6 +262,10 @@
             {
                 "title": "First-Time Login After Welcome Password Setup",
                 "description": "Fixed a critical bug where new users could not log in after setting their password through the welcome link. The signed URL parameters were not forwarded during the password submission, causing the server to reject the request silently. Additionally, error messages from expired or invalid welcome links are now displayed on the login page."
+            },
+            {
+                "title": "Data Editor Accepts DataCite Version Numbers Like 1.0",
+                "description": "Fixed the Version field in the Data Editor so it no longer enforces strict MAJOR.MINOR.PATCH semantic versioning on the client side. Version values are now aligned with DataCite Metadata Schema 4.7 and the backend request rules, which means common inputs such as 1.0, 2.1, 1.0.0, and other valid free-form version strings are accepted. The field tooltip and shared frontend schema were updated accordingly, while the 50-character length guard remains enforced."
             }
         ]
     },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -28,9 +28,9 @@ import {
     validateDate,
     validateDOIFormat,
     validateRequired,
-    validateSemanticVersion,
     validateTextLength,
     validateTitleUniqueness,
+    validateVersion,
     validateYear,
 } from '@/utils/validation-rules';
 
@@ -516,14 +516,14 @@ export default function DataCiteForm({
         },
     ];
 
-    // Version validation rules (optional but must be semantic if provided)
+    // Version validation rules (optional, aligned with DataCite/backend limits)
     const versionValidationRules: ValidationRule[] = [
         {
             validate: (value) => {
                 if (!value || String(value).trim() === '') {
                     return null; // Version is optional
                 }
-                const result = validateSemanticVersion(String(value));
+                const result = validateVersion(String(value));
                 if (!result.isValid) {
                     return { severity: 'error', message: result.error! };
                 }
@@ -2254,7 +2254,8 @@ export default function DataCiteForm({
                                 validationMessages={getFieldState('version').messages}
                                 touched={getFieldState('version').touched}
                                 placeholder="1.0"
-                                labelTooltip="Semantic versioning (e.g., 1.2.3)"
+                                labelTooltip="Version number (e.g., 1.0, 2.1, 1.0.0)"
+                                maxLength={50}
                                 className="min-w-0 md:col-span-1"
                             />
                             <SelectField

--- a/resources/js/schemas/common.schema.ts
+++ b/resources/js/schemas/common.schema.ts
@@ -105,7 +105,8 @@ export const yearSchema = z
 
 export const versionSchema = z
     .string()
-    .regex(/^\d+(\.\d+)*$/, 'Version must follow semantic versioning (e.g., 1.0.0)')
+    .trim()
+    .max(50, 'Version must not exceed 50 characters')
     .optional()
     .or(z.literal(''));
 

--- a/resources/js/utils/validation-rules.ts
+++ b/resources/js/utils/validation-rules.ts
@@ -120,11 +120,11 @@ export function validateYear(year: string | number): {
 }
 
 /**
- * Semantic Versioning Validation
- * Format: MAJOR.MINOR.PATCH (e.g., 1.2.3)
- * Optional pre-release and build metadata allowed
+ * Version Validation
+ * DataCite allows free-form version strings. We mirror the backend contract:
+ * optional value, trimmed input, maximum length of 50 characters.
  */
-export function validateSemanticVersion(version: string): {
+export function validateVersion(version: string): {
     isValid: boolean;
     error?: string;
 } {
@@ -132,14 +132,10 @@ export function validateSemanticVersion(version: string): {
         return { isValid: true }; // Version is optional
     }
 
-    // Semantic versioning pattern (strict)
-    const semverPattern =
-        /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
-
-    if (!semverPattern.test(version.trim())) {
+    if (version.trim().length > 50) {
         return {
             isValid: false,
-            error: 'Invalid semantic version. Use format: MAJOR.MINOR.PATCH (e.g., 1.2.3)',
+            error: 'Version must not exceed 50 characters',
         };
     }
 

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -84,19 +84,19 @@ test.describe('DataCite Form Validation UX', () => {
       await formPage.expectValidationSuccess(formPage.doiInput);
     });
     
-    test('validates semantic version format', async ({ page }) => {
+    test('validates DataCite-aligned version input', async ({ page }) => {
       await formPage.expandAccordion(formPage.resourceInfoAccordion);
       
-      // Invalid version
-      await formPage.versionInput.fill('v1.2');
+      // Invalid version: exceeds backend and frontend max length
+      await formPage.versionInput.fill('123456789012345678901234567890123456789012345678901');
       await formPage.versionInput.blur();
       await page.waitForTimeout(400);
       
       await formPage.expectValidationError(formPage.versionInput);
       
-      // Valid version
+      // Valid version: DataCite-style major.minor value
       await formPage.versionInput.clear();
-      await formPage.versionInput.fill('1.2.3');
+      await formPage.versionInput.fill('1.0');
       await formPage.versionInput.blur();
       await page.waitForTimeout(400);
       

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -84,15 +84,19 @@ test.describe('DataCite Form Validation UX', () => {
       await formPage.expectValidationSuccess(formPage.doiInput);
     });
     
-    test('validates DataCite-aligned version input', async ({ page }) => {
+    test('limits version input to 50 characters and accepts DataCite-style values', async ({ page }) => {
       await formPage.expandAccordion(formPage.resourceInfoAccordion);
+
+      const maxLengthVersion = '1234567890'.repeat(5);
+      const overlongVersion = `${maxLengthVersion}1`;
       
-      // Invalid version: exceeds backend and frontend max length
-      await formPage.versionInput.fill('123456789012345678901234567890123456789012345678901');
+      // Browser input is capped at 50 characters via maxlength.
+      await formPage.versionInput.fill(overlongVersion);
       await formPage.versionInput.blur();
       await page.waitForTimeout(400);
       
-      await formPage.expectValidationError(formPage.versionInput);
+      await expect(formPage.versionInput).toHaveValue(maxLengthVersion);
+      await formPage.expectValidationSuccess(formPage.versionInput);
       
       // Valid version: DataCite-style major.minor value
       await formPage.versionInput.clear();

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -1415,7 +1415,7 @@ describe('DataCiteForm', () => {
         expect(screen.queryByText('Version must not exceed 50 characters')).not.toBeInTheDocument();
     });
 
-    it('shows an inline validation error when Version exceeds 50 characters', async () => {
+    it('applies the native 50 character limit on the Version input', async () => {
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
@@ -1433,12 +1433,7 @@ describe('DataCiteForm', () => {
 
         const versionInput = screen.getByLabelText('Version');
 
-        fireEvent.change(versionInput, {
-            target: { value: '123456789012345678901234567890123456789012345678901' },
-        });
-        fireEvent.blur(versionInput);
-
-        expect(await screen.findByText('Version must not exceed 50 characters')).toBeInTheDocument();
+        expect(versionInput).toHaveAttribute('maxLength', '50');
     });
 
     it('prefills authors when initialAuthors are provided', async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -1387,6 +1387,60 @@ describe('DataCiteForm', () => {
         expect(screen.getByLabelText('Version')).toHaveValue('1.5');
     });
 
+    it('accepts DataCite-style version 1.0 without inline validation errors', async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const versionInput = screen.getByLabelText('Version');
+
+        fireEvent.change(versionInput, { target: { value: '1.0' } });
+        fireEvent.blur(versionInput);
+
+        await waitFor(() => {
+            expect(versionInput).toHaveValue('1.0');
+        });
+
+        expect(screen.queryByText('Version must not exceed 50 characters')).not.toBeInTheDocument();
+    });
+
+    it('shows an inline validation error when Version exceeds 50 characters', async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const versionInput = screen.getByLabelText('Version');
+
+        fireEvent.change(versionInput, {
+            target: { value: '123456789012345678901234567890123456789012345678901' },
+        });
+        fireEvent.blur(versionInput);
+
+        expect(await screen.findByText('Version must not exceed 50 characters')).toBeInTheDocument();
+    });
+
     it('prefills authors when initialAuthors are provided', async () => {
         const user = userEvent.setup();
 

--- a/tests/vitest/schemas/__tests__/common.schema.test.ts
+++ b/tests/vitest/schemas/__tests__/common.schema.test.ts
@@ -155,12 +155,16 @@ describe('Common Schemas', () => {
             expect(versionSchema.safeParse('1.0.0').success).toBe(true);
         });
 
-        it('accepts simple version', () => {
-            expect(versionSchema.safeParse('1').success).toBe(true);
+        it('accepts DataCite example version', () => {
+            expect(versionSchema.safeParse('1.0').success).toBe(true);
         });
 
-        it('rejects version with text', () => {
-            expect(versionSchema.safeParse('v1.0.0').success).toBe(false);
+        it('accepts free-form version text', () => {
+            expect(versionSchema.safeParse('2026 official release').success).toBe(true);
+        });
+
+        it('rejects values longer than 50 characters', () => {
+            expect(versionSchema.safeParse('123456789012345678901234567890123456789012345678901').success).toBe(false);
         });
 
         it('accepts empty string', () => {

--- a/tests/vitest/utils/validation-rules.test.ts
+++ b/tests/vitest/utils/validation-rules.test.ts
@@ -7,9 +7,9 @@ import {
     validateEmail,
     validateORCID,
     validateRequired,
-    validateSemanticVersion,
     validateTextLength,
     validateTitleUniqueness,
+    validateVersion,
     validateYear,
 } from '@/utils/validation-rules';
 
@@ -163,50 +163,45 @@ describe('Validation Rules Utilities', () => {
         });
     });
 
-    describe('validateSemanticVersion', () => {
-        it('should validate basic semantic version', () => {
-            const result = validateSemanticVersion('1.2.3');
+    describe('validateVersion', () => {
+        it('should validate semantic version', () => {
+            const result = validateVersion('1.2.3');
             expect(result.isValid).toBe(true);
         });
 
-        it('should validate version with pre-release', () => {
-            const result = validateSemanticVersion('1.0.0-alpha');
+        it('should validate DataCite example version', () => {
+            const result = validateVersion('1.0');
             expect(result.isValid).toBe(true);
         });
 
-        it('should validate version with build metadata', () => {
-            const result = validateSemanticVersion('1.0.0+20130313144700');
+        it('should validate simple version number', () => {
+            const result = validateVersion('1');
             expect(result.isValid).toBe(true);
         });
 
-        it('should validate complex version', () => {
-            const result = validateSemanticVersion('1.0.0-beta.1+exp.sha.5114f85');
+        it('should validate free-form DataCite-compatible version text', () => {
+            const result = validateVersion('2026 official release');
             expect(result.isValid).toBe(true);
         });
 
         it('should allow empty version (optional field)', () => {
-            const result = validateSemanticVersion('');
-            expect(result.isValid).toBe(true);
-        });
-
-        it('should reject invalid format', () => {
-            const result = validateSemanticVersion('1.2');
-            expect(result.isValid).toBe(false);
-            expect(result.error).toContain('Invalid semantic version');
-        });
-
-        it('should reject version with leading zeros', () => {
-            const result = validateSemanticVersion('01.2.3');
-            expect(result.isValid).toBe(false);
-        });
-
-        it('should validate version 0.0.0', () => {
-            const result = validateSemanticVersion('0.0.0');
+            const result = validateVersion('');
             expect(result.isValid).toBe(true);
         });
 
         it('should trim whitespace', () => {
-            const result = validateSemanticVersion('  1.2.3  ');
+            const result = validateVersion('  1.2.3  ');
+            expect(result.isValid).toBe(true);
+        });
+
+        it('should reject values longer than 50 characters', () => {
+            const result = validateVersion('123456789012345678901234567890123456789012345678901');
+            expect(result.isValid).toBe(false);
+            expect(result.error).toContain('50 characters');
+        });
+
+        it('should validate version 0.0.0', () => {
+            const result = validateVersion('0.0.0');
             expect(result.isValid).toBe(true);
         });
     });


### PR DESCRIPTION
This pull request updates the DataCite "Version" field validation in the Data Editor to better align with DataCite Metadata Schema 4.7 and backend requirements. The strict semantic versioning rule has been replaced with a more flexible, free-form string validation (up to 50 characters), allowing common version formats such as "1.0", "2.1", "1.0.0", and descriptive versions. The UI, validation logic, schemas, tooltips, and tests have all been updated to reflect these changes.

**Validation and Schema Updates:**

* Replaced strict semantic versioning validation with a new `validateVersion` function that accepts any trimmed string up to 50 characters, mirroring DataCite and backend rules. [[1]](diffhunk://#diff-0b8cd1716de79fd672fd3755e02c52c8e2de21ab5ea8c4714ad75a52e4e258f9L123-R138) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L31-R33) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L519-R526) [[4]](diffhunk://#diff-2bd1614b5c5c7afc584b70f13f980d829c1395e048b7523c28ca75e5013a4979L10-R12) [[5]](diffhunk://#diff-2bd1614b5c5c7afc584b70f13f980d829c1395e048b7523c28ca75e5013a4979L166-R204)
* Updated the shared Zod schema (`versionSchema`) to remove the semantic version regex and enforce only trimming and a 50-character maximum.

**UI and User Experience Improvements:**

* Modified the DataCite form to update the Version field's tooltip, enforce a 50-character limit in the input, and use the new validation logic.
* Added and updated Playwright and Vitest tests to cover the new validation rules, input limits, and acceptance of DataCite-style and free-form version values. [[1]](diffhunk://#diff-874c7aee5e1f06fd16bbec3dd688ad961b08f80a83cde9aad1b8211cf1272cc6L87-R103) [[2]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R1390-R1438) [[3]](diffhunk://#diff-8e2c8feaf0626904b6bdf2f346065308a3c96651c965b4fa9be2ee38d64e99c0L158-R167)

**Documentation and Changelog:**

* Added a changelog entry describing the new, more permissive version validation for the Data Editor.