### PR TITLE
Fix: Author and Contributor Data changes when reordered

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -208,6 +208,10 @@
         ],
         "fixes": [
             {
+                "title": "Author and Contributor Reordering No Longer Overwrites Entries",
+                "description": "Dragging authors in the Data Editor now preserves each card's full content instead of overwriting neighbouring entries. The reorder flow was corrected to replace the full author list in one step, and the same fix was applied to contributors because both sections shared the same drag-and-drop update pattern. Focused regression tests now cover list-level drag handling and the parent field wrappers so author names, institution names, ORCID data, roles, and affiliations remain attached to the correct person or institution after reordering."
+            },
+            {
                 "title": "ORCID Affiliation Suggestions No Longer Disappear After Selection",
                 "description": "In the Data Editor, selecting an ORCID result now keeps affiliation suggestions available for curator review instead of dropping them during the immediate form rerender. ORCID, first name, and last name are still filled as before, while current ORCID affiliations such as 'GFZ Helmholtz Centre for Geosciences' remain accessible through the ORCID Suggestions workflow until the curator accepts or discards them."
             },

--- a/resources/js/components/curation/fields/author/author-list.tsx
+++ b/resources/js/components/curation/fields/author/author-list.tsx
@@ -25,6 +25,7 @@ interface AuthorListProps {
     onAdd: () => void;
     onRemove: (index: number) => void;
     onAuthorChange: (index: number, author: AuthorEntry) => void;
+    onReorder: (authors: AuthorEntry[]) => void;
     onBulkAdd?: (authors: AuthorEntry[]) => void;
     affiliationSuggestions: AffiliationSuggestion[];
 }
@@ -32,7 +33,7 @@ interface AuthorListProps {
 /**
  * AuthorList - Manages the list of authors with empty state and drag & drop reordering
  */
-export default function AuthorList({ authors, onAdd, onRemove, onAuthorChange, onBulkAdd, affiliationSuggestions }: AuthorListProps) {
+export default function AuthorList({ authors, onAdd, onRemove, onAuthorChange, onReorder, onBulkAdd, affiliationSuggestions }: AuthorListProps) {
     // State for CSV import dialog
     const [csvDialogOpen, setCsvDialogOpen] = useState(false);
 
@@ -96,18 +97,18 @@ export default function AuthorList({ authors, onAdd, onRemove, onAuthorChange, o
     const handleDragEnd = (event: DragEndEvent) => {
         const { active, over } = event;
 
-        if (over && active.id !== over.id) {
-            const oldIndex = authors.findIndex((author) => author.id === active.id);
-            const newIndex = authors.findIndex((author) => author.id === over.id);
-
-            if (oldIndex !== -1 && newIndex !== -1) {
-                const reorderedAuthors = arrayMove(authors, oldIndex, newIndex);
-                // Update all authors with new order
-                reorderedAuthors.forEach((author, index) => {
-                    onAuthorChange(index, author);
-                });
-            }
+        if (!over || active.id === over.id) {
+            return;
         }
+
+        const oldIndex = authors.findIndex((author) => author.id === active.id);
+        const newIndex = authors.findIndex((author) => author.id === over.id);
+
+        if (oldIndex === -1 || newIndex === -1) {
+            return;
+        }
+
+        onReorder(arrayMove(authors, oldIndex, newIndex));
     };
 
     // Helper: Handle type change

--- a/resources/js/components/curation/fields/author/index.tsx
+++ b/resources/js/components/curation/fields/author/index.tsx
@@ -73,6 +73,10 @@ export default function AuthorField({ authors, onChange, affiliationSuggestions 
         onChange(updated);
     };
 
+    const handleReorder = (reorderedAuthors: AuthorEntry[]) => {
+        onChange(reorderedAuthors);
+    };
+
     const handleBulkAdd = (newAuthors: AuthorEntry[]) => {
         // Check if adding would exceed max limit
         const totalAfterAdd = authors.length + newAuthors.length;
@@ -98,6 +102,7 @@ export default function AuthorField({ authors, onChange, affiliationSuggestions 
                 onAdd={() => handleAdd('person')}
                 onRemove={handleRemove}
                 onAuthorChange={handleAuthorChange}
+                onReorder={handleReorder}
                 onBulkAdd={handleBulkAdd}
                 affiliationSuggestions={affiliationSuggestions}
             />

--- a/resources/js/components/curation/fields/contributor/contributor-list.tsx
+++ b/resources/js/components/curation/fields/contributor/contributor-list.tsx
@@ -25,6 +25,7 @@ interface ContributorListProps {
     onAdd: () => void;
     onRemove: (index: number) => void;
     onContributorChange: (index: number, contributor: ContributorEntry) => void;
+    onReorder: (contributors: ContributorEntry[]) => void;
     onBulkAdd?: (contributors: ContributorEntry[]) => void;
     affiliationSuggestions: AffiliationSuggestion[];
     personRoleOptions: readonly string[];
@@ -39,6 +40,7 @@ export default function ContributorList({
     onAdd,
     onRemove,
     onContributorChange,
+    onReorder,
     onBulkAdd,
     affiliationSuggestions,
     personRoleOptions,
@@ -110,18 +112,18 @@ export default function ContributorList({
     const handleDragEnd = (event: DragEndEvent) => {
         const { active, over } = event;
 
-        if (over && active.id !== over.id) {
-            const oldIndex = contributors.findIndex((contributor) => contributor.id === active.id);
-            const newIndex = contributors.findIndex((contributor) => contributor.id === over.id);
-
-            if (oldIndex !== -1 && newIndex !== -1) {
-                const reorderedContributors = arrayMove(contributors, oldIndex, newIndex);
-                // Update all contributors with new order
-                reorderedContributors.forEach((contributor, index) => {
-                    onContributorChange(index, contributor);
-                });
-            }
+        if (!over || active.id === over.id) {
+            return;
         }
+
+        const oldIndex = contributors.findIndex((contributor) => contributor.id === active.id);
+        const newIndex = contributors.findIndex((contributor) => contributor.id === over.id);
+
+        if (oldIndex === -1 || newIndex === -1) {
+            return;
+        }
+
+        onReorder(arrayMove(contributors, oldIndex, newIndex));
     };
 
     // Helper: Handle type change

--- a/resources/js/components/curation/fields/contributor/index.tsx
+++ b/resources/js/components/curation/fields/contributor/index.tsx
@@ -84,6 +84,10 @@ export default function ContributorField({
         onChange(updated);
     };
 
+    const handleReorder = (reorderedContributors: ContributorEntry[]) => {
+        onChange(reorderedContributors);
+    };
+
     const handleBulkAdd = (newContributors: ContributorEntry[]) => {
         const remainingSlots = MAX_CONTRIBUTORS - contributors.length;
 
@@ -108,6 +112,7 @@ export default function ContributorField({
                 onAdd={() => handleAdd('person')}
                 onRemove={handleRemove}
                 onContributorChange={handleContributorChange}
+                onReorder={handleReorder}
                 onBulkAdd={handleBulkAdd}
                 affiliationSuggestions={affiliationSuggestions}
                 personRoleOptions={personRoleOptions}

--- a/tests/vitest/components/curation/fields/author/author-list.test.tsx
+++ b/tests/vitest/components/curation/fields/author/author-list.test.tsx
@@ -4,14 +4,29 @@
 
 import userEvent from '@testing-library/user-event';
 import { cleanup, render, screen } from '@tests/vitest/utils/render';
+import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AuthorList from '@/components/curation/fields/author/author-list';
 import type { AuthorEntry } from '@/components/curation/fields/author/types';
 
+const dndState = vi.hoisted(() => ({
+    event: {
+        active: { id: 'author-1' },
+        over: { id: 'author-2' } as { id: string } | null,
+    },
+}));
+
 // Mock Drag & Drop
 vi.mock('@dnd-kit/core', () => ({
-    DndContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DndContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (event: { active: { id: string }; over: { id: string } | null }) => void }) => (
+        <div>
+            <button data-testid="trigger-drag" onClick={() => onDragEnd(dndState.event)}>
+                Trigger drag
+            </button>
+            {children}
+        </div>
+    ),
     closestCenter: vi.fn(),
     PointerSensor: vi.fn(),
     KeyboardSensor: vi.fn(),
@@ -75,11 +90,16 @@ describe('AuthorList Component', () => {
         onAdd: vi.fn(),
         onRemove: vi.fn(),
         onAuthorChange: vi.fn(),
+        onReorder: vi.fn(),
         affiliationSuggestions: [],
     };
 
     beforeEach(() => {
         vi.clearAllMocks();
+        dndState.event = {
+            active: { id: 'author-1' },
+            over: { id: 'author-2' },
+        };
     });
 
     afterEach(async () => {
@@ -153,5 +173,65 @@ describe('AuthorList Component', () => {
         
         // CSV import is tested separately in author-csv-import.test.tsx
         expect(screen.getByLabelText('Import authors from CSV file')).toBeInTheDocument();
+    });
+
+    it('calls onReorder with the fully reordered author array after drag end', async () => {
+        const user = userEvent.setup({ delay: null });
+
+        render(<AuthorList authors={mockAuthors} {...mockProps} />);
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockProps.onReorder).toHaveBeenCalledTimes(1);
+        expect(mockProps.onReorder).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'author-2', institutionName: 'Test University' }),
+            expect.objectContaining({ id: 'author-1', firstName: 'John', lastName: 'Doe' }),
+        ]);
+        expect(mockProps.onAuthorChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onReorder when the drop target is missing', async () => {
+        const user = userEvent.setup({ delay: null });
+        dndState.event = {
+            active: { id: 'author-1' },
+            over: null,
+        };
+
+        render(<AuthorList authors={mockAuthors} {...mockProps} />);
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockProps.onReorder).not.toHaveBeenCalled();
+        expect(mockProps.onAuthorChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onReorder when an author is dropped onto itself', async () => {
+        const user = userEvent.setup({ delay: null });
+        dndState.event = {
+            active: { id: 'author-1' },
+            over: { id: 'author-1' },
+        };
+
+        render(<AuthorList authors={mockAuthors} {...mockProps} />);
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockProps.onReorder).not.toHaveBeenCalled();
+        expect(mockProps.onAuthorChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onReorder when sortable ids cannot be resolved', async () => {
+        const user = userEvent.setup({ delay: null });
+        dndState.event = {
+            active: { id: 'author-missing' },
+            over: { id: 'author-2' },
+        };
+
+        render(<AuthorList authors={mockAuthors} {...mockProps} />);
+
+        await user.click(screen.getByTestId('trigger-drag'));
+
+        expect(mockProps.onReorder).not.toHaveBeenCalled();
+        expect(mockProps.onAuthorChange).not.toHaveBeenCalled();
     });
 });

--- a/tests/vitest/components/curation/fields/author/index.test.tsx
+++ b/tests/vitest/components/curation/fields/author/index.test.tsx
@@ -1,0 +1,116 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import AuthorField from '@/components/curation/fields/author';
+import type { AuthorEntry } from '@/components/curation/fields/author/types';
+
+vi.mock('@/components/curation/fields/author/author-list', () => ({
+    default: ({
+        authors,
+        onAuthorChange,
+        onReorder,
+    }: {
+        authors: AuthorEntry[];
+        onAuthorChange: (index: number, author: AuthorEntry) => void;
+        onReorder: (authors: AuthorEntry[]) => void;
+    }) => (
+        <div data-testid="author-list">
+            <button
+                data-testid="reorder-authors"
+                onClick={() =>
+                    onReorder([
+                        authors[2],
+                        authors[0],
+                        authors[1],
+                    ])
+                }
+            >
+                Reorder authors
+            </button>
+            <button
+                data-testid="change-first-author"
+                onClick={() =>
+                    onAuthorChange(0, {
+                        ...authors[0],
+                        firstName: authors[0].type === 'person' ? 'Updated' : undefined,
+                    } as AuthorEntry)
+                }
+            >
+                Change first author
+            </button>
+        </div>
+    ),
+}));
+
+describe('AuthorField', () => {
+    const authors: AuthorEntry[] = [
+        {
+            id: 'author-1',
+            type: 'person',
+            orcid: '0000-0001-1111-1111',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            email: 'ada@example.org',
+            website: 'https://example.org/ada',
+            isContact: true,
+            orcidVerified: true,
+            affiliations: [{ value: 'University A', rorId: null }],
+            affiliationsInput: 'University A',
+        },
+        {
+            id: 'author-2',
+            type: 'institution',
+            institutionName: 'Institute B',
+            affiliations: [{ value: 'Institute B', rorId: 'https://ror.org/02abcde12' }],
+            affiliationsInput: 'Institute B',
+        },
+        {
+            id: 'author-3',
+            type: 'person',
+            orcid: '0000-0002-2222-2222',
+            firstName: 'Grace',
+            lastName: 'Hopper',
+            email: 'grace@example.org',
+            website: 'https://example.org/grace',
+            isContact: false,
+            orcidVerified: false,
+            affiliations: [{ value: 'Lab C', rorId: null }],
+            affiliationsInput: 'Lab C',
+        },
+    ];
+
+    it('replaces the full author array when the list reports a reorder', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn<(authors: AuthorEntry[]) => void>();
+
+        render(<AuthorField authors={authors} onChange={onChange} affiliationSuggestions={[]} />);
+
+        await user.click(screen.getByTestId('reorder-authors'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'author-3', firstName: 'Grace', lastName: 'Hopper' }),
+            expect.objectContaining({ id: 'author-1', firstName: 'Ada', lastName: 'Lovelace' }),
+            expect.objectContaining({ id: 'author-2', institutionName: 'Institute B' }),
+        ]);
+    });
+
+    it('still updates a single author by index for non-reorder changes', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn<(authors: AuthorEntry[]) => void>();
+
+        render(<AuthorField authors={authors} onChange={onChange} affiliationSuggestions={[]} />);
+
+        await user.click(screen.getByTestId('change-first-author'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'author-1', firstName: 'Updated', lastName: 'Lovelace' }),
+            expect.objectContaining({ id: 'author-2', institutionName: 'Institute B' }),
+            expect.objectContaining({ id: 'author-3', firstName: 'Grace', lastName: 'Hopper' }),
+        ]);
+    });
+});

--- a/tests/vitest/components/curation/fields/contributor/__tests__/contributor-list.test.tsx
+++ b/tests/vitest/components/curation/fields/contributor/__tests__/contributor-list.test.tsx
@@ -2,14 +2,29 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ContributorList from '@/components/curation/fields/contributor/contributor-list';
 import type { ContributorEntry } from '@/components/curation/fields/contributor/types';
 
+const dndState = vi.hoisted(() => ({
+    event: {
+        active: { id: 'c1' },
+        over: { id: 'c2' } as { id: string } | null,
+    },
+}));
+
 // Mock DnD kit — simplified to just render children
 vi.mock('@dnd-kit/core', () => ({
-    DndContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DndContext: ({ children, onDragEnd }: { children: ReactNode; onDragEnd: (event: { active: { id: string }; over: { id: string } | null }) => void }) => (
+        <div>
+            <button data-testid="trigger-drag" onClick={() => onDragEnd(dndState.event)}>
+                Trigger drag
+            </button>
+            {children}
+        </div>
+    ),
     closestCenter: vi.fn(),
     KeyboardSensor: vi.fn(),
     PointerSensor: vi.fn(),
@@ -18,7 +33,13 @@ vi.mock('@dnd-kit/core', () => ({
 }));
 
 vi.mock('@dnd-kit/sortable', () => ({
-    SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    arrayMove: <T,>(items: T[], oldIndex: number, newIndex: number) => {
+        const next = [...items];
+        const [moved] = next.splice(oldIndex, 1);
+        next.splice(newIndex, 0, moved);
+        return next;
+    },
+    SortableContext: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     sortableKeyboardCoordinates: vi.fn(),
     verticalListSortingStrategy: 'vertical',
 }));
@@ -128,6 +149,7 @@ describe('ContributorList', () => {
     let onAdd = vi.fn<() => void>();
     let onRemove = vi.fn<(index: number) => void>();
     let onContributorChange = vi.fn<(index: number, contributor: ContributorEntry) => void>();
+    let onReorder = vi.fn<(contributors: ContributorEntry[]) => void>();
     let onBulkAdd = vi.fn<(contributors: ContributorEntry[]) => void>();
 
     const defaultProps = {
@@ -140,7 +162,12 @@ describe('ContributorList', () => {
         onAdd = vi.fn<() => void>();
         onRemove = vi.fn<(index: number) => void>();
         onContributorChange = vi.fn<(index: number, contributor: ContributorEntry) => void>();
+        onReorder = vi.fn<(contributors: ContributorEntry[]) => void>();
         onBulkAdd = vi.fn<(contributors: ContributorEntry[]) => void>();
+        dndState.event = {
+            active: { id: 'c1' },
+            over: { id: 'c2' },
+        };
     });
 
     describe('empty state', () => {
@@ -151,6 +178,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     onBulkAdd={onBulkAdd}
                     {...defaultProps}
                 />,
@@ -167,6 +195,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -184,6 +213,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -199,6 +229,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     onBulkAdd={onBulkAdd}
                     {...defaultProps}
                 />,
@@ -221,6 +252,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -240,6 +272,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -256,6 +289,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -273,6 +307,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -294,6 +329,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -322,6 +358,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -351,6 +388,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -372,6 +410,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -395,6 +434,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -415,6 +455,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     {...defaultProps}
                 />,
             );
@@ -440,6 +481,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     onBulkAdd={onBulkAdd}
                     {...defaultProps}
                 />,
@@ -476,6 +518,7 @@ describe('ContributorList', () => {
                     onAdd={onAdd}
                     onRemove={onRemove}
                     onContributorChange={onContributorChange}
+                    onReorder={onReorder}
                     onBulkAdd={onBulkAdd}
                     {...defaultProps}
                 />,
@@ -490,6 +533,117 @@ describe('ContributorList', () => {
                     expect.objectContaining({ value: 'MIT', rorId: null }),
                 ]),
             );
+        });
+    });
+
+    describe('reordering', () => {
+        it('calls onReorder with the fully reordered contributor array after drag end', async () => {
+            const user = userEvent.setup();
+            const contributors = [
+                createPersonContributor({ id: 'c1', firstName: 'Alice', lastName: 'Johnson' }),
+                createInstitutionContributor({ id: 'c2', institutionName: 'CERN' }),
+            ];
+
+            render(
+                <ContributorList
+                    contributors={contributors}
+                    onAdd={onAdd}
+                    onRemove={onRemove}
+                    onContributorChange={onContributorChange}
+                    onReorder={onReorder}
+                    {...defaultProps}
+                />,
+            );
+
+            await user.click(screen.getByTestId('trigger-drag'));
+
+            expect(onReorder).toHaveBeenCalledTimes(1);
+            expect(onReorder).toHaveBeenCalledWith([
+                expect.objectContaining({ id: 'c2', institutionName: 'CERN' }),
+                expect.objectContaining({ id: 'c1', firstName: 'Alice', lastName: 'Johnson' }),
+            ]);
+            expect(onContributorChange).not.toHaveBeenCalled();
+        });
+
+        it('does not call onReorder when the drop target is missing', async () => {
+            const user = userEvent.setup();
+            dndState.event = {
+                active: { id: 'c1' },
+                over: null,
+            };
+
+            render(
+                <ContributorList
+                    contributors={[
+                        createPersonContributor({ id: 'c1' }),
+                        createInstitutionContributor({ id: 'c2' }),
+                    ]}
+                    onAdd={onAdd}
+                    onRemove={onRemove}
+                    onContributorChange={onContributorChange}
+                    onReorder={onReorder}
+                    {...defaultProps}
+                />,
+            );
+
+            await user.click(screen.getByTestId('trigger-drag'));
+
+            expect(onReorder).not.toHaveBeenCalled();
+            expect(onContributorChange).not.toHaveBeenCalled();
+        });
+
+        it('does not call onReorder when a contributor is dropped onto itself', async () => {
+            const user = userEvent.setup();
+            dndState.event = {
+                active: { id: 'c1' },
+                over: { id: 'c1' },
+            };
+
+            render(
+                <ContributorList
+                    contributors={[
+                        createPersonContributor({ id: 'c1' }),
+                        createInstitutionContributor({ id: 'c2' }),
+                    ]}
+                    onAdd={onAdd}
+                    onRemove={onRemove}
+                    onContributorChange={onContributorChange}
+                    onReorder={onReorder}
+                    {...defaultProps}
+                />,
+            );
+
+            await user.click(screen.getByTestId('trigger-drag'));
+
+            expect(onReorder).not.toHaveBeenCalled();
+            expect(onContributorChange).not.toHaveBeenCalled();
+        });
+
+        it('does not call onReorder when sortable ids cannot be resolved', async () => {
+            const user = userEvent.setup();
+            dndState.event = {
+                active: { id: 'c-missing' },
+                over: { id: 'c2' },
+            };
+
+            render(
+                <ContributorList
+                    contributors={[
+                        createPersonContributor({ id: 'c1' }),
+                        createInstitutionContributor({ id: 'c2' }),
+                    ]}
+                    onAdd={onAdd}
+                    onRemove={onRemove}
+                    onContributorChange={onContributorChange}
+                    onReorder={onReorder}
+                    {...defaultProps}
+                />,
+            );
+
+            await user.click(screen.getByTestId('trigger-drag'));
+
+            expect(onReorder).not.toHaveBeenCalled();
+            expect(onContributorChange).not.toHaveBeenCalled();
         });
     });
 });

--- a/tests/vitest/components/curation/fields/contributor/index.test.tsx
+++ b/tests/vitest/components/curation/fields/contributor/index.test.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import ContributorField from '@/components/curation/fields/contributor';
+import type { ContributorEntry } from '@/components/curation/fields/contributor/types';
+
+vi.mock('@/components/curation/fields/contributor/contributor-list', () => ({
+    default: ({
+        contributors,
+        onContributorChange,
+        onReorder,
+    }: {
+        contributors: ContributorEntry[];
+        onContributorChange: (index: number, contributor: ContributorEntry) => void;
+        onReorder: (contributors: ContributorEntry[]) => void;
+    }) => (
+        <div data-testid="contributor-list">
+            <button
+                data-testid="reorder-contributors"
+                onClick={() =>
+                    onReorder([
+                        contributors[2],
+                        contributors[0],
+                        contributors[1],
+                    ])
+                }
+            >
+                Reorder contributors
+            </button>
+            <button
+                data-testid="change-first-contributor"
+                onClick={() =>
+                    onContributorChange(0, {
+                        ...contributors[0],
+                        firstName: contributors[0].type === 'person' ? 'Updated' : undefined,
+                    } as ContributorEntry)
+                }
+            >
+                Change first contributor
+            </button>
+        </div>
+    ),
+}));
+
+describe('ContributorField', () => {
+    const contributors: ContributorEntry[] = [
+        {
+            id: 'contributor-1',
+            type: 'person',
+            orcid: '0000-0001-1111-1111',
+            firstName: 'Alice',
+            lastName: 'Johnson',
+            email: 'alice@example.org',
+            website: 'https://example.org/alice',
+            roles: [{ value: 'DataCurator' }],
+            rolesInput: 'DataCurator',
+            affiliations: [{ value: 'University A', rorId: null }],
+            affiliationsInput: 'University A',
+            orcidVerified: true,
+        },
+        {
+            id: 'contributor-2',
+            type: 'institution',
+            institutionName: 'Institute B',
+            roles: [{ value: 'HostingInstitution' }],
+            rolesInput: 'HostingInstitution',
+            affiliations: [{ value: 'Institute B', rorId: 'https://ror.org/02abcde12' }],
+            affiliationsInput: 'Institute B',
+        },
+        {
+            id: 'contributor-3',
+            type: 'person',
+            orcid: '0000-0002-2222-2222',
+            firstName: 'Grace',
+            lastName: 'Hopper',
+            email: 'grace@example.org',
+            website: 'https://example.org/grace',
+            roles: [{ value: 'ProjectLeader' }],
+            rolesInput: 'ProjectLeader',
+            affiliations: [{ value: 'Lab C', rorId: null }],
+            affiliationsInput: 'Lab C',
+            orcidVerified: false,
+        },
+    ];
+
+    const roleProps = {
+        personRoleOptions: ['DataCurator', 'ProjectLeader'] as readonly string[],
+        institutionRoleOptions: ['HostingInstitution'] as readonly string[],
+    };
+
+    it('replaces the full contributor array when the list reports a reorder', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn<(contributors: ContributorEntry[]) => void>();
+
+        render(<ContributorField contributors={contributors} onChange={onChange} affiliationSuggestions={[]} {...roleProps} />);
+
+        await user.click(screen.getByTestId('reorder-contributors'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'contributor-3', firstName: 'Grace', lastName: 'Hopper' }),
+            expect.objectContaining({ id: 'contributor-1', firstName: 'Alice', lastName: 'Johnson' }),
+            expect.objectContaining({ id: 'contributor-2', institutionName: 'Institute B' }),
+        ]);
+    });
+
+    it('still updates a single contributor by index for non-reorder changes', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn<(contributors: ContributorEntry[]) => void>();
+
+        render(<ContributorField contributors={contributors} onChange={onChange} affiliationSuggestions={[]} {...roleProps} />);
+
+        await user.click(screen.getByTestId('change-first-contributor'));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'contributor-1', firstName: 'Updated', lastName: 'Johnson' }),
+            expect.objectContaining({ id: 'contributor-2', institutionName: 'Institute B' }),
+            expect.objectContaining({ id: 'contributor-3', firstName: 'Grace', lastName: 'Hopper' }),
+        ]);
+    });
+});


### PR DESCRIPTION
This pull request fixes a critical bug in the drag-and-drop reordering of authors and contributors in the Data Editor, ensuring that all data attached to each entry (such as names, institutions, ORCID data, roles, and affiliations) is preserved after reordering. The implementation now replaces the entire list in one step instead of updating entries individually, and comprehensive regression tests have been added to prevent similar issues in the future.

**Bug Fixes and Functional Improvements:**

* Drag-and-drop reordering for both authors and contributors now replaces the full list at once, preserving all fields and preventing overwrites or data loss for neighboring entries. The same fix is applied to both sections due to shared update logic. [[1]](diffhunk://#diff-9ad9d0321dcec9a468f63a01d869421f38346a9c84670b56a98e80efd678a194L99-R111) [[2]](diffhunk://#diff-52e7672a302a252dc9410c4469620b958fcbd2800fb3367ea673b07d555baa63R76-R79) [[3]](diffhunk://#diff-52e7672a302a252dc9410c4469620b958fcbd2800fb3367ea673b07d555baa63R105) [[4]](diffhunk://#diff-8dfb67f618c3a76795cb6bfdcefeaa8bb0230062cf04f342b396667ce990843fL113-R126) [[5]](diffhunk://#diff-31ccfc3757e5aedb5dd5f9b1b33537b0672d157be09dd4188d7f6fca298b9ab5R87-R90) [[6]](diffhunk://#diff-31ccfc3757e5aedb5dd5f9b1b33537b0672d157be09dd4188d7f6fca298b9ab5R115) [[7]](diffhunk://#diff-8dfb67f618c3a76795cb6bfdcefeaa8bb0230062cf04f342b396667ce990843fR28) [[8]](diffhunk://#diff-8dfb67f618c3a76795cb6bfdcefeaa8bb0230062cf04f342b396667ce990843fR43)
* The changelog has been updated to document this fix and clarify its impact on data integrity for curators.

**Testing and Regression Coverage:**

* New and enhanced tests for author and contributor reordering ensure that the correct array replacement logic is used, that no data is lost or mismatched, and that edge cases (such as missing or self-targeted drops) are handled gracefully. [[1]](diffhunk://#diff-b4d4d1be0212393391e4df0d799f07cf89a720b618c6d5579fe2a3d5cd08c16fR7-R29) [[2]](diffhunk://#diff-b4d4d1be0212393391e4df0d799f07cf89a720b618c6d5579fe2a3d5cd08c16fR93-R102) [[3]](diffhunk://#diff-b4d4d1be0212393391e4df0d799f07cf89a720b618c6d5579fe2a3d5cd08c16fR177-R236) [[4]](diffhunk://#diff-19dce7b0f4cac58982d9e195114f398816bbba40a9eaf60e55cf1048b70b7ba9R1-R116) [[5]](diffhunk://#diff-86df4088d130a7870e7e92c5095f3ffed61037a0df4656cfceca0d6f277e2942R5-R27) [[6]](diffhunk://#diff-86df4088d130a7870e7e92c5095f3ffed61037a0df4656cfceca0d6f277e2942L21-R42) [[7]](diffhunk://#diff-86df4088d130a7870e7e92c5095f3ffed61037a0df4656cfceca0d6f277e2942R152) [[8]](diffhunk://#diff-86df4088d130a7870e7e92c5095f3ffed61037a0df4656cfceca0d6f277e2942R165-R170) [[9]](diffhunk://#diff-86df4088d130a7870e7e92c5095f3ffed61037a0df4656cfceca0d6f277e2942R181) [[10]](diffhunk://#diff-86df4088d130a7870e7e92c5095f3ffed61037a0df4656cfceca0d6f277e2942R198)