### PR TITLE
Feature: HTML Support on Landing Page Templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.6-fpm-trixie@sha256:447f007e804ecf183feefd1202f732ccf2d4998263f9ddc478cf999d12861ee1 AS app-base
+FROM php:8.5.6-fpm-trixie@sha256:fc0e3fbbc15926f27d1213b83abfc8a8665a09cf870c441d425f8805522196ad AS app-base
 
 WORKDIR /var/www/html
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------
 # Stage: PHP-FPM Application (Development)
 # -----------------------------------------------------------------------------
-FROM php:8.5.6-fpm-trixie@sha256:447f007e804ecf183feefd1202f732ccf2d4998263f9ddc478cf999d12861ee1 AS app
+FROM php:8.5.6-fpm-trixie@sha256:fc0e3fbbc15926f27d1213b83abfc8a8665a09cf870c441d425f8805522196ad AS app
 
 WORKDIR /var/www/html
 

--- a/app/Models/Description.php
+++ b/app/Models/Description.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $id
  * @property int $resource_id
  * @property string $value
+ * @property string|null $landing_page_html
  * @property int $description_type_id
  * @property string|null $language
  * @property \Illuminate\Support\Carbon|null $created_at
@@ -26,7 +27,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @see https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/description/
  */
-#[Fillable(['resource_id', 'value', 'description_type_id', 'language'])]
+#[Fillable(['resource_id', 'value', 'landing_page_html', 'description_type_id', 'language'])]
 class Description extends Model
 {
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */

--- a/app/Services/DescriptionFormattingService.php
+++ b/app/Services/DescriptionFormattingService.php
@@ -92,7 +92,7 @@ class DescriptionFormattingService
 
         $loaded = $document->loadHTML(
             '<?xml encoding="utf-8" ?><div id="description-wrapper">'.$html.'</div>',
-            LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED
+            LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED | LIBXML_NONET
         );
 
         libxml_clear_errors();

--- a/app/Services/DescriptionFormattingService.php
+++ b/app/Services/DescriptionFormattingService.php
@@ -76,7 +76,13 @@ class DescriptionFormattingService
 
     private function containsHtml(string $input): bool
     {
-        return preg_match('/<\s*\/?\s*[a-zA-Z][^>]*>/', $input) === 1;
+        $htmlDetectionTags = [...self::ALLOWED_TAGS, ...self::DROP_WITH_CONTENT_TAGS];
+        $detectedTagsPattern = implode('|', array_map(
+            static fn (string $tagName): string => preg_quote($tagName, '/'),
+            $htmlDetectionTags,
+        ));
+
+        return preg_match('/<\s*\/?\s*(?:'.$detectedTagsPattern.')(?=[\s>\/])/i', $input) === 1;
     }
 
     private function parseFragment(string $html): DOMElement

--- a/app/Services/DescriptionFormattingService.php
+++ b/app/Services/DescriptionFormattingService.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+use RuntimeException;
+
+class DescriptionFormattingService
+{
+    /** @var list<string> */
+    private const ALLOWED_TAGS = ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a', 'sub', 'sup', 'code'];
+
+    /** @var list<string> */
+    private const DROP_WITH_CONTENT_TAGS = ['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta', 'base'];
+
+    /**
+     * @return array{plainText: string, landingPageHtml: string|null}
+     */
+    public function formatForStorage(string $input): array
+    {
+        $trimmedInput = $this->normalizePlainText($input);
+
+        if ($trimmedInput === '') {
+            return [
+                'plainText' => '',
+                'landingPageHtml' => null,
+            ];
+        }
+
+        if (! $this->containsHtml($trimmedInput)) {
+            return [
+                'plainText' => $trimmedInput,
+                'landingPageHtml' => null,
+            ];
+        }
+
+        $sanitizedHtml = $this->sanitizeHtml($trimmedInput);
+        $plainText = $this->plainTextFromHtml($sanitizedHtml);
+
+        return [
+            'plainText' => $plainText,
+            'landingPageHtml' => $sanitizedHtml !== '' ? $sanitizedHtml : null,
+        ];
+    }
+
+    public function sanitizeHtml(string $html): string
+    {
+        $wrapper = $this->parseFragment($html);
+
+        return trim($this->sanitizeChildren($wrapper));
+    }
+
+    public function plainTextFromHtml(string $html): string
+    {
+        if (trim($html) === '') {
+            return '';
+        }
+
+        $wrapper = $this->parseFragment($html);
+        $text = $this->extractText($wrapper);
+
+        return $this->normalizeExtractedText($text);
+    }
+
+    private function containsHtml(string $input): bool
+    {
+        return preg_match('/<\s*\/?\s*[a-zA-Z][^>]*>/', $input) === 1;
+    }
+
+    private function parseFragment(string $html): DOMElement
+    {
+        $document = new DOMDocument('1.0', 'UTF-8');
+        $previousLibxmlSetting = libxml_use_internal_errors(true);
+
+        $loaded = $document->loadHTML(
+            '<?xml encoding="utf-8" ?><div id="description-wrapper">'.$html.'</div>',
+            LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED
+        );
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousLibxmlSetting);
+
+        if ($loaded === false) {
+            throw new RuntimeException('Failed to parse description HTML fragment.');
+        }
+
+        $wrapper = $document->getElementsByTagName('div')->item(0);
+
+        if (! $wrapper instanceof DOMElement) {
+            throw new RuntimeException('Description HTML wrapper element is missing.');
+        }
+
+        return $wrapper;
+    }
+
+    private function sanitizeChildren(DOMNode $node): string
+    {
+        $html = '';
+
+        foreach ($node->childNodes as $childNode) {
+            $html .= $this->sanitizeNode($childNode);
+        }
+
+        return $html;
+    }
+
+    private function sanitizeNode(DOMNode $node): string
+    {
+        if ($node instanceof DOMText) {
+            return htmlspecialchars($node->wholeText, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
+        }
+
+        if (! $node instanceof DOMElement) {
+            return '';
+        }
+
+        $tagName = strtolower($node->tagName);
+
+        if (in_array($tagName, self::DROP_WITH_CONTENT_TAGS, true)) {
+            return '';
+        }
+
+        if (! in_array($tagName, self::ALLOWED_TAGS, true)) {
+            return $this->sanitizeChildren($node);
+        }
+
+        if ($tagName === 'br') {
+            return '<br>';
+        }
+
+        $content = $this->sanitizeChildren($node);
+
+        if ($tagName === 'a') {
+            $href = $this->sanitizeHref($node->getAttribute('href'));
+
+            if ($href === null) {
+                return $content;
+            }
+
+            return '<a href="'.htmlspecialchars($href, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false).'">'.$content.'</a>';
+        }
+
+        return sprintf('<%1$s>%2$s</%1$s>', $tagName, $content);
+    }
+
+    private function sanitizeHref(?string $href): ?string
+    {
+        $normalizedHref = trim(html_entity_decode((string) $href, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+
+        if ($normalizedHref === '') {
+            return null;
+        }
+
+        $parts = parse_url($normalizedHref);
+
+        if ($parts === false) {
+            return null;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+
+        if (! in_array($scheme, ['http', 'https', 'mailto'], true)) {
+            return null;
+        }
+
+        return $normalizedHref;
+    }
+
+    private function extractText(DOMNode $node): string
+    {
+        if ($node instanceof DOMText) {
+            return $node->wholeText;
+        }
+
+        if (! $node instanceof DOMElement) {
+            return $this->extractChildrenText($node);
+        }
+
+        $tagName = strtolower($node->tagName);
+
+        return match ($tagName) {
+            'br' => "\n",
+            'p' => $this->formatBlockText($node),
+            'ul', 'ol' => $this->formatListText($node),
+            'a' => $this->formatAnchorText($node),
+            default => $this->extractChildrenText($node),
+        };
+    }
+
+    private function extractChildrenText(DOMNode $node): string
+    {
+        $text = '';
+
+        foreach ($node->childNodes as $childNode) {
+            $text .= $this->extractText($childNode);
+        }
+
+        return $text;
+    }
+
+    private function formatBlockText(DOMElement $element): string
+    {
+        $content = trim($this->extractChildrenText($element));
+
+        if ($content === '') {
+            return '';
+        }
+
+        return $content."\n\n";
+    }
+
+    private function formatListText(DOMElement $list): string
+    {
+        $items = [];
+        $isOrdered = strtolower($list->tagName) === 'ol';
+        $counter = 1;
+
+        foreach ($list->childNodes as $childNode) {
+            if (! $childNode instanceof DOMElement || strtolower($childNode->tagName) !== 'li') {
+                continue;
+            }
+
+            $itemText = $this->normalizeInlineText($this->extractChildrenText($childNode));
+
+            if ($itemText === '') {
+                continue;
+            }
+
+            $items[] = ($isOrdered ? $counter.'. ' : '- ').$itemText;
+            $counter++;
+        }
+
+        if ($items === []) {
+            return '';
+        }
+
+        return implode("\n", $items)."\n\n";
+    }
+
+    private function formatAnchorText(DOMElement $element): string
+    {
+        $label = $this->normalizeInlineText($this->extractChildrenText($element));
+        $href = $this->sanitizeHref($element->getAttribute('href'));
+
+        if ($href === null) {
+            return $label;
+        }
+
+        if ($label === '') {
+            return $href;
+        }
+
+        return $label === $href ? $label : sprintf('%s (%s)', $label, $href);
+    }
+
+    private function normalizePlainText(string $text): string
+    {
+        $text = str_replace(["\r\n", "\r"], "\n", $text);
+
+        return trim($text);
+    }
+
+    private function normalizeExtractedText(string $text): string
+    {
+        $text = str_replace(["\r\n", "\r"], "\n", $text);
+        $text = str_replace("\u{00A0}", ' ', $text);
+        $text = preg_replace('/[ \t]+/u', ' ', $text) ?? $text;
+        $text = preg_replace('/ *\n */u', "\n", $text) ?? $text;
+        $text = preg_replace('/\n{3,}/u', "\n\n", $text) ?? $text;
+
+        return trim($text);
+    }
+
+    private function normalizeInlineText(string $text): string
+    {
+        $text = str_replace(["\r\n", "\r", "\n"], ' ', $text);
+        $text = preg_replace('/\s+/u', ' ', $text) ?? $text;
+
+        return trim($text);
+    }
+}

--- a/app/Services/DescriptionFormattingService.php
+++ b/app/Services/DescriptionFormattingService.php
@@ -82,7 +82,14 @@ class DescriptionFormattingService
             $htmlDetectionTags,
         ));
 
-        return preg_match('/<\s*\/?\s*(?:'.$detectedTagsPattern.')(?=[\s>\/])/i', $input) === 1;
+        if (preg_match('/<\/?(?:'.$detectedTagsPattern.')(?=[\s>\/])/i', $input) === 1) {
+            return true;
+        }
+
+        return preg_match('/<([A-Za-z][A-Za-z0-9:-]*)\b[^>]*>.*<\/\1\s*>/is', $input) === 1
+            || preg_match('/<[A-Za-z][A-Za-z0-9:-]*\b[^>]*\/>/i', $input) === 1
+            || preg_match('/<[A-Za-z][A-Za-z0-9:-]*\b[^>]*\s+[A-Za-z_:][A-Za-z0-9:._-]*\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^\s"\'=<>`]+)[^>]*>/i', $input) === 1
+            || preg_match('/<\/[A-Za-z][A-Za-z0-9:-]*\s*>/i', $input) === 1;
     }
 
     private function parseFragment(string $html): DOMElement

--- a/app/Services/DescriptionFormattingService.php
+++ b/app/Services/DescriptionFormattingService.php
@@ -42,6 +42,13 @@ class DescriptionFormattingService
         $sanitizedHtml = $this->sanitizeHtml($trimmedInput);
         $plainText = $this->plainTextFromHtml($sanitizedHtml);
 
+        if ($plainText === '') {
+            return [
+                'plainText' => '',
+                'landingPageHtml' => null,
+            ];
+        }
+
         return [
             'plainText' => $plainText,
             'landingPageHtml' => $sanitizedHtml !== '' ? $sanitizedHtml : null,

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -281,10 +281,11 @@ class EditorDataTransformer
             // @phpstan-ignore nullCoalesce.expr (defensive coding)
             $typeSlug = Str::kebab($description->descriptionType?->slug ?? 'other');
             $frontendType = self::DESCRIPTION_TYPE_MAP[$typeSlug] ?? 'Other';
+            $editableDescription = $description->landing_page_html ?? $description->value;
 
             return [
                 'type' => $frontendType,
-                'description' => $description->value,
+                'description' => $editableDescription,
                 'language' => $description->language,
             ];
         })->toArray();

--- a/app/Services/LandingPageResourceTransformer.php
+++ b/app/Services/LandingPageResourceTransformer.php
@@ -196,6 +196,7 @@ final class LandingPageResourceTransformer
                 return [
                     'id' => $desc->id,
                     'value' => $desc->value,
+                    'landing_page_html' => $desc->landing_page_html,
                     'description_type' => $descriptionType !== null ? $descriptionType->name : null,
                 ];
             })

--- a/app/Services/LandingPageResourceTransformer.php
+++ b/app/Services/LandingPageResourceTransformer.php
@@ -188,15 +188,17 @@ final class LandingPageResourceTransformer
             })
             ->all();
 
+        $descriptionFormattingService = new DescriptionFormattingService;
+
         $resourceData['descriptions'] = $resource->descriptions
-            ->map(static function (Description $desc): array {
+            ->map(function (Description $desc) use ($descriptionFormattingService): array {
                 /** @var DescriptionType|null $descriptionType */
                 $descriptionType = $desc->descriptionType;
 
                 return [
                     'id' => $desc->id,
                     'value' => $desc->value,
-                    'landing_page_html' => $desc->landing_page_html,
+                    'landing_page_html' => $this->sanitizeLandingPageHtml($desc->landing_page_html, $descriptionFormattingService),
                     'description_type' => $descriptionType !== null ? $descriptionType->name : null,
                 ];
             })
@@ -484,5 +486,16 @@ final class LandingPageResourceTransformer
         }
 
         return $resourceData;
+    }
+
+    private function sanitizeLandingPageHtml(?string $html, DescriptionFormattingService $descriptionFormattingService): ?string
+    {
+        if ($html === null || trim($html) === '') {
+            return null;
+        }
+
+        $sanitizedHtml = $descriptionFormattingService->sanitizeHtml($html);
+
+        return $sanitizedHtml !== '' ? $sanitizedHtml : null;
     }
 }

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -659,7 +659,7 @@ class ResourceStorageService
 
             $formattedDescription = $this->descriptionFormattingService->formatForStorage((string) ($description['description'] ?? ''));
 
-            if ($formattedDescription['plainText'] === '' && $formattedDescription['landingPageHtml'] === null) {
+            if ($formattedDescription['plainText'] === '') {
                 throw ValidationException::withMessages([
                     'descriptions' => ["Description type {$displayType} does not contain any supported content after HTML sanitization."],
                 ]);

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -36,6 +36,7 @@ class ResourceStorageService
     private ?array $contactPersonNames = null;
 
     public function __construct(
+        protected DescriptionFormattingService $descriptionFormattingService,
         protected PersonService $personService,
         protected InstitutionService $institutionService,
         protected AffiliationService $affiliationService,
@@ -642,13 +643,13 @@ class ResourceStorageService
 
         foreach ($descriptions as $description) {
             $rawType = (string) ($description['descriptionType'] ?? '');
+            $displayType = $rawType !== '' ? $rawType : 'empty';
             $descTypeKey = Str::kebab($rawType);
             $descTypeId = $descriptionTypeLookup[$descTypeKey] ?? null;
 
             if ($descTypeId === null) {
                 // Throw validation exception for unknown description type to prevent silent data loss.
                 // This matches the date type handling behavior for consistency.
-                $displayType = $rawType !== '' ? $rawType : 'empty';
                 Log::warning('Unknown description type slug: '.$displayType);
 
                 throw ValidationException::withMessages([
@@ -656,9 +657,18 @@ class ResourceStorageService
                 ]);
             }
 
+            $formattedDescription = $this->descriptionFormattingService->formatForStorage((string) ($description['description'] ?? ''));
+
+            if ($formattedDescription['plainText'] === '' && $formattedDescription['landingPageHtml'] === null) {
+                throw ValidationException::withMessages([
+                    'descriptions' => ["Description type {$displayType} does not contain any supported content after HTML sanitization."],
+                ]);
+            }
+
             $resource->descriptions()->create([
                 'description_type_id' => $descTypeId,
-                'value' => $description['description'],
+                'value' => $formattedDescription['plainText'],
+                'landing_page_html' => $formattedDescription['landingPageHtml'],
                 'language' => $description['language'] ?? null,
             ]);
         }

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -661,7 +661,7 @@ class ResourceStorageService
 
             if ($formattedDescription['plainText'] === '') {
                 throw ValidationException::withMessages([
-                    'descriptions' => ["Description type {$displayType} does not contain any supported content after HTML sanitization."],
+                    'descriptions' => ["Description type {$displayType} does not contain any content after trimming and sanitization."],
                 ]);
             }
 

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -368,6 +368,7 @@ entity "descriptions" as descriptions {
     * resource_id : BIGINT <<FK>>
     * description_type_id : BIGINT <<FK>>
     * value : TEXT
+    landing_page_html : LONGTEXT
     language : VARCHAR(10)
     created_at : TIMESTAMP
     updated_at : TIMESTAMP

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -329,6 +329,7 @@ erDiagram
         bigint resource_id FK
         bigint description_type_id FK
         text value
+        longtext landing_page_html
         varchar language
         timestamp created_at
         timestamp updated_at

--- a/database/factories/DescriptionFactory.php
+++ b/database/factories/DescriptionFactory.php
@@ -32,6 +32,7 @@ class DescriptionFactory extends Factory
         return [
             'resource_id' => Resource::factory(),
             'value' => fake()->paragraphs(2, true),
+            'landing_page_html' => null,
             'description_type_id' => $descriptionType->id,
             'language' => 'en',
         ];

--- a/database/migrations/2026_05_19_120000_add_landing_page_html_to_descriptions_table.php
+++ b/database/migrations/2026_05_19_120000_add_landing_page_html_to_descriptions_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('descriptions', function (Blueprint $table): void {
+            $table->longText('landing_page_html')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('descriptions', function (Blueprint $table): void {
+            $table->dropColumn('landing_page_html');
+        });
+    }
+};

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-19",
+        "date": "2026-05-20",
         "features": [
             {
                 "title": "Single DOI Import for GFZ Legacy Resources",
@@ -93,6 +93,10 @@
             }
         ],
         "improvements": [
+            {
+                "title": "HTML Formatting for Landing Page Descriptions",
+                "description": "Descriptions such as Abstract, Methods, Technical Information, Table of Contents, Series Information, and Other can now contain a limited HTML subset for landing-page display. ERNIE stores the formatted landing-page version separately from the canonical plain-text description, renders the sanitized markup on public and preview landing pages, and continues to use plain text only for DataCite registration, metadata updates, XML export, JSON export, JSON-LD export, and Schema.org output."
+            },
             {
                 "title": "Split Portal Keyword Filters into Free and Thesaurus Search",
                 "description": "The public Data Portal now separates plain free-form keywords from controlled thesaurus terms. Free keywords remain available as the compact searchable multi-select, while controlled vocabularies are filtered in a dedicated hierarchical tree per thesaurus. Unused vocabulary branches are hidden automatically, selecting a parent term includes matching descendants, and multiple thesaurus selections are combined consistently with AND logic."

--- a/resources/js/components/curation/fields/description-field.tsx
+++ b/resources/js/components/curation/fields/description-field.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { FieldValidationFeedback } from '@/components/ui/field-validation-feedback';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -150,11 +151,13 @@ export default function DescriptionField({
 
     return (
         <div className="space-y-4">
-            <div className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
-                Landing pages support a limited HTML subset in descriptions: &lt;p&gt;, &lt;br&gt;, &lt;strong&gt;, &lt;em&gt;, &lt;ul&gt;,
-                &lt;ol&gt;, &lt;li&gt;, &lt;a&gt;, &lt;sub&gt;, &lt;sup&gt;, and &lt;code&gt;. ERNIE stores a plain-text version for DataCite,
-                XML, JSON, and JSON-LD exports.
-            </div>
+            <Alert className="bg-muted/40">
+                <AlertDescription>
+                    Landing pages support a limited HTML subset in descriptions: &lt;p&gt;, &lt;br&gt;, &lt;strong&gt;, &lt;em&gt;,
+                    &lt;ul&gt;, &lt;ol&gt;, &lt;li&gt;, &lt;a&gt;, &lt;sub&gt;, &lt;sup&gt;, and &lt;code&gt;. ERNIE stores a plain-text version
+                    for DataCite, XML, JSON, and JSON-LD exports.
+                </AlertDescription>
+            </Alert>
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DescriptionType)}>
                 <TabsList className={`grid w-full`} style={{ gridTemplateColumns: `repeat(${visibleTypes.length}, minmax(0, 1fr))` }}>
                     {visibleTypes.map((type) => {

--- a/resources/js/components/curation/fields/description-field.tsx
+++ b/resources/js/components/curation/fields/description-field.tsx
@@ -40,7 +40,7 @@ const DESCRIPTION_TYPE_META: Record<
         placeholder: 'Enter a brief summary of the resource...',
         required: true,
         helpText:
-            'A brief description of the resource and the context in which the resource was created. Use "<br>" to indicate a line break for improved rendering of multiple paragraphs, but otherwise no HTML markup.',
+            'A brief description of the resource and the context in which the resource was created.',
     },
     Methods: {
         label: 'Methods',
@@ -58,7 +58,7 @@ const DESCRIPTION_TYPE_META: Record<
         label: 'Table of Contents',
         placeholder: 'Enter the table of contents...',
         helpText:
-            'A listing of the Table of Contents. Use "<br>" to indicate a line break for improved rendering of multiple paragraphs, but otherwise no HTML markup.',
+            'A listing of the Table of Contents.',
     },
     TechnicalInfo: {
         label: 'Technical Info',
@@ -150,6 +150,11 @@ export default function DescriptionField({
 
     return (
         <div className="space-y-4">
+            <div className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+                Landing pages support a limited HTML subset in descriptions: &lt;p&gt;, &lt;br&gt;, &lt;strong&gt;, &lt;em&gt;, &lt;ul&gt;,
+                &lt;ol&gt;, &lt;li&gt;, &lt;a&gt;, &lt;sub&gt;, &lt;sup&gt;, and &lt;code&gt;. ERNIE stores a plain-text version for DataCite,
+                XML, JSON, and JSON-LD exports.
+            </div>
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DescriptionType)}>
                 <TabsList className={`grid w-full`} style={{ gridTemplateColumns: `repeat(${visibleTypes.length}, minmax(0, 1fr))` }}>
                     {visibleTypes.map((type) => {

--- a/resources/js/pages/LandingPages/components/DescriptionSection.tsx
+++ b/resources/js/pages/LandingPages/components/DescriptionSection.tsx
@@ -28,15 +28,30 @@ export function DescriptionSection({ descriptions, sectionKey }: DescriptionSect
                 {heading}
             </h3>
             <div className="prose prose-sm max-w-none space-y-4 text-gray-700 dark:prose-invert dark:text-gray-300">
-                {matchingDescriptions.map((description, index) => (
-                    <p
-                        key={description.id}
-                        className="mt-0 whitespace-pre-wrap"
-                        data-testid={index === 0 ? `${sectionKey}-text` : `${sectionKey}-text-${index + 1}`}
-                    >
-                        {description.value}
-                    </p>
-                ))}
+                {matchingDescriptions.map((description, index) => {
+                    const testId = index === 0 ? `${sectionKey}-text` : `${sectionKey}-text-${index + 1}`;
+
+                    if (description.landing_page_html) {
+                        return (
+                            <div
+                                key={description.id}
+                                className="mt-0 [&_a]:break-words [&_a]:underline [&_ol]:pl-5 [&_ol]:marker:font-medium [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_ul]:pl-5 [&_ul]:marker:font-medium"
+                                data-testid={testId}
+                                dangerouslySetInnerHTML={{ __html: description.landing_page_html }}
+                            />
+                        );
+                    }
+
+                    return (
+                        <p
+                            key={description.id}
+                            className="mt-0 whitespace-pre-wrap"
+                            data-testid={testId}
+                        >
+                            {description.value}
+                        </p>
+                    );
+                })}
             </div>
         </section>
     );

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -912,6 +912,16 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                         <h3 className="mt-8">Descriptions</h3>
                         <p>Provide detailed information about your dataset with different description types:</p>
 
+                        <div className="mt-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950">
+                            <p className="text-sm text-blue-900 dark:text-blue-100">
+                                <strong>Landing Page Formatting:</strong> Description fields support a limited HTML subset for landing-page display
+                                only: <code>&lt;p&gt;</code>, <code>&lt;br&gt;</code>, <code>&lt;strong&gt;</code>, <code>&lt;em&gt;</code>,{' '}
+                                <code>&lt;ul&gt;</code>, <code>&lt;ol&gt;</code>, <code>&lt;li&gt;</code>, <code>&lt;a&gt;</code>, <code>&lt;sub&gt;</code>,{' '}
+                                <code>&lt;sup&gt;</code>, and <code>&lt;code&gt;</code>. ERNIE stores and shows this formatting on landing pages, but
+                                all exports and DataCite submissions remain plain text.
+                            </p>
+                        </div>
+
                         <h4>Description Types</h4>
                         <ul className="list-inside list-disc space-y-1">
                             <li>

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -293,6 +293,7 @@ export interface LandingPageTitle {
 export interface LandingPageDescription {
     id: number;
     value: string;
+    landing_page_html?: string | null;
     description_type: string | null;
 }
 

--- a/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
@@ -313,6 +313,27 @@ describe('DataCiteJsonExporter - Descriptions', function () {
 
         expect($descriptions[0]['descriptionType'])->toBeIn(['Methods', 'methods']);
     });
+
+    test('exports plain text descriptions even when landing page html exists', function () {
+        $resource = Resource::factory()->create();
+        $abstractType = DescriptionType::firstOrCreate(
+            ['slug' => 'Abstract'],
+            ['name' => 'Abstract']
+        );
+
+        Description::create([
+            'resource_id' => $resource->id,
+            'value' => 'Plain export description.',
+            'landing_page_html' => '<p>Plain <strong>export</strong> description.</p>',
+            'description_type_id' => $abstractType->id,
+        ]);
+
+        $result = $this->exporter->export($resource);
+        $descriptions = $result['data']['attributes']['descriptions'];
+
+        expect($descriptions[0]['description'])->toBe('Plain export description.')
+            ->and($descriptions[0]['description'])->not->toContain('<strong>');
+    });
 });
 
 describe('DataCiteJsonExporter - Resource Types', function () {

--- a/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
@@ -422,6 +422,27 @@ describe('DataCiteXmlExporter - Descriptions', function () {
         expect($xml)->toContain('descriptionType="Methods"')
             ->and($xml)->toContain('Methodology used in data collection.</description>');
     });
+
+    test('exports plain text descriptions when landing page html exists', function () {
+        $resource = Resource::factory()->create();
+
+        $abstractType = DescriptionType::firstOrCreate(
+            ['slug' => 'Abstract'],
+            ['name' => 'Abstract', 'slug' => 'Abstract', 'is_active' => true]
+        );
+
+        Description::create([
+            'resource_id' => $resource->id,
+            'value' => 'Plain XML description.',
+            'landing_page_html' => '<p>Plain <strong>XML</strong> description.</p>',
+            'description_type_id' => $abstractType->id,
+        ]);
+
+        $xml = $this->exporter->export($resource);
+
+        expect($xml)->toContain('Plain XML description.</description>')
+            ->and($xml)->not->toContain('<strong>XML</strong>');
+    });
 });
 
 describe('DataCiteXmlExporter - Subjects', function () {

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -687,6 +687,22 @@ describe('transformDescriptions', function (): void {
         expect($result[0]['language'])->toBe('fr')
             ->and($result[1]['language'])->toBeNull();
     });
+
+    it('prefers landing page html for editor round-trips when available', function (): void {
+        $abstractType = DescriptionType::where('slug', 'Abstract')->first();
+
+        Description::create([
+            'resource_id' => $this->resource->id,
+            'description_type_id' => $abstractType->id,
+            'value' => 'Plain text fallback',
+            'landing_page_html' => '<p>Plain text <strong>with formatting</strong></p>',
+        ]);
+        $this->resource->load('descriptions.descriptionType');
+
+        $result = $this->transformer->transformDescriptions($this->resource);
+
+        expect($result[0]['description'])->toBe('<p>Plain text <strong>with formatting</strong></p>');
+    });
 });
 
 // =========================================================================

--- a/tests/pest/Feature/Services/ResourceStorageServiceDescriptionHtmlTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceDescriptionHtmlTest.php
@@ -7,6 +7,7 @@ use App\Models\Right;
 use App\Models\User;
 use App\Services\ResourceStorageService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
 uses(RefreshDatabase::class);
@@ -92,4 +93,21 @@ describe('ResourceStorageService – Description HTML handling', function () {
 
         (void) $this->service->store($data, $this->user->id);
     })->throws(ValidationException::class);
+
+    it('returns a neutral validation message for plain whitespace descriptions', function (): void {
+        $data = ($this->buildResourceData)([
+            [
+                'descriptionType' => 'other',
+                'description' => '   ',
+            ],
+        ]);
+
+        try {
+            (void) $this->service->store($data, $this->user->id);
+            $this->fail('Expected validation exception was not thrown.');
+        } catch (ValidationException $exception) {
+            expect(Arr::first($exception->errors()['descriptions'] ?? []))
+                ->toBe('Description type other does not contain any content after trimming and sanitization.');
+        }
+    });
 });

--- a/tests/pest/Feature/Services/ResourceStorageServiceDescriptionHtmlTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceDescriptionHtmlTest.php
@@ -81,4 +81,15 @@ describe('ResourceStorageService – Description HTML handling', function () {
 
         (void) $this->service->store($data, $this->user->id);
     })->throws(ValidationException::class);
+
+    it('rejects descriptions that only contain formatting wrappers after sanitization', function (): void {
+        $data = ($this->buildResourceData)([
+            [
+                'descriptionType' => 'other',
+                'description' => '<p><br></p>',
+            ],
+        ]);
+
+        (void) $this->service->store($data, $this->user->id);
+    })->throws(ValidationException::class);
 });

--- a/tests/pest/Feature/Services/ResourceStorageServiceDescriptionHtmlTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceDescriptionHtmlTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ResourceType;
+use App\Models\Right;
+use App\Models\User;
+use App\Services\ResourceStorageService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+describe('ResourceStorageService – Description HTML handling', function () {
+    beforeEach(function (): void {
+        $this->service = app(ResourceStorageService::class);
+        $this->user = User::factory()->create();
+
+        $this->seed(\Database\Seeders\TitleTypeSeeder::class);
+        $this->seed(\Database\Seeders\ResourceTypeSeeder::class);
+        $this->seed(\Database\Seeders\DescriptionTypeSeeder::class);
+        Right::create(['identifier' => 'CC-BY-4.0', 'name' => 'Creative Commons Attribution 4.0']);
+
+        $this->resourceType = ResourceType::firstOrFail();
+        $this->buildResourceData = function (array $descriptions): array {
+            return [
+                'resourceId' => null,
+                'year' => 2024,
+                'resourceType' => $this->resourceType->id,
+                'titles' => [
+                    ['title' => 'HTML Description Resource', 'titleType' => 'MainTitle'],
+                ],
+                'licenses' => ['CC-BY-4.0'],
+                'authors' => [
+                    ['type' => 'person', 'firstName' => 'Ada', 'lastName' => 'Lovelace', 'position' => 0],
+                ],
+                'descriptions' => $descriptions,
+            ];
+        };
+    });
+
+    it('stores sanitized landing page html separately from plain text', function (): void {
+        $data = ($this->buildResourceData)([
+            [
+                'descriptionType' => 'abstract',
+                'description' => '<p>Abstract with <strong>formatting</strong> and <a href="https://example.org/file">download link</a>.</p>',
+            ],
+        ]);
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $description = $resource->descriptions()->firstOrFail();
+
+        expect($description->landing_page_html)->toBe('<p>Abstract with <strong>formatting</strong> and <a href="https://example.org/file">download link</a>.</p>')
+            ->and($description->value)->toBe('Abstract with formatting and download link (https://example.org/file).');
+    });
+
+    it('keeps plain text descriptions without creating landing page html', function (): void {
+        $data = ($this->buildResourceData)([
+            [
+                'descriptionType' => 'methods',
+                'description' => 'Plain methods text only.',
+            ],
+        ]);
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $description = $resource->descriptions()->firstOrFail();
+
+        expect($description->landing_page_html)->toBeNull()
+            ->and($description->value)->toBe('Plain methods text only.');
+    });
+
+    it('rejects descriptions that become empty after sanitization', function (): void {
+        $data = ($this->buildResourceData)([
+            [
+                'descriptionType' => 'other',
+                'description' => '<script>alert("x")</script>',
+            ],
+        ]);
+
+        (void) $this->service->store($data, $this->user->id);
+    })->throws(ValidationException::class);
+});

--- a/tests/pest/Unit/Models/DescriptionTest.php
+++ b/tests/pest/Unit/Models/DescriptionTest.php
@@ -13,6 +13,7 @@ describe('fillable', function () {
         expect($model->getFillable())->toBe([
             'resource_id',
             'value',
+            'landing_page_html',
             'description_type_id',
             'language',
         ]);

--- a/tests/pest/Unit/Services/DataCiteLinkedDataExporterTest.php
+++ b/tests/pest/Unit/Services/DataCiteLinkedDataExporterTest.php
@@ -228,6 +228,23 @@ describe('descriptions', function () {
         expect($desc)->toHaveKey('attrs');
         expect($desc['attrs']['descriptionType'])->toBe('Abstract');
     });
+
+    it('keeps linked data descriptions plain text when landing page html exists', function () {
+        $resource = createResourceWithTitle();
+
+        $abstractType = DescriptionType::where('slug', 'Abstract')->first();
+        $resource->descriptions()->create([
+            'value' => 'Plain JSON-LD description',
+            'landing_page_html' => '<p>Plain <strong>JSON-LD</strong> description</p>',
+            'description_type_id' => $abstractType?->id,
+        ]);
+
+        $result = $this->exporter->export($resource->fresh());
+        $desc = $result['descriptions']['description'];
+
+        expect($desc['value'])->toBe('Plain JSON-LD description')
+            ->and($desc['value'])->not->toContain('<strong>');
+    });
 });
 
 describe('geoLocations', function () {

--- a/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
+++ b/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
@@ -51,3 +51,10 @@ it('keeps literal angle-bracketed plain text untouched when no supported html ta
     expect($result['landingPageHtml'])->toBeNull()
         ->and($result['plainText'])->toBe('Use placeholder <x> in the formula and keep it literal.');
 });
+
+it('sanitizes unsupported html wrappers into plain text content', function (): void {
+    $result = $this->service->formatForStorage('<span>Inline <mark>formatting</mark></span>');
+
+    expect($result['landingPageHtml'])->toBe('Inline formatting')
+        ->and($result['plainText'])->toBe('Inline formatting');
+});

--- a/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
+++ b/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DescriptionFormattingService;
+
+covers(DescriptionFormattingService::class);
+
+beforeEach(function (): void {
+    $this->service = new DescriptionFormattingService;
+});
+
+it('keeps plain text descriptions unchanged', function (): void {
+    $result = $this->service->formatForStorage("Plain text\nwith line breaks");
+
+    expect($result['plainText'])->toBe("Plain text\nwith line breaks")
+        ->and($result['landingPageHtml'])->toBeNull();
+});
+
+it('sanitizes allowed html and strips unsupported markup', function (): void {
+    $result = $this->service->formatForStorage('<p>Hello <strong>world</strong><script>alert(1)</script> <a href="javascript:alert(1)">bad link</a> <a href="https://example.org/docs">Documentation</a></p>');
+
+    expect($result['landingPageHtml'])->toBe('<p>Hello <strong>world</strong> bad link <a href="https://example.org/docs">Documentation</a></p>')
+        ->and($result['plainText'])->toBe('Hello world bad link Documentation (https://example.org/docs)');
+});
+
+it('converts formatted lists into readable plain text for exports', function (): void {
+    $result = $this->service->formatForStorage('<p>Overview</p><ul><li>First item</li><li>Second item</li></ul>');
+
+    expect($result['landingPageHtml'])->toBe('<p>Overview</p><ul><li>First item</li><li>Second item</li></ul>')
+        ->and($result['plainText'])->toBe("Overview\n\n- First item\n- Second item");
+});
+
+it('drops unsupported links from landing page html while preserving link text', function (): void {
+    $result = $this->service->formatForStorage('<p><a href="ftp://example.org/file">FTP resource</a></p>');
+
+    expect($result['landingPageHtml'])->toBe('<p>FTP resource</p>')
+        ->and($result['plainText'])->toBe('FTP resource');
+});

--- a/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
+++ b/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
@@ -44,3 +44,10 @@ it('treats formatting-only html as empty content', function (): void {
     expect($result['landingPageHtml'])->toBeNull()
         ->and($result['plainText'])->toBe('');
 });
+
+it('keeps literal angle-bracketed plain text untouched when no supported html tag exists', function (): void {
+    $result = $this->service->formatForStorage('Use placeholder <x> in the formula and keep it literal.');
+
+    expect($result['landingPageHtml'])->toBeNull()
+        ->and($result['plainText'])->toBe('Use placeholder <x> in the formula and keep it literal.');
+});

--- a/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
+++ b/tests/pest/Unit/Services/DescriptionFormattingServiceTest.php
@@ -37,3 +37,10 @@ it('drops unsupported links from landing page html while preserving link text', 
     expect($result['landingPageHtml'])->toBe('<p>FTP resource</p>')
         ->and($result['plainText'])->toBe('FTP resource');
 });
+
+it('treats formatting-only html as empty content', function (): void {
+    $result = $this->service->formatForStorage('<p><br></p>');
+
+    expect($result['landingPageHtml'])->toBeNull()
+        ->and($result['plainText'])->toBe('');
+});

--- a/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
+++ b/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
@@ -201,6 +201,45 @@ test('transforms landing page html alongside plain text descriptions', function 
     ]);
 });
 
+test('sanitizes landing page html before exposing it to the client', function () {
+    $transformer = new LandingPageResourceTransformer;
+
+    $resource = new Resource;
+
+    $descriptionType = new DescriptionType;
+    $descriptionType->forceFill([
+        'id' => 1,
+        'name' => 'Abstract',
+        'slug' => 'Abstract',
+    ]);
+
+    $description = new Description;
+    $description->forceFill([
+        'id' => 1,
+        'value' => 'Safe abstract text',
+        'landing_page_html' => '<script>alert(1)</script><p>Safe <strong>abstract</strong></p><span> extra</span>',
+    ]);
+    $description->setRelation('descriptionType', $descriptionType);
+
+    $resource->setRelation('titles', new EloquentCollection);
+    $resource->setRelation('creators', new EloquentCollection);
+    $resource->setRelation('contributors', new EloquentCollection);
+    $resource->setRelation('relatedIdentifiers', new EloquentCollection);
+    $resource->setRelation('descriptions', new EloquentCollection([$description]));
+    $resource->setRelation('fundingReferences', new EloquentCollection);
+    $resource->setRelation('subjects', new EloquentCollection);
+    $resource->setRelation('geoLocations', new EloquentCollection);
+    $resource->setRelation('rights', new EloquentCollection);
+
+    $data = $transformer->transform($resource);
+
+    expect($data['descriptions'][0])->toMatchArray([
+        'value' => 'Safe abstract text',
+        'landing_page_html' => '<p>Safe <strong>abstract</strong></p> extra',
+        'description_type' => 'Abstract',
+    ]);
+});
+
 test('transforms related identifier slugs and citation label for landing pages', function () {
     $transformer = new LandingPageResourceTransformer;
 

--- a/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
+++ b/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\ContributorType;
 use App\Models\DateType;
 use App\Models\Description;
+use App\Models\DescriptionType;
 use App\Models\IgsnClassification;
 use App\Models\IgsnMetadata;
 use App\Models\LandingPage;
@@ -106,6 +107,7 @@ test('transformation is null-safe for optional relationships', function () {
     $description->forceFill([
         'id' => 1,
         'value' => 'Some description',
+        'landing_page_html' => '<p>Some <strong>description</strong></p>',
     ]);
     $description->setRelation('descriptionType', null);
 
@@ -151,12 +153,52 @@ test('transformation is null-safe for optional relationships', function () {
     expect($data['descriptions'][0])
         ->toMatchArray([
             'value' => 'Some description',
+            'landing_page_html' => '<p>Some <strong>description</strong></p>',
             'description_type' => null,
         ]);
 
     expect($data['contributors'][0])
         ->toHaveKey('contributor_types')
         ->and($data['contributors'][0]['contributor_types'])->toBeArray();
+});
+
+test('transforms landing page html alongside plain text descriptions', function () {
+    $transformer = new LandingPageResourceTransformer;
+
+    $resource = new Resource;
+
+    $descriptionType = new DescriptionType;
+    $descriptionType->forceFill([
+        'id' => 1,
+        'name' => 'Abstract',
+        'slug' => 'Abstract',
+    ]);
+
+    $description = new Description;
+    $description->forceFill([
+        'id' => 1,
+        'value' => 'Formatted abstract',
+        'landing_page_html' => '<p>Formatted <strong>abstract</strong></p>',
+    ]);
+    $description->setRelation('descriptionType', $descriptionType);
+
+    $resource->setRelation('titles', new EloquentCollection);
+    $resource->setRelation('creators', new EloquentCollection);
+    $resource->setRelation('contributors', new EloquentCollection);
+    $resource->setRelation('relatedIdentifiers', new EloquentCollection);
+    $resource->setRelation('descriptions', new EloquentCollection([$description]));
+    $resource->setRelation('fundingReferences', new EloquentCollection);
+    $resource->setRelation('subjects', new EloquentCollection);
+    $resource->setRelation('geoLocations', new EloquentCollection);
+    $resource->setRelation('rights', new EloquentCollection);
+
+    $data = $transformer->transform($resource);
+
+    expect($data['descriptions'][0])->toMatchArray([
+        'value' => 'Formatted abstract',
+        'landing_page_html' => '<p>Formatted <strong>abstract</strong></p>',
+        'description_type' => 'Abstract',
+    ]);
 });
 
 test('transforms related identifier slugs and citation label for landing pages', function () {

--- a/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
+++ b/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
@@ -210,6 +210,22 @@ describe('descriptions', function () {
 
         expect($result)->not->toHaveKey('description');
     });
+
+    it('keeps schema org description plain text when landing page html exists', function () {
+        $resource = createSchemaOrgResource();
+
+        $abstractType = DescriptionType::where('slug', 'Abstract')->first();
+        $resource->descriptions()->create([
+            'value' => 'Schema.org plain text abstract',
+            'landing_page_html' => '<p>Schema.org <strong>formatted</strong> abstract</p>',
+            'description_type_id' => $abstractType?->id,
+        ]);
+
+        $result = $this->exporter->export($resource->fresh());
+
+        expect($result['description'])->toBe('Schema.org plain text abstract')
+            ->and($result['description'])->not->toContain('<strong>');
+    });
 });
 
 describe('dates', function () {

--- a/tests/vitest/components/curation/fields/__tests__/description-field.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/description-field.test.tsx
@@ -48,6 +48,15 @@ describe('DescriptionField', () => {
         expect(abstractTab).toHaveAttribute('aria-selected', 'true');
     });
 
+    it('renders the formatting notice as an alert', () => {
+        render(<DescriptionField {...defaultProps} />);
+
+        const notice = screen.getByRole('alert');
+
+        expect(notice).toHaveTextContent(/Landing pages support a limited HTML subset in descriptions/i);
+        expect(notice).toHaveTextContent(/DataCite, XML, JSON, and JSON-LD exports/i);
+    });
+
     it('renders Abstract textarea with placeholder', () => {
         render(<DescriptionField {...defaultProps} />);
 

--- a/tests/vitest/pages/LandingPages/__tests__/DescriptionSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/DescriptionSection.test.tsx
@@ -47,4 +47,23 @@ describe('DescriptionSection', () => {
         render(<DescriptionSection descriptions={descriptions} sectionKey="abstract" />);
         expect(screen.getByTestId('abstract-text')).toBeInTheDocument();
     });
+
+    it('renders stored landing page html instead of plain text fallback', () => {
+        const descriptions = [
+            {
+                id: 1,
+                value: 'Plain text fallback',
+                landing_page_html: '<p>Formatted <strong>abstract</strong> with <a href="https://example.org">link</a>.</p>',
+                description_type: 'Abstract',
+            },
+        ];
+
+        render(<DescriptionSection descriptions={descriptions} sectionKey="abstract" />);
+
+        const block = screen.getByTestId('abstract-text');
+        expect(block.querySelector('strong')).toHaveTextContent('abstract');
+        expect(block.querySelector('a')).toHaveAttribute('href', 'https://example.org');
+        expect(block).toHaveTextContent('Formatted abstract with link.');
+        expect(block).not.toHaveTextContent('Plain text fallback');
+    });
 });


### PR DESCRIPTION
This pull request introduces support for storing and displaying HTML-formatted descriptions for resources, such as Abstracts and Methods, while maintaining plain-text versions for metadata exports and registrations. It adds a new `landing_page_html` field to the `descriptions` table, implements robust HTML sanitization and formatting logic, and updates both backend and frontend code to handle and safely render the formatted descriptions. The change ensures that only a safe subset of HTML is allowed and that plain text remains the canonical source for external systems.

**Database and Model Changes:**

* Added a nullable `landing_page_html` column to the `descriptions` table via a new migration, and updated the Eloquent model and ER diagrams to reflect this addition. [[1]](diffhunk://#diff-2c818ae0be49793bd24a7d0d2ce6b6c17f87464d4add390e5d698df14aaf1f72R1-R24) [[2]](diffhunk://#diff-93c5ccc462193ba9c74a8d6a5ff8d2d64ebd0b9aa011708531c3c55d024c8ac1R20) [[3]](diffhunk://#diff-93c5ccc462193ba9c74a8d6a5ff8d2d64ebd0b9aa011708531c3c55d024c8ac1L29-R30) [[4]](diffhunk://#diff-a8d0111421d72b79d6b1e81ad37d41a69ce2f2f1b765ba6e5def7d7311d72814R371) [[5]](diffhunk://#diff-e0196f1170dc7341f74a244f8ee5ad1128d2350be6c80928486fe029eb3867e3R332) [[6]](diffhunk://#diff-d5144dcfd5e30071e75c536f570c5525fe25129ad37e53830a6a283c80cd7642R35)

**Backend Logic and Data Handling:**

* Introduced `DescriptionFormattingService` to sanitize, validate, and extract both plain-text and safe HTML from user-provided description content, ensuring only allowed tags are stored and that dangerous content is removed.
* Updated `ResourceStorageService` to use the new formatting service when storing descriptions, saving both plain text and sanitized HTML, and enforcing validation that non-empty content remains after sanitization. [[1]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16R39) [[2]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16R646-R671)
* Modified resource transformers to include and sanitize the `landing_page_html` field when preparing data for landing page display. [[1]](diffhunk://#diff-152895a4dc200dc6ddfbb901961d748ac9a353889ad198f1008fd5813cc97137R191-R201) [[2]](diffhunk://#diff-152895a4dc200dc6ddfbb901961d748ac9a353889ad198f1008fd5813cc97137R490-R500)

**Frontend and User Experience:**

* Updated frontend help texts for description fields to remove instructions about manually entering `<br>` tags, reflecting the new support for limited HTML formatting. [[1]](diffhunk://#diff-ec3b78f26e5b9b518e1929f699def3b4f5e49d02b31856e8bb3f42a3a226dfefL43-R44) [[2]](diffhunk://#diff-ec3b78f26e5b9b518e1929f699def3b4f5e49d02b31856e8bb3f42a3a226dfefL61-R62)
* Imported UI components to support improved feedback and display for HTML-formatted descriptions.

**Documentation and Changelog:**

* Added a changelog entry describing the new HTML formatting capability for landing page descriptions, clarifying its scope and behavior. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR96-R99) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4)

**Infrastructure:**

* Updated the PHP base image hash in both `Dockerfile` and `Dockerfile.dev` for consistency and reproducibility. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL11-R11)