### PR TITLE
Feature: Order and highlight landing page templates

### DIFF
--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -30,11 +30,9 @@ class LandingPageTemplateController extends Controller
         LandingPageTemplate::ensureSystemTemplatesExist();
 
         $templates = LandingPageTemplate::query()
+            ->orderedForDisplay()
             ->with('creator:id,name')
             ->withCount('landingPages')
-            ->orderBy('template_type')
-            ->orderByDesc('is_default')
-            ->orderBy('name')
             ->get();
 
         return Inertia::render('landing-page-templates', [
@@ -236,9 +234,7 @@ class LandingPageTemplateController extends Controller
         LandingPageTemplate::ensureSystemTemplatesExist();
 
         $templates = LandingPageTemplate::query()
-            ->orderBy('template_type')
-            ->orderByDesc('is_default')
-            ->orderBy('name')
+            ->orderedForDisplay()
             ->get([
                 'id',
                 'name',

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -248,6 +248,26 @@ class LandingPageTemplate extends Model
     }
 
     /**
+     * Apply the canonical display ordering for template listings.
+     *
+     * Defaults stay on top, resource templates come before IGSN templates,
+     * and names are sorted alphabetically within each bucket.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeOrderedForDisplay(Builder $query): Builder
+    {
+        return $query
+            ->orderByDesc('is_default')
+            ->orderByRaw(
+                'case template_type when ? then 0 when ? then 1 else 2 end',
+                [self::TEMPLATE_TYPE_RESOURCE, self::TEMPLATE_TYPE_IGSN],
+            )
+            ->orderBy('name');
+    }
+
+    /**
      * Validate that a section order array contains exactly the valid keys.
      *
      * @param  array<int, string>  $order

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -94,6 +94,10 @@
         ],
         "improvements": [
             {
+                "title": "Clearer Landing Page Template Ordering",
+                "description": "Landing Page Template Management now keeps the built-in Resource and IGSN defaults pinned at the top of the template list, with cloned templates grouped below them by type and sorted alphabetically within each group. Default templates are also shown with a subtle muted background so administrators and group leaders can distinguish the immutable built-ins from editable clones more quickly."
+            },
+            {
                 "title": "HTML Formatting for Landing Page Descriptions",
                 "description": "Descriptions such as Abstract, Methods, Technical Information, Table of Contents, Series Information, and Other can now contain a limited HTML subset for landing-page display. ERNIE stores the formatted landing-page version separately from the canonical plain-text description, renders the sanitized markup on public and preview landing pages, and continues to use plain text only for DataCite registration, metadata updates, XML export, JSON export, JSON-LD export, and Schema.org output."
             },

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1482,7 +1482,8 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                         <p>
                             Admins and Group Leaders can create custom landing page templates to control the layout and branding of landing pages.
                             Custom templates are cloned from the immutable <strong>Default GFZ</strong> template and allow customization of section
-                            order and header logo.
+                            order and header logo. In template management, the built-in Resource and IGSN defaults stay pinned at the top and are
+                            subtly highlighted so cloned templates are easier to distinguish.
                         </p>
 
                         <WorkflowSteps>

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -435,7 +435,7 @@ export default function LandingPageTemplatesPage() {
                 {/* Template Cards */}
                 <div className="grid gap-4 md:grid-cols-2">
                     {templates.map((tmpl) => (
-                        <Card key={tmpl.id} className={tmpl.is_default ? 'border-primary/30' : ''}>
+                        <Card key={tmpl.id} className={tmpl.is_default ? 'border-primary/30 bg-muted/20' : ''}>
                             <CardHeader className="pb-3">
                                 <div className="flex items-start justify-between">
                                     <div className="flex items-center gap-2">

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -116,6 +116,42 @@ describe('Index', function (): void {
                 ->has('templates', 4) // resource default + IGSN default + 2 custom
             );
     });
+
+    it('orders defaults first and keeps resource templates ahead of igsn templates', function (): void {
+        LandingPageTemplate::factory()->create([
+            'name' => 'Zulu Resource Clone',
+            'template_type' => LandingPageTemplate::TEMPLATE_TYPE_RESOURCE,
+            'created_by' => $this->admin->id,
+        ]);
+
+        LandingPageTemplate::factory()->create([
+            'name' => 'Alpha Resource Clone',
+            'template_type' => LandingPageTemplate::TEMPLATE_TYPE_RESOURCE,
+            'created_by' => $this->admin->id,
+        ]);
+
+        LandingPageTemplate::factory()->igsn()->create([
+            'name' => 'Zulu IGSN Clone',
+            'created_by' => $this->admin->id,
+        ]);
+
+        LandingPageTemplate::factory()->igsn()->create([
+            'name' => 'Alpha IGSN Clone',
+            'created_by' => $this->admin->id,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get('/landing-pages')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('templates.0.name', LandingPageTemplate::DEFAULT_TEMPLATE_NAME)
+                ->where('templates.1.name', LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_NAME)
+                ->where('templates.2.name', 'Alpha Resource Clone')
+                ->where('templates.3.name', 'Zulu Resource Clone')
+                ->where('templates.4.name', 'Alpha IGSN Clone')
+                ->where('templates.5.name', 'Zulu IGSN Clone')
+            );
+    });
 });
 
 // ─── Clone (Store) ───────────────────────────────────────────────────────────
@@ -543,6 +579,45 @@ describe('API List', function (): void {
                         'left_column_order',
                     ],
                 ],
+            ]);
+    });
+
+    it('returns defaults first and sorts resource templates ahead of igsn templates', function (): void {
+        LandingPageTemplate::factory()->create([
+            'name' => 'Zulu Resource Clone',
+            'template_type' => LandingPageTemplate::TEMPLATE_TYPE_RESOURCE,
+            'created_by' => $this->admin->id,
+        ]);
+
+        LandingPageTemplate::factory()->create([
+            'name' => 'Alpha Resource Clone',
+            'template_type' => LandingPageTemplate::TEMPLATE_TYPE_RESOURCE,
+            'created_by' => $this->admin->id,
+        ]);
+
+        LandingPageTemplate::factory()->igsn()->create([
+            'name' => 'Zulu IGSN Clone',
+            'created_by' => $this->admin->id,
+        ]);
+
+        LandingPageTemplate::factory()->igsn()->create([
+            'name' => 'Alpha IGSN Clone',
+            'created_by' => $this->admin->id,
+        ]);
+
+        $response = $this->actingAs($this->curator)
+            ->getJson('/api/landing-page-templates');
+
+        $response->assertOk();
+
+        expect(array_column($response->json('templates'), 'name'))
+            ->toBe([
+                LandingPageTemplate::DEFAULT_TEMPLATE_NAME,
+                LandingPageTemplate::IGSN_DEFAULT_TEMPLATE_NAME,
+                'Alpha Resource Clone',
+                'Zulu Resource Clone',
+                'Alpha IGSN Clone',
+                'Zulu IGSN Clone',
             ]);
     });
 

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -246,6 +246,16 @@ describe('LandingPageTemplatesPage', () => {
             expect(screen.getByText('Default')).toBeInTheDocument();
         });
 
+        it('uses a subtle muted background for default template cards', () => {
+            render(<LandingPageTemplatesPage />);
+
+            const defaultCard = screen.getByText('Default GFZ Data Services').closest('[data-slot="card"]');
+            const customCard = screen.getByText('Geophysics Template').closest('[data-slot="card"]');
+
+            expect(defaultCard).toHaveClass('bg-muted/20');
+            expect(customCard).not.toHaveClass('bg-muted/20');
+        });
+
         it('shows usage count badges', () => {
             render(<LandingPageTemplatesPage />);
             expect(screen.getByText('5 pages')).toBeInTheDocument();


### PR DESCRIPTION
This pull request improves the ordering and visual distinction of landing page templates in both the UI and API, making it easier for administrators and group leaders to identify and work with default and custom templates. It introduces a new canonical ordering for template listings, ensures consistent display across endpoints, adds UI highlighting for default templates, updates documentation, and expands test coverage to verify these behaviors.

**Landing Page Template Ordering Improvements:**

* Added a new `orderedForDisplay` query scope in `LandingPageTemplate` to ensure default templates appear first, resource templates are listed before IGSN templates, and names are sorted alphabetically within each group. This replaces previous manual ordering logic in controllers.
* Updated both the `index` and `list` methods in `LandingPageTemplateController` to use the new `orderedForDisplay` scope, ensuring consistent ordering in both the web UI and API responses. [[1]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR33-L37) [[2]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dL239-R237)

**User Interface Enhancements:**

* Modified the landing page templates UI so that default template cards have a subtle muted background, making them visually distinct from custom templates.
* Updated documentation and help text to clarify that built-in Resource and IGSN templates are pinned at the top and highlighted for easy identification.

**Test Coverage:**

* Added new feature and API tests to verify that default templates are listed first, resource templates are sorted ahead of IGSN templates, and alphabetical ordering is preserved within each group. [[1]](diffhunk://#diff-b424d0f3cf7da00afcdcffab1163f0cce95d7893fed751dc7389f162c9ed0005R119-R154) [[2]](diffhunk://#diff-b424d0f3cf7da00afcdcffab1163f0cce95d7893fed751dc7389f162c9ed0005R585-R623)
* Added a UI test to confirm that default template cards have the expected muted background class.

**Changelog:**

* Added a changelog entry describing the clearer ordering and visual distinction for landing page templates.