### PR TITLE
Fix: Custom Header Images are not rendered

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,3 +96,6 @@ WORKDIR /var/www/html
 COPY docker/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=app /var/www/html/public /var/www/html/public
 COPY --from=app /var/www/html/storage /var/www/html/storage
+RUN mkdir -p /var/www/html/public \
+    && rm -rf /var/www/html/public/storage \
+    && ln -s ../storage/app/public /var/www/html/public/storage

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -220,6 +220,10 @@
         ],
         "fixes": [
             {
+                "title": "Custom Landing Page Template Logos Render",
+                "description": "Uploading a header logo to a cloned landing page template now works reliably beyond local development. The deployment images for Stage and Production now preserve Laravel's `/storage/...` asset path inside the webserver container, so uploaded custom logos appear again in template management cards as well as on preview and published landing pages that use the cloned template."
+            },
+            {
                 "title": "Landing Pages Keep All Supported Controlled Keyword Schemes Visible",
                 "description": "GFZ landing pages now render Analytical Methods and EuroSciVoc keywords alongside the existing GCMD, MSL, GEMET, and Chronostrat thesauri. Stored scheme aliases are normalized consistently in the backend payload and frontend grouping logic so controlled keyword badges and portal search links no longer disappear when legacy scheme names are present."
             },

--- a/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
+++ b/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\Yaml\Yaml;
+
 describe('landing page template logo deployment regression guard', function () {
     $deploymentFileContents = static function (string $relativePath): string {
         $contents = file_get_contents(base_path($relativePath));
@@ -11,6 +13,50 @@ describe('landing page template logo deployment regression guard', function () {
         }
 
         return $contents;
+    };
+
+    $parsedCompose = static function (string $relativePath) use ($deploymentFileContents): array {
+        $parsed = Yaml::parse($deploymentFileContents($relativePath));
+
+        if (! is_array($parsed)) {
+            throw new RuntimeException("Compose file did not parse to an array: {$relativePath}");
+        }
+
+        return $parsed;
+    };
+
+    $serviceVolumeMount = static function (array $service, string $targetPath): array {
+        $volumes = $service['volumes'] ?? null;
+
+        if (! is_array($volumes)) {
+            throw new RuntimeException("Service is missing a volumes list for target path: {$targetPath}");
+        }
+
+        foreach ($volumes as $volume) {
+            if (! is_string($volume)) {
+                continue;
+            }
+
+            $segments = explode(':', $volume);
+
+            if (count($segments) < 2) {
+                continue;
+            }
+
+            $source = $segments[0];
+            $target = $segments[1];
+            $mode = $segments[2] ?? null;
+
+            if ($target === $targetPath) {
+                return [
+                    'source' => $source,
+                    'target' => $target,
+                    'mode' => $mode,
+                ];
+            }
+        }
+
+        throw new RuntimeException("No volume mount found for target path: {$targetPath}");
     };
 
     it('creates the public storage symlink in the final nginx image', function () use ($deploymentFileContents) {
@@ -24,13 +70,34 @@ describe('landing page template logo deployment regression guard', function () {
             ->toContain('ln -s ../storage/app/public /var/www/html/public/storage');
     });
 
-    it('keeps app and webserver on the shared storage volume in stage and production', function (string $composeFile) use ($deploymentFileContents) {
-        $compose = $deploymentFileContents($composeFile);
+    it('keeps app and webserver on the shared storage volume in stage and production', function (string $composeFile) use ($parsedCompose, $serviceVolumeMount) {
+        $compose = $parsedCompose($composeFile);
+        $services = $compose['services'] ?? null;
 
-        expect($compose)
-            ->toContain('- storage-data:/var/www/html/storage')
-            ->toContain('- storage-data:/var/www/html/storage:ro')
-            ->toContain('dockerfile: Dockerfile');
+        if (! is_array($services)) {
+            throw new RuntimeException("Compose file is missing the services map: {$composeFile}");
+        }
+
+        $app = $services['app'] ?? null;
+        $webserver = $services['webserver'] ?? null;
+
+        if (! is_array($app) || ! is_array($webserver)) {
+            throw new RuntimeException("Compose file is missing the app or webserver service: {$composeFile}");
+        }
+
+        $appStorageMount = $serviceVolumeMount($app, '/var/www/html/storage');
+        $webserverStorageMount = $serviceVolumeMount($webserver, '/var/www/html/storage');
+
+        expect($app['build']['dockerfile'] ?? null)
+            ->toBe('Dockerfile')
+            ->and($webserver['build']['dockerfile'] ?? null)->toBe('Dockerfile')
+            ->and($appStorageMount['source'])->toBe('storage-data')
+            ->and($webserverStorageMount['source'])->toBe('storage-data')
+            ->and($appStorageMount['source'])->toBe($webserverStorageMount['source'])
+            ->and($appStorageMount['target'])->toBe('/var/www/html/storage')
+            ->and($webserverStorageMount['target'])->toBe('/var/www/html/storage')
+            ->and($appStorageMount['mode'])->toBeNull()
+            ->and($webserverStorageMount['mode'])->toBe('ro');
     })->with([
         'stage' => 'docker-compose.stage.yml',
         'production' => 'docker-compose.prod.yml',

--- a/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
+++ b/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
@@ -2,20 +2,19 @@
 
 declare(strict_types=1);
 
-function deploymentFileContents(string $relativePath): string
-{
-    $contents = file_get_contents(base_path($relativePath));
-
-    if ($contents === false) {
-        throw new RuntimeException("Failed to read deployment file: {$relativePath}");
-    }
-
-    return $contents;
-}
-
 describe('landing page template logo deployment regression guard', function () {
-    it('creates the public storage symlink in the final nginx image', function () {
-        $dockerfile = deploymentFileContents('Dockerfile');
+    $deploymentFileContents = static function (string $relativePath): string {
+        $contents = file_get_contents(base_path($relativePath));
+
+        if ($contents === false) {
+            throw new RuntimeException("Failed to read deployment file: {$relativePath}");
+        }
+
+        return $contents;
+    };
+
+    it('creates the public storage symlink in the final nginx image', function () use ($deploymentFileContents) {
+        $dockerfile = $deploymentFileContents('Dockerfile');
 
         expect($dockerfile)
             ->toContain('FROM nginx:')
@@ -25,8 +24,8 @@ describe('landing page template logo deployment regression guard', function () {
             ->toContain('ln -s ../storage/app/public /var/www/html/public/storage');
     });
 
-    it('keeps app and webserver on the shared storage volume in stage and production', function (string $composeFile) {
-        $compose = deploymentFileContents($composeFile);
+    it('keeps app and webserver on the shared storage volume in stage and production', function (string $composeFile) use ($deploymentFileContents) {
+        $compose = $deploymentFileContents($composeFile);
 
         expect($compose)
             ->toContain('- storage-data:/var/www/html/storage')

--- a/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
+++ b/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
@@ -18,7 +18,8 @@ describe('landing page template logo deployment regression guard', function () {
         $dockerfile = deploymentFileContents('Dockerfile');
 
         expect($dockerfile)
-            ->toContain('FROM nginx:1.29.8-alpine')
+            ->toContain('FROM nginx:')
+            ->toContain(' AS nginx')
             ->toContain('COPY --from=app /var/www/html/public /var/www/html/public')
             ->toContain('COPY --from=app /var/www/html/storage /var/www/html/storage')
             ->toContain('ln -s ../storage/app/public /var/www/html/public/storage');

--- a/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
+++ b/tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+function deploymentFileContents(string $relativePath): string
+{
+    $contents = file_get_contents(base_path($relativePath));
+
+    if ($contents === false) {
+        throw new RuntimeException("Failed to read deployment file: {$relativePath}");
+    }
+
+    return $contents;
+}
+
+describe('landing page template logo deployment regression guard', function () {
+    it('creates the public storage symlink in the final nginx image', function () {
+        $dockerfile = deploymentFileContents('Dockerfile');
+
+        expect($dockerfile)
+            ->toContain('FROM nginx:1.29.8-alpine')
+            ->toContain('COPY --from=app /var/www/html/public /var/www/html/public')
+            ->toContain('COPY --from=app /var/www/html/storage /var/www/html/storage')
+            ->toContain('ln -s ../storage/app/public /var/www/html/public/storage');
+    });
+
+    it('keeps app and webserver on the shared storage volume in stage and production', function (string $composeFile) {
+        $compose = deploymentFileContents($composeFile);
+
+        expect($compose)
+            ->toContain('- storage-data:/var/www/html/storage')
+            ->toContain('- storage-data:/var/www/html/storage:ro')
+            ->toContain('dockerfile: Dockerfile');
+    })->with([
+        'stage' => 'docker-compose.stage.yml',
+        'production' => 'docker-compose.prod.yml',
+    ]);
+});


### PR DESCRIPTION
This pull request addresses a regression that caused uploaded header logos on cloned landing page templates to not render correctly in non-local environments. The main changes ensure that uploaded assets (like custom logos) are reliably available in Stage and Production deployments by preserving Laravel's `/storage/...` asset paths inside the webserver container. Additionally, a regression test was added to prevent similar deployment issues in the future.

**Deployment fixes for asset storage and logo rendering:**

* Updated the `Dockerfile` to always create a symlink from `/var/www/html/public/storage` to `../storage/app/public`, ensuring that uploaded assets are accessible in the webserver image.
* Added a changelog entry describing the fix for custom landing page template logo rendering in deployment environments.

**Testing and regression prevention:**

* Added a new regression test (`tests/pest/Unit/Deployment/LandingPageTemplateLogoDeploymentTest.php`) that:
  * Verifies the public storage symlink is created in the final nginx image.
  * Ensures both `app` and `webserver` services share the `/var/www/html/storage` volume in Stage and Production, with correct mount modes.