### PR TITLE
 Fix: Remove Resolved Title from Related Work Form Group in data Editor

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-20",
+        "date": "2026-05-21",
         "features": [
             {
                 "title": "Single DOI Import for GFZ Legacy Resources",

--- a/resources/js/components/curation/fields/related-work/related-work-item.tsx
+++ b/resources/js/components/curation/fields/related-work/related-work-item.tsx
@@ -134,7 +134,7 @@ export default function RelatedWorkItem({
                             type="button"
                             variant="ghost"
                             size="icon"
-                            className="mt-0.5 h-8 w-8 flex-shrink-0 cursor-grab text-muted-foreground"
+                            className="mt-0.5 h-8 w-8 shrink-0 cursor-grab text-muted-foreground"
                             aria-label={`Reorder related work ${index + 1}`}
                             {...attributes}
                             {...listeners}
@@ -163,7 +163,7 @@ export default function RelatedWorkItem({
                         size="icon"
                         onClick={() => onRemove(index)}
                         aria-label="Remove related work"
-                        className="h-8 w-8 flex-shrink-0"
+                        className="h-8 w-8 shrink-0"
                     >
                         <Trash2 className="h-4 w-4" />
                     </Button>
@@ -212,7 +212,7 @@ export default function RelatedWorkItem({
                             <SelectTrigger id={`related-work-${index}-relation-type`}>
                                 <SelectValue />
                             </SelectTrigger>
-                            <SelectContent className="max-h-[400px]">
+                            <SelectContent className="max-h-100">
                                 {filteredMostUsedRelationTypes.length > 0 && (
                                     <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Most Used</div>
                                 )}
@@ -251,7 +251,7 @@ export default function RelatedWorkItem({
                                 className="group inline-flex min-w-0 items-center gap-1 text-primary hover:underline"
                             >
                                 <span className="break-all">{item.identifier}</span>
-                                <ExternalLink className="h-3 w-3 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+                                <ExternalLink className="h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
                             </a>
                         ) : (
                             <span className="break-all text-muted-foreground">{item.identifier}</span>
@@ -260,8 +260,8 @@ export default function RelatedWorkItem({
                     <p className="text-xs text-muted-foreground">{description}</p>
                 </div>
 
-                <div className="mt-4 grid gap-4 md:grid-cols-12">
-                    <div className="md:col-span-8">
+                <div className="mt-4">
+                    <div>
                         <Label htmlFor={`related-work-${index}-citation-label`}>Citation label</Label>
                         <Textarea
                             id={`related-work-${index}-citation-label`}
@@ -273,19 +273,6 @@ export default function RelatedWorkItem({
                         <p className="mt-1 text-xs text-muted-foreground">
                             This text is preferred on landing pages and in relation graphs. Leave it empty to let the backend resolve a DOI citation.
                         </p>
-                    </div>
-
-                    <div className="md:col-span-4">
-                        <p id={`related-work-${index}-resolved-title-label`} className="text-sm font-medium leading-none">
-                            Resolved title
-                        </p>
-                        <div
-                            id={`related-work-${index}-resolved-title`}
-                            aria-labelledby={`related-work-${index}-resolved-title-label`}
-                            className="min-h-24 rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
-                        >
-                            {item.related_title?.trim() ? item.related_title : 'No resolved title available yet.'}
-                        </div>
                     </div>
                 </div>
 

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1227,7 +1227,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 <p>The relation menu keeps the most frequently used DataCite relation types in a dedicated <em>Most used</em> block, with the full schema available below it.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={3} title="Refine the Card">
-                                <p>After adding an entry, edit the related-work card directly. You can adjust the identifier, change the relation type, add a custom citation label for landing pages, and review any resolved title metadata.</p>
+                                <p>After adding an entry, edit the related-work card directly. You can adjust the identifier, change the relation type, and add a custom citation label for landing pages.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={4} title="Reorder the List">
                                 <p>Drag related-work cards into the order you want. This order is preserved in the editor and reused on the landing page.</p>

--- a/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
+++ b/tests/vitest/components/curation/fields/related-work/__tests__/related-work-item.test.tsx
@@ -143,10 +143,11 @@ describe('RelatedWorkItem', () => {
         );
     });
 
-    it('shows a fallback message when no resolved title is available', () => {
+    it('does not render the removed resolved title helper UI', () => {
         render(<RelatedWorkItem {...defaultProps} />);
 
-        expect(screen.getByText('No resolved title available yet.')).toBeInTheDocument();
+        expect(screen.queryByText('Resolved title')).not.toBeInTheDocument();
+        expect(screen.queryByText('No resolved title available yet.')).not.toBeInTheDocument();
     });
 
     it('renders validation tooltips for valid items', async () => {
@@ -179,7 +180,7 @@ describe('RelatedWorkItem', () => {
         expect((await screen.findAllByText('Validation warning')).length).toBeGreaterThan(0);
     });
 
-    it('shows the resolved title helper when related_title is available', () => {
+    it('does not surface related_title metadata in the editor card', () => {
         render(
             <RelatedWorkItem
                 {...defaultProps}
@@ -190,14 +191,9 @@ describe('RelatedWorkItem', () => {
             />,
         );
 
-        expect(screen.getByText('Related Research Paper Title')).toBeInTheDocument();
-    });
-
-    it('associates the resolved title content with its visible heading', () => {
-        render(<RelatedWorkItem {...defaultProps} />);
-
-        expect(screen.getByText('Resolved title')).toBeInTheDocument();
-        expect(screen.getByText('No resolved title available yet.')).toHaveAttribute('aria-labelledby', 'related-work-0-resolved-title-label');
+        expect(screen.queryByText('Resolved title')).not.toBeInTheDocument();
+        expect(screen.queryByText('Related Research Paper Title')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Citation label')).toBeInTheDocument();
     });
 
     it('shows the relation type information field for Other', () => {


### PR DESCRIPTION
This pull request primarily removes the "resolved title" helper UI from the related work editor card, simplifying the user interface and updating related documentation and tests. It also makes minor style and layout adjustments to the `RelatedWorkItem` component.

Main changes include:

**Removal of Resolved Title Helper UI:**

- The "resolved title" section, which previously displayed metadata about related works, has been removed from the `RelatedWorkItem` editor card UI (`related-work-item.tsx`). Associated documentation and tests have been updated to reflect this removal. [[1]](diffhunk://#diff-23aafeb47f4899ff63a0e5137c2eaf3c52533b7fce3c0bb04604472abf55cf2aL263-R264) [[2]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL1230-R1230) [[3]](diffhunk://#diff-24c95171d5ae757fe3fff464b0136888c5a6e9e0f5b717f63d890ba57f400dd7L146-R150) [[4]](diffhunk://#diff-24c95171d5ae757fe3fff464b0136888c5a6e9e0f5b717f63d890ba57f400dd7L182-R183) [[5]](diffhunk://#diff-24c95171d5ae757fe3fff464b0136888c5a6e9e0f5b717f63d890ba57f400dd7L193-R196)

**UI and Style Adjustments:**

- Replaced `flex-shrink-0` with the modern `shrink-0` utility in several button and icon classes for consistency and future-proofing (`related-work-item.tsx`). [[1]](diffhunk://#diff-23aafeb47f4899ff63a0e5137c2eaf3c52533b7fce3c0bb04604472abf55cf2aL137-R137) [[2]](diffhunk://#diff-23aafeb47f4899ff63a0e5137c2eaf3c52533b7fce3c0bb04604472abf55cf2aL166-R166) [[3]](diffhunk://#diff-23aafeb47f4899ff63a0e5137c2eaf3c52533b7fce3c0bb04604472abf55cf2aL254-R254)
- Simplified the layout of the citation label section by removing the grid and column structure, resulting in a cleaner and more straightforward form (`related-work-item.tsx`).

**Other Minor Updates:**

- Changed the `SelectContent` dropdown's max height class from a pixel value to a Tailwind utility class for consistency (`related-work-item.tsx`).
- Updated the changelog date to reflect the new release date (`changelog.json`).