### PR TITLE
Fix: PID Update for PIDINST does not work

### DIFF
--- a/app/Console/Commands/GetPid4instInstruments.php
+++ b/app/Console/Commands/GetPid4instInstruments.php
@@ -46,7 +46,6 @@ class GetPid4instInstruments extends Command
                 ->get("{$host}/api/records", [
                     'size' => $pageSize,
                     'page' => $page,
-                    'sort' => 'mostrecent',
                 ]);
 
             if (! $response->successful()) {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,6 +1,16 @@
 [
     {
         "version": "1.0.0",
+        "date": "2026-05-22",
+        "fixes": [
+            {
+                "title": "PID4INST Registry Update Works with Current b2inst API",
+                "description": "The 'Check for Updates' and 'Update Now' flow in Editor Settings now works again for PID4INST instrument data. ERNIE no longer sends the outdated sort=mostrecent query parameter when downloading the b2inst registry, so the initial download and later refreshes no longer fail with 'Command exited with code 1' after the remote count check succeeds."
+            }
+        ]
+    },
+    {
+        "version": "1.0.0",
         "date": "2026-05-21",
         "features": [
             {

--- a/tests/pest/Feature/Commands/GetPid4instInstrumentsCommandTest.php
+++ b/tests/pest/Feature/Commands/GetPid4instInstrumentsCommandTest.php
@@ -3,20 +3,31 @@
 declare(strict_types=1);
 
 use App\Console\Commands\GetPid4instInstruments;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
-uses(RefreshDatabase::class);
-
 covers(GetPid4instInstruments::class);
+
+function pid4instHost(): string
+{
+    return rtrim((string) config('b2inst.host'), '/');
+}
+
+function pid4instRecordsUrlPattern(): string
+{
+    return pid4instHost() . '/api/records*';
+}
+
+beforeEach(function (): void {
+    config(['b2inst.host' => 'https://b2inst.example.test']);
+});
 
 it('fetches and stores pid4inst instruments without sending the rejected sort parameter', function (): void {
     Storage::fake('local');
 
-    Http::fakeSequence('https://b2inst.gwdg.de/api/records*')
+    Http::fakeSequence(pid4instRecordsUrlPattern())
         ->push([
             'hits' => [
                 'total' => 3,
@@ -128,9 +139,16 @@ it('fetches and stores pid4inst instruments without sending the rejected sort pa
         parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
 
         return $request->method() === 'GET'
-            && str_starts_with($request->url(), 'https://b2inst.gwdg.de/api/records?')
+            && str_starts_with($request->url(), pid4instHost() . '/api/records?')
             && ! array_key_exists('sort', $query)
             && isset($query['size'], $query['page']);
+    });
+
+    Http::assertNotSent(function (Request $request): bool {
+        parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        return str_starts_with($request->url(), pid4instHost() . '/api/records?')
+            && array_key_exists('sort', $query);
     });
 });
 
@@ -138,7 +156,7 @@ it('fails without creating a registry file when b2inst rejects the request', fun
     Storage::fake('local');
 
     Http::fake([
-        'https://b2inst.gwdg.de/api/records*' => Http::response([
+        pid4instRecordsUrlPattern() => Http::response([
             'errors' => [
                 ['message' => 'Invalid sort parameter'],
             ],

--- a/tests/pest/Feature/Commands/GetPid4instInstrumentsCommandTest.php
+++ b/tests/pest/Feature/Commands/GetPid4instInstrumentsCommandTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\GetPid4instInstruments;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+covers(GetPid4instInstruments::class);
+
+it('fetches and stores pid4inst instruments without sending the rejected sort parameter', function (): void {
+    Storage::fake('local');
+
+    Http::fakeSequence('https://b2inst.gwdg.de/api/records*')
+        ->push([
+            'hits' => [
+                'total' => 3,
+                'hits' => [
+                    [
+                        'id' => 'inst-1',
+                        'metadata' => [
+                            'Identifier' => [
+                                'identifierType' => 'Handle',
+                                'identifierValue' => '21.T11148/alpha',
+                            ],
+                            'Name' => 'Alpha Instrument',
+                            'Description' => 'Primary test instrument',
+                            'LandingPage' => 'https://example.org/instruments/alpha',
+                            'Owner' => [
+                                ['ownerName' => 'GFZ'],
+                            ],
+                            'Manufacturer' => [
+                                ['manufacturerName' => 'Acme'],
+                            ],
+                            'Model' => [
+                                'modelName' => 'A-1',
+                            ],
+                            'InstrumentType' => [
+                                ['instrumentTypeName' => 'Spectrometer'],
+                            ],
+                            'MeasuredVariable' => ['Temperature'],
+                        ],
+                    ],
+                    [
+                        'id' => 'inst-2',
+                        'metadata' => [
+                            'Identifier' => [
+                                'identifierType' => 'DOI',
+                                'identifierValue' => '10.1234/example',
+                            ],
+                            'Name' => 'Beta Instrument',
+                            'Description' => 'Second test instrument',
+                            'LandingPage' => 'https://example.org/instruments/beta',
+                            'Owner' => [
+                                ['ownerName' => 'UFZ'],
+                            ],
+                            'Manufacturer' => [
+                                ['manufacturerName' => 'Contoso'],
+                            ],
+                            'InstrumentType' => [
+                                ['instrumentTypeName' => 'Sensor'],
+                            ],
+                            'MeasuredVariable' => ['Pressure'],
+                        ],
+                    ],
+                ],
+            ],
+        ], 200)
+        ->push([
+            'hits' => [
+                'total' => 3,
+                'hits' => [
+                    [
+                        'id' => 'inst-3',
+                        'metadata' => [
+                            'Identifier' => [
+                                'identifierType' => 'ARK',
+                                'identifierValue' => 'ark:/12345/example',
+                            ],
+                            'Name' => 'Gamma Instrument',
+                            'Description' => '',
+                            'LandingPage' => '',
+                            'Owner' => [],
+                            'Manufacturer' => [],
+                            'InstrumentType' => [],
+                            'MeasuredVariable' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ], 200);
+
+    $exitCode = Artisan::call('get-pid4inst-instruments');
+
+    expect($exitCode)->toBe(0);
+    Storage::assertExists('pid4inst-instruments.json');
+
+    $payload = json_decode(Storage::get('pid4inst-instruments.json'), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($payload)->toHaveKeys(['lastUpdated', 'total', 'data'])
+        ->and($payload['total'])->toBe(3)
+        ->and($payload['data'])->toHaveCount(3)
+        ->and($payload['data'][0])->toMatchArray([
+            'id' => 'inst-1',
+            'pid' => '21.T11148/alpha',
+            'pidType' => 'Handle',
+            'name' => 'Alpha Instrument',
+            'description' => 'Primary test instrument',
+            'landingPage' => 'https://example.org/instruments/alpha',
+            'owners' => ['GFZ'],
+            'manufacturers' => ['Acme'],
+            'model' => 'A-1',
+            'instrumentTypes' => ['Spectrometer'],
+            'measuredVariables' => ['Temperature'],
+        ])
+        ->and($payload['data'][1]['pidType'])->toBe('DOI')
+        ->and($payload['data'][2]['pidType'])->toBe('Handle')
+        ->and($payload['data'][2]['model'])->toBeNull();
+
+    Http::assertSentCount(2);
+
+    Http::assertSent(function (Request $request): bool {
+        parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        return $request->method() === 'GET'
+            && str_starts_with($request->url(), 'https://b2inst.gwdg.de/api/records?')
+            && ! array_key_exists('sort', $query)
+            && isset($query['size'], $query['page']);
+    });
+});
+
+it('fails without creating a registry file when b2inst rejects the request', function (): void {
+    Storage::fake('local');
+
+    Http::fake([
+        'https://b2inst.gwdg.de/api/records*' => Http::response([
+            'errors' => [
+                ['message' => 'Invalid sort parameter'],
+            ],
+        ], 400),
+    ]);
+
+    $exitCode = Artisan::call('get-pid4inst-instruments');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('Failed to fetch page 1: HTTP 400');
+
+    Storage::assertMissing('pid4inst-instruments.json');
+});

--- a/tests/pest/Unit/Services/Pid4instStatusServiceTest.php
+++ b/tests/pest/Unit/Services/Pid4instStatusServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\PidSetting;
 use App\Services\Pid4instStatusService;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
@@ -102,6 +103,16 @@ describe('Pid4instStatusService', function () {
             $result = $this->service->getRemoteCount();
 
             expect($result)->toBe(500);
+
+            Http::assertSent(function (Request $request): bool {
+                parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+                return $request->method() === 'GET'
+                    && str_starts_with($request->url(), 'https://b2inst.gwdg.de/api/records?')
+                    && ($query['size'] ?? null) === '1'
+                    && ($query['page'] ?? null) === '1'
+                    && ! array_key_exists('sort', $query);
+            });
         });
 
         it('throws RuntimeException on API failure', function () {

--- a/tests/pest/Unit/Services/Pid4instStatusServiceTest.php
+++ b/tests/pest/Unit/Services/Pid4instStatusServiceTest.php
@@ -10,8 +10,14 @@ use Illuminate\Support\Facades\Storage;
 
 covers(Pid4instStatusService::class);
 
+function pid4instStatusHost(): string
+{
+    return rtrim((string) config('b2inst.host'), '/');
+}
+
 describe('Pid4instStatusService', function () {
     beforeEach(function () {
+        config(['b2inst.host' => 'https://b2inst.example.test']);
         $this->service = new Pid4instStatusService;
     });
 
@@ -95,7 +101,7 @@ describe('Pid4instStatusService', function () {
     describe('getRemoteCount', function () {
         it('returns total hits from b2inst API', function () {
             Http::fake([
-                '*' => Http::response([
+                pid4instStatusHost() . '/api/records*' => Http::response([
                     'hits' => ['total' => 500],
                 ]),
             ]);
@@ -104,11 +110,13 @@ describe('Pid4instStatusService', function () {
 
             expect($result)->toBe(500);
 
+            Http::assertSentCount(1);
+
             Http::assertSent(function (Request $request): bool {
                 parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
 
                 return $request->method() === 'GET'
-                    && str_starts_with($request->url(), 'https://b2inst.gwdg.de/api/records?')
+                    && str_starts_with($request->url(), pid4instStatusHost() . '/api/records?')
                     && ($query['size'] ?? null) === '1'
                     && ($query['page'] ?? null) === '1'
                     && ! array_key_exists('sort', $query);
@@ -117,7 +125,7 @@ describe('Pid4instStatusService', function () {
 
         it('throws RuntimeException on API failure', function () {
             Http::fake([
-                '*' => Http::response('Server Error', 500),
+                pid4instStatusHost() . '/api/records*' => Http::response('Server Error', 500),
             ]);
 
             $this->service->getRemoteCount();


### PR DESCRIPTION
This pull request updates the way the application interacts with the b2inst API for PID4INST instrument data, ensuring compatibility with the current API by removing the outdated `sort=mostrecent` parameter. It also adds comprehensive feature and unit tests to verify correct request behavior and error handling. These changes resolve previous failures in the "Check for Updates" and "Update Now" flows and improve test reliability.

**API Compatibility and Bug Fixes:**

* Removed the `sort=mostrecent` query parameter from b2inst API requests in `GetPid4instInstruments`, fixing failures when downloading or refreshing the PID4INST registry.
* Updated the changelog to document that the PID4INST registry update now works with the current b2inst API, and that the previous error after the remote count check is resolved.

**Testing Improvements:**

* Added a feature test `GetPid4instInstrumentsCommandTest` to ensure the command fetches and stores instrument data without sending the rejected `sort` parameter, and correctly handles API errors without creating a registry file.
* Improved unit tests for `Pid4instStatusService` to assert that requests do not include the `sort` parameter and to verify correct query parameters are sent to the b2inst API.
* Added utility functions and configuration setup in tests to standardize API host usage and improve test reliability.