### PR TITLE
Feature: Landing Page Download URL Suggestions

### DIFF
--- a/app/Enums/CacheKey.php
+++ b/app/Enums/CacheKey.php
@@ -73,6 +73,9 @@ enum CacheKey: string
     // Landing page Schema.org JSON-LD
     case SCHEMA_ORG_JSONLD = 'landing_pages:schema_org_jsonld';
 
+    // Landing page setup modal download URL suggestions
+    case LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS = 'landing-page.download-url-suggestions';
+
     /**
      * Get the full cache key with optional suffix.
      *
@@ -155,6 +158,10 @@ enum CacheKey: string
 
             // Schema.org JSON-LD - 1 hour (invalidated by ResourceObserver on update)
             self::SCHEMA_ORG_JSONLD => 3600,
+
+            // Download URL suggestions use rememberForever and explicit invalidation.
+            // This TTL acts only as a safe default if the enum is reused elsewhere.
+            self::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS => 86400,
         };
     }
 
@@ -214,6 +221,8 @@ enum CacheKey: string
             self::FUJI_HEALTH_STATUS => ['assessments'],
 
             self::SCHEMA_ORG_JSONLD => ['resources', 'landing_pages'],
+
+            self::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS => [],
         };
     }
 

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -606,12 +606,16 @@ class LandingPageController extends Controller
     public function downloadUrlSuggestions(): JsonResponse
     {
         return response()->json([
-            'suggestions' => Cache::remember(
+            'suggestions' => Cache::rememberForever(
                 self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY,
-                now()->addMinutes(10),
                 static fn (): array => self::buildDownloadUrlSuggestionPayload(self::loadDownloadUrlSuggestionSourceCounts()),
             ),
         ]);
+    }
+
+    public static function forgetDownloadUrlSuggestionsCache(): void
+    {
+        Cache::forget(self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY);
     }
 
     /**
@@ -811,7 +815,7 @@ class LandingPageController extends Controller
     {
         // Forget main cache
         Cache::forget("landing-page.{$resourceId}");
-        Cache::forget(self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY);
+        self::forgetDownloadUrlSuggestionsCache();
 
         // Invalidate portal facets (datacenter + resource type) because
         // publishing/unpublishing changes which resources are "published".

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -29,8 +29,6 @@ class LandingPageController extends Controller
     use AuthorizesRequests;
     use ChecksCacheTagging;
 
-    private const DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY = 'landing-page.download-url-suggestions';
-
     public static function templateSupportsCustomTemplateId(string $template): bool
     {
         return in_array($template, [
@@ -367,11 +365,11 @@ class LandingPageController extends Controller
         // Invalidate keyword suggestions cache if landing page was created as published
         if ($landingPage->is_published) {
             $this->keywordService->invalidateCache();
+            $this->invalidatePortalFacets();
         }
 
-        // Invalidate landing page caches after successful creation so newly
-        // persisted download URLs become visible in the setup modal immediately.
-        $this->invalidateCache($resource->id);
+        $this->forgetLandingPageCache($resource->id);
+        $this->forgetDownloadUrlSuggestionsCache();
 
         return response()->json([
             'message' => 'Landing page created successfully',
@@ -517,14 +515,17 @@ class LandingPageController extends Controller
             }
         });
 
+        $becamePublished = $requestedStatus !== null && $requestedStatus && ! $currentlyPublished;
+
         // Handle publication status change: allow publishing a draft
-        if ($requestedStatus !== null && $requestedStatus && ! $currentlyPublished) {
+        if ($becamePublished) {
             $landingPage->publish();
             $this->keywordService->invalidateCache();
+            $this->invalidatePortalFacets();
         }
 
-        // Invalidate cache
-        $this->invalidateCache($resource->id);
+        $this->forgetLandingPageCache($resource->id);
+        $this->forgetDownloadUrlSuggestionsCache();
 
         $freshLandingPage = LandingPage::query()
             ->with(['externalDomain', 'files', 'links', 'landingPageTemplate'])
@@ -565,8 +566,8 @@ class LandingPageController extends Controller
 
         $landingPage->delete();
 
-        // Invalidate cache
-        $this->invalidateCache($resource->id);
+        $this->forgetLandingPageCache($resource->id);
+        $this->forgetDownloadUrlSuggestionsCache();
 
         return response()->json([
             'message' => 'Landing page deleted successfully',
@@ -607,15 +608,10 @@ class LandingPageController extends Controller
     {
         return response()->json([
             'suggestions' => Cache::rememberForever(
-                self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY,
+                CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key(),
                 static fn (): array => self::buildDownloadUrlSuggestionPayload(self::loadDownloadUrlSuggestionSourceCounts()),
             ),
         ]);
-    }
-
-    public static function forgetDownloadUrlSuggestionsCache(): void
-    {
-        Cache::forget(self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY);
     }
 
     /**
@@ -808,22 +804,14 @@ class LandingPageController extends Controller
         return array_slice($suggestions, 0, 20);
     }
 
-    /**
-     * Invalidate landing page cache.
-     */
-    private function invalidateCache(int $resourceId): void
+    private function forgetLandingPageCache(int $resourceId): void
     {
-        // Forget main cache
         Cache::forget("landing-page.{$resourceId}");
-        self::forgetDownloadUrlSuggestionsCache();
+    }
 
-        // Invalidate portal facets (datacenter + resource type) because
-        // publishing/unpublishing changes which resources are "published".
-        $this->invalidatePortalFacets();
-
-        // Also try to forget preview caches (pattern matching would require Redis tags)
-        // For now, we'll clear individual cache entries when we know the token
-        // In production with Redis, you could use Cache::tags()
+    private function forgetDownloadUrlSuggestionsCache(): void
+    {
+        CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->forget();
     }
 
     /**
@@ -832,11 +820,7 @@ class LandingPageController extends Controller
     private function invalidatePortalFacets(): void
     {
         foreach ([CacheKey::PORTAL_DATACENTER_FACETS, CacheKey::PORTAL_RESOURCE_TYPE_FACETS] as $cacheKey) {
-            if ($this->supportsTagging()) {
-                Cache::tags($cacheKey->tags())->flush();
-            } else {
-                Cache::forget($cacheKey->key());
-            }
+            $cacheKey->forget();
         }
     }
 }

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -29,6 +29,8 @@ class LandingPageController extends Controller
     use AuthorizesRequests;
     use ChecksCacheTagging;
 
+    private const DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY = 'landing-page.download-url-suggestions';
+
     public static function templateSupportsCustomTemplateId(string $template): bool
     {
         return in_array($template, [
@@ -367,6 +369,10 @@ class LandingPageController extends Controller
             $this->keywordService->invalidateCache();
         }
 
+        // Invalidate landing page caches after successful creation so newly
+        // persisted download URLs become visible in the setup modal immediately.
+        $this->invalidateCache($resource->id);
+
         return response()->json([
             'message' => 'Landing page created successfully',
             'landing_page' => self::serializeLandingPagePayload($resource, $landingPage),
@@ -599,23 +605,12 @@ class LandingPageController extends Controller
      */
     public function downloadUrlSuggestions(): JsonResponse
     {
-        /** @var list<string> $sourceUrls */
-        $sourceUrls = [
-            ...DB::table('landing_pages')
-                ->whereNotNull('ftp_url')
-                ->pluck('ftp_url')
-                ->filter(static fn (mixed $url): bool => is_string($url))
-                ->values()
-                ->all(),
-            ...DB::table('landing_page_files')
-                ->pluck('url')
-                ->filter(static fn (mixed $url): bool => is_string($url))
-                ->values()
-                ->all(),
-        ];
-
         return response()->json([
-            'suggestions' => self::buildDownloadUrlSuggestionPayload($sourceUrls),
+            'suggestions' => Cache::remember(
+                self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY,
+                now()->addMinutes(10),
+                static fn (): array => self::buildDownloadUrlSuggestionPayload(self::loadDownloadUrlSuggestionSourceCounts()),
+            ),
         ]);
     }
 
@@ -667,32 +662,32 @@ class LandingPageController extends Controller
     }
 
     /**
-     * @param  list<string>  $sourceUrls
+     * @param  array<string, int>  $sourceUrlCounts
      * @return array{
      *     domains: list<array{value: string, usage_count: int}>,
      *     urls: list<array{value: string, usage_count: int}>
      * }
      */
-    private static function buildDownloadUrlSuggestionPayload(array $sourceUrls): array
+    private static function buildDownloadUrlSuggestionPayload(array $sourceUrlCounts): array
     {
         /** @var array<string, int> $domainCounts */
         $domainCounts = [];
         /** @var array<string, int> $urlCounts */
         $urlCounts = [];
 
-        foreach ($sourceUrls as $sourceUrl) {
+        foreach ($sourceUrlCounts as $sourceUrl => $sourceUsageCount) {
             $normalizedUrl = self::normalizeDownloadSuggestionUrl($sourceUrl);
 
             if ($normalizedUrl === null) {
                 continue;
             }
 
-            $urlCounts[$normalizedUrl] = ($urlCounts[$normalizedUrl] ?? 0) + 1;
+            $urlCounts[$normalizedUrl] = ($urlCounts[$normalizedUrl] ?? 0) + $sourceUsageCount;
 
             $domain = self::extractDownloadSuggestionDomain($normalizedUrl);
 
             if ($domain !== null) {
-                $domainCounts[$domain] = ($domainCounts[$domain] ?? 0) + 1;
+                $domainCounts[$domain] = ($domainCounts[$domain] ?? 0) + $sourceUsageCount;
             }
         }
 
@@ -700,6 +695,37 @@ class LandingPageController extends Controller
             'domains' => self::sortDownloadSuggestionCounts($domainCounts),
             'urls' => self::sortDownloadSuggestionCounts($urlCounts),
         ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private static function loadDownloadUrlSuggestionSourceCounts(): array
+    {
+        /** @var list<object{value: string, usage_count: int|string}> $groupedSources */
+        $groupedSources = [
+            ...DB::table('landing_pages')
+                ->selectRaw('ftp_url as value, COUNT(*) as usage_count')
+                ->whereNotNull('ftp_url')
+                ->whereRaw("TRIM(ftp_url) <> ''")
+                ->groupBy('ftp_url')
+                ->get()
+                ->all(),
+            ...DB::table('landing_page_files')
+                ->selectRaw('url as value, COUNT(*) as usage_count')
+                ->whereRaw("TRIM(url) <> ''")
+                ->groupBy('url')
+                ->get()
+                ->all(),
+        ];
+
+        $sourceCounts = [];
+
+        foreach ($groupedSources as $groupedSource) {
+            $sourceCounts[$groupedSource->value] = ($sourceCounts[$groupedSource->value] ?? 0) + (int) $groupedSource->usage_count;
+        }
+
+        return $sourceCounts;
     }
 
     private static function normalizeDownloadSuggestionUrl(string $url): ?string
@@ -785,6 +811,7 @@ class LandingPageController extends Controller
     {
         // Forget main cache
         Cache::forget("landing-page.{$resourceId}");
+        Cache::forget(self::DOWNLOAD_URL_SUGGESTIONS_CACHE_KEY);
 
         // Invalidate portal facets (datacenter + resource type) because
         // publishing/unpublishing changes which resources are "published".

--- a/app/Http/Controllers/LandingPageController.php
+++ b/app/Http/Controllers/LandingPageController.php
@@ -12,6 +12,7 @@ use App\Models\LandingPage;
 use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Services\KeywordSuggestionService;
+use App\Support\UrlNormalizer;
 use App\Support\Traits\ChecksCacheTagging;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -587,6 +588,38 @@ class LandingPageController extends Controller
     }
 
     /**
+     * Return grouped download URL suggestions for the landing page setup modal.
+     *
+     * Suggestions are derived from real download sources only:
+     * - landing_pages.ftp_url
+     * - landing_page_files.url
+     *
+     * External landing page domains are intentionally excluded unless they also
+     * appear as actual download URLs.
+     */
+    public function downloadUrlSuggestions(): JsonResponse
+    {
+        /** @var list<string> $sourceUrls */
+        $sourceUrls = [
+            ...DB::table('landing_pages')
+                ->whereNotNull('ftp_url')
+                ->pluck('ftp_url')
+                ->filter(static fn (mixed $url): bool => is_string($url))
+                ->values()
+                ->all(),
+            ...DB::table('landing_page_files')
+                ->pluck('url')
+                ->filter(static fn (mixed $url): bool => is_string($url))
+                ->values()
+                ->all(),
+        ];
+
+        return response()->json([
+            'suggestions' => self::buildDownloadUrlSuggestionPayload($sourceUrls),
+        ]);
+    }
+
+    /**
      * Return the normalized landing page contract exposed to API consumers.
      *
      * Legacy Physical Object pages may still be stored with the old default
@@ -631,6 +664,118 @@ class LandingPageController extends Controller
         }
 
         return $payload;
+    }
+
+    /**
+     * @param  list<string>  $sourceUrls
+     * @return array{
+     *     domains: list<array{value: string, usage_count: int}>,
+     *     urls: list<array{value: string, usage_count: int}>
+     * }
+     */
+    private static function buildDownloadUrlSuggestionPayload(array $sourceUrls): array
+    {
+        /** @var array<string, int> $domainCounts */
+        $domainCounts = [];
+        /** @var array<string, int> $urlCounts */
+        $urlCounts = [];
+
+        foreach ($sourceUrls as $sourceUrl) {
+            $normalizedUrl = self::normalizeDownloadSuggestionUrl($sourceUrl);
+
+            if ($normalizedUrl === null) {
+                continue;
+            }
+
+            $urlCounts[$normalizedUrl] = ($urlCounts[$normalizedUrl] ?? 0) + 1;
+
+            $domain = self::extractDownloadSuggestionDomain($normalizedUrl);
+
+            if ($domain !== null) {
+                $domainCounts[$domain] = ($domainCounts[$domain] ?? 0) + 1;
+            }
+        }
+
+        return [
+            'domains' => self::sortDownloadSuggestionCounts($domainCounts),
+            'urls' => self::sortDownloadSuggestionCounts($urlCounts),
+        ];
+    }
+
+    private static function normalizeDownloadSuggestionUrl(string $url): ?string
+    {
+        $normalizedUrl = UrlNormalizer::normalizeAppUrl($url);
+
+        if ($normalizedUrl === null) {
+            return null;
+        }
+
+        $parts = parse_url($normalizedUrl);
+
+        if ($parts === false) {
+            return null;
+        }
+
+        /** @var array<string, int|string> $parts */
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return null;
+        }
+
+        $port = isset($parts['port']) ? ':'.(string) $parts['port'] : '';
+        $path = (string) ($parts['path'] ?? '');
+        $query = isset($parts['query']) ? '?'.(string) $parts['query'] : '';
+
+        return sprintf('%s://%s%s%s%s', $scheme, $host, $port, $path !== '' ? $path : '/', $query);
+    }
+
+    private static function extractDownloadSuggestionDomain(string $normalizedUrl): ?string
+    {
+        $parts = parse_url($normalizedUrl);
+
+        if ($parts === false) {
+            return null;
+        }
+
+        /** @var array<string, int|string> $parts */
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return null;
+        }
+
+        $port = isset($parts['port']) ? ':'.(string) $parts['port'] : '';
+
+        return sprintf('%s://%s%s/', $scheme, $host, $port);
+    }
+
+    /**
+     * @param  array<string, int>  $counts
+     * @return list<array{value: string, usage_count: int}>
+     */
+    private static function sortDownloadSuggestionCounts(array $counts): array
+    {
+        $suggestions = [];
+
+        foreach ($counts as $value => $usageCount) {
+            $suggestions[] = [
+                'value' => $value,
+                'usage_count' => $usageCount,
+            ];
+        }
+
+        usort(
+            $suggestions,
+            static fn (array $left, array $right): int => ($right['usage_count'] <=> $left['usage_count'])
+                ?: ($left['value'] <=> $right['value'])
+        );
+
+        return array_slice($suggestions, 0, 20);
     }
 
     /**

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
-use App\Http\Controllers\LandingPageController;
+use App\Enums\CacheKey;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteImportService;
@@ -624,7 +624,7 @@ class ImportFromDataCiteJob implements ShouldQueue
             }
         });
 
-        LandingPageController::forgetDownloadUrlSuggestionsCache();
+        CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->forget();
     }
 
     /**

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Http\Controllers\LandingPageController;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteImportService;
@@ -622,6 +623,8 @@ class ImportFromDataCiteJob implements ShouldQueue
                 ]);
             }
         });
+
+        LandingPageController::forgetDownloadUrlSuggestionsCache();
     }
 
     /**

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -2,16 +2,6 @@
     {
         "version": "1.0.0",
         "date": "2026-05-22",
-        "fixes": [
-            {
-                "title": "PID4INST Registry Update Works with Current b2inst API",
-                "description": "The 'Check for Updates' and 'Update Now' flow in Editor Settings now works again for PID4INST instrument data. ERNIE no longer sends the outdated sort=mostrecent query parameter when downloading the b2inst registry, so the initial download and later refreshes no longer fail with 'Command exited with code 1' after the remote count check succeeds."
-            }
-        ]
-    },
-    {
-        "version": "1.0.0",
-        "date": "2026-05-21",
         "features": [
             {
                 "title": "Single DOI Import for GFZ Legacy Resources",
@@ -103,6 +93,10 @@
             }
         ],
         "improvements": [
+            {
+                "title": "Download URL Suggestions in Landing Page Setup",
+                "description": "When curators set up a GFZ-hosted landing page from the Resources page, the primary Download URL field now suggests both frequently reused base domains and previously used full download URLs from existing landing pages. Suggestions open as soon as the field receives focus, can be filtered while typing, and let curators insert a base domain such as https://datapub.gfz.de/ before completing the remainder of the path manually. Imported legacy download files continue to disable the editable field as before."
+            },
             {
                 "title": "Workspace-Based Sidebar for Admins and Group Leaders",
                 "description": "The authenticated sidebar now gives Admins and Group Leaders an explicit workspace switcher with two modes: Curation and Administration. Daily metadata tasks such as Dashboard, Data Editor, Resources, and IGSN tools stay in Curation, while management pages like Users, Editor Settings, Landing Pages, Assistance, Assessment, Logs, and legacy administration tools move into Administration. The last selected workspace is remembered locally, and opening an admin route automatically reveals the matching workspace so privileged navigation stays easier to scan without forcing a long scrolling sidebar."
@@ -237,6 +231,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "PID4INST Registry Update Works with Current b2inst API",
+                "description": "The 'Check for Updates' and 'Update Now' flow in Editor Settings now works again for PID4INST instrument data. ERNIE no longer sends the outdated sort=mostrecent query parameter when downloading the b2inst registry, so the initial download and later refreshes no longer fail with 'Command exited with code 1' after the remote count check succeeds."
+            },
             {
                 "title": "Custom Landing Page Template Logos Render",
                 "description": "Uploading a header logo to a cloned landing page template now works reliably beyond local development. The deployment images for Stage and Production now preserve Laravel's `/storage/...` asset path inside the webserver container, so uploaded custom logos appear again in template management cards as well as on preview and published landing pages that use the cloned template."

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -874,6 +874,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                     <Input
                                         id="ftp-url"
                                         type="url"
+                                        role="combobox"
                                         placeholder="https://datapub.gfz-potsdam.de/download/..."
                                         value={ftpUrl}
                                         onChange={(e) => {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -4,7 +4,7 @@ import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, v
 import { CSS } from '@dnd-kit/utilities';
 import axios, { isAxiosError } from 'axios';
 import { Copy, ExternalLink, Eye, Globe, GripVertical, Plus, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import {
@@ -15,13 +15,13 @@ import {
     normalizeExternalPath,
 } from '@/components/landing-pages/modals/landing-page-modal-helpers';
 import { Button } from '@/components/ui/button';
-import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import {
     getTemplateOptions,
     isIgsnLandingPageResourceType,
@@ -52,6 +52,12 @@ interface SetupLandingPageModalProps {
 const EMPTY_DOWNLOAD_URL_SUGGESTIONS: LandingPageDownloadUrlSuggestions = {
     domains: [],
     urls: [],
+};
+
+type DownloadUrlSuggestionEntry = {
+    id: string;
+    value: string;
+    usageCount: number;
 };
 
 function SortableLinkItem({
@@ -138,7 +144,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const [downloadUrlSuggestionsLoading, setDownloadUrlSuggestionsLoading] = useState(false);
     const [downloadUrlSuggestionsOpen, setDownloadUrlSuggestionsOpen] = useState(false);
     const [downloadUrlSuggestionQuery, setDownloadUrlSuggestionQuery] = useState('');
-    const downloadUrlAutocompleteRef = useRef<HTMLDivElement | null>(null);
+    const [activeDownloadUrlSuggestionIndex, setActiveDownloadUrlSuggestionIndex] = useState<number | null>(null);
 
     // Landing page template ID (for custom templates)
     const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
@@ -218,6 +224,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setDownloadUrlSuggestionsLoading(false);
             setDownloadUrlSuggestionsOpen(false);
             setDownloadUrlSuggestionQuery('');
+            setActiveDownloadUrlSuggestionIndex(null);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [applyConfigState, defaultTemplateForResource, existingConfig, isOpen, resource.id]);
@@ -290,6 +297,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         if (!supportsFtpUrl || hasImportedFiles) {
             setDownloadUrlSuggestionsOpen(false);
             setDownloadUrlSuggestionQuery('');
+            setActiveDownloadUrlSuggestionIndex(null);
         }
     }, [hasImportedFiles, supportsFtpUrl]);
 
@@ -493,8 +501,42 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         };
     }, [downloadUrlSuggestionQuery, downloadUrlSuggestions]);
 
+    const visibleDownloadUrlSuggestionEntries = useMemo(
+        () => [
+            ...filteredDownloadUrlSuggestions.domains.map((suggestion, index): DownloadUrlSuggestionEntry => ({
+                id: `ftp-url-domain-suggestion-${index}`,
+                value: suggestion.value,
+                usageCount: suggestion.usage_count,
+            })),
+            ...filteredDownloadUrlSuggestions.urls.map((suggestion, index): DownloadUrlSuggestionEntry => ({
+                id: `ftp-url-full-suggestion-${index}`,
+                value: suggestion.value,
+                usageCount: suggestion.usage_count,
+            })),
+        ],
+        [filteredDownloadUrlSuggestions.domains, filteredDownloadUrlSuggestions.urls],
+    );
+
     const shouldShowDownloadUrlSuggestions = supportsFtpUrl && !hasImportedFiles && downloadUrlSuggestionsOpen;
     const hasVisibleDownloadUrlSuggestions = filteredDownloadUrlSuggestions.domains.length > 0 || filteredDownloadUrlSuggestions.urls.length > 0;
+    const activeDownloadUrlSuggestion = activeDownloadUrlSuggestionIndex === null
+        ? null
+        : (visibleDownloadUrlSuggestionEntries[activeDownloadUrlSuggestionIndex] ?? null);
+
+    useEffect(() => {
+        if (!shouldShowDownloadUrlSuggestions) {
+            setActiveDownloadUrlSuggestionIndex(null);
+
+            return;
+        }
+
+        if (
+            activeDownloadUrlSuggestionIndex !== null
+            && activeDownloadUrlSuggestionIndex >= visibleDownloadUrlSuggestionEntries.length
+        ) {
+            setActiveDownloadUrlSuggestionIndex(null);
+        }
+    }, [activeDownloadUrlSuggestionIndex, shouldShowDownloadUrlSuggestions, visibleDownloadUrlSuggestionEntries.length]);
 
     const openDownloadUrlSuggestions = () => {
         if (!supportsFtpUrl || hasImportedFiles) {
@@ -502,6 +544,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         }
 
         setDownloadUrlSuggestionsOpen(true);
+        setActiveDownloadUrlSuggestionIndex(null);
 
         void loadDownloadUrlSuggestions();
     };
@@ -510,6 +553,25 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         setFtpUrl(value);
         setDownloadUrlSuggestionQuery('');
         setDownloadUrlSuggestionsOpen(false);
+        setActiveDownloadUrlSuggestionIndex(null);
+    };
+
+    const moveActiveDownloadUrlSuggestion = (direction: 'next' | 'previous') => {
+        if (visibleDownloadUrlSuggestionEntries.length === 0) {
+            return;
+        }
+
+        setActiveDownloadUrlSuggestionIndex((currentIndex) => {
+            if (currentIndex === null) {
+                return direction === 'next' ? 0 : visibleDownloadUrlSuggestionEntries.length - 1;
+            }
+
+            if (direction === 'next') {
+                return (currentIndex + 1) % visibleDownloadUrlSuggestionEntries.length;
+            }
+
+            return (currentIndex - 1 + visibleDownloadUrlSuggestionEntries.length) % visibleDownloadUrlSuggestionEntries.length;
+        });
     };
 
     const openPreview = async () => {
@@ -797,7 +859,6 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                             <div className="space-y-2">
                                 <Label htmlFor="ftp-url">Download URL (FTP)</Label>
                                 <div
-                                    ref={downloadUrlAutocompleteRef}
                                     className="relative"
                                     onFocusCapture={openDownloadUrlSuggestions}
                                     onBlurCapture={(event) => {
@@ -807,6 +868,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
                                         setDownloadUrlSuggestionsOpen(false);
                                         setDownloadUrlSuggestionQuery('');
+                                        setActiveDownloadUrlSuggestionIndex(null);
                                     }}
                                 >
                                     <Input
@@ -817,6 +879,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                         onChange={(e) => {
                                             setFtpUrl(e.target.value);
                                             setDownloadUrlSuggestionQuery(e.target.value);
+                                            setActiveDownloadUrlSuggestionIndex(null);
 
                                             if (!downloadUrlSuggestionsOpen) {
                                                 setDownloadUrlSuggestionsOpen(true);
@@ -825,13 +888,43 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                             void loadDownloadUrlSuggestions();
                                         }}
                                         onKeyDown={(event) => {
+                                            if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && !downloadUrlSuggestionsOpen) {
+                                                setDownloadUrlSuggestionsOpen(true);
+                                                setActiveDownloadUrlSuggestionIndex(null);
+                                                void loadDownloadUrlSuggestions();
+                                            }
+
+                                            if (event.key === 'ArrowDown') {
+                                                event.preventDefault();
+                                                moveActiveDownloadUrlSuggestion('next');
+
+                                                return;
+                                            }
+
+                                            if (event.key === 'ArrowUp') {
+                                                event.preventDefault();
+                                                moveActiveDownloadUrlSuggestion('previous');
+
+                                                return;
+                                            }
+
+                                            if (event.key === 'Enter' && activeDownloadUrlSuggestion !== null) {
+                                                event.preventDefault();
+                                                applyDownloadUrlSuggestion(activeDownloadUrlSuggestion.value);
+
+                                                return;
+                                            }
+
                                             if (event.key === 'Escape') {
                                                 setDownloadUrlSuggestionsOpen(false);
                                                 setDownloadUrlSuggestionQuery('');
+                                                setActiveDownloadUrlSuggestionIndex(null);
                                             }
                                         }}
                                         disabled={hasImportedFiles}
                                         autoComplete="off"
+                                        aria-activedescendant={activeDownloadUrlSuggestion?.id}
+                                        aria-autocomplete="list"
                                         aria-expanded={shouldShowDownloadUrlSuggestions}
                                         aria-controls={shouldShowDownloadUrlSuggestions ? 'ftp-url-suggestions' : undefined}
                                         aria-haspopup="listbox"
@@ -839,55 +932,81 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
                                     {shouldShowDownloadUrlSuggestions && (
                                         <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md">
-                                            <Command shouldFilter={false} className="bg-transparent">
-                                                <CommandList id="ftp-url-suggestions" className="max-h-64">
-                                                    {downloadUrlSuggestionsLoading ? (
-                                                        <div className="px-3 py-2 text-sm text-muted-foreground" role="status">
-                                                            Loading suggestions...
-                                                        </div>
-                                                    ) : !hasVisibleDownloadUrlSuggestions ? (
-                                                        <div className="px-3 py-2 text-sm text-muted-foreground">No matching suggestions.</div>
-                                                    ) : (
-                                                        <>
-                                                            {filteredDownloadUrlSuggestions.domains.length > 0 && (
-                                                                <CommandGroup heading="Suggested domains">
-                                                                    {filteredDownloadUrlSuggestions.domains.map((suggestion) => (
-                                                                        <CommandItem
-                                                                            key={`domain-${suggestion.value}`}
-                                                                            value={suggestion.value}
-                                                                            onMouseDown={(event) => event.preventDefault()}
-                                                                            onSelect={() => applyDownloadUrlSuggestion(suggestion.value)}
-                                                                        >
-                                                                            <span className="truncate">{suggestion.value}</span>
-                                                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                                                                                {suggestion.usage_count}x
-                                                                            </span>
-                                                                        </CommandItem>
-                                                                    ))}
-                                                                </CommandGroup>
-                                                            )}
+                                            <div id="ftp-url-suggestions" role="listbox" className="max-h-64 overflow-y-auto py-1">
+                                                {downloadUrlSuggestionsLoading ? (
+                                                    <div className="px-3 py-2 text-sm text-muted-foreground" role="status">
+                                                        Loading suggestions...
+                                                    </div>
+                                                ) : !hasVisibleDownloadUrlSuggestions ? (
+                                                    <div className="px-3 py-2 text-sm text-muted-foreground">No matching suggestions.</div>
+                                                ) : (
+                                                    <>
+                                                        {filteredDownloadUrlSuggestions.domains.length > 0 && (
+                                                            <div className="p-1 text-foreground">
+                                                                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Suggested domains</div>
+                                                                {filteredDownloadUrlSuggestions.domains.map((suggestion, index) => {
+                                                                    const suggestionId = `ftp-url-domain-suggestion-${index}`;
+                                                                    const suggestionIndex = index;
+                                                                    const isActive = activeDownloadUrlSuggestion?.id === suggestionId;
 
-                                                            {filteredDownloadUrlSuggestions.urls.length > 0 && (
-                                                                <CommandGroup heading="Previously used full URLs">
-                                                                    {filteredDownloadUrlSuggestions.urls.map((suggestion) => (
-                                                                        <CommandItem
-                                                                            key={`url-${suggestion.value}`}
-                                                                            value={suggestion.value}
+                                                                    return (
+                                                                        <div
+                                                                            key={`domain-${suggestion.value}`}
+                                                                            id={suggestionId}
+                                                                            role="option"
+                                                                            aria-selected={isActive}
+                                                                            className={cn(
+                                                                                'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
+                                                                                isActive ? 'bg-accent text-accent-foreground' : 'text-foreground',
+                                                                            )}
                                                                             onMouseDown={(event) => event.preventDefault()}
-                                                                            onSelect={() => applyDownloadUrlSuggestion(suggestion.value)}
+                                                                            onMouseEnter={() => setActiveDownloadUrlSuggestionIndex(suggestionIndex)}
+                                                                            onClick={() => applyDownloadUrlSuggestion(suggestion.value)}
                                                                         >
                                                                             <span className="truncate">{suggestion.value}</span>
                                                                             <span className="ml-auto shrink-0 text-xs text-muted-foreground">
                                                                                 {suggestion.usage_count}x
                                                                             </span>
-                                                                        </CommandItem>
-                                                                    ))}
-                                                                </CommandGroup>
-                                                            )}
-                                                        </>
-                                                    )}
-                                                </CommandList>
-                                            </Command>
+                                                                        </div>
+                                                                    );
+                                                                })}
+                                                            </div>
+                                                        )}
+
+                                                        {filteredDownloadUrlSuggestions.urls.length > 0 && (
+                                                            <div className="p-1 text-foreground">
+                                                                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Previously used full URLs</div>
+                                                                {filteredDownloadUrlSuggestions.urls.map((suggestion, index) => {
+                                                                    const suggestionId = `ftp-url-full-suggestion-${index}`;
+                                                                    const suggestionIndex = filteredDownloadUrlSuggestions.domains.length + index;
+                                                                    const isActive = activeDownloadUrlSuggestion?.id === suggestionId;
+
+                                                                    return (
+                                                                        <div
+                                                                            key={`url-${suggestion.value}`}
+                                                                            id={suggestionId}
+                                                                            role="option"
+                                                                            aria-selected={isActive}
+                                                                            className={cn(
+                                                                                'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
+                                                                                isActive ? 'bg-accent text-accent-foreground' : 'text-foreground',
+                                                                            )}
+                                                                            onMouseDown={(event) => event.preventDefault()}
+                                                                            onMouseEnter={() => setActiveDownloadUrlSuggestionIndex(suggestionIndex)}
+                                                                            onClick={() => applyDownloadUrlSuggestion(suggestion.value)}
+                                                                        >
+                                                                            <span className="truncate">{suggestion.value}</span>
+                                                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                                                                                {suggestion.usage_count}x
+                                                                            </span>
+                                                                        </div>
+                                                                    );
+                                                                })}
+                                                            </div>
+                                                        )}
+                                                    </>
+                                                )}
+                                            </div>
                                         </div>
                                     )}
                                 </div>

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -4,7 +4,7 @@ import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, v
 import { CSS } from '@dnd-kit/utilities';
 import axios, { isAxiosError } from 'axios';
 import { Copy, ExternalLink, Eye, Globe, GripVertical, Plus, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import {
@@ -15,13 +15,23 @@ import {
     normalizeExternalPath,
 } from '@/components/landing-pages/modals/landing-page-modal-helpers';
 import { Button } from '@/components/ui/button';
+import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { getTemplateOptions, isIgsnLandingPageResourceType, type LandingPageConfig, type LandingPageDomain, type LandingPageLink, type LandingPageTemplateSummary } from '@/types/landing-page';
+import {
+    getTemplateOptions,
+    isIgsnLandingPageResourceType,
+    type LandingPageConfig,
+    type LandingPageDomain,
+    type LandingPageDownloadUrlSuggestionItem,
+    type LandingPageDownloadUrlSuggestions,
+    type LandingPageLink,
+    type LandingPageTemplateSummary,
+} from '@/types/landing-page';
 
 interface Resource {
     id: number;
@@ -38,6 +48,11 @@ interface SetupLandingPageModalProps {
     onSuccess?: () => void;
     existingConfig?: LandingPageConfig | null;
 }
+
+const EMPTY_DOWNLOAD_URL_SUGGESTIONS: LandingPageDownloadUrlSuggestions = {
+    domains: [],
+    urls: [],
+};
 
 function SortableLinkItem({
     link,
@@ -117,6 +132,14 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     // Custom templates state
     const [customTemplates, setCustomTemplates] = useState<LandingPageTemplateSummary[]>([]);
 
+    // Download URL suggestion state
+    const [downloadUrlSuggestions, setDownloadUrlSuggestions] = useState<LandingPageDownloadUrlSuggestions>(EMPTY_DOWNLOAD_URL_SUGGESTIONS);
+    const [downloadUrlSuggestionsLoaded, setDownloadUrlSuggestionsLoaded] = useState(false);
+    const [downloadUrlSuggestionsLoading, setDownloadUrlSuggestionsLoading] = useState(false);
+    const [downloadUrlSuggestionsOpen, setDownloadUrlSuggestionsOpen] = useState(false);
+    const [downloadUrlSuggestionQuery, setDownloadUrlSuggestionQuery] = useState('');
+    const downloadUrlAutocompleteRef = useRef<HTMLDivElement | null>(null);
+
     // Landing page template ID (for custom templates)
     const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
         getHydratedLandingPageTemplateId(initialTemplate, existingConfig),
@@ -153,6 +176,8 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         () => getTemplateOptions(resource.resourcetypegeneral),
         [resource.resourcetypegeneral],
     );
+    const importedDownloadFiles = currentConfig?.files ?? existingConfig?.files ?? [];
+    const hasImportedFiles = importedDownloadFiles.length > 0;
 
     const applyConfigState = useCallback((config: LandingPageConfig) => {
         const preferredTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, config.template);
@@ -188,6 +213,11 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setExternalPath('');
             setLinks([]);
             setLandingPageTemplateId(null);
+            setDownloadUrlSuggestions(EMPTY_DOWNLOAD_URL_SUGGESTIONS);
+            setDownloadUrlSuggestionsLoaded(false);
+            setDownloadUrlSuggestionsLoading(false);
+            setDownloadUrlSuggestionsOpen(false);
+            setDownloadUrlSuggestionQuery('');
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [applyConfigState, defaultTemplateForResource, existingConfig, isOpen, resource.id]);
@@ -208,6 +238,26 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setCustomTemplates(response.data.templates ?? []);
         } catch (error) {
             console.error('Failed to load custom templates:', error);
+        }
+    };
+
+    const loadDownloadUrlSuggestions = async () => {
+        if (downloadUrlSuggestionsLoaded || downloadUrlSuggestionsLoading) {
+            return;
+        }
+
+        setDownloadUrlSuggestionsLoading(true);
+
+        try {
+            const response = await axios.get<{ suggestions: LandingPageDownloadUrlSuggestions }>('/api/landing-page-download-url-suggestions');
+            setDownloadUrlSuggestions(response.data.suggestions ?? EMPTY_DOWNLOAD_URL_SUGGESTIONS);
+            setDownloadUrlSuggestionsLoaded(true);
+        } catch (error) {
+            console.error('Failed to load landing page download URL suggestions:', error);
+            setDownloadUrlSuggestions(EMPTY_DOWNLOAD_URL_SUGGESTIONS);
+            setDownloadUrlSuggestionsLoaded(true);
+        } finally {
+            setDownloadUrlSuggestionsLoading(false);
         }
     };
 
@@ -235,6 +285,13 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setIsLoading(false);
         }
     };
+
+    useEffect(() => {
+        if (!supportsFtpUrl || hasImportedFiles) {
+            setDownloadUrlSuggestionsOpen(false);
+            setDownloadUrlSuggestionQuery('');
+        }
+    }, [hasImportedFiles, supportsFtpUrl]);
 
     const handleSave = async () => {
         if (!resource.id) {
@@ -418,6 +475,42 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             isExternal,
         });
     }, [isExternal, externalDomainId, externalPath, availableDomains]);
+
+    const filteredDownloadUrlSuggestions = useMemo(() => {
+        const normalizedQuery = downloadUrlSuggestionQuery.trim().toLowerCase();
+
+        const filterSuggestions = (suggestions: LandingPageDownloadUrlSuggestionItem[]) => {
+            if (normalizedQuery === '') {
+                return suggestions;
+            }
+
+            return suggestions.filter((suggestion) => suggestion.value.toLowerCase().includes(normalizedQuery));
+        };
+
+        return {
+            domains: filterSuggestions(downloadUrlSuggestions.domains),
+            urls: filterSuggestions(downloadUrlSuggestions.urls),
+        };
+    }, [downloadUrlSuggestionQuery, downloadUrlSuggestions]);
+
+    const shouldShowDownloadUrlSuggestions = supportsFtpUrl && !hasImportedFiles && downloadUrlSuggestionsOpen;
+    const hasVisibleDownloadUrlSuggestions = filteredDownloadUrlSuggestions.domains.length > 0 || filteredDownloadUrlSuggestions.urls.length > 0;
+
+    const openDownloadUrlSuggestions = () => {
+        if (!supportsFtpUrl || hasImportedFiles) {
+            return;
+        }
+
+        setDownloadUrlSuggestionsOpen(true);
+
+        void loadDownloadUrlSuggestions();
+    };
+
+    const applyDownloadUrlSuggestion = (value: string) => {
+        setFtpUrl(value);
+        setDownloadUrlSuggestionQuery('');
+        setDownloadUrlSuggestionsOpen(false);
+    };
 
     const openPreview = async () => {
         // For external landing pages, open the external URL directly
@@ -703,30 +796,120 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                         {supportsFtpUrl && (
                             <div className="space-y-2">
                                 <Label htmlFor="ftp-url">Download URL (FTP)</Label>
-                                <Input
-                                    id="ftp-url"
-                                    type="url"
-                                    placeholder="https://datapub.gfz-potsdam.de/download/..."
-                                    value={ftpUrl}
-                                    onChange={(e) => setFtpUrl(e.target.value)}
-                                    disabled={existingConfig?.files && existingConfig.files.length > 0}
-                                />
-                                {existingConfig?.files && existingConfig.files.length > 0 ? (
+                                <div
+                                    ref={downloadUrlAutocompleteRef}
+                                    className="relative"
+                                    onFocusCapture={openDownloadUrlSuggestions}
+                                    onBlurCapture={(event) => {
+                                        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
+                                            return;
+                                        }
+
+                                        setDownloadUrlSuggestionsOpen(false);
+                                        setDownloadUrlSuggestionQuery('');
+                                    }}
+                                >
+                                    <Input
+                                        id="ftp-url"
+                                        type="url"
+                                        placeholder="https://datapub.gfz-potsdam.de/download/..."
+                                        value={ftpUrl}
+                                        onChange={(e) => {
+                                            setFtpUrl(e.target.value);
+                                            setDownloadUrlSuggestionQuery(e.target.value);
+
+                                            if (!downloadUrlSuggestionsOpen) {
+                                                setDownloadUrlSuggestionsOpen(true);
+                                            }
+
+                                            void loadDownloadUrlSuggestions();
+                                        }}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Escape') {
+                                                setDownloadUrlSuggestionsOpen(false);
+                                                setDownloadUrlSuggestionQuery('');
+                                            }
+                                        }}
+                                        disabled={hasImportedFiles}
+                                        autoComplete="off"
+                                        aria-expanded={shouldShowDownloadUrlSuggestions}
+                                        aria-controls={shouldShowDownloadUrlSuggestions ? 'ftp-url-suggestions' : undefined}
+                                        aria-haspopup="listbox"
+                                    />
+
+                                    {shouldShowDownloadUrlSuggestions && (
+                                        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md">
+                                            <Command shouldFilter={false} className="bg-transparent">
+                                                <CommandList id="ftp-url-suggestions" className="max-h-64">
+                                                    {downloadUrlSuggestionsLoading ? (
+                                                        <div className="px-3 py-2 text-sm text-muted-foreground" role="status">
+                                                            Loading suggestions...
+                                                        </div>
+                                                    ) : !hasVisibleDownloadUrlSuggestions ? (
+                                                        <div className="px-3 py-2 text-sm text-muted-foreground">No matching suggestions.</div>
+                                                    ) : (
+                                                        <>
+                                                            {filteredDownloadUrlSuggestions.domains.length > 0 && (
+                                                                <CommandGroup heading="Suggested domains">
+                                                                    {filteredDownloadUrlSuggestions.domains.map((suggestion) => (
+                                                                        <CommandItem
+                                                                            key={`domain-${suggestion.value}`}
+                                                                            value={suggestion.value}
+                                                                            onMouseDown={(event) => event.preventDefault()}
+                                                                            onSelect={() => applyDownloadUrlSuggestion(suggestion.value)}
+                                                                        >
+                                                                            <span className="truncate">{suggestion.value}</span>
+                                                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                                                                                {suggestion.usage_count}x
+                                                                            </span>
+                                                                        </CommandItem>
+                                                                    ))}
+                                                                </CommandGroup>
+                                                            )}
+
+                                                            {filteredDownloadUrlSuggestions.urls.length > 0 && (
+                                                                <CommandGroup heading="Previously used full URLs">
+                                                                    {filteredDownloadUrlSuggestions.urls.map((suggestion) => (
+                                                                        <CommandItem
+                                                                            key={`url-${suggestion.value}`}
+                                                                            value={suggestion.value}
+                                                                            onMouseDown={(event) => event.preventDefault()}
+                                                                            onSelect={() => applyDownloadUrlSuggestion(suggestion.value)}
+                                                                        >
+                                                                            <span className="truncate">{suggestion.value}</span>
+                                                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                                                                                {suggestion.usage_count}x
+                                                                            </span>
+                                                                        </CommandItem>
+                                                                    ))}
+                                                                </CommandGroup>
+                                                            )}
+                                                        </>
+                                                    )}
+                                                </CommandList>
+                                            </Command>
+                                        </div>
+                                    )}
+                                </div>
+                                {hasImportedFiles ? (
                                     <p className="text-sm text-muted-foreground">
                                         This field is not used because imported download files are available below.
                                     </p>
                                 ) : (
-                                    <p className="text-sm text-muted-foreground">Direct link to download the primary data files</p>
+                                    <p className="text-sm text-muted-foreground">
+                                        Direct link to download the primary data files. Start typing or pick a suggested domain or full URL from
+                                        existing landing pages.
+                                    </p>
                                 )}
                             </div>
                         )}
 
                         {/* Imported download files (read-only, from legacy database) */}
-                        {!isExternal && existingConfig?.files && existingConfig.files.length > 0 && (
+                        {!isExternal && hasImportedFiles && (
                             <div className="space-y-2">
                                 <Label>Imported Download Files</Label>
                                 <div className="space-y-1 rounded-md border bg-muted/50 p-3">
-                                    {existingConfig.files.map((file) => (
+                                    {importedDownloadFiles.map((file) => (
                                         <a
                                             key={file.id ?? file.url}
                                             href={file.url}

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1391,6 +1391,11 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             label, exposes the full path on hover, uses darker linked badges for controlled terms and lighter blue badges for free
                             keywords, and opens the matching portal filter either from the label itself or from the dedicated magnifying-glass action.
                         </p>
+                        <p>
+                            In the landing page setup modal, the primary <strong>Download URL</strong> field now suggests frequently reused base
+                            domains and full URLs from existing landing pages. Click into the field to open the suggestions, pick a base domain such
+                            as <code>https://datapub.gfz.de/</code> to save typing, and then continue editing the remainder of the path if needed.
+                        </p>
 
                         <WorkflowSteps>
                             <WorkflowSteps.Step number={1} title="Navigate to Resources">

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -116,6 +116,31 @@ export interface LandingPageDomain {
 }
 
 /**
+ * Download URL suggestion item.
+ *
+ * Used by the Setup Landing Page modal to suggest frequently reused base
+ * domains and full download URLs.
+ */
+export interface LandingPageDownloadUrlSuggestionItem {
+    /** Suggested domain or full URL value */
+    value: string;
+
+    /** Number of existing landing pages/files using this value */
+    usage_count: number;
+}
+
+/**
+ * Grouped download URL suggestions returned by the landing page API.
+ */
+export interface LandingPageDownloadUrlSuggestions {
+    /** Base domain suggestions such as https://datapub.gfz.de/ */
+    domains: LandingPageDownloadUrlSuggestionItem[];
+
+    /** Full previously used download URLs */
+    urls: LandingPageDownloadUrlSuggestionItem[];
+}
+
+/**
  * Landing Page File
  *
  * Represents a download file entry from the landing_page_files table.

--- a/routes/web.php
+++ b/routes/web.php
@@ -426,6 +426,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('api/landing-page-domains/list', [LandingPageDomainController::class, 'index'])
         ->name('landing-page-domains.list');
 
+    // Download URL suggestions - read-only for all authenticated users (curators need this for the modal autocomplete)
+    Route::get('api/landing-page-download-url-suggestions', [LandingPageController::class, 'downloadUrlSuggestions'])
+        ->name('landing-page-download-url-suggestions.index');
+
     // Datacenters - read-only for all authenticated users (editor dropdown)
     Route::get('api/datacenters', [DatacenterController::class, 'index'])
         ->name('datacenters.index');

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\CacheKey;
 use App\Enums\UserRole;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Models\LandingPage;
@@ -630,7 +631,7 @@ describe('ImportFromDataCiteJob', function () {
 
 describe('ImportFromDataCiteJob download URL enrichment', function () {
     it('creates landing page with files when metaworks has download URLs', function () {
-        Cache::put('landing-page.download-url-suggestions', [
+        Cache::put(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key(), [
             'domains' => [['value' => 'https://stale.example.org/', 'usage_count' => 99]],
             'urls' => [['value' => 'https://stale.example.org/download/file.zip', 'usage_count' => 99]],
         ]);
@@ -695,7 +696,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($files[1]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip')
             ->and($files[1]->position)->toBe(1);
 
-        expect(Cache::get('landing-page.download-url-suggestions'))->toBeNull();
+        expect(Cache::get(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key()))->toBeNull();
     });
 
     it('creates unpublished landing page when metaworks files are non-public', function () {

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -630,6 +630,11 @@ describe('ImportFromDataCiteJob', function () {
 
 describe('ImportFromDataCiteJob download URL enrichment', function () {
     it('creates landing page with files when metaworks has download URLs', function () {
+        Cache::put('landing-page.download-url-suggestions', [
+            'domains' => [['value' => 'https://stale.example.org/', 'usage_count' => 99]],
+            'urls' => [['value' => 'https://stale.example.org/download/file.zip', 'usage_count' => 99]],
+        ]);
+
         $this->importService
             ->shouldReceive('getTotalDoiCount')
             ->once()
@@ -689,6 +694,8 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($files[0]->position)->toBe(0)
             ->and($files[1]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip')
             ->and($files[1]->position)->toBe(1);
+
+        expect(Cache::get('landing-page.download-url-suggestions'))->toBeNull();
     });
 
     it('creates unpublished landing page when metaworks files are non-public', function () {

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -736,3 +736,70 @@ describe('Landing Page GET Endpoint', function () {
             ->assertJsonPath('landing_page.landing_page_template_id', null);
     });
 });
+
+describe('Landing Page Download URL Suggestions', function () {
+    test('aggregates domain and url suggestions from existing download sources', function () {
+        $duplicateUrl = 'https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW';
+
+        $draftLandingPage = LandingPage::factory()->draft()->create([
+            'ftp_url' => $duplicateUrl,
+        ]);
+
+        LandingPage::factory()->published()->create([
+            'ftp_url' => 'https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.003-ZZZZZ',
+        ]);
+
+        LandingPage::factory()->published()->create([
+            'ftp_url' => $duplicateUrl,
+        ]);
+
+        LandingPage::factory()->draft()->create([
+            'ftp_url' => '   ',
+        ]);
+
+        $externalOnlyDomain = LandingPageDomain::factory()->withDomain('https://external-only.example.org/')->create();
+
+        LandingPage::factory()->published()->external()->create([
+            'external_domain_id' => $externalOnlyDomain->id,
+            'external_path' => 'dataset/should-not-appear',
+        ]);
+
+        $draftLandingPage->files()->createMany([
+            [
+                'url' => 'https://datapub.gfz.de/download/supporting-file.csv',
+                'position' => 0,
+            ],
+            [
+                'url' => 'https://archive.gfz.de/files/supplement.pdf',
+                'position' => 1,
+            ],
+        ]);
+
+        $response = $this->getJson('/api/landing-page-download-url-suggestions');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('suggestions.domains.0.value', 'https://datapub.gfz.de/')
+            ->assertJsonPath('suggestions.domains.0.usage_count', 4)
+            ->assertJsonPath('suggestions.urls.0.value', $duplicateUrl)
+            ->assertJsonPath('suggestions.urls.0.usage_count', 2);
+
+        $domainSuggestions = collect($response->json('suggestions.domains'));
+        $urlSuggestions = collect($response->json('suggestions.urls'));
+
+        expect($domainSuggestions->pluck('value')->all())
+            ->toContain('https://archive.gfz.de/')
+            ->not->toContain('https://external-only.example.org/');
+
+        expect($urlSuggestions->pluck('value')->all())
+            ->toContain('https://archive.gfz.de/files/supplement.pdf')
+            ->not->toContain('');
+    });
+
+    test('requires authentication for download url suggestions', function () {
+        auth()->logout();
+
+        $this->getJson('/api/landing-page-download-url-suggestions')
+            ->assertUnauthorized();
+    });
+});

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\LandingPageDomain;
 use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Models\User;
+use Illuminate\Support\Facades\Cache;
 
 covers(LandingPageController::class);
 
@@ -738,6 +739,10 @@ describe('Landing Page GET Endpoint', function () {
 });
 
 describe('Landing Page Download URL Suggestions', function () {
+    beforeEach(function () {
+        Cache::flush();
+    });
+
     test('aggregates domain and url suggestions from existing download sources', function () {
         $duplicateUrl = 'https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW';
 
@@ -801,5 +806,23 @@ describe('Landing Page Download URL Suggestions', function () {
 
         $this->getJson('/api/landing-page-download-url-suggestions')
             ->assertUnauthorized();
+    });
+
+    test('invalidates cached suggestions when landing pages change', function () {
+        $this->getJson('/api/landing-page-download-url-suggestions')
+            ->assertOk()
+            ->assertJsonPath('suggestions.domains', [])
+            ->assertJsonPath('suggestions.urls', []);
+
+        $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz.de/download/newly-created-file.zip',
+            'status' => 'draft',
+        ])->assertCreated();
+
+        $this->getJson('/api/landing-page-download-url-suggestions')
+            ->assertOk()
+            ->assertJsonPath('suggestions.domains.0.value', 'https://datapub.gfz.de/')
+            ->assertJsonPath('suggestions.urls.0.value', 'https://datapub.gfz.de/download/newly-created-file.zip');
     });
 });

--- a/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageControllerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\LandingPageController;
+use App\Enums\CacheKey;
 use App\Models\LandingPage;
 use App\Models\LandingPageDomain;
 use App\Models\LandingPageTemplate;
@@ -13,6 +14,15 @@ use Illuminate\Support\Facades\Cache;
 covers(LandingPageController::class);
 
 uses()->group('landing-pages');
+
+function portalFacetCacheRepository(CacheKey $cacheKey): \Illuminate\Contracts\Cache\Repository
+{
+    if (method_exists(Cache::getStore(), 'tags')) {
+        return Cache::tags($cacheKey->tags());
+    }
+
+    return Cache::store();
+}
 
 beforeEach(function () {
     $this->user = User::factory()->curator()->create();
@@ -51,6 +61,22 @@ describe('Landing Page Creation', function () {
             ->status->toBe('draft')
             ->preview_token->not->toBeNull()
             ->published_at->toBeNull();
+    });
+
+    test('creating a draft landing page does not invalidate portal facet caches', function () {
+        portalFacetCacheRepository(CacheKey::PORTAL_DATACENTER_FACETS)
+            ->put(CacheKey::PORTAL_DATACENTER_FACETS->key(), ['stale-datacenter'], CacheKey::PORTAL_DATACENTER_FACETS->ttl());
+        portalFacetCacheRepository(CacheKey::PORTAL_RESOURCE_TYPE_FACETS)
+            ->put(CacheKey::PORTAL_RESOURCE_TYPE_FACETS->key(), ['stale-resource-type'], CacheKey::PORTAL_RESOURCE_TYPE_FACETS->ttl());
+
+        $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/test.zip',
+            'status' => 'draft',
+        ])->assertCreated();
+
+        expect(portalFacetCacheRepository(CacheKey::PORTAL_DATACENTER_FACETS)->get(CacheKey::PORTAL_DATACENTER_FACETS->key()))->toBe(['stale-datacenter'])
+            ->and(portalFacetCacheRepository(CacheKey::PORTAL_RESOURCE_TYPE_FACETS)->get(CacheKey::PORTAL_RESOURCE_TYPE_FACETS->key()))->toBe(['stale-resource-type']);
     });
 
     test('can create landing page as published', function () {
@@ -148,6 +174,11 @@ describe('Landing Page Updates', function () {
     });
 
     test('can publish draft landing page', function () {
+        portalFacetCacheRepository(CacheKey::PORTAL_DATACENTER_FACETS)
+            ->put(CacheKey::PORTAL_DATACENTER_FACETS->key(), ['stale-datacenter'], CacheKey::PORTAL_DATACENTER_FACETS->ttl());
+        portalFacetCacheRepository(CacheKey::PORTAL_RESOURCE_TYPE_FACETS)
+            ->put(CacheKey::PORTAL_RESOURCE_TYPE_FACETS->key(), ['stale-resource-type'], CacheKey::PORTAL_RESOURCE_TYPE_FACETS->ttl());
+
         $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
             'template' => 'default_gfz',
             'status' => 'published',
@@ -158,6 +189,30 @@ describe('Landing Page Updates', function () {
         expect($this->landingPage->fresh())
             ->status->toBe('published')
             ->published_at->not->toBeNull();
+
+        expect(portalFacetCacheRepository(CacheKey::PORTAL_DATACENTER_FACETS)->get(CacheKey::PORTAL_DATACENTER_FACETS->key()))->toBeNull()
+            ->and(portalFacetCacheRepository(CacheKey::PORTAL_RESOURCE_TYPE_FACETS)->get(CacheKey::PORTAL_RESOURCE_TYPE_FACETS->key()))->toBeNull();
+    });
+
+    test('updating a published landing page keeps portal facet caches intact', function () {
+        $this->landingPage->publish();
+
+        Cache::put("landing-page.{$this->resource->id}", ['stale-landing-page']);
+        portalFacetCacheRepository(CacheKey::PORTAL_DATACENTER_FACETS)
+            ->put(CacheKey::PORTAL_DATACENTER_FACETS->key(), ['stale-datacenter'], CacheKey::PORTAL_DATACENTER_FACETS->ttl());
+        portalFacetCacheRepository(CacheKey::PORTAL_RESOURCE_TYPE_FACETS)
+            ->put(CacheKey::PORTAL_RESOURCE_TYPE_FACETS->key(), ['stale-resource-type'], CacheKey::PORTAL_RESOURCE_TYPE_FACETS->ttl());
+
+        $response = $this->putJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'ftp_url' => 'https://datapub.gfz-potsdam.de/download/published-update.zip',
+        ]);
+
+        $response->assertOk();
+
+        expect(Cache::get("landing-page.{$this->resource->id}"))->toBeNull()
+            ->and(portalFacetCacheRepository(CacheKey::PORTAL_DATACENTER_FACETS)->get(CacheKey::PORTAL_DATACENTER_FACETS->key()))->toBe(['stale-datacenter'])
+            ->and(portalFacetCacheRepository(CacheKey::PORTAL_RESOURCE_TYPE_FACETS)->get(CacheKey::PORTAL_RESOURCE_TYPE_FACETS->key()))->toBe(['stale-resource-type']);
     });
 
     test('cannot depublish published landing page because DOIs are persistent', function () {
@@ -740,7 +795,7 @@ describe('Landing Page GET Endpoint', function () {
 
 describe('Landing Page Download URL Suggestions', function () {
     beforeEach(function () {
-        Cache::flush();
+        CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->forget();
     });
 
     test('aggregates domain and url suggestions from existing download sources', function () {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -367,6 +367,37 @@ describe('SetupLandingPageModal', () => {
             expect(ftpInput).toHaveValue('https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW');
         });
 
+        it('supports keyboard navigation and selection for download url suggestions', async () => {
+            mockModalGetRequests();
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+
+            await user.click(ftpInput);
+
+            await waitFor(() => {
+                expect(screen.getByRole('listbox')).toBeInTheDocument();
+            });
+
+            await user.keyboard('{ArrowDown}');
+
+            expect(ftpInput).toHaveAttribute('aria-activedescendant', 'ftp-url-domain-suggestion-0');
+
+            await user.keyboard('{Enter}');
+
+            expect(ftpInput).toHaveValue('https://datapub.gfz.de/');
+            expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+        });
+
         it('does not fetch suggestions when imported files disable the ftp field', async () => {
             mockModalGetRequests({
                 landingPage: {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -8,7 +8,7 @@ import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SetupLandingPageModal from '@/components/landing-pages/modals/SetupLandingPageModal';
-import type { LandingPageConfig } from '@/types/landing-page';
+import type { LandingPageConfig, LandingPageDownloadUrlSuggestions } from '@/types/landing-page';
 
 // Mock dependencies
 vi.mock('axios', () => {
@@ -59,6 +59,17 @@ describe('SetupLandingPageModal', () => {
         { id: 2, domain: 'https://resources.example.org/' },
     ];
 
+    const mockDownloadUrlSuggestions: LandingPageDownloadUrlSuggestions = {
+        domains: [
+            { value: 'https://datapub.gfz.de/', usage_count: 4 },
+            { value: 'https://archive.gfz.de/', usage_count: 1 },
+        ],
+        urls: [
+            { value: 'https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW', usage_count: 2 },
+            { value: 'https://archive.gfz.de/files/supplement.pdf', usage_count: 1 },
+        ],
+    };
+
     const mockResource = {
         id: 123,
         doi: '10.5880/GFZ.TEST.2025.001',
@@ -86,6 +97,47 @@ describe('SetupLandingPageModal', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
+
+    const mockModalGetRequests = ({
+        landingPage = null,
+        downloadSuggestions = mockDownloadUrlSuggestions,
+        downloadSuggestionsError,
+    }: {
+        landingPage?: LandingPageConfig | null;
+        downloadSuggestions?: LandingPageDownloadUrlSuggestions;
+        downloadSuggestionsError?: unknown;
+    } = {}) => {
+        mockedAxiosGet.mockImplementation((url: string) => {
+            if (url.includes(`/resources/${mockResource.id}/landing-page`)) {
+                if (landingPage === null) {
+                    return Promise.reject({
+                        isAxiosError: true,
+                        response: { status: 404 },
+                    });
+                }
+
+                return Promise.resolve({ data: { landing_page: landingPage } });
+            }
+
+            if (url === '/api/landing-page-domains/list') {
+                return Promise.resolve({ data: { domains: mockDomains } });
+            }
+
+            if (url === '/api/landing-page-templates') {
+                return Promise.resolve({ data: { templates: [] } });
+            }
+
+            if (url === '/api/landing-page-download-url-suggestions') {
+                if (downloadSuggestionsError) {
+                    return Promise.reject(downloadSuggestionsError);
+                }
+
+                return Promise.resolve({ data: { suggestions: downloadSuggestions } });
+            }
+
+            return Promise.reject(new Error(`Unexpected GET request: ${url}`));
+        });
+    };
 
     describe('Rendering', () => {
         it('renders modal when open', async () => {
@@ -235,6 +287,155 @@ describe('SetupLandingPageModal', () => {
                 const ftpInput = screen.getByLabelText(/Download URL \(FTP\)/i) as HTMLInputElement;
                 expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
             });
+        });
+
+        it('shows grouped download url suggestions when the field receives focus', async () => {
+            mockModalGetRequests();
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            await user.click(ftpInput);
+
+            await waitFor(() => {
+                expect(axios.get).toHaveBeenCalledWith('/api/landing-page-download-url-suggestions');
+            });
+
+            expect(screen.getByText('Suggested domains')).toBeInTheDocument();
+            expect(screen.getByText('Previously used full URLs')).toBeInTheDocument();
+            expect(screen.getByText('https://datapub.gfz.de/')).toBeInTheDocument();
+            expect(screen.getByText('https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW')).toBeInTheDocument();
+        });
+
+        it('filters suggestions and lets the user keep editing after choosing a domain', async () => {
+            mockModalGetRequests();
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+
+            await user.click(ftpInput);
+            await user.type(ftpInput, 'archive');
+
+            expect(screen.queryByText('https://datapub.gfz.de/')).not.toBeInTheDocument();
+            expect(screen.getByText('https://archive.gfz.de/')).toBeInTheDocument();
+
+            await user.clear(ftpInput);
+            await user.click(screen.getByText('https://datapub.gfz.de/'));
+
+            expect(ftpInput).toHaveValue('https://datapub.gfz.de/');
+
+            await user.type(ftpInput, 'download/custom-file');
+
+            expect(ftpInput).toHaveValue('https://datapub.gfz.de/download/custom-file');
+        });
+
+        it('inserts the full url when a full-url suggestion is selected', async () => {
+            mockModalGetRequests();
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+
+            await user.click(ftpInput);
+            await user.click(screen.getByText('https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW'));
+
+            expect(ftpInput).toHaveValue('https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW');
+        });
+
+        it('does not fetch suggestions when imported files disable the ftp field', async () => {
+            mockModalGetRequests({
+                landingPage: {
+                    ...mockExistingConfig,
+                    files: [
+                        {
+                            id: 1,
+                            url: 'https://legacy.gfz.de/download/file-one.zip',
+                            position: 0,
+                        },
+                    ],
+                },
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    existingConfig={{
+                        ...mockExistingConfig,
+                        files: [
+                            {
+                                id: 1,
+                                url: 'https://legacy.gfz.de/download/file-one.zip',
+                                position: 0,
+                            },
+                        ],
+                    }}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            expect(ftpInput).toBeDisabled();
+
+            await user.click(ftpInput);
+
+            expect(axios.get).not.toHaveBeenCalledWith('/api/landing-page-download-url-suggestions');
+        });
+
+        it('keeps the modal usable when loading download url suggestions fails', async () => {
+            mockModalGetRequests({
+                downloadSuggestionsError: new Error('Network error'),
+            });
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            await user.click(ftpInput);
+
+            await waitFor(() => {
+                expect(axios.get).toHaveBeenCalledWith('/api/landing-page-download-url-suggestions');
+            });
+
+            expect(mockedToastError).not.toHaveBeenCalled();
+            expect(screen.getByText('No matching suggestions.')).toBeInTheDocument();
+
+            await user.type(ftpInput, 'https://manual.example.org/file.zip');
+            expect(ftpInput).toHaveValue('https://manual.example.org/file.zip');
         });
 
         it('normalizes a legacy Physical Object config passed via props to the IGSN template', async () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -260,10 +260,10 @@ describe('SetupLandingPageModal', () => {
             );
 
             await waitFor(() => {
-                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+                expect(screen.getByRole('combobox', { name: /landing page template/i })).toHaveTextContent('Default GFZ IGSN Template');
             });
 
-            await user.click(screen.getByRole('combobox'));
+            await user.click(screen.getByRole('combobox', { name: /landing page template/i }));
 
             const optionsList = screen.getByRole('listbox');
             expect(optionsList).toHaveTextContent('Default GFZ IGSN Template');
@@ -313,6 +313,23 @@ describe('SetupLandingPageModal', () => {
             expect(screen.getByText('Previously used full URLs')).toBeInTheDocument();
             expect(screen.getByText('https://datapub.gfz.de/')).toBeInTheDocument();
             expect(screen.getByText('https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW')).toBeInTheDocument();
+        });
+
+        it('exposes the download url input as a combobox for assistive technology', async () => {
+            mockModalGetRequests();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+
+            expect(ftpInput).toHaveAttribute('role', 'combobox');
+            expect(ftpInput).toHaveAttribute('aria-autocomplete', 'list');
         });
 
         it('filters suggestions and lets the user keep editing after choosing a domain', async () => {
@@ -497,7 +514,7 @@ describe('SetupLandingPageModal', () => {
             );
 
             await waitFor(() => {
-                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+                expect(screen.getByRole('combobox', { name: /landing page template/i })).toHaveTextContent('Default GFZ IGSN Template');
             });
 
             expect(screen.queryByLabelText(/Download URL \(FTP\)/i)).not.toBeInTheDocument();
@@ -577,7 +594,7 @@ describe('SetupLandingPageModal', () => {
             );
 
             await waitFor(() => {
-                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+                expect(screen.getByRole('combobox', { name: /landing page template/i })).toHaveTextContent('Default GFZ IGSN Template');
             });
 
             await user.click(screen.getByRole('button', { name: /Update/i }));
@@ -1080,7 +1097,7 @@ describe('SetupLandingPageModal', () => {
             );
 
             await waitFor(() => {
-                expect(screen.getByRole('combobox')).toHaveTextContent('Default GFZ IGSN Template');
+                expect(screen.getByRole('combobox', { name: /landing page template/i })).toHaveTextContent('Default GFZ IGSN Template');
             });
 
             expect(screen.queryByText(/You have unsaved changes/i)).not.toBeInTheDocument();


### PR DESCRIPTION
This pull request introduces Download URL suggestions to the landing page setup flow, improving curator experience by providing frequently used domains and URLs for the Download URL field. It also refactors cache invalidation logic for better maintainability and ensures that suggestion data stays up to date after landing page changes. Additionally, the changelog is updated to document these improvements.

**Download URL Suggestions Feature:**

* Adds backend logic in `LandingPageController` to aggregate and normalize download URLs from existing landing pages and files, returning the top domains and URLs for use as suggestions in the setup modal. (`downloadUrlSuggestions`, `buildDownloadUrlSuggestionPayload`, `loadDownloadUrlSuggestionSourceCounts`, etc.) [[1]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR597-R616) [[2]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL637-R814)
* Implements frontend state and logic in `SetupLandingPageModal.tsx` to fetch, display, and filter download URL suggestions, opening the suggestions dropdown as soon as the field receives focus. (`downloadUrlSuggestions`, state management, and API call) [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950L24-R34) [[2]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R52-R62) [[3]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R141-R148) [[4]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R185-R186) [[5]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R222-R227) [[6]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R251-R270)

**Cache Management Improvements:**

* Introduces a dedicated cache key (`LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS`) for download URL suggestions, with explicit invalidation after landing page create, update, destroy, or import operations. [[1]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfR76-R78) [[2]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfR161-R164) [[3]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfR224-R225) [[4]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR368-R373) [[5]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccR518-R528) [[6]](diffhunk://#diff-4a17ab1a40f0d2d60b77d3f424e3f8270c311bfdc3c35fb2fda6899c33c403ccL561-R570) [[7]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R7) [[8]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R626-R627)
* Refactors cache invalidation methods for landing page and facet caches to use the new enum-based approach, improving consistency and clarity.

**Changelog Updates:**

* Documents the new Download URL suggestions feature and moves a previously misplaced fix entry to the correct section for better release notes clarity. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL5-L14) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR96-R99) [[3]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR234-R237)