### PR TITLE
Fix: Hide used instruments when PID4INST was disabled

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -232,6 +232,10 @@
         ],
         "fixes": [
             {
+                "title": "Hide Used Instruments When PID4INST Is Disabled",
+                "description": "When administrators or group leaders deactivate PID4INST in Settings, the Data Editor now hides the entire 'Used Instruments' form group instead of showing it with a misleading 'Unable to load instrument data' error."
+            },
+            {
                 "title": "PID4INST Registry Update Works with Current b2inst API",
                 "description": "The 'Check for Updates' and 'Update Now' flow in Editor Settings now works again for PID4INST instrument data. ERNIE no longer sends the outdated sort=mostrecent query parameter when downloading the b2inst registry, so the initial download and later refreshes no longer fail with 'Command exited with code 1' after the remote count check succeeds."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -667,7 +667,7 @@ export default function DataCiteForm({
         analytical_methods: true,
         euroscivoc: true,
     });
-    const [isPid4instAvailable, setIsPid4instAvailable] = useState(false);
+    const [pid4instAvailability, setPid4instAvailability] = useState<'checking' | 'available' | 'unavailable'>('checking');
 
     useEffect(() => {
         let isCancelled = false;
@@ -677,6 +677,9 @@ export default function DataCiteForm({
                 const response = await fetch('/api/v1/vocabularies/pid-availability');
 
                 if (!response.ok) {
+                    if (!isCancelled) {
+                        setPid4instAvailability('available');
+                    }
                     return;
                 }
 
@@ -687,10 +690,13 @@ export default function DataCiteForm({
                 };
 
                 if (!isCancelled) {
-                    setIsPid4instAvailable(availabilityData.pid4inst?.available === true);
+                    setPid4instAvailability(availabilityData.pid4inst?.available === false ? 'unavailable' : 'available');
                 }
             } catch {
-                console.warn('Failed to check PID availability, hiding PID-dependent fields');
+                if (!isCancelled) {
+                    setPid4instAvailability('available');
+                }
+                console.warn('Failed to check PID availability, keeping PID-dependent fields visible');
             }
         };
 
@@ -700,6 +706,9 @@ export default function DataCiteForm({
             isCancelled = true;
         };
     }, []);
+
+    const shouldShowUsedInstrumentsSection = pid4instAvailability !== 'unavailable';
+    const canLoadUsedInstrumentsField = pid4instAvailability === 'available';
 
     // Load thesauri availability and GCMD vocabularies from web routes on mount
     useEffect(() => {
@@ -2644,7 +2653,7 @@ export default function DataCiteForm({
                         <CitationsField resourceId={resolvedResourceId} />
                     </AccordionContent>
                 </AccordionItem>
-                {isPid4instAvailable && (
+                {shouldShowUsedInstrumentsSection && (
                     <AccordionItem value="used-instruments" data-testid="used-instruments-section">
                         <AccordionTrigger data-testid="used-instruments-accordion-trigger">
                             <div className="flex items-center gap-2">
@@ -2659,7 +2668,11 @@ export default function DataCiteForm({
                                 tooltip="Select instruments from the PID4INST / b2inst registry. Instruments will be linked via Handle PIDs as DataCite relatedIdentifiers."
                                 counter={{ current: instruments.length, max: 100 }}
                             />
-                            <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
+                            {canLoadUsedInstrumentsField ? (
+                                <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
+                            ) : (
+                                <p className="text-sm text-muted-foreground">Checking PID4INST availability...</p>
+                            )}
                         </AccordionContent>
                     </AccordionItem>
                 )}

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -692,11 +692,11 @@ export default function DataCiteForm({
                 if (!isCancelled) {
                     setPid4instAvailability(availabilityData.pid4inst?.available === false ? 'unavailable' : 'available');
                 }
-            } catch {
+            } catch (error) {
                 if (!isCancelled) {
                     setPid4instAvailability('available');
+                    console.warn('Failed to check PID availability, keeping PID-dependent fields visible', error);
                 }
-                console.warn('Failed to check PID availability, keeping PID-dependent fields visible');
             }
         };
 

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -707,8 +707,7 @@ export default function DataCiteForm({
         };
     }, []);
 
-    const shouldShowUsedInstrumentsSection = pid4instAvailability !== 'unavailable';
-    const canLoadUsedInstrumentsField = pid4instAvailability === 'available';
+    const shouldShowUsedInstrumentsSection = pid4instAvailability === 'available';
 
     // Load thesauri availability and GCMD vocabularies from web routes on mount
     useEffect(() => {
@@ -2668,11 +2667,7 @@ export default function DataCiteForm({
                                 tooltip="Select instruments from the PID4INST / b2inst registry. Instruments will be linked via Handle PIDs as DataCite relatedIdentifiers."
                                 counter={{ current: instruments.length, max: 100 }}
                             />
-                            {canLoadUsedInstrumentsField ? (
-                                <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
-                            ) : (
-                                <p className="text-sm text-muted-foreground">Checking PID4INST availability...</p>
-                            )}
+                            <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
                         </AccordionContent>
                     </AccordionItem>
                 )}

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -667,6 +667,39 @@ export default function DataCiteForm({
         analytical_methods: true,
         euroscivoc: true,
     });
+    const [isPid4instAvailable, setIsPid4instAvailable] = useState(false);
+
+    useEffect(() => {
+        let isCancelled = false;
+
+        const loadPidAvailability = async () => {
+            try {
+                const response = await fetch('/api/v1/vocabularies/pid-availability');
+
+                if (!response.ok) {
+                    return;
+                }
+
+                const availabilityData = (await response.json()) as {
+                    pid4inst?: {
+                        available?: boolean;
+                    };
+                };
+
+                if (!isCancelled) {
+                    setIsPid4instAvailable(availabilityData.pid4inst?.available === true);
+                }
+            } catch {
+                console.warn('Failed to check PID availability, hiding PID-dependent fields');
+            }
+        };
+
+        void loadPidAvailability();
+
+        return () => {
+            isCancelled = true;
+        };
+    }, []);
 
     // Load thesauri availability and GCMD vocabularies from web routes on mount
     useEffect(() => {
@@ -2611,23 +2644,25 @@ export default function DataCiteForm({
                         <CitationsField resourceId={resolvedResourceId} />
                     </AccordionContent>
                 </AccordionItem>
-                <AccordionItem value="used-instruments" data-testid="used-instruments-section">
-                    <AccordionTrigger data-testid="used-instruments-accordion-trigger">
-                        <div className="flex items-center gap-2">
-                            <span>Used Instruments</span>
-                            {renderStatusBadge(instrumentsStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent data-testid="used-instruments-accordion-content">
-                        <SectionHeader
-                            label="Used Instruments"
-                            description="Research instruments used for data collection."
-                            tooltip="Select instruments from the PID4INST / b2inst registry. Instruments will be linked via Handle PIDs as DataCite relatedIdentifiers."
-                            counter={{ current: instruments.length, max: 100 }}
-                        />
-                        <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
-                    </AccordionContent>
-                </AccordionItem>
+                {isPid4instAvailable && (
+                    <AccordionItem value="used-instruments" data-testid="used-instruments-section">
+                        <AccordionTrigger data-testid="used-instruments-accordion-trigger">
+                            <div className="flex items-center gap-2">
+                                <span>Used Instruments</span>
+                                {renderStatusBadge(instrumentsStatus)}
+                            </div>
+                        </AccordionTrigger>
+                        <AccordionContent data-testid="used-instruments-accordion-content">
+                            <SectionHeader
+                                label="Used Instruments"
+                                description="Research instruments used for data collection."
+                                tooltip="Select instruments from the PID4INST / b2inst registry. Instruments will be linked via Handle PIDs as DataCite relatedIdentifiers."
+                                counter={{ current: instruments.length, max: 100 }}
+                            />
+                            <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
+                        </AccordionContent>
+                    </AccordionItem>
+                )}
                 <AccordionItem value="funding-references">
                     <AccordionTrigger>
                         <div className="flex items-center gap-2">

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -65,6 +65,21 @@ describe('DataCiteForm', () => {
             headers,
         });
     };
+    const createDeferred = <T,>() => {
+        let resolvePromise!: (value: T | PromiseLike<T>) => void;
+        let rejectPromise!: (reason?: unknown) => void;
+
+        const promise = new Promise<T>((resolve, reject) => {
+            resolvePromise = resolve;
+            rejectPromise = reject;
+        });
+
+        return {
+            promise,
+            resolve: resolvePromise,
+            reject: rejectPromise,
+        };
+    };
     const thesauriAvailabilityResponse = {
         science_keywords: { available: true },
         platforms: { available: true },
@@ -666,7 +681,70 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(await screen.findByTestId('used-instruments-section')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith('/api/v1/vocabularies/pid-availability');
+        });
+
+        expect(await screen.findByText('Add Instrument')).toBeInTheDocument();
+        expect(screen.getByTestId('used-instruments-section')).toBeInTheDocument();
+    });
+
+    it('does not render the used instruments section while PID4INST availability is still loading', async () => {
+        const pidAvailabilityRequest = createDeferred<Response>();
+
+        vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                return pidAvailabilityRequest.promise;
+            }
+
+            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
+                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+            }
+
+            if (url.includes('/vocabularies/msl')) {
+                return Promise.resolve(createJsonResponse([]));
+            }
+
+            if (url.includes('/vocabularies/')) {
+                return Promise.resolve(createJsonResponse({ data: [] }));
+            }
+
+            return Promise.resolve(createJsonResponse([]));
+        });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                descriptionTypes={descriptionTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith('/api/v1/vocabularies/pid-availability');
+        });
+
+        expect(screen.queryByTestId('used-instruments-section')).not.toBeInTheDocument();
+        expect(screen.queryByText('Add Instrument')).not.toBeInTheDocument();
+
+        pidAvailabilityRequest.resolve(
+            createJsonResponse({
+                pid4inst: { available: true },
+                ror: { available: true },
+            }),
+        );
+
+        expect(await screen.findByText('Add Instrument')).toBeInTheDocument();
+        expect(screen.getByTestId('used-instruments-section')).toBeInTheDocument();
     });
 
     it('hides the used instruments section when PID4INST is disabled', async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -53,12 +53,18 @@ vi.mock('@/hooks/use-ror-affiliations', () => ({
 
 describe('DataCiteForm', () => {
     const originalFetch = global.fetch;
-    const createJsonResponse = (body: unknown): Response =>
-        ({
-            ok: true,
-            status: 200,
-            json: () => Promise.resolve(body),
-        }) as Response;
+    const createJsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+        const headers = new Headers(init.headers);
+
+        if (!headers.has('Content-Type')) {
+            headers.set('Content-Type', 'application/json');
+        }
+
+        return new Response(JSON.stringify(body), {
+            ...init,
+            headers,
+        });
+    };
     const thesauriAvailabilityResponse = {
         science_keywords: { available: true },
         platforms: { available: true },
@@ -718,11 +724,7 @@ describe('DataCiteForm', () => {
             const url = input.toString();
 
             if (url.includes('/api/v1/vocabularies/pid-availability')) {
-                return Promise.resolve({
-                    ok: false,
-                    status: 500,
-                    json: () => Promise.resolve({}),
-                } as Response);
+                return Promise.resolve(createJsonResponse({}, { status: 500 }));
             }
 
             if (url.includes('/api/v1/vocabularies/thesauri-availability')) {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -89,6 +89,11 @@ describe('DataCiteForm', () => {
         analytical_methods: { available: true },
         euroscivoc: { available: true },
     };
+    const citationVocabulariesResponse = {
+        resourceTypes: [],
+        relationTypes: [],
+        contributorTypes: [],
+    };
 
     // Helper Functions
     const clearXsrfCookie = () => {
@@ -293,6 +298,14 @@ describe('DataCiteForm', () => {
 
             if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
                 return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+            }
+
+            if (url.includes('/related-items/vocabularies')) {
+                return Promise.resolve(createJsonResponse(citationVocabulariesResponse));
+            }
+
+            if (/\/resources\/\d+\/related-items(?:\/.*)?$/.test(url)) {
+                return Promise.resolve(createJsonResponse({ data: [] }));
             }
 
             if (url.includes('/vocabularies/msl')) {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -94,6 +94,38 @@ describe('DataCiteForm', () => {
         relationTypes: [],
         contributorTypes: [],
     };
+    const createDefaultFetchResponse = (url: string): Promise<Response> => {
+        if (url.includes('/api/v1/vocabularies/pid-availability')) {
+            return Promise.resolve(
+                createJsonResponse({
+                    pid4inst: { available: true },
+                    ror: { available: true },
+                }),
+            );
+        }
+
+        if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
+            return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+        }
+
+        if (url.includes('/related-items/vocabularies')) {
+            return Promise.resolve(createJsonResponse(citationVocabulariesResponse));
+        }
+
+        if (/\/resources\/\d+\/related-items(?:\/.*)?$/.test(url)) {
+            return Promise.resolve(createJsonResponse({ data: [] }));
+        }
+
+        if (url.includes('/vocabularies/msl')) {
+            return Promise.resolve(createJsonResponse([]));
+        }
+
+        if (url.includes('/vocabularies/')) {
+            return Promise.resolve(createJsonResponse({ data: [] }));
+        }
+
+        return Promise.resolve(createJsonResponse([]));
+    };
 
     // Helper Functions
     const clearXsrfCookie = () => {
@@ -284,40 +316,7 @@ describe('DataCiteForm', () => {
         };
         
         // Keep global.fetch mock for backward compatibility with other parts
-        global.fetch = vi.fn((input: RequestInfo | URL) => {
-            const url = input.toString();
-
-            if (url.includes('/api/v1/vocabularies/pid-availability')) {
-                return Promise.resolve(
-                    createJsonResponse({
-                        pid4inst: { available: true },
-                        ror: { available: true },
-                    }),
-                );
-            }
-
-            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
-                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
-            }
-
-            if (url.includes('/related-items/vocabularies')) {
-                return Promise.resolve(createJsonResponse(citationVocabulariesResponse));
-            }
-
-            if (/\/resources\/\d+\/related-items(?:\/.*)?$/.test(url)) {
-                return Promise.resolve(createJsonResponse({ data: [] }));
-            }
-
-            if (url.includes('/vocabularies/msl')) {
-                return Promise.resolve(createJsonResponse([]));
-            }
-
-            if (url.includes('/vocabularies/')) {
-                return Promise.resolve(createJsonResponse({ data: [] }));
-            }
-
-            return Promise.resolve(createJsonResponse([]));
-        });
+        global.fetch = vi.fn((input: RequestInfo | URL) => createDefaultFetchResponse(input.toString()));
         
         document.head.innerHTML = '<meta name="csrf-token" content="test-csrf-token">';
         clearXsrfCookie();
@@ -712,19 +711,7 @@ describe('DataCiteForm', () => {
                 return pidAvailabilityRequest.promise;
             }
 
-            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
-                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
-            }
-
-            if (url.includes('/vocabularies/msl')) {
-                return Promise.resolve(createJsonResponse([]));
-            }
-
-            if (url.includes('/vocabularies/')) {
-                return Promise.resolve(createJsonResponse({ data: [] }));
-            }
-
-            return Promise.resolve(createJsonResponse([]));
+            return createDefaultFetchResponse(url);
         });
 
         render(
@@ -773,15 +760,7 @@ describe('DataCiteForm', () => {
                 );
             }
 
-            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
-                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
-            }
-
-            if (url.includes('/vocabularies/')) {
-                return Promise.resolve(createJsonResponse({ data: [] }));
-            }
-
-            return Promise.resolve(createJsonResponse([]));
+            return createDefaultFetchResponse(url);
         });
 
         render(
@@ -818,19 +797,7 @@ describe('DataCiteForm', () => {
                 return Promise.resolve(createJsonResponse({}, { status: 500 }));
             }
 
-            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
-                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
-            }
-
-            if (url.includes('/vocabularies/msl')) {
-                return Promise.resolve(createJsonResponse([]));
-            }
-
-            if (url.includes('/vocabularies/')) {
-                return Promise.resolve(createJsonResponse({ data: [] }));
-            }
-
-            return Promise.resolve(createJsonResponse([]));
+            return createDefaultFetchResponse(url);
         });
 
         render(
@@ -860,19 +827,7 @@ describe('DataCiteForm', () => {
                 return Promise.reject(new Error('network down'));
             }
 
-            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
-                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
-            }
-
-            if (url.includes('/vocabularies/msl')) {
-                return Promise.resolve(createJsonResponse([]));
-            }
-
-            if (url.includes('/vocabularies/')) {
-                return Promise.resolve(createJsonResponse({ data: [] }));
-            }
-
-            return Promise.resolve(createJsonResponse([]));
+            return createDefaultFetchResponse(url);
         });
 
         render(
@@ -892,6 +847,49 @@ describe('DataCiteForm', () => {
 
         expect(await screen.findByTestId('used-instruments-section')).toBeInTheDocument();
         expect(await screen.findByText('Add Instrument')).toBeInTheDocument();
+    });
+
+    it('does not warn about PID availability after the form unmounts', async () => {
+        const pidAvailabilityRequest = createDeferred<Response>();
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                return pidAvailabilityRequest.promise;
+            }
+
+            return createDefaultFetchResponse(url);
+        });
+
+        const { unmount } = render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                descriptionTypes={descriptionTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith('/api/v1/vocabularies/pid-availability');
+        });
+
+        unmount();
+
+        await act(async () => {
+            pidAvailabilityRequest.reject(new Error('network down'));
+            await Promise.resolve();
+        });
+
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it(

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -274,6 +274,10 @@ describe('DataCiteForm', () => {
                 return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
             }
 
+            if (url.includes('/vocabularies/msl')) {
+                return Promise.resolve(createJsonResponse([]));
+            }
+
             if (url.includes('/vocabularies/')) {
                 return Promise.resolve(createJsonResponse({ data: [] }));
             }

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -713,6 +713,94 @@ describe('DataCiteForm', () => {
         expect(screen.queryByText('Unable to load instrument data')).not.toBeInTheDocument();
     });
 
+    it('keeps the used instruments section visible when the PID availability check returns non-OK', async () => {
+        vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                return Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    json: () => Promise.resolve({}),
+                } as Response);
+            }
+
+            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
+                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+            }
+
+            if (url.includes('/vocabularies/msl')) {
+                return Promise.resolve(createJsonResponse([]));
+            }
+
+            if (url.includes('/vocabularies/')) {
+                return Promise.resolve(createJsonResponse({ data: [] }));
+            }
+
+            return Promise.resolve(createJsonResponse([]));
+        });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                descriptionTypes={descriptionTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        expect(await screen.findByTestId('used-instruments-section')).toBeInTheDocument();
+        expect(await screen.findByText('Add Instrument')).toBeInTheDocument();
+    });
+
+    it('keeps the used instruments section visible when the PID availability check throws', async () => {
+        vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                return Promise.reject(new Error('network down'));
+            }
+
+            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
+                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+            }
+
+            if (url.includes('/vocabularies/msl')) {
+                return Promise.resolve(createJsonResponse([]));
+            }
+
+            if (url.includes('/vocabularies/')) {
+                return Promise.resolve(createJsonResponse({ data: [] }));
+            }
+
+            return Promise.resolve(createJsonResponse([]));
+        });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                descriptionTypes={descriptionTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        expect(await screen.findByTestId('used-instruments-section')).toBeInTheDocument();
+        expect(await screen.findByText('Add Instrument')).toBeInTheDocument();
+    });
+
     it(
         'shows validation error list when saving with missing required fields (Issue #538)',
         { timeout: 60000 },

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -53,6 +53,21 @@ vi.mock('@/hooks/use-ror-affiliations', () => ({
 
 describe('DataCiteForm', () => {
     const originalFetch = global.fetch;
+    const createJsonResponse = (body: unknown): Response =>
+        ({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(body),
+        }) as Response;
+    const thesauriAvailabilityResponse = {
+        science_keywords: { available: true },
+        platforms: { available: true },
+        instruments: { available: true },
+        chronostratigraphy: { available: true },
+        gemet: { available: true },
+        analytical_methods: { available: true },
+        euroscivoc: { available: true },
+    };
 
     // Helper Functions
     const clearXsrfCookie = () => {
@@ -243,21 +258,28 @@ describe('DataCiteForm', () => {
         };
         
         // Keep global.fetch mock for backward compatibility with other parts
-        global.fetch = vi.fn();
-        
-        // Mock the controlled vocabulary fetches that DataCiteForm makes on mount
-        // (GCMD Science Keywords, Platforms, Instruments, and ROR Funders)
-        const emptyVocabularyResponse = {
-            ok: true,
-            status: 200,
-            json: () => Promise.resolve([]),
-        } as Response;
-        
-        (global.fetch as unknown as ReturnType<typeof vi.fn>)
-            .mockResolvedValueOnce(emptyVocabularyResponse) // gcmd-science-keywords
-            .mockResolvedValueOnce(emptyVocabularyResponse) // gcmd-platforms
-            .mockResolvedValueOnce(emptyVocabularyResponse) // gcmd-instruments
-            .mockResolvedValueOnce(emptyVocabularyResponse); // ror-funders
+        global.fetch = vi.fn((input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                return Promise.resolve(
+                    createJsonResponse({
+                        pid4inst: { available: true },
+                        ror: { available: true },
+                    }),
+                );
+            }
+
+            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
+                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+            }
+
+            if (url.includes('/vocabularies/')) {
+                return Promise.resolve(createJsonResponse({ data: [] }));
+            }
+
+            return Promise.resolve(createJsonResponse([]));
+        });
         
         document.head.innerHTML = '<meta name="csrf-token" content="test-csrf-token">';
         clearXsrfCookie();
@@ -617,6 +639,75 @@ describe('DataCiteForm', () => {
             expect(saveButton).toHaveAttribute('aria-disabled', 'false');
         },
     );
+
+    it('shows the used instruments section when PID4INST is enabled', async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                descriptionTypes={descriptionTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        expect(await screen.findByTestId('used-instruments-section')).toBeInTheDocument();
+    });
+
+    it('hides the used instruments section when PID4INST is disabled', async () => {
+        vi.mocked(fetch).mockImplementation((input: RequestInfo | URL) => {
+            const url = input.toString();
+
+            if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                return Promise.resolve(
+                    createJsonResponse({
+                        pid4inst: { available: false },
+                        ror: { available: true },
+                    }),
+                );
+            }
+
+            if (url.includes('/api/v1/vocabularies/thesauri-availability')) {
+                return Promise.resolve(createJsonResponse(thesauriAvailabilityResponse));
+            }
+
+            if (url.includes('/vocabularies/')) {
+                return Promise.resolve(createJsonResponse({ data: [] }));
+            }
+
+            return Promise.resolve(createJsonResponse([]));
+        });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                descriptionTypes={descriptionTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith('/api/v1/vocabularies/pid-availability');
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('used-instruments-section')).not.toBeInTheDocument();
+        });
+
+        expect(screen.queryByText('Unable to load instrument data')).not.toBeInTheDocument();
+    });
 
     it(
         'shows validation error list when saving with missing required fields (Issue #538)',


### PR DESCRIPTION
This pull request improves the user experience in the DataCite form by conditionally showing or hiding the "Used Instruments" section based on the availability of the PID4INST feature. When PID4INST is disabled in settings, the section is now completely hidden instead of displaying an error, and comprehensive tests have been added to ensure correct behavior in all scenarios.

Conditional display of "Used Instruments" section:

* The `DataCiteForm` component now checks PID4INST availability on mount via a new `/api/v1/vocabularies/pid-availability` endpoint and only renders the "Used Instruments" section if PID4INST is available. This prevents confusing error messages when the feature is disabled. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R670-R710) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R2655) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R2673)

Testing improvements:

* Extensive tests were added to `datacite-form.test.tsx` to verify the presence or absence of the "Used Instruments" section under all relevant PID4INST availability states (enabled, disabled, loading, error, and network failure), and to ensure no warnings are logged after unmount.
* Helper functions were introduced to streamline mocking of fetch responses and deferred promises in tests, improving test clarity and maintainability. [[1]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R56-R128) [[2]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9L246-R319)

Changelog update:

* The changelog was updated to describe the improved behavior: the "Used Instruments" section is now hidden entirely when PID4INST is disabled, rather than showing a misleading error.