### PR TITLE
Fix: Dates can not be imported from old Resources

### DIFF
--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -306,7 +306,7 @@ class EditorDataTransformer
             ->filter(function (ResourceDate $date): bool {
                 // Use null-safe operator to handle missing dateType relationship
                 // @phpstan-ignore nullCoalesce.expr (defensive coding for data integrity)
-                $slug = $date->dateType?->slug ?? '';
+                $slug = mb_strtolower($date->dateType?->slug ?? '');
 
                 return ! in_array($slug, ['coverage', 'created', 'updated'], true);
             })
@@ -315,7 +315,7 @@ class EditorDataTransformer
                     // Use null-safe operator to handle missing dateType relationship
                     // @phpstan-ignore nullCoalesce.expr (defensive coding for data integrity)
                     'dateType' => $date->dateType?->slug ?? '',
-                    'startDate' => $this->formatStoredDate($date->start_date),
+                    'startDate' => $this->formatStoredDate($date->start_date ?? $date->date_value),
                     'endDate' => $this->formatStoredDate($date->end_date),
                 ];
             })

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -240,6 +240,10 @@
         ],
         "fixes": [
             {
+                "title": "Imported DataCite Dates Reload Correctly in the Editor",
+                "description": "Resources imported from DataCite via the Resources page now repopulate the Dates form group with their actual date values instead of showing only the date type. Single-value imported dates that were stored in the dedicated database field are now loaded back into the editor correctly, while auto-managed dates such as Created, Updated, and Coverage remain hidden as intended."
+            },
+            {
                 "title": "Hide Used Instruments When PID4INST Is Disabled",
                 "description": "When administrators or group leaders deactivate PID4INST in Settings, the Data Editor now hides the entire 'Used Instruments' form group instead of showing it with a misleading 'Unable to load instrument data' error."
             },

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -20,6 +20,8 @@ use App\Models\Right;
 use App\Models\Setting;
 use App\Models\Subject;
 use App\Models\Title;
+use App\Models\User;
+use App\Services\DataCiteToResourceTransformer;
 use App\Services\Editor\EditorDataTransformer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -728,6 +730,25 @@ describe('transformDates', function (): void {
             ->and($result[0]['endDate'])->toBe('2024-06-30');
     });
 
+    it('falls back to date_value for imported single dates', function (): void {
+        $dateType = DateType::factory()->create(['slug' => 'Issued', 'name' => 'Issued']);
+        ResourceDate::create([
+            'resource_id' => $this->resource->id,
+            'date_type_id' => $dateType->id,
+            'date_value' => '2026-02-10',
+            'start_date' => null,
+            'end_date' => null,
+        ]);
+        $this->resource->load('dates.dateType');
+
+        $result = $this->transformer->transformDates($this->resource);
+
+        expect($result)->toHaveCount(1)
+            ->and($result[0]['dateType'])->toBe('Issued')
+            ->and($result[0]['startDate'])->toBe('2026-02-10')
+            ->and($result[0]['endDate'])->toBe('');
+    });
+
     it('excludes coverage, created, and updated date types', function (): void {
         foreach (['coverage', 'created', 'updated'] as $slug) {
             $dateType = DateType::factory()->create(['slug' => $slug, 'name' => ucfirst($slug)]);
@@ -735,6 +756,22 @@ describe('transformDates', function (): void {
                 'resource_id' => $this->resource->id,
                 'date_type_id' => $dateType->id,
                 'start_date' => '2024-01-01',
+            ]);
+        }
+        $this->resource->load('dates.dateType');
+
+        $result = $this->transformer->transformDates($this->resource);
+
+        expect($result)->toBeEmpty();
+    });
+
+    it('excludes coverage, created, and updated even when only date_value is populated', function (): void {
+        foreach (['coverage', 'created', 'updated'] as $slug) {
+            $dateType = DateType::factory()->create(['slug' => $slug, 'name' => ucfirst($slug)]);
+            ResourceDate::create([
+                'resource_id' => $this->resource->id,
+                'date_type_id' => $dateType->id,
+                'date_value' => '2024-01-01',
             ]);
         }
         $this->resource->load('dates.dateType');
@@ -819,6 +856,49 @@ describe('transformDates', function (): void {
         $result = $this->transformer->transformDates($this->resource);
 
         expect($result[0]['startDate'])->toBe('');
+    });
+
+    it('loads imported DataCite single dates into the editor payload', function (): void {
+        test()->seed(\Database\Seeders\ResourceTypeSeeder::class);
+        test()->seed(\Database\Seeders\TitleTypeSeeder::class);
+        test()->seed(\Database\Seeders\DateTypeSeeder::class);
+
+        $user = User::factory()->create();
+        $importTransformer = new DataCiteToResourceTransformer;
+
+        $resource = $importTransformer->transform([
+            'attributes' => [
+                'doi' => '10.5880/editor.dates.2026.001',
+                'publicationYear' => 2026,
+                'publisher' => 'GFZ Test Publisher',
+                'types' => ['resourceTypeGeneral' => 'Dataset'],
+                'titles' => [
+                    ['title' => 'Imported Dates Resource'],
+                ],
+                'creators' => [
+                    ['familyName' => 'Doe', 'givenName' => 'Jane', 'nameType' => 'Personal'],
+                ],
+                'dates' => [
+                    ['date' => '2025-06-03', 'dateType' => 'Collected'],
+                    ['date' => '2026-02-10', 'dateType' => 'Issued'],
+                    ['date' => '2027-06', 'dateType' => 'Available'],
+                ],
+            ],
+        ], $user->id);
+
+        $resource->load('dates.dateType');
+
+        $result = collect($this->transformer->transformDates($resource))->keyBy('dateType');
+
+        expect($resource->dates)->toHaveCount(4)
+            ->and($result)->toHaveCount(3)
+            ->and($result->keys()->all())->toContain('Collected')
+            ->and($result->keys()->all())->toContain('Issued')
+            ->and($result->keys()->all())->toContain('Available')
+            ->and($result['Collected']['startDate'])->toBe('2025-06-03')
+            ->and($result['Collected']['endDate'])->toBe('')
+            ->and($result['Issued']['startDate'])->toBe('2026-02-10')
+            ->and($result['Available']['startDate'])->toBe('2027-06-01');
     });
 });
 


### PR DESCRIPTION
This pull request improves the handling and display of imported date fields for resources, especially those imported from DataCite, ensuring that single-value dates are loaded correctly in the editor and that auto-managed date types remain hidden. It also adds comprehensive tests to verify these behaviors.

**Editor Data Handling Improvements:**

* The `transformDates` method in `EditorDataTransformer` now falls back to using `date_value` when `start_date` is not set, ensuring that single-value imported dates (such as those from DataCite) are displayed correctly in the editor.
* Date type slugs are now normalized to lowercase before filtering, making the exclusion of auto-managed types (`coverage`, `created`, `updated`) more robust regardless of case.

**Test Coverage Enhancements:**

* Added tests to ensure that:
  - Single-value imported dates are correctly loaded into the editor (`startDate` falls back to `date_value`).
  - Auto-managed date types are excluded even when only `date_value` is present.
  - DataCite-imported resources populate the editor with the correct dates and types.

**Documentation and Changelog:**

* Updated `changelog.json` to document the fix: imported DataCite dates now reload correctly in the editor, and auto-managed dates remain hidden.