### PR TITLE
Fix: Separater in Keyword Breadcomb shows HTML Entity

### DIFF
--- a/app/Support/PortalSubjectNormalizer.php
+++ b/app/Support/PortalSubjectNormalizer.php
@@ -10,6 +10,8 @@ final class PortalSubjectNormalizer
 {
     public const BREADCRUMB_SEPARATOR = ' > ';
 
+    private const ENCODED_BREADCRUMB_SEPARATOR_PATTERN = '/\s*&(?:amp;)?gt;?\s*/iu';
+
     public const SCHEME_ICS_CHRONOSTRAT = 'International Chronostratigraphic Chart';
 
     public const SCHEME_ANALYTICAL_METHODS = 'Analytical Methods for Geochemistry and Cosmochemistry';
@@ -21,7 +23,8 @@ final class PortalSubjectNormalizer
             return null;
         }
 
-        $normalizedSeparators = preg_replace('/\s*>\s*/u', self::BREADCRUMB_SEPARATOR, $trimmed) ?? $trimmed;
+        $decodedEntitySeparators = preg_replace(self::ENCODED_BREADCRUMB_SEPARATOR_PATTERN, self::BREADCRUMB_SEPARATOR, $trimmed) ?? $trimmed;
+        $normalizedSeparators = preg_replace('/\s*>\s*/u', self::BREADCRUMB_SEPARATOR, $decodedEntitySeparators) ?? $decodedEntitySeparators;
         $normalizedWhitespace = preg_replace('/\s+/u', ' ', $normalizedSeparators) ?? $normalizedSeparators;
         $normalizedValue = trim($normalizedWhitespace);
 
@@ -59,6 +62,9 @@ final class PortalSubjectNormalizer
         $expression = "REPLACE({$expression}, {$characterFunction}(13), ' ')";
         $expression = "REPLACE({$expression}, {$characterFunction}(10), ' ')";
         $expression = "REPLACE({$expression}, {$characterFunction}(9), ' ')";
+        $expression = "REPLACE({$expression}, '&amp;gt;', '>')";
+        $expression = "REPLACE({$expression}, '&gt;', '>')";
+        $expression = "REPLACE({$expression}, '&gt', '>')";
         $expression = "REPLACE(REPLACE(REPLACE({$expression}, ' > ', '>'), ' >', '>'), '> ', '>')";
         $expression = "REPLACE({$expression}, '>', ' > ')";
 

--- a/app/Support/PortalSubjectNormalizer.php
+++ b/app/Support/PortalSubjectNormalizer.php
@@ -58,11 +58,12 @@ final class PortalSubjectNormalizer
     public static function normalizedControlledSubjectValueSql(string $column, ?string $driverName = null): string
     {
         $characterFunction = self::characterCodeSqlFunction($driverName);
-        $expression = self::trimmedSql($column);
+        $expression = 'LOWER('.self::trimmedSql($column).')';
         $expression = "REPLACE({$expression}, {$characterFunction}(13), ' ')";
         $expression = "REPLACE({$expression}, {$characterFunction}(10), ' ')";
         $expression = "REPLACE({$expression}, {$characterFunction}(9), ' ')";
         $expression = "REPLACE({$expression}, '&amp;gt;', '>')";
+        $expression = "REPLACE({$expression}, '&amp;gt', '>')";
         $expression = "REPLACE({$expression}, '&gt;', '>')";
         $expression = "REPLACE({$expression}, '&gt', '>')";
         $expression = "REPLACE(REPLACE(REPLACE({$expression}, ' > ', '>'), ' >', '>'), '> ', '>')";
@@ -72,7 +73,7 @@ final class PortalSubjectNormalizer
             $expression = "REPLACE({$expression}, '  ', ' ')";
         }
 
-        return "LOWER(TRIM({$expression}))";
+        return "TRIM({$expression})";
     }
 
     public static function normalizedSchemeSql(string $column): string

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -240,6 +240,10 @@
         ],
         "fixes": [
             {
+                "title": "Landing Page Keyword Breadcrumbs Show Literal Greater-Than Separators",
+                "description": "Legacy imported thesaurus keywords that still carry encoded breadcrumb separators such as &gt now render on published landing pages with readable > hierarchy markers instead of the raw entity text. The normalization happens in the shared controlled-subject path so landing page keyword badges recover clean breadcrumb labels without changing their existing portal filter links."
+            },
+            {
                 "title": "Imported DataCite Dates Reload Correctly in the Editor",
                 "description": "Resources imported from DataCite via the Resources page now repopulate the Dates form group with their actual date values instead of showing only the date type. Single-value imported dates that were stored in the dedicated database field are now loaded back into the editor correctly, while auto-managed dates such as Created, Updated, and Coverage remain hidden as intended."
             },

--- a/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
+++ b/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
@@ -344,6 +344,40 @@ test('derives landing page breadcrumb_path from legacy full-path subject values'
     ]);
 });
 
+test('derives landing page breadcrumb_path from legacy entity-encoded subject values', function () {
+    $transformer = new LandingPageResourceTransformer;
+
+    $resource = new Resource;
+
+    $subject = new Subject;
+    $subject->forceFill([
+        'id' => 1,
+        'value' => 'EARTH SCIENCE &gt; SOLID EARTH &gt SEISMOLOGY',
+        'subject_scheme' => 'Science Keywords',
+        'scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+        'value_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/uuid-seismology',
+        'classification_code' => null,
+        'breadcrumb_path' => null,
+    ]);
+
+    $resource->setRelation('titles', new EloquentCollection);
+    $resource->setRelation('creators', new EloquentCollection);
+    $resource->setRelation('contributors', new EloquentCollection);
+    $resource->setRelation('relatedIdentifiers', new EloquentCollection);
+    $resource->setRelation('descriptions', new EloquentCollection);
+    $resource->setRelation('fundingReferences', new EloquentCollection);
+    $resource->setRelation('subjects', new EloquentCollection([$subject]));
+    $resource->setRelation('geoLocations', new EloquentCollection);
+    $resource->setRelation('rights', new EloquentCollection);
+
+    $data = $transformer->transform($resource);
+
+    expect($data['subjects'][0])->toMatchArray([
+        'subject' => 'SEISMOLOGY',
+        'breadcrumb_path' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+    ]);
+});
+
 test('transforms related identifier slugs and citation label for landing pages', function () {
     $transformer = new LandingPageResourceTransformer;
 

--- a/tests/pest/Unit/Support/PortalSubjectNormalizerTest.php
+++ b/tests/pest/Unit/Support/PortalSubjectNormalizerTest.php
@@ -3,8 +3,17 @@
 declare(strict_types=1);
 
 use App\Support\PortalSubjectNormalizer;
+use Illuminate\Support\Facades\DB;
 
 covers(PortalSubjectNormalizer::class);
+
+describe('PortalSubjectNormalizer::normalizeControlledSubjectValue()', function () {
+    it('normalizes legacy encoded breadcrumb separators', function () {
+        expect(PortalSubjectNormalizer::normalizeControlledSubjectValue(
+            '  EARTH SCIENCE &gt; SOLID EARTH &amp;gt; SEISMOLOGY  ',
+        ))->toBe('EARTH SCIENCE > SOLID EARTH > SEISMOLOGY');
+    });
+});
 
 describe('PortalSubjectNormalizer::normalizedControlledSubjectValueSql()', function () {
     it('uses CHAR() on sqlite-compatible drivers', function () {
@@ -15,6 +24,18 @@ describe('PortalSubjectNormalizer::normalizedControlledSubjectValueSql()', funct
             ->toContain('CHAR(10)')
             ->toContain('CHAR(9)')
             ->not->toContain('CHR(13)');
+    });
+
+    it('normalizes legacy encoded breadcrumb separators on sqlite', function () {
+        $sql = PortalSubjectNormalizer::normalizedControlledSubjectValueSql('?', 'sqlite');
+        $row = DB::selectOne(
+            "SELECT {$sql} AS normalized",
+            ['  EARTH SCIENCE &gt; SOLID EARTH &gt SEISMOLOGY  '],
+        );
+
+        expect($row)->not->toBeNull();
+        expect(is_object($row))->toBeTrue();
+        expect($row->normalized ?? null)->toBe('earth science > solid earth > seismology');
     });
 
     it('uses CHR() on pgsql', function () {

--- a/tests/pest/Unit/Support/PortalSubjectNormalizerTest.php
+++ b/tests/pest/Unit/Support/PortalSubjectNormalizerTest.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\DB;
 covers(PortalSubjectNormalizer::class);
 
 describe('PortalSubjectNormalizer::normalizeControlledSubjectValue()', function () {
-    it('normalizes legacy encoded breadcrumb separators', function () {
+    it('normalizes legacy encoded breadcrumb separators case-insensitively', function () {
         expect(PortalSubjectNormalizer::normalizeControlledSubjectValue(
-            '  EARTH SCIENCE &gt; SOLID EARTH &amp;gt; SEISMOLOGY  ',
+            '  EARTH SCIENCE &GT; SOLID EARTH &AMP;GT SEISMOLOGY  ',
         ))->toBe('EARTH SCIENCE > SOLID EARTH > SEISMOLOGY');
     });
 });
@@ -26,11 +26,11 @@ describe('PortalSubjectNormalizer::normalizedControlledSubjectValueSql()', funct
             ->not->toContain('CHR(13)');
     });
 
-    it('normalizes legacy encoded breadcrumb separators on sqlite', function () {
+    it('normalizes legacy encoded breadcrumb separators on sqlite with php parity', function () {
         $sql = PortalSubjectNormalizer::normalizedControlledSubjectValueSql('?', 'sqlite');
         $row = DB::selectOne(
             "SELECT {$sql} AS normalized",
-            ['  EARTH SCIENCE &gt; SOLID EARTH &gt SEISMOLOGY  '],
+            ['  EARTH SCIENCE &GT; SOLID EARTH &AMP;GT SEISMOLOGY  '],
         );
 
         expect($row)->not->toBeNull();


### PR DESCRIPTION
This pull request improves the normalization of subject breadcrumb separators, ensuring that legacy encoded greater-than symbols (such as `&gt;` and `&amp;gt;`) are consistently displayed as human-readable `>` characters in landing page subject breadcrumbs. The changes address both PHP and SQL normalization paths and add comprehensive tests to guarantee correct behavior for both new and legacy data.

**Subject Breadcrumb Normalization Improvements:**

* Added a regex pattern (`ENCODED_BREADCRUMB_SEPARATOR_PATTERN`) in `PortalSubjectNormalizer` to match and normalize encoded breadcrumb separators (e.g., `&gt;`, `&amp;gt;`) to the standard `>` separator in controlled subject values. [[1]](diffhunk://#diff-c674aa0c42e2e3b7eaf13abe5c3342a426059f0a8745c39d5836b2def2077c4bR13-R14) [[2]](diffhunk://#diff-c674aa0c42e2e3b7eaf13abe5c3342a426059f0a8745c39d5836b2def2077c4bL24-R27)
* Updated the SQL normalization function to explicitly replace encoded greater-than entities with `>` before applying other whitespace and separator normalization logic, ensuring database queries also handle legacy data correctly.

**Testing Enhancements:**

* Added unit tests to confirm that both PHP and SQL normalization functions handle legacy encoded breadcrumb separators case-insensitively and match expected output, including integration with SQLite. [[1]](diffhunk://#diff-073c063f657dccf34c1f20e02461c69b8e3b737c2ce4a905c22c136452c33b8dR6-R17) [[2]](diffhunk://#diff-073c063f657dccf34c1f20e02461c69b8e3b737c2ce4a905c22c136452c33b8dR29-R40)
* Added a test to verify that landing page resource transformation correctly derives the `breadcrumb_path` from legacy entity-encoded subject values, ensuring the UI displays clean breadcrumbs.

**Documentation:**

* Updated the changelog to document the fix for landing page keyword breadcrumbs, clarifying that legacy encoded separators are now rendered as readable hierarchy markers.