### PR TITLE
Feature: Statistics for Landing Pages and Search Terms

### DIFF
--- a/app/Http/Controllers/LandingPageDownloadRedirectController.php
+++ b/app/Http/Controllers/LandingPageDownloadRedirectController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\LandingPage;
+use App\Models\LandingPageFile;
+use App\Services\BotProtection\BotClassifierService;
+use App\Services\Statistics\LandingPageAnalyticsService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+class LandingPageDownloadRedirectController extends Controller
+{
+    public function __construct(
+        private readonly BotClassifierService $botClassifier,
+        private readonly LandingPageAnalyticsService $analyticsService,
+    ) {}
+
+    public function primary(Request $request, LandingPage $landingPage): RedirectResponse
+    {
+        abort_if(! $landingPage->isPublished(), HttpResponse::HTTP_NOT_FOUND, 'Download not found');
+
+        $targetUrl = $landingPage->ftp_url;
+
+        abort_if(! is_string($targetUrl) || trim($targetUrl) === '', HttpResponse::HTTP_NOT_FOUND, 'Download not found');
+
+        $this->recordDownloadClick($request, $landingPage);
+
+        return redirect()->away($targetUrl, HttpResponse::HTTP_FOUND);
+    }
+
+    public function file(Request $request, LandingPage $landingPage, LandingPageFile $landingPageFile): RedirectResponse
+    {
+        abort_if(! $landingPage->isPublished(), HttpResponse::HTTP_NOT_FOUND, 'Download not found');
+        abort_if($landingPageFile->landing_page_id !== $landingPage->id, HttpResponse::HTTP_NOT_FOUND, 'Download not found');
+
+        $targetUrl = $landingPageFile->url;
+
+        abort_if(trim($targetUrl) === '', HttpResponse::HTTP_NOT_FOUND, 'Download not found');
+
+        $this->recordDownloadClick($request, $landingPage);
+
+        return redirect()->away($targetUrl, HttpResponse::HTTP_FOUND);
+    }
+
+    private function recordDownloadClick(Request $request, LandingPage $landingPage): void
+    {
+        if ((bool) config('bot_protection.enabled', true) && $this->botClassifier->isKnownAiBot($request)) {
+            return;
+        }
+
+        $this->analyticsService->recordFileDownloadClick($landingPage);
+    }
+}

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -322,6 +322,10 @@ class LandingPagePublicController extends Controller
 
             $landingPageData = LandingPageController::serializeLandingPagePayload($resource, $landingPage);
 
+            if ($landingPage->isPublished() && $previewToken === null) {
+                $landingPageData = $this->attachTrackedDownloadUrls($landingPageData, $landingPage);
+            }
+
             return [
                 'template' => $effectiveTemplate,
                 'props' => [
@@ -340,6 +344,52 @@ class LandingPagePublicController extends Controller
             : $buildRenderData();
 
         return Inertia::render("LandingPages/{$renderData['template']}", $renderData['props']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $landingPageData
+     * @return array<string, mixed>
+     */
+    private function attachTrackedDownloadUrls(array $landingPageData, LandingPage $landingPage): array
+    {
+        $landingPageData['tracked_ftp_url'] = $this->buildTrackedPrimaryDownloadUrl($landingPageData, $landingPage);
+
+        $files = $landingPageData['files'] ?? [];
+
+        if (! is_array($files)) {
+            $landingPageData['files'] = [];
+
+            return $landingPageData;
+        }
+
+        $landingPageData['files'] = array_map(function (mixed $file) use ($landingPage): mixed {
+            if (! is_array($file) || ! isset($file['id']) || ! is_numeric($file['id'])) {
+                return $file;
+            }
+
+            $file['tracked_url'] = route('landing-page.download.file', [
+                'landingPage' => $landingPage->id,
+                'landingPageFile' => (int) $file['id'],
+            ]);
+
+            return $file;
+        }, $files);
+
+        return $landingPageData;
+    }
+
+    /**
+     * @param  array<string, mixed>  $landingPageData
+     */
+    private function buildTrackedPrimaryDownloadUrl(array $landingPageData, LandingPage $landingPage): ?string
+    {
+        $ftpUrl = $landingPageData['ftp_url'] ?? null;
+
+        if (! is_string($ftpUrl) || trim($ftpUrl) === '') {
+            return null;
+        }
+
+        return route('landing-page.download.primary', ['landingPage' => $landingPage->id]);
     }
 
     /**

--- a/app/Http/Controllers/PortalSearchAnalyticsController.php
+++ b/app/Http/Controllers/PortalSearchAnalyticsController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Services\Statistics\PortalSearchAnalyticsService;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+class PortalSearchAnalyticsController extends Controller
+{
+    public function __construct(
+        private readonly PortalSearchAnalyticsService $analyticsService,
+    ) {}
+
+    public function store(Request $request): \Illuminate\Http\Response
+    {
+        $validated = $request->validate([
+            'search_term' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $this->analyticsService->recordSearch($request, $validated['search_term'] ?? null);
+
+        return response()->noContent(HttpResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/PortalSearchAnalyticsController.php
+++ b/app/Http/Controllers/PortalSearchAnalyticsController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\PortalSearchAnalyticsRequest;
 use App\Services\Statistics\PortalSearchAnalyticsService;
-use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 class PortalSearchAnalyticsController extends Controller
@@ -14,13 +14,9 @@ class PortalSearchAnalyticsController extends Controller
         private readonly PortalSearchAnalyticsService $analyticsService,
     ) {}
 
-    public function store(Request $request): \Illuminate\Http\Response
+    public function store(PortalSearchAnalyticsRequest $request): \Illuminate\Http\Response
     {
-        $validated = $request->validate([
-            'search_term' => ['nullable', 'string', 'max:255'],
-        ]);
-
-        $this->analyticsService->recordSearch($request, $validated['search_term'] ?? null);
+        $this->analyticsService->recordSearch($request, $request->searchTerm());
 
         return response()->noContent(HttpResponse::HTTP_NO_CONTENT);
     }

--- a/app/Http/Controllers/StatisticsController.php
+++ b/app/Http/Controllers/StatisticsController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Services\Statistics\StatisticsDashboardService;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class StatisticsController extends Controller
+{
+    public function __construct(
+        private readonly StatisticsDashboardService $dashboardService,
+    ) {}
+
+    public function index(): Response
+    {
+        return Inertia::render('statistics', [
+            ...$this->dashboardService->build(),
+            'lastUpdated' => now()->toIso8601String(),
+        ]);
+    }
+}

--- a/app/Http/Requests/PortalSearchAnalyticsRequest.php
+++ b/app/Http/Requests/PortalSearchAnalyticsRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PortalSearchAnalyticsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'search_term' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function searchTerm(): ?string
+    {
+        $searchTerm = $this->validated('search_term');
+
+        return is_string($searchTerm) ? $searchTerm : null;
+    }
+}

--- a/app/Models/LandingPage.php
+++ b/app/Models/LandingPage.php
@@ -289,6 +289,16 @@ class LandingPage extends Model
     }
 
     /**
+     * Get the daily analytics aggregates associated with this landing page.
+     *
+     * @return HasMany<LandingPageDailyStatistic, $this>
+     */
+    public function dailyStatistics(): HasMany
+    {
+        return $this->hasMany(LandingPageDailyStatistic::class);
+    }
+
+    /**
      * Get the additional links associated with this landing page.
      *
      * Curators can add extra download links (e.g., GitLab repository, project website)

--- a/app/Models/LandingPageDailyStatistic.php
+++ b/app/Models/LandingPageDailyStatistic.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Daily aggregate counters for published landing page analytics.
+ *
+ * @property int $id
+ * @property int $landing_page_id
+ * @property \Illuminate\Support\Carbon $statistic_date
+ * @property int $page_view_count
+ * @property int $file_download_click_count
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read LandingPage $landingPage
+ */
+#[Fillable(['landing_page_id', 'statistic_date', 'page_view_count', 'file_download_click_count'])]
+class LandingPageDailyStatistic extends Model
+{
+    /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
+    use HasFactory;
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'statistic_date' => 'date',
+        'page_view_count' => 'integer',
+        'file_download_click_count' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<LandingPage, static>
+     */
+    public function landingPage(): BelongsTo
+    {
+        /** @var BelongsTo<LandingPage, static> $relation */
+        $relation = $this->belongsTo(LandingPage::class);
+
+        return $relation;
+    }
+}

--- a/app/Models/PortalSearchDailyStatistic.php
+++ b/app/Models/PortalSearchDailyStatistic.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Daily aggregate counters for normalized portal search terms.
+ *
+ * @property int $id
+ * @property \Illuminate\Support\Carbon $statistic_date
+ * @property string $normalized_term
+ * @property int $search_count
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+#[Fillable(['statistic_date', 'normalized_term', 'search_count'])]
+class PortalSearchDailyStatistic extends Model
+{
+    /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
+    use HasFactory;
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'statistic_date' => 'date',
+        'search_count' => 'integer',
+    ];
+}

--- a/app/Services/BotProtection/LandingPageViewCounterService.php
+++ b/app/Services/BotProtection/LandingPageViewCounterService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\BotProtection;
 
 use App\Models\LandingPage;
+use App\Services\Statistics\LandingPageAnalyticsService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 
@@ -12,12 +13,13 @@ class LandingPageViewCounterService
 {
     public function __construct(
         private readonly BotClassifierService $botClassifier,
+        private readonly LandingPageAnalyticsService $analyticsService,
     ) {}
 
     public function record(Request $request, LandingPage $landingPage): void
     {
         if (! (bool) config('bot_protection.enabled', true)) {
-            $landingPage->incrementViewCount();
+            $this->recordView($landingPage);
 
             return;
         }
@@ -29,14 +31,20 @@ class LandingPageViewCounterService
         $debounceSeconds = max(0, (int) config('bot_protection.view_count_debounce_seconds', 3600));
 
         if ($debounceSeconds === 0) {
-            $landingPage->incrementViewCount();
+            $this->recordView($landingPage);
 
             return;
         }
 
         if (Cache::add($this->debounceKey($request, $landingPage), true, $debounceSeconds)) {
-            $landingPage->incrementViewCount();
+            $this->recordView($landingPage);
         }
+    }
+
+    private function recordView(LandingPage $landingPage): void
+    {
+        $landingPage->incrementViewCount();
+        $this->analyticsService->recordPageView($landingPage);
     }
 
     private function debounceKey(Request $request, LandingPage $landingPage): string

--- a/app/Services/Statistics/LandingPageAnalyticsService.php
+++ b/app/Services/Statistics/LandingPageAnalyticsService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Statistics;
+
+use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
+use Illuminate\Support\Facades\DB;
+
+class LandingPageAnalyticsService
+{
+    public function recordPageView(LandingPage $landingPage): void
+    {
+        $this->incrementDailyCounter($landingPage, 'page_view_count');
+    }
+
+    public function recordFileDownloadClick(LandingPage $landingPage): void
+    {
+        $this->incrementDailyCounter($landingPage, 'file_download_click_count');
+    }
+
+    private function incrementDailyCounter(LandingPage $landingPage, string $column): void
+    {
+        $timestamp = now();
+        $statisticDate = $timestamp->toDateString();
+        $incrementExpression = $this->incrementExpression($column);
+
+        LandingPageDailyStatistic::query()->insertOrIgnore([
+            'landing_page_id' => $landingPage->getKey(),
+            'statistic_date' => $statisticDate,
+            'page_view_count' => 0,
+            'file_download_click_count' => 0,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        LandingPageDailyStatistic::query()
+            ->where('landing_page_id', $landingPage->getKey())
+            ->where('statistic_date', $statisticDate)
+            ->update([
+                $column => DB::raw($incrementExpression),
+                'updated_at' => $timestamp,
+            ]);
+    }
+
+    /**
+     * @return literal-string
+     */
+    private function incrementExpression(string $column): string
+    {
+        return match ($column) {
+            'page_view_count' => 'page_view_count + 1',
+            'file_download_click_count' => 'file_download_click_count + 1',
+            default => throw new \InvalidArgumentException('Unsupported analytics counter column.'),
+        };
+    }
+}

--- a/app/Services/Statistics/PortalSearchAnalyticsService.php
+++ b/app/Services/Statistics/PortalSearchAnalyticsService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Statistics;
+
+use App\Models\PortalSearchDailyStatistic;
+use App\Services\BotProtection\BotClassifierService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PortalSearchAnalyticsService
+{
+    public function __construct(
+        private readonly BotClassifierService $botClassifier,
+    ) {}
+
+    public function recordSearch(Request $request, ?string $term): void
+    {
+        $normalizedTerm = $this->normalizeTerm($term);
+
+        if ($normalizedTerm === '') {
+            return;
+        }
+
+        if ((bool) config('bot_protection.enabled', true) && $this->botClassifier->isKnownAiBot($request)) {
+            return;
+        }
+
+        $timestamp = now();
+        $statisticDate = $timestamp->toDateString();
+
+        PortalSearchDailyStatistic::query()->insertOrIgnore([
+            'statistic_date' => $statisticDate,
+            'normalized_term' => $normalizedTerm,
+            'search_count' => 0,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        PortalSearchDailyStatistic::query()
+            ->where('statistic_date', $statisticDate)
+            ->where('normalized_term', $normalizedTerm)
+            ->update([
+                'search_count' => DB::raw('search_count + 1'),
+                'updated_at' => $timestamp,
+            ]);
+    }
+
+    public function normalizeTerm(?string $term): string
+    {
+        if (! is_string($term)) {
+            return '';
+        }
+
+        $trimmed = trim($term);
+
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $collapsedWhitespace = preg_replace('/\s+/u', ' ', $trimmed);
+
+        return mb_strtolower(is_string($collapsedWhitespace) ? $collapsedWhitespace : $trimmed);
+    }
+}

--- a/app/Services/Statistics/StatisticsDashboardService.php
+++ b/app/Services/Statistics/StatisticsDashboardService.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Statistics;
+
+use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
+use App\Models\PortalSearchDailyStatistic;
+use App\Models\Title;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+class StatisticsDashboardService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(): array
+    {
+        $endDate = CarbonImmutable::today();
+        $startDate = $endDate->subDays(13);
+
+        return [
+            'overview' => $this->buildOverview(),
+            'trends' => $this->buildTrends($startDate, $endDate),
+            'topLandingPagesByViews' => $this->buildTopLandingPages('page_view_count', 'total_page_views'),
+            'topLandingPagesByDownloads' => $this->buildTopLandingPages('file_download_click_count', 'total_download_clicks'),
+            'portalSearchTerms' => $this->buildTopSearchTerms(),
+            'typeSplit' => $this->buildTypeSplit(),
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function buildOverview(): array
+    {
+        /** @var object{total_page_views:int|string, total_download_clicks:int|string, tracked_landing_pages:int|string} $landingPageTotals */
+        $landingPageTotals = DB::table('landing_page_daily_statistics')
+            ->selectRaw('COALESCE(SUM(page_view_count), 0) as total_page_views')
+            ->selectRaw('COALESCE(SUM(file_download_click_count), 0) as total_download_clicks')
+            ->selectRaw('COUNT(DISTINCT landing_page_id) as tracked_landing_pages')
+            ->first();
+
+        return [
+            'totalPageViews' => (int) $landingPageTotals->total_page_views,
+            'totalDownloadClicks' => (int) $landingPageTotals->total_download_clicks,
+            'totalPortalSearches' => (int) PortalSearchDailyStatistic::query()->sum('search_count'),
+            'trackedLandingPages' => (int) $landingPageTotals->tracked_landing_pages,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     days: list<string>,
+     *     pageViews: list<int>,
+     *     downloadClicks: list<int>,
+     *     portalSearches: list<int>
+     * }
+     */
+    private function buildTrends(CarbonImmutable $startDate, CarbonImmutable $endDate): array
+    {
+        /** @var list<object{statistic_date:string, total_page_views:int|string, total_download_clicks:int|string}> $landingPageTrendRows */
+        $landingPageTrendRows = DB::table('landing_page_daily_statistics')
+            ->selectRaw('statistic_date, COALESCE(SUM(page_view_count), 0) as total_page_views')
+            ->selectRaw('COALESCE(SUM(file_download_click_count), 0) as total_download_clicks')
+            ->whereBetween('statistic_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->groupBy('statistic_date')
+            ->get()
+            ->all();
+
+        /** @var list<object{statistic_date:string, total_searches:int|string}> $searchTrendRows */
+        $searchTrendRows = DB::table('portal_search_daily_statistics')
+            ->selectRaw('statistic_date, COALESCE(SUM(search_count), 0) as total_searches')
+            ->whereBetween('statistic_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->groupBy('statistic_date')
+            ->get()
+            ->all();
+
+        /** @var array<string, array{pageViews:int, downloadClicks:int}> $landingPageRows */
+        $landingPageRows = [];
+        foreach ($landingPageTrendRows as $row) {
+            $landingPageRows[$row->statistic_date] = [
+                'pageViews' => (int) $row->total_page_views,
+                'downloadClicks' => (int) $row->total_download_clicks,
+            ];
+        }
+
+        /** @var array<string, int> $searchRows */
+        $searchRows = [];
+        foreach ($searchTrendRows as $row) {
+            $searchRows[$row->statistic_date] = (int) $row->total_searches;
+        }
+
+        $days = [];
+        $pageViews = [];
+        $downloadClicks = [];
+        $portalSearches = [];
+
+        for ($date = $startDate; $date->lessThanOrEqualTo($endDate); $date = $date->addDay()) {
+            $key = $date->toDateString();
+            $days[] = $key;
+            $pageViews[] = $landingPageRows[$key]['pageViews'] ?? 0;
+            $downloadClicks[] = $landingPageRows[$key]['downloadClicks'] ?? 0;
+            $portalSearches[] = $searchRows[$key] ?? 0;
+        }
+
+        return [
+            'days' => $days,
+            'pageViews' => $pageViews,
+            'downloadClicks' => $downloadClicks,
+            'portalSearches' => $portalSearches,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function buildTopLandingPages(string $metricColumn, string $sumAlias): array
+    {
+        /** @var Collection<int, LandingPage> $landingPages */
+        $landingPages = LandingPage::query()
+            ->where('is_published', true)
+            ->with([
+                'resource.titles.titleType',
+                'resource.resourceType',
+            ])
+            ->withSum('dailyStatistics as '.$sumAlias, $metricColumn)
+            ->orderByDesc($sumAlias)
+            ->limit(8)
+            ->get()
+            ->filter(fn (LandingPage $landingPage): bool => (int) ($landingPage->{$sumAlias} ?? 0) > 0)
+            ->values();
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = array_values($landingPages
+            ->map(function (LandingPage $landingPage) use ($sumAlias): array {
+                $resourceType = $landingPage->resource->resourceType;
+
+                return [
+                    'landingPageId' => $landingPage->id,
+                    'title' => $this->resolveLandingPageTitle($landingPage),
+                    'identifier' => $landingPage->doi_prefix ?? ('draft-'.$landingPage->resource_id),
+                    'resourceTypeLabel' => $resourceType instanceof \App\Models\ResourceType ? $resourceType->name : 'Other',
+                    'total' => (int) ($landingPage->{$sumAlias} ?? 0),
+                    'publicUrl' => $landingPage->public_url,
+                    'isExternal' => $landingPage->isExternal(),
+                ];
+            })
+            ->all());
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array{term: string, total: int}>
+     */
+    private function buildTopSearchTerms(): array
+    {
+        /** @var list<object{normalized_term: string, total_searches: int|string}> $rows */
+        $rows = PortalSearchDailyStatistic::query()
+            ->selectRaw('normalized_term, SUM(search_count) as total_searches')
+            ->groupBy('normalized_term')
+            ->orderByDesc('total_searches')
+            ->limit(10)
+            ->get()
+            ->all();
+
+        return array_map(static fn (object $row): array => [
+            'term' => $row->normalized_term,
+            'total' => (int) $row->total_searches,
+        ], $rows);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function buildTypeSplit(): array
+    {
+        /** @var object{
+         *     resource_page_views:int|string,
+         *     physical_object_page_views:int|string,
+         *     resource_download_clicks:int|string,
+         *     physical_object_download_clicks:int|string
+         * }|null $row
+         */
+        $row = DB::table('landing_page_daily_statistics')
+            ->join('landing_pages', 'landing_pages.id', '=', 'landing_page_daily_statistics.landing_page_id')
+            ->join('resources', 'resources.id', '=', 'landing_pages.resource_id')
+            ->leftJoin('resource_types', 'resource_types.id', '=', 'resources.resource_type_id')
+            ->selectRaw("COALESCE(SUM(CASE WHEN LOWER(COALESCE(resource_types.slug, '')) = 'physical-object' THEN page_view_count ELSE 0 END), 0) as physical_object_page_views")
+            ->selectRaw("COALESCE(SUM(CASE WHEN LOWER(COALESCE(resource_types.slug, '')) = 'physical-object' THEN file_download_click_count ELSE 0 END), 0) as physical_object_download_clicks")
+            ->selectRaw("COALESCE(SUM(CASE WHEN LOWER(COALESCE(resource_types.slug, '')) <> 'physical-object' OR resource_types.slug IS NULL THEN page_view_count ELSE 0 END), 0) as resource_page_views")
+            ->selectRaw("COALESCE(SUM(CASE WHEN LOWER(COALESCE(resource_types.slug, '')) <> 'physical-object' OR resource_types.slug IS NULL THEN file_download_click_count ELSE 0 END), 0) as resource_download_clicks")
+            ->first();
+
+        if ($row === null) {
+            return [
+                'resourcePageViews' => 0,
+                'physicalObjectPageViews' => 0,
+                'resourceDownloadClicks' => 0,
+                'physicalObjectDownloadClicks' => 0,
+            ];
+        }
+
+        return [
+            'resourcePageViews' => (int) $row->resource_page_views,
+            'physicalObjectPageViews' => (int) $row->physical_object_page_views,
+            'resourceDownloadClicks' => (int) $row->resource_download_clicks,
+            'physicalObjectDownloadClicks' => (int) $row->physical_object_download_clicks,
+        ];
+    }
+
+    private function resolveLandingPageTitle(LandingPage $landingPage): string
+    {
+        $titles = $landingPage->resource->titles;
+
+        if ($titles->isEmpty()) {
+            return 'Untitled';
+        }
+
+        $mainTitle = $titles->first(fn (Title $title): bool => $title->isMainTitle());
+        if ($mainTitle instanceof Title) {
+            return $mainTitle->value;
+        }
+
+        /** @var Title $firstTitle */
+        $firstTitle = $titles->first();
+
+        return $firstTitle->value;
+    }
+}

--- a/app/Services/Statistics/StatisticsDashboardService.php
+++ b/app/Services/Statistics/StatisticsDashboardService.php
@@ -66,7 +66,8 @@ class StatisticsDashboardService
         $landingPageTrendRows = DB::table('landing_page_daily_statistics')
             ->selectRaw('statistic_date, COALESCE(SUM(page_view_count), 0) as total_page_views')
             ->selectRaw('COALESCE(SUM(file_download_click_count), 0) as total_download_clicks')
-            ->whereBetween('statistic_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->whereDate('statistic_date', '>=', $startDate->toDateString())
+            ->whereDate('statistic_date', '<=', $endDate->toDateString())
             ->groupBy('statistic_date')
             ->get()
             ->all();
@@ -74,7 +75,8 @@ class StatisticsDashboardService
         /** @var list<object{statistic_date:string, total_searches:int|string}> $searchTrendRows */
         $searchTrendRows = DB::table('portal_search_daily_statistics')
             ->selectRaw('statistic_date, COALESCE(SUM(search_count), 0) as total_searches')
-            ->whereBetween('statistic_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->whereDate('statistic_date', '>=', $startDate->toDateString())
+            ->whereDate('statistic_date', '<=', $endDate->toDateString())
             ->groupBy('statistic_date')
             ->get()
             ->all();
@@ -82,7 +84,9 @@ class StatisticsDashboardService
         /** @var array<string, array{pageViews:int, downloadClicks:int}> $landingPageRows */
         $landingPageRows = [];
         foreach ($landingPageTrendRows as $row) {
-            $landingPageRows[$row->statistic_date] = [
+            $dateKey = CarbonImmutable::parse($row->statistic_date)->toDateString();
+
+            $landingPageRows[$dateKey] = [
                 'pageViews' => (int) $row->total_page_views,
                 'downloadClicks' => (int) $row->total_download_clicks,
             ];
@@ -91,7 +95,9 @@ class StatisticsDashboardService
         /** @var array<string, int> $searchRows */
         $searchRows = [];
         foreach ($searchTrendRows as $row) {
-            $searchRows[$row->statistic_date] = (int) $row->total_searches;
+            $dateKey = CarbonImmutable::parse($row->statistic_date)->toDateString();
+
+            $searchRows[$dateKey] = (int) $row->total_searches;
         }
 
         $days = [];

--- a/composer.lock
+++ b/composer.lock
@@ -9040,16 +9040,16 @@
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf"
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/2f7d27dada8effc48b8c424445a69cca7007daaa",
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa",
                 "shasum": ""
             },
             "require": {
@@ -9116,7 +9116,7 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2026-02-09T13:44:54+00:00"
+            "time": "2026-05-20T22:24:57+00:00"
         },
         {
             "name": "laravel/pint",
@@ -9188,16 +9188,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.60.0",
+            "version": "v1.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "2a1538ed22eed4210ac1e17904235032571bd89c"
+                "reference": "68ef35015630fe510432e63e11e21749006df688"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/2a1538ed22eed4210ac1e17904235032571bd89c",
-                "reference": "2a1538ed22eed4210ac1e17904235032571bd89c",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/68ef35015630fe510432e63e11e21749006df688",
+                "reference": "68ef35015630fe510432e63e11e21749006df688",
                 "shasum": ""
             },
             "require": {
@@ -9247,7 +9247,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-05-14T17:29:51+00:00"
+            "time": "2026-05-23T23:33:57+00:00"
         },
         {
             "name": "league/uri-components",

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -641,6 +641,27 @@ entity "landing_page_links" as landing_page_links {
     updated_at : TIMESTAMP
 }
 
+entity "landing_page_daily_statistics" as landing_page_daily_statistics {
+    * **id** : BIGINT <<PK>>
+    --
+    * landing_page_id : BIGINT <<FK>>
+    * statistic_date : DATE <<UK(landing_page_id, statistic_date)>>
+    * page_view_count : INT = 0
+    * file_download_click_count : INT = 0
+    created_at : TIMESTAMP
+    updated_at : TIMESTAMP
+}
+
+entity "portal_search_daily_statistics" as portal_search_daily_statistics {
+    * **id** : BIGINT <<PK>>
+    --
+    * statistic_date : DATE <<UK(statistic_date, normalized_term)>>
+    * normalized_term : VARCHAR(255)
+    * search_count : INT = 0
+    created_at : TIMESTAMP
+    updated_at : TIMESTAMP
+}
+
 entity "landing_page_domains" as landing_page_domains {
     * **id** : BIGINT <<PK>>
     --
@@ -1106,6 +1127,7 @@ users }o--o| users : "deactivated_by"
 landing_pages }o--o| landing_page_domains
 landing_pages ||--o{ landing_page_files
 landing_pages ||--o{ landing_page_links
+landing_pages ||--o{ landing_page_daily_statistics
 landing_pages }o--o| landing_page_templates
 landing_page_templates }o--o| users
 

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -573,6 +573,25 @@ erDiagram
         timestamp updated_at
     }
 
+    landing_page_daily_statistics {
+        bigint id PK
+        bigint landing_page_id FK
+        date statistic_date "UK with landing_page_id"
+        int page_view_count "default 0"
+        int file_download_click_count "default 0"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    portal_search_daily_statistics {
+        bigint id PK
+        date statistic_date "UK with normalized_term"
+        varchar normalized_term "255"
+        int search_count "default 0"
+        timestamp created_at
+        timestamp updated_at
+    }
+
     settings {
         bigint id PK
         varchar key UK
@@ -1027,6 +1046,7 @@ erDiagram
     landing_pages }o--o| landing_page_domains : "external domain"
     landing_pages ||--o{ landing_page_files : "has files"
     landing_pages ||--o{ landing_page_links : "has links"
+    landing_pages ||--o{ landing_page_daily_statistics : "tracks daily analytics"
     landing_pages }o--o| landing_page_templates : "uses template"
     landing_page_templates }o--o| users : "created by"
 

--- a/database/migrations/2026_05_27_000001_create_landing_page_daily_statistics_table.php
+++ b/database/migrations/2026_05_27_000001_create_landing_page_daily_statistics_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('landing_page_daily_statistics', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('landing_page_id')
+                ->constrained('landing_pages')
+                ->cascadeOnDelete();
+            $table->date('statistic_date');
+            $table->unsignedInteger('page_view_count')->default(0);
+            $table->unsignedInteger('file_download_click_count')->default(0);
+            $table->timestamps();
+
+            $table->unique(['landing_page_id', 'statistic_date']);
+            $table->index('statistic_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('landing_page_daily_statistics');
+    }
+};

--- a/database/migrations/2026_05_27_000002_create_portal_search_daily_statistics_table.php
+++ b/database/migrations/2026_05_27_000002_create_portal_search_daily_statistics_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('portal_search_daily_statistics', function (Blueprint $table): void {
+            $table->id();
+            $table->date('statistic_date');
+            $table->string('normalized_term', 255);
+            $table->unsignedInteger('search_count')->default(0);
+            $table->timestamps();
+
+            $table->unique(['statistic_date', 'normalized_term']);
+            $table->index('normalized_term');
+            $table->index('statistic_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('portal_search_daily_statistics');
+    }
+};

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-05-27",
         "features": [
             {
+                "title": "Landing Page and Portal Statistics Dashboard",
+                "description": "Admins and Group Leaders now get a new Statistics page at /statistics in the Administration workspace of the main navigation. The dashboard tracks only published landing pages and excludes preview/review traffic. It shows daily trends and rankings for landing page views, clicks on real download targets in the Files section, and explicit search submissions from the public /portal search box. Physical Objects and regular resources are split out separately, while the legacy /old-statistics page remains available as a distinct legacy destination."
+            },
+            {
                 "title": "Single DOI Import for GFZ Legacy Resources",
                 "description": "The Resources page now distinguishes between importing all historical GFZ DataCite records and importing a single old resource. The former action was renamed to 'Import all old Resources'. A new adjacent action, 'Import old single Resource', opens a dialog where admins and group leaders can enter either a bare DOI or a doi.org URL for one dataset. Before the import starts, ERNIE now verifies that the DOI belongs to the GFZ legacy database; already imported resources are detected and skipped without overwriting the existing record."
             },

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -170,13 +170,20 @@ export function AppSidebar() {
 
     if (auth.user?.can_access_statistics) {
         const statisticsItem: NavItem = {
-            title: 'Statistics (old)',
-            href: '/old-statistics',
+            title: 'Statistics',
+            href: '/statistics',
             icon: BarChart3,
         };
 
+        const legacyStatisticsItem: NavItem = {
+            title: 'Statistics (old)',
+            href: '/old-statistics',
+            icon: History,
+        };
+
         administrationItems.push(statisticsItem);
-        legacyItems.push(statisticsItem);
+        operationsItems.push(statisticsItem);
+        legacyItems.push(legacyStatisticsItem);
     }
 
     if (auth.user?.can_access_users) {

--- a/resources/js/components/portal/PortalFilters.tsx
+++ b/resources/js/components/portal/PortalFilters.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { ChevronLeft, ChevronRight, Filter, Search, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -84,6 +85,11 @@ export function PortalFilters({
     const handleSearchSubmit = useCallback(
         (e: React.FormEvent) => {
             e.preventDefault();
+
+            if (searchInput.trim() !== '') {
+                void axios.post('/portal/search-analytics', { search_term: searchInput }).catch(() => undefined);
+            }
+
             onSearchChange(searchInput);
         },
         [searchInput, onSearchChange],

--- a/resources/js/pages/LandingPages/components/FilesSection.tsx
+++ b/resources/js/pages/LandingPages/components/FilesSection.tsx
@@ -10,7 +10,7 @@ import { LandingPageCard } from './LandingPageCard';
 
 interface FilesSectionProps {
     downloadUrl?: string | null;
-    downloadFiles?: { url: string }[];
+    downloadFiles?: { url: string; tracked_url?: string | null }[];
     licenses: LandingPageLicense[];
     contactPersons?: LandingPageContactPerson[];
     datasetTitle?: string;
@@ -34,7 +34,9 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
     // Build effective list of download URLs: prefer downloadFiles, fall back to single downloadUrl
     const hasDownloadUrl = typeof downloadUrl === 'string' && downloadUrl !== '#' && downloadUrl.trim() !== '';
     const effectiveDownloads =
-        downloadFiles && downloadFiles.length > 0 ? downloadFiles.map((f) => f.url) : hasDownloadUrl ? [downloadUrl!] : [];
+        downloadFiles && downloadFiles.length > 0
+            ? downloadFiles.map((file) => file.tracked_url ?? file.url)
+            : hasDownloadUrl ? [downloadUrl!] : [];
 
     // Find contact persons for fallback options
     const contactPersonWithEmail = contactPersons.find((p) => p.has_email);

--- a/resources/js/pages/LandingPages/default_gfz.tsx
+++ b/resources/js/pages/LandingPages/default_gfz.tsx
@@ -75,7 +75,7 @@ export default function DefaultGfzTemplate() {
             files: (
                 <FilesSection
                     key="files"
-                    downloadUrl={landingPage?.ftp_url}
+                    downloadUrl={landingPage?.tracked_ftp_url ?? landingPage?.ftp_url}
                     downloadFiles={landingPage?.files}
                     licenses={resource.licenses || []}
                     contactPersons={resource.contact_persons || []}

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1,5 +1,6 @@
 import { Head } from '@inertiajs/react';
 import {
+    BarChart3,
     BookOpen,
     Braces,
     Calendar,
@@ -126,8 +127,8 @@ export default function Docs({ userRole, editorSettings }: DocsProps) {
                                 <strong>Workspace Switcher:</strong> Admins and Group Leaders now see a <strong>Curation</strong> /{' '}
                                 <strong>Administration</strong> switcher at the top of the sidebar. Use <strong>Curation</strong> for
                                 day-to-day metadata work such as the Dashboard, Resources, and IGSN tools. Use <strong>Administration</strong>{' '}
-                                for privileged destinations such as Users, Editor Settings, Landing Pages, Assistance, Assessment, Logs, and
-                                legacy maintenance pages. ERNIE remembers the last selected workspace locally.
+                                for privileged destinations such as Users, Statistics, Editor Settings, Landing Pages, Assistance, Assessment,
+                                Logs, and legacy maintenance pages. ERNIE remembers the last selected workspace locally.
                             </p>
                         </div>
 
@@ -480,6 +481,58 @@ DATACITE_TEST_USERNAME=your_test_username
 DATACITE_TEST_PASSWORD=your_test_password`}
                             language="bash"
                         />
+                    </>
+                ),
+            },
+            {
+                id: 'statistics-dashboard',
+                title: 'Statistics',
+                icon: BarChart3,
+                minRole: 'group_leader',
+                content: (
+                    <>
+                        <h3>Public Engagement Statistics</h3>
+                        <p>
+                            The <strong>Statistics</strong> page (<code>/statistics</code>) is available to Admins and Group Leaders in the{' '}
+                            <strong>Administration</strong> workspace of the sidebar. It summarizes how published landing pages perform after go-live.
+                        </p>
+
+                        <h4>What is counted</h4>
+                        <ul className="list-inside list-disc space-y-1">
+                            <li>
+                                <strong>Landing page views</strong> for published landing pages only
+                            </li>
+                            <li>
+                                <strong>Download clicks</strong> on real file targets from the <strong>Files</strong> section
+                            </li>
+                            <li>
+                                <strong>Portal searches</strong> submitted explicitly through the public <code>/portal</code> search box
+                            </li>
+                        </ul>
+
+                        <h4>What is excluded</h4>
+                        <ul className="list-inside list-disc space-y-1">
+                            <li>Preview and review links</li>
+                            <li>Draft landing pages</li>
+                            <li>Additional curator-defined links below the main download area</li>
+                            <li>Known bot traffic when bot protection is enabled</li>
+                        </ul>
+
+                        <h4>Dashboard modules</h4>
+                        <ul className="list-inside list-disc space-y-1">
+                            <li>Overview cards for landing page views, download clicks, portal searches, and tracked landing pages</li>
+                            <li>Daily trend charts for the last 14 days</li>
+                            <li>Top landing pages by views and by download clicks</li>
+                            <li>Top normalized portal search terms</li>
+                            <li>Separate engagement split for regular resources and Physical Objects</li>
+                        </ul>
+
+                        <div className="mt-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900 dark:bg-blue-950">
+                            <p className="text-sm text-blue-900 dark:text-blue-100">
+                                <strong>Go-live baseline:</strong> The dashboard starts counting from the moment this analytics feature is deployed.
+                                Older legacy counters are not backfilled into the new dashboard.
+                            </p>
+                        </div>
                     </>
                 ),
             },

--- a/resources/js/pages/statistics.tsx
+++ b/resources/js/pages/statistics.tsx
@@ -1,0 +1,337 @@
+import { Head } from '@inertiajs/react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+
+type StatisticsOverview = {
+    totalPageViews: number;
+    totalDownloadClicks: number;
+    totalPortalSearches: number;
+    trackedLandingPages: number;
+};
+
+type StatisticsTrends = {
+    days: string[];
+    pageViews: number[];
+    downloadClicks: number[];
+    portalSearches: number[];
+};
+
+type RankedLandingPage = {
+    landingPageId: number;
+    title: string;
+    identifier: string;
+    resourceTypeLabel: string;
+    total: number;
+    publicUrl: string;
+    isExternal: boolean;
+};
+
+type SearchTermStat = {
+    term: string;
+    total: number;
+};
+
+type TypeSplit = {
+    resourcePageViews: number;
+    physicalObjectPageViews: number;
+    resourceDownloadClicks: number;
+    physicalObjectDownloadClicks: number;
+};
+
+type StatisticsPageProps = {
+    overview: StatisticsOverview;
+    trends: StatisticsTrends;
+    topLandingPagesByViews: RankedLandingPage[];
+    topLandingPagesByDownloads: RankedLandingPage[];
+    portalSearchTerms: SearchTermStat[];
+    typeSplit: TypeSplit;
+    lastUpdated: string;
+};
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Statistics',
+        href: '/statistics',
+    },
+];
+
+function formatCompactNumber(value: number): string {
+    return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatDateTime(value: string): string {
+    return new Date(value).toLocaleString('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+}
+
+function formatDayLabel(value: string): string {
+    return new Date(`${value}T00:00:00`).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+    });
+}
+
+function maxValue(values: number[]): number {
+    return values.length > 0 ? Math.max(...values, 1) : 1;
+}
+
+function OverviewCard({ title, value, description }: { title: string; value: number; description: string }) {
+    return (
+        <Card className="border-border/70 bg-card/80 backdrop-blur">
+            <CardHeader className="pb-3">
+                <CardDescription>{title}</CardDescription>
+                <CardTitle className="text-3xl font-semibold text-foreground">{formatCompactNumber(value)}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <p className="text-sm text-muted-foreground">{description}</p>
+            </CardContent>
+        </Card>
+    );
+}
+
+function TrendCard({ title, description, days, values, toneClass }: { title: string; description: string; days: string[]; values: number[]; toneClass: string }) {
+    const peak = maxValue(values);
+
+    return (
+        <Card className="border-border/70 bg-card/80 backdrop-blur">
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                {values.some((value) => value > 0) ? (
+                    <div className="grid grid-cols-14 gap-2" data-testid={`trend-${title.toLowerCase().replace(/\s+/g, '-')}`}>
+                        {days.map((day, index) => (
+                            <div key={day} className="flex min-w-0 flex-col items-center gap-2">
+                                <div className="flex h-32 w-full items-end rounded-xl bg-muted/50 px-1 py-1">
+                                    <div
+                                        className={`w-full rounded-md ${toneClass}`}
+                                        style={{ height: `${Math.max((values[index] / peak) * 100, values[index] > 0 ? 10 : 0)}%` }}
+                                        aria-label={`${title} on ${day}: ${values[index]}`}
+                                    />
+                                </div>
+                                <div className="text-center">
+                                    <p className="text-sm font-medium text-foreground">{formatCompactNumber(values[index])}</p>
+                                    <p className="text-xs text-muted-foreground">{formatDayLabel(day)}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="rounded-2xl border border-dashed border-border/70 bg-muted/30 p-6 text-sm text-muted-foreground">
+                        No tracked activity yet.
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function RankingCard({ title, description, items, emptyMessage }: { title: string; description: string; items: RankedLandingPage[]; emptyMessage: string }) {
+    const peak = maxValue(items.map((item) => item.total));
+
+    return (
+        <Card className="border-border/70 bg-card/80 backdrop-blur">
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {items.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-border/70 bg-muted/30 p-6 text-sm text-muted-foreground">
+                        {emptyMessage}
+                    </div>
+                ) : (
+                    items.map((item, index) => (
+                        <a
+                            key={`${item.landingPageId}-${item.total}`}
+                            href={item.publicUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="block rounded-2xl border border-border/60 bg-background/80 p-4 transition-colors hover:border-gfz-primary/40 hover:bg-muted/40"
+                        >
+                            <div className="flex items-start justify-between gap-3">
+                                <div className="space-y-1">
+                                    <div className="flex items-center gap-2">
+                                        <Badge variant="outline">#{index + 1}</Badge>
+                                        <Badge variant="secondary">{item.resourceTypeLabel}</Badge>
+                                        {item.isExternal && <Badge variant="outline">External</Badge>}
+                                    </div>
+                                    <h3 className="text-base font-semibold text-foreground">{item.title}</h3>
+                                    <p className="text-sm text-muted-foreground">{item.identifier}</p>
+                                </div>
+                                <p className="text-xl font-semibold text-gfz-primary">{formatCompactNumber(item.total)}</p>
+                            </div>
+                            <div className="mt-4 h-2 rounded-full bg-muted">
+                                <div
+                                    className="h-2 rounded-full bg-gradient-to-r from-gfz-primary to-sky-500"
+                                    style={{ width: `${(item.total / peak) * 100}%` }}
+                                />
+                            </div>
+                        </a>
+                    ))
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function SearchTermsCard({ items }: { items: SearchTermStat[] }) {
+    const peak = maxValue(items.map((item) => item.total));
+
+    return (
+        <Card className="border-border/70 bg-card/80 backdrop-blur">
+            <CardHeader>
+                <CardTitle>Top Portal Search Terms</CardTitle>
+                <CardDescription>Normalized terms submitted through the portal search box.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                {items.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-border/70 bg-muted/30 p-6 text-sm text-muted-foreground">
+                        No portal searches have been tracked yet.
+                    </div>
+                ) : (
+                    items.map((item) => (
+                        <div key={item.term} className="rounded-2xl border border-border/60 bg-background/80 p-4">
+                            <div className="flex items-center justify-between gap-3">
+                                <div className="min-w-0">
+                                    <p className="truncate text-sm font-medium text-foreground">{item.term}</p>
+                                    <p className="text-xs text-muted-foreground">Search submissions</p>
+                                </div>
+                                <Badge variant="secondary">{formatCompactNumber(item.total)}</Badge>
+                            </div>
+                            <div className="mt-3 h-2 rounded-full bg-muted">
+                                <div
+                                    className="h-2 rounded-full bg-gradient-to-r from-amber-500 to-rose-500"
+                                    style={{ width: `${(item.total / peak) * 100}%` }}
+                                />
+                            </div>
+                        </div>
+                    ))
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function TypeSplitCard({ title, pageViews, downloadClicks }: { title: string; pageViews: number; downloadClicks: number }) {
+    return (
+        <Card className="border-border/70 bg-card/80 backdrop-blur">
+            <CardHeader>
+                <CardTitle>{title}</CardTitle>
+                <CardDescription>Engagement split by publication type.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-2xl bg-muted/40 p-4">
+                    <p className="text-sm text-muted-foreground">Page views</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">{formatCompactNumber(pageViews)}</p>
+                </div>
+                <div className="rounded-2xl bg-muted/40 p-4">
+                    <p className="text-sm text-muted-foreground">Download clicks</p>
+                    <p className="mt-2 text-2xl font-semibold text-foreground">{formatCompactNumber(downloadClicks)}</p>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+export default function Statistics({ overview, trends, topLandingPagesByViews, topLandingPagesByDownloads, portalSearchTerms, typeSplit, lastUpdated }: StatisticsPageProps) {
+    const hasAnyAnalytics = overview.totalPageViews > 0 || overview.totalDownloadClicks > 0 || overview.totalPortalSearches > 0;
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Statistics" />
+
+            <div className="flex flex-1 flex-col gap-6 rounded-xl bg-gradient-to-b from-background via-background to-muted/20 p-4 md:p-6">
+                <section className="overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-gfz-primary/10 via-background to-sky-100/50 p-6 shadow-sm dark:to-gfz-primary/15">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                        <div className="space-y-3">
+                            <Badge variant="secondary" className="bg-white/70 text-gfz-primary dark:bg-white/10 dark:text-sky-100">
+                                Go-live analytics
+                            </Badge>
+                            <div className="space-y-2">
+                                <h1 className="text-3xl font-semibold tracking-tight text-foreground md:text-4xl">Public engagement statistics</h1>
+                                <p className="max-w-3xl text-sm leading-6 text-muted-foreground md:text-base">
+                                    This dashboard tracks published landing page views, file download clicks, and explicit portal search submissions.
+                                    Review and preview traffic is excluded.
+                                </p>
+                            </div>
+                        </div>
+                        <div className="rounded-2xl border border-white/50 bg-white/60 px-4 py-3 text-sm text-muted-foreground shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5">
+                            Last updated: {formatDateTime(lastUpdated)}
+                        </div>
+                    </div>
+                </section>
+
+                <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                    <OverviewCard title="Landing page views" value={overview.totalPageViews} description="Published landing page requests tracked since go-live." />
+                    <OverviewCard title="Download clicks" value={overview.totalDownloadClicks} description="Clicks on real download targets in the Files section." />
+                    <OverviewCard title="Portal searches" value={overview.totalPortalSearches} description="Explicit submissions from the public portal search slot." />
+                    <OverviewCard title="Tracked landing pages" value={overview.trackedLandingPages} description="Published landing pages with recorded engagement data." />
+                </section>
+
+                {!hasAnyAnalytics && (
+                    <section>
+                        <Card className="border-dashed border-border/80 bg-card/60">
+                            <CardContent className="p-6 text-sm text-muted-foreground">
+                                No analytics have been recorded yet. Metrics start at go-live and will fill in as published landing pages and portal searches receive traffic.
+                            </CardContent>
+                        </Card>
+                    </section>
+                )}
+
+                <section className="grid gap-4 xl:grid-cols-3">
+                    <TrendCard
+                        title="Landing page views"
+                        description="Daily published landing page traffic over the last 14 days."
+                        days={trends.days}
+                        values={trends.pageViews}
+                        toneClass="bg-gradient-to-t from-gfz-primary to-sky-500"
+                    />
+                    <TrendCard
+                        title="Download clicks"
+                        description="Daily file download clicks from the Files section."
+                        days={trends.days}
+                        values={trends.downloadClicks}
+                        toneClass="bg-gradient-to-t from-emerald-500 to-teal-400"
+                    />
+                    <TrendCard
+                        title="Portal searches"
+                        description="Daily explicit portal search submissions."
+                        days={trends.days}
+                        values={trends.portalSearches}
+                        toneClass="bg-gradient-to-t from-amber-500 to-rose-500"
+                    />
+                </section>
+
+                <section className="grid gap-4 xl:grid-cols-2">
+                    <RankingCard
+                        title="Top landing pages by views"
+                        description="Published landing pages with the most recorded public traffic."
+                        items={topLandingPagesByViews}
+                        emptyMessage="No landing page views have been recorded yet."
+                    />
+                    <RankingCard
+                        title="Top landing pages by download clicks"
+                        description="Published landing pages whose Files section gets the most download activity."
+                        items={topLandingPagesByDownloads}
+                        emptyMessage="No download clicks have been recorded yet."
+                    />
+                </section>
+
+                <section className="grid gap-4 xl:grid-cols-[1.35fr_1fr]">
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <TypeSplitCard title="Resources" pageViews={typeSplit.resourcePageViews} downloadClicks={typeSplit.resourceDownloadClicks} />
+                        <TypeSplitCard title="Physical Objects" pageViews={typeSplit.physicalObjectPageViews} downloadClicks={typeSplit.physicalObjectDownloadClicks} />
+                    </div>
+                    <SearchTermsCard items={portalSearchTerms} />
+                </section>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -153,6 +153,9 @@ export interface LandingPageFile {
     /** Download URL */
     url: string;
 
+    /** Public tracked redirect URL used only on published landing pages */
+    tracked_url?: string | null;
+
     /** Display order */
     position: number;
 }
@@ -203,6 +206,9 @@ export interface LandingPageConfig {
 
     /** FTP URL for dataset downloads (optional) */
     ftp_url?: string | null;
+
+    /** Public tracked redirect URL used only on published landing pages */
+    tracked_ftp_url?: string | null;
 
     /** FK to landing_page_domains (only for external template) */
     external_domain_id?: number | null;

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\IgsnController;
 use App\Http\Controllers\IgsnImportController;
 use App\Http\Controllers\IgsnMapController;
 use App\Http\Controllers\LandingPageController;
+use App\Http\Controllers\LandingPageDownloadRedirectController;
 use App\Http\Controllers\LandingPageDomainController;
 use App\Http\Controllers\LandingPagePreviewController;
 use App\Http\Controllers\LandingPagePublicController;
@@ -27,12 +28,14 @@ use App\Http\Controllers\OaiPmh\OaiPmhDocsController;
 use App\Http\Controllers\OldDatasetController;
 use App\Http\Controllers\OldDataStatisticsController;
 use App\Http\Controllers\PortalController;
+use App\Http\Controllers\PortalSearchAnalyticsController;
 use App\Http\Controllers\RelatedItemController;
 use App\Http\Controllers\ResourceController;
 use App\Http\Controllers\ResourceDoiRegistrationController;
 use App\Http\Controllers\ResourceExportController;
 use App\Http\Controllers\ResourceFilterController;
 use App\Http\Controllers\Settings\PidSettingsController;
+use App\Http\Controllers\StatisticsController;
 use App\Http\Controllers\Settings\ThesaurusSettingsController;
 use App\Http\Controllers\TestHelperController;
 use App\Http\Controllers\UploadIgsnCsvController;
@@ -103,6 +106,10 @@ Route::get('/portal', [PortalController::class, 'index'])
     ->middleware('throttle:public-portal')
     ->name('portal');
 
+Route::post('/portal/search-analytics', [PortalSearchAnalyticsController::class, 'store'])
+    ->middleware('throttle:public-portal')
+    ->name('portal.search-analytics');
+
 // OAI-PMH Harvesting Endpoint
 // ===========================================================
 Route::get('/oai-pmh/docs', [OaiPmhDocsController::class, 'index'])->name('oaipmh.docs');
@@ -110,6 +117,17 @@ Route::match(['get', 'post'], '/oai-pmh', OaiPmhController::class)->middleware('
 
 // Public Landing Pages (accessible without authentication)
 // ===========================================================
+
+Route::get('landing-page-downloads/{landingPage}/primary', [LandingPageDownloadRedirectController::class, 'primary'])
+    ->middleware('throttle:public-landing-page')
+    ->name('landing-page.download.primary')
+    ->whereNumber('landingPage');
+
+Route::get('landing-page-downloads/{landingPage}/files/{landingPageFile}', [LandingPageDownloadRedirectController::class, 'file'])
+    ->middleware('throttle:public-landing-page')
+    ->name('landing-page.download.file')
+    ->whereNumber('landingPage')
+    ->whereNumber('landingPageFile');
 
 // Landing Pages with DOI (e.g., /10.5880/test.001/my-dataset-title)
 // DOI prefix format: 10.NNNN/suffix where suffix contains valid DOI characters.
@@ -268,6 +286,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Statistics routes (Admin, Group Leader - Issue #379)
     Route::middleware(['can:access-statistics'])->group(function () {
+        Route::get('statistics', [StatisticsController::class, 'index'])
+            ->name('statistics');
+
         Route::get('old-statistics', [OldDataStatisticsController::class, 'index'])
             ->name('old-statistics');
     });

--- a/tests/pest/Feature/Database/CreateStatisticsTablesMigrationTest.php
+++ b/tests/pest/Feature/Database/CreateStatisticsTablesMigrationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+function loadLandingPageDailyStatisticsMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_05_27_000001_create_landing_page_daily_statistics_table.php');
+
+    return $migration;
+}
+
+function loadPortalSearchDailyStatisticsMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_05_27_000002_create_portal_search_daily_statistics_table.php');
+
+    return $migration;
+}
+
+it('creates and drops the landing_page_daily_statistics table through up and down', function (): void {
+    expect(Schema::hasTable('landing_page_daily_statistics'))->toBeTrue();
+
+    $migration = loadLandingPageDailyStatisticsMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    expect(Schema::hasTable('landing_page_daily_statistics'))->toBeFalse();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Schema::hasTable('landing_page_daily_statistics'))->toBeTrue()
+        ->and(Schema::hasColumns('landing_page_daily_statistics', [
+            'landing_page_id',
+            'statistic_date',
+            'page_view_count',
+            'file_download_click_count',
+        ]))->toBeTrue();
+});
+
+it('creates and drops the portal_search_daily_statistics table through up and down', function (): void {
+    expect(Schema::hasTable('portal_search_daily_statistics'))->toBeTrue();
+
+    $migration = loadPortalSearchDailyStatisticsMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    expect(Schema::hasTable('portal_search_daily_statistics'))->toBeFalse();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Schema::hasTable('portal_search_daily_statistics'))->toBeTrue()
+        ->and(Schema::hasColumns('portal_search_daily_statistics', [
+            'statistic_date',
+            'normalized_term',
+            'search_count',
+        ]))->toBeTrue();
+});

--- a/tests/pest/Feature/LandingPages/LandingPageDownloadRedirectControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageDownloadRedirectControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\LandingPageDownloadRedirectController;
+use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
+use App\Models\Resource;
+
+covers(LandingPageDownloadRedirectController::class);
+
+uses()->group('landing-pages', 'downloads');
+
+beforeEach(function () {
+    $this->resource = Resource::factory()->create([
+        'doi' => '10.5880/test.downloads.001',
+    ]);
+});
+
+function dailyDownloadCount(LandingPage $landingPage): ?int
+{
+    return LandingPageDailyStatistic::query()
+        ->where('landing_page_id', $landingPage->id)
+        ->whereDate('statistic_date', now()->toDateString())
+        ->value('file_download_click_count');
+}
+
+describe('primary download redirect', function () {
+    test('redirects and counts clicks for published landing pages', function () {
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $this->resource->id,
+            'doi_prefix' => '10.5880/test.downloads.001',
+            'slug' => 'primary-download',
+            'ftp_url' => 'https://downloads.example.org/archive.zip',
+        ]);
+
+        $this->get(route('landing-page.download.primary', ['landingPage' => $landingPage->id]))
+            ->assertRedirect('https://downloads.example.org/archive.zip')
+            ->assertStatus(302);
+
+        expect(dailyDownloadCount($landingPage))->toBe(1);
+    });
+
+    test('returns 404 for draft landing pages', function () {
+        $landingPage = LandingPage::factory()->draft()->create([
+            'resource_id' => $this->resource->id,
+            'doi_prefix' => '10.5880/test.downloads.001',
+            'slug' => 'draft-primary-download',
+            'ftp_url' => 'https://downloads.example.org/archive.zip',
+        ]);
+
+        $this->get(route('landing-page.download.primary', ['landingPage' => $landingPage->id]))
+            ->assertNotFound();
+
+        expect(dailyDownloadCount($landingPage))->toBeNull();
+    });
+
+    test('does not count known ai bots for primary download redirects', function () {
+        config([
+            'bot_protection.enabled' => true,
+            'bot_protection.ai_user_agents' => ['GPTBot'],
+        ]);
+
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $this->resource->id,
+            'doi_prefix' => '10.5880/test.downloads.001',
+            'slug' => 'primary-download-ai-bot',
+            'ftp_url' => 'https://downloads.example.org/archive.zip',
+        ]);
+
+        $this->withServerVariables([
+            'REMOTE_ADDR' => '203.0.113.50',
+            'HTTP_USER_AGENT' => 'GPTBot',
+        ])->get(route('landing-page.download.primary', ['landingPage' => $landingPage->id]))
+            ->assertRedirect('https://downloads.example.org/archive.zip');
+
+        expect(dailyDownloadCount($landingPage))->toBeNull();
+    });
+});
+
+describe('file download redirect', function () {
+    test('redirects and counts clicks for imported landing page files', function () {
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $this->resource->id,
+            'doi_prefix' => '10.5880/test.downloads.001',
+            'slug' => 'file-download',
+        ]);
+
+        $file = $landingPage->files()->create([
+            'url' => 'https://downloads.example.org/supplement.csv',
+            'position' => 0,
+        ]);
+
+        $this->get(route('landing-page.download.file', ['landingPage' => $landingPage->id, 'landingPageFile' => $file->id]))
+            ->assertRedirect('https://downloads.example.org/supplement.csv')
+            ->assertStatus(302);
+
+        expect(dailyDownloadCount($landingPage))->toBe(1);
+    });
+
+    test('returns 404 when the file does not belong to the landing page', function () {
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $this->resource->id,
+            'doi_prefix' => '10.5880/test.downloads.001',
+            'slug' => 'mismatched-file-download',
+        ]);
+
+        $otherLandingPage = LandingPage::factory()->published()->create([
+            'resource_id' => Resource::factory()->create(['doi' => '10.5880/test.downloads.002'])->id,
+            'doi_prefix' => '10.5880/test.downloads.002',
+            'slug' => 'other-landing-page',
+        ]);
+
+        $file = $otherLandingPage->files()->create([
+            'url' => 'https://downloads.example.org/other.csv',
+            'position' => 0,
+        ]);
+
+        $this->get(route('landing-page.download.file', ['landingPage' => $landingPage->id, 'landingPageFile' => $file->id]))
+            ->assertNotFound();
+
+        expect(dailyDownloadCount($landingPage))->toBeNull();
+        expect(dailyDownloadCount($otherLandingPage))->toBeNull();
+    });
+});

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -55,6 +55,15 @@ function landingPageDailyDownloadCount(LandingPage $landingPage): ?int
         ->value('file_download_click_count');
 }
 
+function invokeLandingPagePublicControllerHelper(string $method, mixed ...$arguments): mixed
+{
+    $controller = new LandingPagePublicController;
+    $reflection = new ReflectionMethod($controller, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invokeArgs($controller, $arguments);
+}
+
 describe('Public Landing Page Access', function () {
     test('can access published landing page', function () {
         $landingPage = LandingPage::factory()
@@ -521,6 +530,54 @@ describe('Tracked Download URLs', function () {
                 ->missing('landingPage.tracked_ftp_url')
                 ->missing('landingPage.files.0.tracked_url')
             );
+    });
+
+    test('tracked download helper clears malformed file payloads and omits blank primary download urls', function () {
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'tracked-download-helper-test',
+            ]);
+
+        $result = invokeLandingPagePublicControllerHelper('attachTrackedDownloadUrls', [
+            'ftp_url' => '   ',
+            'files' => 'invalid-payload',
+        ], $landingPage);
+
+        expect($result['tracked_ftp_url'])->toBeNull()
+            ->and($result['files'])->toBe([]);
+    });
+
+    test('tracked download helper leaves malformed file entries untouched', function () {
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'tracked-download-helper-invalid-file-test',
+                'ftp_url' => 'https://downloads.example.org/dataset.zip',
+            ]);
+
+        $result = invokeLandingPagePublicControllerHelper('attachTrackedDownloadUrls', [
+            'ftp_url' => 'https://downloads.example.org/dataset.zip',
+            'files' => [
+                'plain-string',
+                ['id' => 'not-numeric', 'url' => 'https://downloads.example.org/ignored.zip'],
+                ['id' => 42, 'url' => 'https://downloads.example.org/tracked.zip'],
+            ],
+        ], $landingPage);
+
+        expect($result['files'][0])->toBe('plain-string')
+            ->and($result['files'][1])->toBe([
+                'id' => 'not-numeric',
+                'url' => 'https://downloads.example.org/ignored.zip',
+            ])
+            ->and($result['files'][2]['tracked_url'])->toBe(route('landing-page.download.file', [
+                'landingPage' => $landingPage->id,
+                'landingPageFile' => 42,
+            ]));
     });
 });
 

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\CacheKey;
 use App\Http\Controllers\LandingPagePublicController;
 use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
 use App\Models\LandingPageDomain;
 use App\Models\LandingPageTemplate;
 use App\Models\Resource;
@@ -36,6 +37,22 @@ function landingPageUrl(LandingPage $landingPage, ?string $preview = null): stri
     $url = $landingPage->public_url;
 
     return $preview ? "{$url}?preview={$preview}" : $url;
+}
+
+function landingPageDailyViewCount(LandingPage $landingPage): ?int
+{
+    return LandingPageDailyStatistic::query()
+        ->where('landing_page_id', $landingPage->id)
+        ->whereDate('statistic_date', now()->toDateString())
+        ->value('page_view_count');
+}
+
+function landingPageDailyDownloadCount(LandingPage $landingPage): ?int
+{
+    return LandingPageDailyStatistic::query()
+        ->where('landing_page_id', $landingPage->id)
+        ->whereDate('statistic_date', now()->toDateString())
+        ->value('file_download_click_count');
 }
 
 describe('Public Landing Page Access', function () {
@@ -328,6 +345,7 @@ describe('View Counter', function () {
         $this->get(landingPageUrl($landingPage));
 
         expect($landingPage->fresh()->view_count)->toBe(1);
+        expect(landingPageDailyViewCount($landingPage))->toBe(1);
     });
 
     test('does not increment view count for draft previews', function () {
@@ -343,6 +361,7 @@ describe('View Counter', function () {
         $this->get(landingPageUrl($landingPage, $landingPage->preview_token));
 
         expect($landingPage->fresh()->view_count)->toBe(0);
+        expect(landingPageDailyViewCount($landingPage))->toBeNull();
     });
 
     test('increments view count for repeated requests when bot protection is disabled', function () {
@@ -358,10 +377,12 @@ describe('View Counter', function () {
         // First request
         $this->get(landingPageUrl($landingPage));
         expect($landingPage->fresh()->view_count)->toBe(1);
+        expect(landingPageDailyViewCount($landingPage))->toBe(1);
 
         // Second request
         $this->get(landingPageUrl($landingPage));
         expect($landingPage->fresh()->view_count)->toBe(2);
+        expect(landingPageDailyViewCount($landingPage))->toBe(2);
     });
 
     test('debounces view count per visitor when bot protection is enabled', function () {
@@ -389,15 +410,18 @@ describe('View Counter', function () {
 
         $this->withServerVariables($server)->get(landingPageUrl($landingPage))->assertOk();
         expect($landingPage->fresh()->view_count)->toBe(1);
+        expect(landingPageDailyViewCount($landingPage))->toBe(1);
 
         $this->withServerVariables($server)->get(landingPageUrl($landingPage))->assertOk();
         expect($landingPage->fresh()->view_count)->toBe(1);
+        expect(landingPageDailyViewCount($landingPage))->toBe(1);
 
         $this->withServerVariables([
             'REMOTE_ADDR' => '203.0.113.31',
             'HTTP_USER_AGENT' => 'Mozilla/5.0',
         ])->get(landingPageUrl($landingPage))->assertOk();
         expect($landingPage->fresh()->view_count)->toBe(2);
+        expect(landingPageDailyViewCount($landingPage))->toBe(2);
     });
 
     test('does not count known ai bot landing page views when bot protection is enabled', function () {
@@ -424,6 +448,7 @@ describe('View Counter', function () {
         ])->get(landingPageUrl($landingPage))->assertOk();
 
         expect($landingPage->fresh()->view_count)->toBe(0);
+        expect(landingPageDailyViewCount($landingPage))->toBeNull();
     });
 });
 
@@ -446,6 +471,56 @@ describe('Resource Data Loading', function () {
             ->has('resource.funding_references')
             ->has('resource.related_identifiers')
         );
+    });
+});
+
+describe('Tracked Download URLs', function () {
+    test('published landing pages expose tracked download URLs in the public payload', function () {
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'tracked-downloads-test',
+                'ftp_url' => 'https://downloads.example.org/dataset.zip',
+            ]);
+
+        $file = $landingPage->files()->create([
+            'url' => 'https://downloads.example.org/supplement.csv',
+            'position' => 0,
+        ]);
+
+        $this->get(landingPageUrl($landingPage))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('landingPage.ftp_url', 'https://downloads.example.org/dataset.zip')
+                ->where('landingPage.tracked_ftp_url', route('landing-page.download.primary', ['landingPage' => $landingPage->id]))
+                ->where('landingPage.files.0.url', 'https://downloads.example.org/supplement.csv')
+                ->where('landingPage.files.0.tracked_url', route('landing-page.download.file', ['landingPage' => $landingPage->id, 'landingPageFile' => $file->id]))
+            );
+    });
+
+    test('preview payloads do not expose tracked download URLs', function () {
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'tracked-download-preview-test',
+                'ftp_url' => 'https://downloads.example.org/dataset.zip',
+            ]);
+
+        $landingPage->files()->create([
+            'url' => 'https://downloads.example.org/supplement.csv',
+            'position' => 0,
+        ]);
+
+        $this->get(landingPageUrl($landingPage, $landingPage->preview_token))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->missing('landingPage.tracked_ftp_url')
+                ->missing('landingPage.files.0.tracked_url')
+            );
     });
 });
 
@@ -489,6 +564,7 @@ describe('External Landing Page Redirect', function () {
         $this->get($landingPage->getPublicPath());
 
         expect($landingPage->fresh()->view_count)->toBe(1);
+        expect(landingPageDailyViewCount($landingPage))->toBe(1);
     });
 
     test('external draft is not accessible without preview token', function () {

--- a/tests/pest/Feature/PortalSearchAnalyticsControllerTest.php
+++ b/tests/pest/Feature/PortalSearchAnalyticsControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\PortalSearchAnalyticsController;
+use App\Models\PortalSearchDailyStatistic;
+
+covers(PortalSearchAnalyticsController::class);
+
+uses()->group('portal', 'statistics');
+
+function portalSearchCountForToday(string $normalizedTerm): ?int
+{
+    return PortalSearchDailyStatistic::query()
+        ->whereDate('statistic_date', now()->toDateString())
+        ->where('normalized_term', $normalizedTerm)
+        ->value('search_count');
+}
+
+describe('portal search analytics', function () {
+    test('stores normalized search terms as daily aggregates', function () {
+        $this->post('/portal/search-analytics', ['search_term' => '  Test   Query  '])
+            ->assertNoContent();
+
+        expect(portalSearchCountForToday('test query'))->toBe(1);
+    });
+
+    test('increments repeated normalized search terms', function () {
+        $this->post('/portal/search-analytics', ['search_term' => 'Climate'])
+            ->assertNoContent();
+
+        $this->post('/portal/search-analytics', ['search_term' => ' climate '])
+            ->assertNoContent();
+
+        expect(portalSearchCountForToday('climate'))->toBe(2);
+    });
+
+    test('ignores blank search terms', function () {
+        $this->post('/portal/search-analytics', ['search_term' => '   '])
+            ->assertNoContent();
+
+        expect(PortalSearchDailyStatistic::query()->count())->toBe(0);
+    });
+
+    test('does not count known ai bots', function () {
+        config([
+            'bot_protection.enabled' => true,
+            'bot_protection.ai_user_agents' => ['GPTBot'],
+        ]);
+
+        $this->withServerVariables([
+            'REMOTE_ADDR' => '203.0.113.60',
+            'HTTP_USER_AGENT' => 'GPTBot',
+        ])->post('/portal/search-analytics', ['search_term' => 'seismic'])
+            ->assertNoContent();
+
+        expect(PortalSearchDailyStatistic::query()->count())->toBe(0);
+    });
+});

--- a/tests/pest/Feature/StatisticsControllerTest.php
+++ b/tests/pest/Feature/StatisticsControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\StatisticsController;
+use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
+use App\Models\PortalSearchDailyStatistic;
+use App\Models\Resource;
+use App\Models\ResourceType;
+use App\Models\Title;
+use App\Models\TitleType;
+use App\Models\User;
+
+covers(StatisticsController::class);
+
+uses()->group('statistics');
+
+beforeEach(function () {
+    $this->admin = User::factory()->admin()->create();
+    $this->groupLeader = User::factory()->groupLeader()->create();
+    $this->curator = User::factory()->curator()->create();
+});
+
+describe('statistics access', function () {
+    test('requires authentication', function () {
+        $this->get('/statistics')->assertRedirect(route('login'));
+    });
+
+    test('allows admins and group leaders', function () {
+        $this->actingAs($this->admin)->get('/statistics')->assertOk();
+        $this->actingAs($this->groupLeader)->get('/statistics')->assertOk();
+    });
+
+    test('denies curators', function () {
+        $this->actingAs($this->curator)->get('/statistics')->assertForbidden();
+    });
+});
+
+describe('statistics payload', function () {
+    test('returns aggregated analytics data', function () {
+        $mainTitleType = TitleType::firstOrCreate(
+            ['slug' => 'MainTitle'],
+            ['name' => 'Main Title', 'slug' => 'MainTitle', 'is_active' => true],
+        );
+
+        $datasetType = ResourceType::firstOrCreate(
+            ['slug' => 'dataset'],
+            ['name' => 'Dataset', 'slug' => 'dataset', 'is_active' => true],
+        );
+
+        $physicalObjectType = ResourceType::firstOrCreate(
+            ['slug' => 'physical-object'],
+            ['name' => 'Physical Object', 'slug' => 'physical-object', 'is_active' => true],
+        );
+
+        $datasetResource = Resource::factory()->create([
+            'doi' => '10.5880/stats.dataset.001',
+            'resource_type_id' => $datasetType->id,
+        ]);
+
+        Title::factory()->create([
+            'resource_id' => $datasetResource->id,
+            'title_type_id' => $mainTitleType->id,
+            'value' => 'Dataset Title',
+        ]);
+
+        $sampleResource = Resource::factory()->create([
+            'doi' => '10.5880/stats.sample.001',
+            'resource_type_id' => $physicalObjectType->id,
+        ]);
+
+        Title::factory()->create([
+            'resource_id' => $sampleResource->id,
+            'title_type_id' => $mainTitleType->id,
+            'value' => 'Sample Title',
+        ]);
+
+        $datasetLandingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $datasetResource->id,
+            'doi_prefix' => '10.5880/stats.dataset.001',
+            'slug' => 'dataset-title',
+        ]);
+
+        $sampleLandingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $sampleResource->id,
+            'doi_prefix' => '10.5880/stats.sample.001',
+            'slug' => 'sample-title',
+        ]);
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $datasetLandingPage->id,
+            'statistic_date' => now()->subDay()->toDateString(),
+            'page_view_count' => 8,
+            'file_download_click_count' => 3,
+        ]);
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $sampleLandingPage->id,
+            'statistic_date' => now()->toDateString(),
+            'page_view_count' => 2,
+            'file_download_click_count' => 1,
+        ]);
+
+        PortalSearchDailyStatistic::query()->create([
+            'statistic_date' => now()->toDateString(),
+            'normalized_term' => 'climate',
+            'search_count' => 5,
+        ]);
+
+        PortalSearchDailyStatistic::query()->create([
+            'statistic_date' => now()->toDateString(),
+            'normalized_term' => 'igsn',
+            'search_count' => 2,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get('/statistics')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('statistics')
+                ->where('overview.totalPageViews', 10)
+                ->where('overview.totalDownloadClicks', 4)
+                ->where('overview.totalPortalSearches', 7)
+                ->where('overview.trackedLandingPages', 2)
+                ->where('topLandingPagesByViews.0.title', 'Dataset Title')
+                ->where('topLandingPagesByDownloads.0.title', 'Dataset Title')
+                ->where('portalSearchTerms.0.term', 'climate')
+                ->where('typeSplit.resourcePageViews', 8)
+                ->where('typeSplit.physicalObjectPageViews', 2)
+                ->has('trends.days', 14)
+            );
+    });
+});

--- a/tests/pest/Unit/BotProtection/LandingPageViewCounterServiceTest.php
+++ b/tests/pest/Unit/BotProtection/LandingPageViewCounterServiceTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 use App\Enums\CacheKey;
 use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
 use App\Models\Resource;
 use App\Services\BotProtection\BotClassifierService;
 use App\Services\BotProtection\LandingPageViewCounterService;
+use App\Services\Statistics\LandingPageAnalyticsService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 
@@ -42,43 +44,59 @@ function botProtectionViewCounterRequest(string $ipAddress = '203.0.113.10', str
     ]);
 }
 
+function botProtectionViewCounterDailyViewCount(LandingPage $landingPage): ?int
+{
+    return LandingPageDailyStatistic::query()
+        ->where('landing_page_id', $landingPage->id)
+        ->whereDate('statistic_date', now()->toDateString())
+        ->value('page_view_count');
+}
+
+function botProtectionViewCounterService(): LandingPageViewCounterService
+{
+    return new LandingPageViewCounterService(new BotClassifierService, new LandingPageAnalyticsService);
+}
+
 it('increments every request when bot protection is disabled', function (): void {
     config(['bot_protection.enabled' => false]);
 
-    $service = new LandingPageViewCounterService(new BotClassifierService);
+    $service = botProtectionViewCounterService();
     $landingPage = botProtectionViewCounterLandingPage();
     $request = botProtectionViewCounterRequest();
 
     $service->record($request, $landingPage);
     $service->record($request, $landingPage->fresh());
 
-    expect($landingPage->fresh()->view_count)->toBe(2);
+    expect($landingPage->fresh()->view_count)->toBe(2)
+        ->and(botProtectionViewCounterDailyViewCount($landingPage))->toBe(2);
 });
 
 it('skips known ai bot requests when bot protection is enabled', function (): void {
-    $service = new LandingPageViewCounterService(new BotClassifierService);
+    $service = botProtectionViewCounterService();
     $landingPage = botProtectionViewCounterLandingPage();
 
     $service->record(botProtectionViewCounterRequest(userAgent: 'GPTBot'), $landingPage);
 
-    expect($landingPage->fresh()->view_count)->toBe(0);
+    expect($landingPage->fresh()->view_count)->toBe(0)
+        ->and(botProtectionViewCounterDailyViewCount($landingPage))->toBeNull();
 });
 
 it('increments every request when the debounce window is disabled', function (): void {
     config(['bot_protection.view_count_debounce_seconds' => 0]);
 
-    $service = new LandingPageViewCounterService(new BotClassifierService);
+    $service = botProtectionViewCounterService();
     $landingPage = botProtectionViewCounterLandingPage();
     $request = botProtectionViewCounterRequest();
 
     $service->record($request, $landingPage);
     $service->record($request, $landingPage->fresh());
 
-    expect($landingPage->fresh()->view_count)->toBe(2);
+    expect($landingPage->fresh()->view_count)->toBe(2)
+        ->and(botProtectionViewCounterDailyViewCount($landingPage))->toBe(2);
 });
 
 it('debounces repeated requests from the same visitor fingerprint', function (): void {
-    $service = new LandingPageViewCounterService(new BotClassifierService);
+    $service = botProtectionViewCounterService();
     $landingPage = botProtectionViewCounterLandingPage();
     $request = botProtectionViewCounterRequest();
 
@@ -86,11 +104,12 @@ it('debounces repeated requests from the same visitor fingerprint', function ():
     $service->record($request, $landingPage->fresh());
     $service->record(botProtectionViewCounterRequest(ipAddress: '203.0.113.11'), $landingPage->fresh());
 
-    expect($landingPage->fresh()->view_count)->toBe(2);
+    expect($landingPage->fresh()->view_count)->toBe(2)
+        ->and(botProtectionViewCounterDailyViewCount($landingPage))->toBe(2);
 });
 
 it('keeps public caches warm when recording a human view', function (): void {
-    $service = new LandingPageViewCounterService(new BotClassifierService);
+    $service = botProtectionViewCounterService();
     $landingPage = botProtectionViewCounterLandingPage();
     $renderCacheKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id);
     $portalCacheKey = CacheKey::PORTAL_PAGE_PAYLOAD->key('page:filters');
@@ -101,6 +120,7 @@ it('keeps public caches warm when recording a human view', function (): void {
     $service->record(botProtectionViewCounterRequest(), $landingPage);
 
     expect($landingPage->fresh()->view_count)->toBe(1)
+        ->and(botProtectionViewCounterDailyViewCount($landingPage))->toBe(1)
         ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($renderCacheKey))->toBeTrue()
         ->and(Cache::tags(CacheKey::PORTAL_PAGE_PAYLOAD->tags())->has($portalCacheKey))->toBeTrue();
 });

--- a/tests/pest/Unit/Services/StatisticsAnalyticsServicesTest.php
+++ b/tests/pest/Unit/Services/StatisticsAnalyticsServicesTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\LandingPageDailyStatistic;
+use App\Models\PortalSearchDailyStatistic;
+use App\Models\Resource;
+use App\Models\ResourceType;
+use App\Models\Title;
+use App\Models\TitleType;
+use App\Services\BotProtection\BotClassifierService;
+use App\Services\Statistics\LandingPageAnalyticsService;
+use App\Services\Statistics\PortalSearchAnalyticsService;
+use App\Services\Statistics\StatisticsDashboardService;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+covers(
+    StatisticsDashboardService::class,
+    PortalSearchAnalyticsService::class,
+    LandingPageAnalyticsService::class,
+    LandingPageDailyStatistic::class,
+    LandingPage::class,
+);
+
+beforeEach(function (): void {
+    Carbon::setTestNow('2026-05-27 12:00:00');
+
+    config([
+        'bot_protection.enabled' => true,
+        'bot_protection.ai_user_agents' => ['GPTBot'],
+    ]);
+});
+
+afterEach(function (): void {
+    Carbon::setTestNow();
+});
+
+function statisticsTitleType(string $slug, string $name): TitleType
+{
+    return TitleType::firstOrCreate(
+        ['slug' => $slug],
+        ['name' => $name, 'slug' => $slug, 'is_active' => true, 'is_elmo_active' => true],
+    );
+}
+
+function statisticsResourceType(string $slug, string $name): ResourceType
+{
+    return ResourceType::firstOrCreate(
+        ['slug' => $slug],
+        ['name' => $name, 'slug' => $slug, 'is_active' => true, 'is_elmo_active' => true],
+    );
+}
+
+function statisticsRequest(string $userAgent = 'Mozilla/5.0', string $ipAddress = '203.0.113.50'): Request
+{
+    return Request::create('/portal/search-analytics', 'POST', server: [
+        'REMOTE_ADDR' => $ipAddress,
+        'HTTP_USER_AGENT' => $userAgent,
+    ]);
+}
+
+function statisticsLandingPage(
+    string $doi,
+    string $slug,
+    ?ResourceType $resourceType = null,
+    ?string $title = null,
+    ?TitleType $titleType = null,
+): LandingPage {
+    $resource = Resource::factory()->create([
+        'doi' => $doi,
+        'resource_type_id' => $resourceType?->id,
+    ]);
+
+    if ($title !== null) {
+        Title::factory()->create([
+            'resource_id' => $resource->id,
+            'title_type_id' => $titleType?->id,
+            'value' => $title,
+        ]);
+    }
+
+    return LandingPage::factory()->published()->create([
+        'resource_id' => $resource->id,
+        'doi_prefix' => $doi,
+        'slug' => $slug,
+    ]);
+}
+
+describe('LandingPageAnalyticsService', function () {
+    it('records page views and file download clicks in the same daily aggregate row', function (): void {
+        $service = new LandingPageAnalyticsService;
+        $landingPage = statisticsLandingPage('10.5880/stats.analytics.001', 'stats-analytics');
+
+        $service->recordPageView($landingPage);
+        $service->recordPageView($landingPage);
+        $service->recordFileDownloadClick($landingPage);
+
+        $statistic = LandingPageDailyStatistic::query()->sole();
+
+        expect($statistic->landing_page_id)->toBe($landingPage->id)
+            ->and($statistic->page_view_count)->toBe(2)
+            ->and($statistic->file_download_click_count)->toBe(1)
+            ->and($statistic->statistic_date->toDateString())->toBe('2026-05-27');
+    });
+
+    it('rejects unsupported aggregate columns defensively', function (): void {
+        $service = new LandingPageAnalyticsService;
+        $method = new ReflectionMethod($service, 'incrementExpression');
+        $method->setAccessible(true);
+
+        expect(fn (): mixed => $method->invoke($service, 'unexpected_counter'))
+            ->toThrow(InvalidArgumentException::class, 'Unsupported analytics counter column.');
+    });
+});
+
+describe('PortalSearchAnalyticsService', function () {
+    it('normalizes whitespace and case before aggregating searches', function (): void {
+        $service = new PortalSearchAnalyticsService(new BotClassifierService);
+        $request = statisticsRequest();
+
+        $service->recordSearch($request, '  GFZ   DATA  ');
+        $service->recordSearch($request, 'gfz data');
+
+        $statistic = PortalSearchDailyStatistic::query()->sole();
+
+        expect($statistic->normalized_term)->toBe('gfz data')
+            ->and($statistic->search_count)->toBe(2)
+            ->and($service->normalizeTerm("\nGFZ\tDATA\n"))->toBe('gfz data');
+    });
+
+    it('ignores blank search submissions before touching the aggregate table', function (): void {
+        $service = new PortalSearchAnalyticsService(new BotClassifierService);
+
+        $service->recordSearch(statisticsRequest(), '   ');
+
+        expect(PortalSearchDailyStatistic::query()->count())->toBe(0);
+    });
+
+    it('skips bots when protection is enabled and records them when protection is disabled', function (): void {
+        $service = new PortalSearchAnalyticsService(new BotClassifierService);
+        $botRequest = statisticsRequest(userAgent: 'GPTBot');
+
+        $service->recordSearch($botRequest, 'Core Samples');
+
+        expect(PortalSearchDailyStatistic::query()->count())->toBe(0)
+            ->and($service->normalizeTerm(null))->toBe('')
+            ->and($service->normalizeTerm('   '))->toBe('');
+
+        config(['bot_protection.enabled' => false]);
+
+        $service->recordSearch($botRequest, 'Core Samples');
+
+        expect(PortalSearchDailyStatistic::query()
+            ->where('normalized_term', 'core samples')
+            ->value('search_count'))->toBe(1);
+    });
+});
+
+describe('StatisticsDashboardService', function () {
+    it('builds the statistics dashboard from landing page and portal aggregates', function (): void {
+        $mainTitleType = statisticsTitleType('MainTitle', 'Main Title');
+        $alternativeTitleType = statisticsTitleType('AlternativeTitle', 'Alternative Title');
+        $datasetType = statisticsResourceType('dataset', 'Dataset');
+        $physicalObjectType = statisticsResourceType('physical-object', 'Physical Object');
+
+        $datasetLandingPage = statisticsLandingPage(
+            '10.5880/stats.dataset.001',
+            'dataset-alpha',
+            $datasetType,
+            'Dataset Alpha',
+            $mainTitleType,
+        );
+
+        $sampleLandingPage = statisticsLandingPage(
+            '10.5880/stats.sample.001',
+            'sample-beta',
+            $physicalObjectType,
+            'Sample Beta',
+            $mainTitleType,
+        );
+
+        $alternativeTitleLandingPage = statisticsLandingPage(
+            '10.5880/stats.alt.001',
+            'alternative-title',
+            null,
+            'Alternative Title',
+            $alternativeTitleType,
+        );
+
+        $untitledLandingPage = statisticsLandingPage(
+            '10.5880/stats.untitled.001',
+            'untitled-resource',
+            $datasetType,
+        );
+
+        statisticsLandingPage(
+            '10.5880/stats.zero.001',
+            'zero-stats-resource',
+            $datasetType,
+            'Zero Stats',
+            $mainTitleType,
+        );
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $datasetLandingPage->id,
+            'statistic_date' => now()->toDateString(),
+            'page_view_count' => 10,
+            'file_download_click_count' => 2,
+        ]);
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $datasetLandingPage->id,
+            'statistic_date' => now()->subDays(20)->toDateString(),
+            'page_view_count' => 5,
+            'file_download_click_count' => 1,
+        ]);
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $sampleLandingPage->id,
+            'statistic_date' => now()->subDay()->toDateString(),
+            'page_view_count' => 4,
+            'file_download_click_count' => 7,
+        ]);
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $alternativeTitleLandingPage->id,
+            'statistic_date' => now()->toDateString(),
+            'page_view_count' => 3,
+            'file_download_click_count' => 1,
+        ]);
+
+        LandingPageDailyStatistic::query()->create([
+            'landing_page_id' => $untitledLandingPage->id,
+            'statistic_date' => now()->subDays(2)->toDateString(),
+            'page_view_count' => 2,
+            'file_download_click_count' => 1,
+        ]);
+
+        PortalSearchDailyStatistic::query()->create([
+            'statistic_date' => now()->toDateString(),
+            'normalized_term' => 'climate',
+            'search_count' => 5,
+        ]);
+
+        PortalSearchDailyStatistic::query()->create([
+            'statistic_date' => now()->subDay()->toDateString(),
+            'normalized_term' => 'igsn',
+            'search_count' => 2,
+        ]);
+
+        PortalSearchDailyStatistic::query()->create([
+            'statistic_date' => now()->subDays(20)->toDateString(),
+            'normalized_term' => 'climate',
+            'search_count' => 4,
+        ]);
+
+        $dashboard = (new StatisticsDashboardService)->build();
+
+        expect($dashboard['overview'])->toBe([
+            'totalPageViews' => 24,
+            'totalDownloadClicks' => 12,
+            'totalPortalSearches' => 11,
+            'trackedLandingPages' => 4,
+        ]);
+
+        expect($dashboard['trends']['days'])->toHaveCount(14)
+            ->and($dashboard['trends']['days'][13])->toBe('2026-05-27')
+            ->and($dashboard['trends']['pageViews'][13])->toBe(13)
+            ->and($dashboard['trends']['downloadClicks'][13])->toBe(3)
+            ->and($dashboard['trends']['pageViews'][12])->toBe(4)
+            ->and($dashboard['trends']['pageViews'][11])->toBe(2)
+            ->and($dashboard['trends']['portalSearches'][13])->toBe(5)
+            ->and($dashboard['trends']['portalSearches'][12])->toBe(2);
+
+        expect(array_column($dashboard['topLandingPagesByViews'], 'title'))->toBe([
+            'Dataset Alpha',
+            'Sample Beta',
+            'Alternative Title',
+            'Untitled',
+        ]);
+
+        expect($dashboard['topLandingPagesByViews'][0]['total'])->toBe(15)
+            ->and($dashboard['topLandingPagesByViews'][2]['resourceTypeLabel'])->toBe('Other')
+            ->and(count($dashboard['topLandingPagesByViews']))->toBe(4)
+            ->and($dashboard['topLandingPagesByDownloads'][0]['title'])->toBe('Sample Beta')
+            ->and($dashboard['topLandingPagesByDownloads'][0]['total'])->toBe(7)
+            ->and($dashboard['portalSearchTerms'][0])->toBe([
+                'term' => 'climate',
+                'total' => 9,
+            ])
+            ->and($dashboard['typeSplit'])->toBe([
+                'resourcePageViews' => 20,
+                'physicalObjectPageViews' => 4,
+                'resourceDownloadClicks' => 5,
+                'physicalObjectDownloadClicks' => 7,
+            ]);
+    });
+
+    it('returns empty dashboard state when no statistics exist', function (): void {
+        $dashboard = (new StatisticsDashboardService)->build();
+
+        expect($dashboard['overview'])->toBe([
+            'totalPageViews' => 0,
+            'totalDownloadClicks' => 0,
+            'totalPortalSearches' => 0,
+            'trackedLandingPages' => 0,
+        ])
+            ->and($dashboard['topLandingPagesByViews'])->toBe([])
+            ->and($dashboard['topLandingPagesByDownloads'])->toBe([])
+            ->and($dashboard['portalSearchTerms'])->toBe([])
+            ->and($dashboard['typeSplit'])->toBe([
+                'resourcePageViews' => 0,
+                'physicalObjectPageViews' => 0,
+                'resourceDownloadClicks' => 0,
+                'physicalObjectDownloadClicks' => 0,
+            ])
+            ->and($dashboard['trends']['days'])->toHaveCount(14)
+            ->and(array_sum($dashboard['trends']['pageViews']))->toBe(0)
+            ->and(array_sum($dashboard['trends']['downloadClicks']))->toBe(0)
+            ->and(array_sum($dashboard['trends']['portalSearches']))->toBe(0);
+    });
+});
+
+it('casts landing page daily statistics and exposes analytics relationships', function (): void {
+    $landingPage = statisticsLandingPage('10.5880/stats.model.001', 'stats-model');
+    $statistic = new LandingPageDailyStatistic([
+        'landing_page_id' => $landingPage->id,
+        'statistic_date' => '2026-05-27',
+        'page_view_count' => '2',
+        'file_download_click_count' => '3',
+    ]);
+
+    expect($statistic->getFillable())->toBe([
+        'landing_page_id',
+        'statistic_date',
+        'page_view_count',
+        'file_download_click_count',
+    ])
+        ->and($statistic->statistic_date)->toBeInstanceOf(Carbon::class)
+        ->and($statistic->page_view_count)->toBeInt()
+        ->and($statistic->file_download_click_count)->toBeInt()
+        ->and($statistic->landingPage())->toBeInstanceOf(BelongsTo::class)
+        ->and($landingPage->dailyStatistics())->toBeInstanceOf(HasMany::class);
+});

--- a/tests/playwright/critical/landing-pages.spec.ts
+++ b/tests/playwright/critical/landing-pages.spec.ts
@@ -407,8 +407,8 @@ test.describe('Landing Page - Files Section (Issue #373)', () => {
     // Verify files section is visible
     await landingPage.verifyFilesSectionVisible();
 
-    // Verify download button is visible with correct URL
-    await landingPage.verifyDownloadButtonVisible('https://datapub.gfz-potsdam.de/download/test-data.zip');
+    // Verify download button is visible with the tracked redirect URL
+    await landingPage.verifyDownloadButtonVisible(/\/landing-page-downloads\/\d+\/primary$/);
 
     // Contact form button should NOT be visible when download URL exists
     await landingPage.verifyContactFormButtonNotVisible();

--- a/tests/playwright/helpers/page-objects/LandingPage.ts
+++ b/tests/playwright/helpers/page-objects/LandingPage.ts
@@ -437,7 +437,7 @@ export class LandingPage {
   /**
    * Verify download button is visible and has correct URL
    */
-  async verifyDownloadButtonVisible(expectedUrl?: string) {
+  async verifyDownloadButtonVisible(expectedUrl?: string | RegExp) {
     await expect(this.downloadButton).toBeVisible();
     if (expectedUrl) {
       await expect(this.downloadButton).toHaveAttribute('href', expectedUrl);

--- a/tests/vitest/components/__tests__/app-sidebar.test.tsx
+++ b/tests/vitest/components/__tests__/app-sidebar.test.tsx
@@ -209,7 +209,7 @@ describe('AppSidebar', () => {
         expect(sectionCalls.map((call) => call[0].label)).toEqual(['Team', 'Configuration', 'Operations', 'Legacy']);
         expect(sectionCalls[0][0].items.map((item: NavItem) => item.title)).toEqual(['Users']);
         expect(sectionCalls[1][0].items.map((item: NavItem) => item.title)).toEqual(['Editor Settings']);
-        expect(sectionCalls[2][0].items.map((item: NavItem) => item.title)).toEqual(['Logs']);
+        expect(sectionCalls[2][0].items.map((item: NavItem) => item.title)).toEqual(['Statistics', 'Logs']);
         expect(sectionCalls[3][0].items.map((item: NavItem) => item.title)).toEqual(['Old Datasets', 'Statistics (old)']);
     });
 
@@ -229,10 +229,11 @@ describe('AppSidebar', () => {
         expect(screen.getByTestId('workspace-switcher')).toHaveAttribute('data-value', 'administration');
 
         const sectionCalls = NavSectionMock.mock.calls;
-        expect(sectionCalls.map((call) => call[0].label)).toEqual(['Team', 'Configuration', 'Legacy']);
+        expect(sectionCalls.map((call) => call[0].label)).toEqual(['Team', 'Configuration', 'Operations', 'Legacy']);
         expect(sectionCalls[0][0].items.map((item: NavItem) => item.title)).toEqual(['Users']);
         expect(sectionCalls[1][0].items.map((item: NavItem) => item.title)).toEqual(['Editor Settings']);
-        expect(sectionCalls[2][0].items.map((item: NavItem) => item.title)).toEqual(['Statistics (old)']);
+        expect(sectionCalls[2][0].items.map((item: NavItem) => item.title)).toEqual(['Statistics']);
+        expect(sectionCalls[3][0].items.map((item: NavItem) => item.title)).toEqual(['Statistics (old)']);
     });
 
     it('does not render a leading separator when the team section is filtered out', () => {
@@ -284,7 +285,7 @@ describe('AppSidebar', () => {
 
         const operationsSection = NavSectionMock.mock.calls.find((call) => call[0].label === 'Operations');
         expect(operationsSection).toBeDefined();
-        expect(operationsSection?.[0].items.map((item: NavItem) => item.title)).toEqual(['Assessment', 'Logs']);
+        expect(operationsSection?.[0].items.map((item: NavItem) => item.title)).toEqual(['Assessment', 'Statistics', 'Logs']);
         expect(operationsSection?.[0].items[0].badge).toBe('6.9 / 3.2');
     });
 

--- a/tests/vitest/components/portal/portal-filters.test.tsx
+++ b/tests/vitest/components/portal/portal-filters.test.tsx
@@ -4,6 +4,16 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { mockAxiosPost } = vi.hoisted(() => ({
+    mockAxiosPost: vi.fn(),
+}));
+
+vi.mock('axios', () => ({
+    default: {
+        post: mockAxiosPost,
+    },
+}));
+
 import { PortalFilters } from '@/components/portal/PortalFilters';
 import type { PortalFilters as PortalFiltersType } from '@/types/portal';
 
@@ -69,6 +79,7 @@ describe('PortalFilters', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockAxiosPost.mockResolvedValue({ status: 204 });
     });
 
     describe('Expanded State', () => {
@@ -167,7 +178,26 @@ describe('PortalFilters', () => {
             fireEvent.change(input, { target: { value: 'submitted query' } });
             fireEvent.submit(input.closest('form')!);
 
+            await vi.waitFor(() => {
+                expect(mockAxiosPost).toHaveBeenCalledWith('/portal/search-analytics', { search_term: 'submitted query' });
+            });
+
             expect(onSearchChange).toHaveBeenCalledWith('submitted query');
+        });
+
+        it('does not send analytics for blank submitted queries', async () => {
+            const onSearchChange = vi.fn();
+            render(<PortalFilters {...defaultProps} onSearchChange={onSearchChange} />);
+
+            const input = screen.getByPlaceholderText(/search datasets/i);
+            fireEvent.change(input, { target: { value: '   ' } });
+            fireEvent.submit(input.closest('form')!);
+
+            await vi.waitFor(() => {
+                expect(onSearchChange).toHaveBeenCalledWith('   ');
+            });
+
+            expect(mockAxiosPost).not.toHaveBeenCalled();
         });
 
         it('shows clear button when search input has value and clears on click', async () => {
@@ -188,6 +218,7 @@ describe('PortalFilters', () => {
             await user.click(clearButton);
 
             expect(onSearchChange).toHaveBeenCalledWith('');
+            expect(mockAxiosPost).not.toHaveBeenCalled();
         });
     });
 

--- a/tests/vitest/hooks/use-sidebar-workspace.test.ts
+++ b/tests/vitest/hooks/use-sidebar-workspace.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@/hooks/use-sidebar-workspace';
 
 const workspacePaths = {
-    administration: ['/users', '/logs', '/settings', '/landing-pages', '/assistance', '/assessment', '/old-statistics', '/old-datasets'],
+    administration: ['/users', '/logs', '/settings', '/landing-pages', '/assistance', '/assessment', '/statistics', '/old-statistics', '/old-datasets'],
     curation: ['/dashboard', '/editor', '/resources', '/igsns', '/igsns-map', '/igsn-editor'],
 };
 

--- a/tests/vitest/pages/LandingPages/__tests__/FilesSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/FilesSection.test.tsx
@@ -17,6 +17,17 @@ describe('FilesSection', () => {
         expect(screen.getByText('Download data and description')).toBeInTheDocument();
     });
 
+    it('prefers tracked file URLs over raw file URLs', () => {
+        render(
+            <FilesSection
+                downloadFiles={[{ url: 'https://example.com/raw.csv', tracked_url: '/landing-page-downloads/1/files/7' }]}
+                licenses={[]}
+            />,
+        );
+
+        expect(screen.getByRole('link', { name: /Download data and description/i })).toHaveAttribute('href', '/landing-page-downloads/1/files/7');
+    });
+
     it('renders fallback message when no download or contacts', () => {
         render(<FilesSection licenses={[]} />);
 

--- a/tests/vitest/pages/__tests__/statistics.test.tsx
+++ b/tests/vitest/pages/__tests__/statistics.test.tsx
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ title }: { title: string }) => <title>{title}</title>,
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <div data-testid="app-layout">{children}</div>,
+}));
+
+import StatisticsPage from '@/pages/statistics';
+
+describe('StatisticsPage', () => {
+    const props = {
+        overview: {
+            totalPageViews: 120,
+            totalDownloadClicks: 45,
+            totalPortalSearches: 33,
+            trackedLandingPages: 9,
+        },
+        trends: {
+            days: ['2026-05-14', '2026-05-15', '2026-05-16'],
+            pageViews: [10, 20, 15],
+            downloadClicks: [4, 8, 6],
+            portalSearches: [3, 6, 5],
+        },
+        topLandingPagesByViews: [
+            {
+                landingPageId: 1,
+                title: 'Top Dataset',
+                identifier: '10.5880/top.dataset',
+                resourceTypeLabel: 'Dataset',
+                total: 55,
+                publicUrl: '/10.5880/top.dataset/top-dataset',
+                isExternal: false,
+            },
+        ],
+        topLandingPagesByDownloads: [
+            {
+                landingPageId: 2,
+                title: 'Downloaded Dataset',
+                identifier: '10.5880/downloaded.dataset',
+                resourceTypeLabel: 'Dataset',
+                total: 18,
+                publicUrl: '/10.5880/downloaded.dataset/downloaded-dataset',
+                isExternal: false,
+            },
+        ],
+        portalSearchTerms: [
+            { term: 'climate', total: 11 },
+            { term: 'igsn', total: 6 },
+        ],
+        typeSplit: {
+            resourcePageViews: 90,
+            physicalObjectPageViews: 30,
+            resourceDownloadClicks: 35,
+            physicalObjectDownloadClicks: 10,
+        },
+        lastUpdated: '2026-05-27T08:30:00Z',
+    };
+
+    it('renders the new statistics dashboard sections', () => {
+        render(<StatisticsPage {...props} />);
+
+        expect(screen.getByText('Public engagement statistics')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Landing page views' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Download clicks' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Portal searches' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Top landing pages by views' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Top Portal Search Terms' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Resources' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Physical Objects' })).toBeInTheDocument();
+    });
+
+    it('renders empty-state messaging when no analytics exist', () => {
+        render(
+            <StatisticsPage
+                {...props}
+                overview={{
+                    totalPageViews: 0,
+                    totalDownloadClicks: 0,
+                    totalPortalSearches: 0,
+                    trackedLandingPages: 0,
+                }}
+                topLandingPagesByViews={[]}
+                topLandingPagesByDownloads={[]}
+                portalSearchTerms={[]}
+                trends={{
+                    days: ['2026-05-14'],
+                    pageViews: [0],
+                    downloadClicks: [0],
+                    portalSearches: [0],
+                }}
+            />,
+        );
+
+        expect(screen.getByText(/No analytics have been recorded yet/i)).toBeInTheDocument();
+        expect(screen.getByText(/No landing page views have been recorded yet/i)).toBeInTheDocument();
+        expect(screen.getByText(/No portal searches have been tracked yet/i)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
This pull request introduces a new analytics system for tracking landing page downloads, page views, and portal search analytics, with bot detection and daily aggregation. It adds new controller endpoints, models, and services to support analytics collection and reporting, and updates download URLs to support tracking. The changes are grouped as follows:

**Landing Page Analytics and Download Tracking:**
* Added `LandingPageDownloadRedirectController` to handle tracked download redirects and record analytics, with bot detection to exclude known bots. (`app/Http/Controllers/LandingPageDownloadRedirectController.php`, [app/Http/Controllers/LandingPageDownloadRedirectController.phpR1-R57](diffhunk://#diff-efb3b3f513e832b86cd662a7cf715b40e168bcf060392618a2eec32a53d077acR1-R57))
* Introduced `LandingPageAnalyticsService` to record page views and download clicks as daily aggregates, and integrated it into the landing page view counter service. (`app/Services/Statistics/LandingPageAnalyticsService.php`, [[1]](diffhunk://#diff-2ff8b440ad62e9cd3edf63002eede728fbbf2d3c78589675dcf8c8b947cb199dR1-R58); `app/Services/BotProtection/LandingPageViewCounterService.php`, [[2]](diffhunk://#diff-9085d46ebbcbf644a4e71bc1deb9ab3faf55bdd55dfeee8a9bfd127530338e4bR8-R22) [[3]](diffhunk://#diff-9085d46ebbcbf644a4e71bc1deb9ab3faf55bdd55dfeee8a9bfd127530338e4bL32-R47)
* Added `LandingPageDailyStatistic` model to store daily aggregate counters for landing pages and exposed a relation on the `LandingPage` model. (`app/Models/LandingPageDailyStatistic.php`, [[1]](diffhunk://#diff-5e22327d0acc7d250a3bf5b2ceb5e326a93b3516b7dc6b9838e3dba8269ae0a9R1-R51); `app/Models/LandingPage.php`, [[2]](diffhunk://#diff-5d4d5238ae0c0fcab489aa9e8cead48fadf26bbf9746891eeb5afc8e22c209c1R291-R300)
* Updated landing page public controller to generate tracked download URLs for primary and file downloads, ensuring analytics are recorded on download events. (`app/Http/Controllers/LandingPagePublicController.php`, [[1]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR325-R328) [[2]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR349-R394)

**Portal Search Analytics:**
* Added `PortalSearchAnalyticsController` and `PortalSearchAnalyticsRequest` to accept and validate search analytics events from the portal. (`app/Http/Controllers/PortalSearchAnalyticsController.php`, [[1]](diffhunk://#diff-0e8286778ae997f60ae4d8275b7a818e0cb033598ada371c9d001f4f99b5f453R1-R23); `app/Http/Requests/PortalSearchAnalyticsRequest.php`, [[2]](diffhunk://#diff-62e276d981823c3e5e4f3b769bbadd79933ad995145deab1f09b5592c1aa5f16R1-R32)
* Introduced `PortalSearchAnalyticsService` to normalize search terms, filter out bots, and aggregate search counts daily in the new `PortalSearchDailyStatistic` model. (`app/Services/Statistics/PortalSearchAnalyticsService.php`, [[1]](diffhunk://#diff-e8862994c74f473cbee25a55e7d66c5bdda743758ad1db95cc9e9550ccbc2230R1-R66); `app/Models/PortalSearchDailyStatistic.php`, [[2]](diffhunk://#diff-2d47913ca10d4a3ea2052aa1fe83faf291aa99f4afe89822a0a52bf94bf0e787R1-R36)

**Statistics Dashboard:**
* Added `StatisticsController` and connected it to a statistics dashboard service, exposing daily analytics data and last updated timestamp for reporting. (`app/Http/Controllers/StatisticsController.php`, [app/Http/Controllers/StatisticsController.phpR1-R24](diffhunk://#diff-5097a4f053350d839f507dc3dcfab7f038b218cd4ea7bdc284dfaf917b1b8582R1-R24))

These changes collectively enable robust, bot-aware analytics for landing page interactions and portal searches, supporting future reporting and dashboard features.