### PR TITLE
Feature: Make Validation Errors clickable and navigable

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -98,6 +98,10 @@
         ],
         "improvements": [
             {
+                "title": "Clickable Save & Validate Error Navigation",
+                "description": "The Data Editor now turns Save & Validate blocking messages into a grouped clickable summary. When required fields such as title, datacenter, authors, abstract, licenses, or funding references need attention, curators can select the matching entry to reopen the relevant accordion section and jump directly to the affected field instead of scanning the entire form manually."
+            },
+            {
                 "title": "Go-Live Hardening for Contact Delivery and Public Operations",
                 "description": "Stage and production stacks no longer expose database and Redis ports on the host, CloudBeaver has been removed from the maintained Docker profiles, and the public /health endpoint now returns only a minimal status payload. Landing-page contact requests are also tracked more accurately across queued, sent, and failed delivery states so successful dispatch is no longer recorded before the queued mail actually leaves the application."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -94,6 +94,10 @@ function appendValidationMessage(errors: Record<string, string[]>, backendKey: s
     errors[backendKey] = [message];
 }
 
+function isDatacenterErrorKey(backendKey: string): boolean {
+    return backendKey === 'datacenters' || backendKey.startsWith('datacenters.');
+}
+
 export default function DataCiteForm({
     resourceTypes,
     titleTypes,
@@ -1794,7 +1798,7 @@ export default function DataCiteForm({
             setMappedValidationErrors(mapped);
             setValidationAlertHeader(headerMessage);
 
-            if (Object.hasOwn(errors, 'datacenters')) {
+            if (Object.keys(errors).some(isDatacenterErrorKey)) {
                 setDatacenterTouched(true);
             }
 
@@ -1820,6 +1824,23 @@ export default function DataCiteForm({
         },
         [setFieldErrors, setOpenAccordionItems],
     );
+
+    const datacenterErrorMessage = useMemo(() => {
+        if (!datacenterTouched) {
+            return null;
+        }
+
+        const mappedDatacenterError = mappedValidationErrors.find((error) => isDatacenterErrorKey(error.backendKey));
+        if (mappedDatacenterError) {
+            return mappedDatacenterError.message;
+        }
+
+        if (selectedDatacenters.length === 0) {
+            return 'At least one datacenter is required.';
+        }
+
+        return null;
+    }, [datacenterTouched, mappedValidationErrors, selectedDatacenters.length]);
 
     /**
      * Shared handler for 422 backend validation errors.
@@ -2172,7 +2193,8 @@ export default function DataCiteForm({
                                 }}
                                 className="min-w-0 md:col-span-3"
                                 required
-                                hasError={datacenterTouched && selectedDatacenters.length === 0}
+                                hasError={datacenterErrorMessage !== null}
+                                errorMessage={datacenterErrorMessage ?? undefined}
                             />
                             <InputField
                                 id="version"

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -80,6 +80,9 @@ export type { DataCiteFormProps, InitialAuthor, InitialContributor } from './typ
 // Re-export helper functions for backward compatibility
 export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
 
+const ABSTRACT_MIN_LENGTH = 50;
+const ABSTRACT_MAX_LENGTH = 17500;
+
 function appendValidationMessage(errors: Record<string, string[]>, backendKey: string, message: string): void {
     const existing = errors[backendKey];
 
@@ -607,8 +610,8 @@ export default function DataCiteForm({
 
                 // Length check (50-17500 characters)
                 const lengthResult = validateTextLength(text, {
-                    min: 50,
-                    max: 17500,
+                    min: ABSTRACT_MIN_LENGTH,
+                    max: ABSTRACT_MAX_LENGTH,
                     fieldName: 'Abstract',
                 });
                 if (!lengthResult.isValid) {
@@ -616,11 +619,10 @@ export default function DataCiteForm({
                 }
 
                 // Warning at 90% of max length
-                if (text.length > 15750) {
-                    // 90% of 17500
+                if (text.length > ABSTRACT_MAX_LENGTH * 0.9) {
                     return {
                         severity: 'warning',
-                        message: `Abstract is very long (${text.length}/17500 characters). Consider condensing if possible.`,
+                        message: `Abstract is very long (${text.length}/${ABSTRACT_MAX_LENGTH} characters). Consider condensing if possible.`,
                     };
                 }
 
@@ -1117,8 +1119,20 @@ export default function DataCiteForm({
         }
 
         const abstractEntry = descriptions.find((desc) => desc.type === 'Abstract');
-        if (!abstractEntry?.value.trim()) {
+        const abstractText = abstractEntry?.value.trim() ?? '';
+
+        if (!abstractText) {
             appendValidationMessage(errors, 'descriptions.0.description', 'Abstract is required.');
+        } else {
+            const abstractLengthResult = validateTextLength(abstractText, {
+                min: ABSTRACT_MIN_LENGTH,
+                max: ABSTRACT_MAX_LENGTH,
+                fieldName: 'Abstract',
+            });
+
+            if (!abstractLengthResult.isValid) {
+                appendValidationMessage(errors, 'descriptions.0.description', abstractLengthResult.error!);
+            }
         }
 
         if (selectedDatacenters.length === 0) {
@@ -1206,7 +1220,7 @@ export default function DataCiteForm({
         if (!abstractEntry?.value.trim()) {
             return 'invalid';
         }
-        if (abstractEntry.value.trim().length < 50) {
+        if (abstractEntry.value.trim().length < ABSTRACT_MIN_LENGTH) {
             return 'invalid';
         }
 
@@ -2093,7 +2107,7 @@ export default function DataCiteForm({
                         <SectionHeader
                             label="Resource Information"
                             description="Basic metadata about your dataset including identifiers and type."
-                            tooltip="Required fields: Year, Resource Type, Main Title, Language"
+                            tooltip="Required fields: Year, Resource Type, Main Title, Language, Datacenter"
                             required
                         />
                         <div className="grid gap-4 md:grid-cols-12">
@@ -2321,7 +2335,7 @@ export default function DataCiteForm({
                         <SectionHeader
                             label="Descriptions"
                             description="Detailed information about your dataset."
-                            tooltip="Abstract is required (50-17,500 characters). Other description types are optional."
+                            tooltip={`Abstract is required (${ABSTRACT_MIN_LENGTH}-${ABSTRACT_MAX_LENGTH.toLocaleString('en-US')} characters). Other description types are optional.`}
                             required
                         />
                         <DescriptionField

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -1851,6 +1851,21 @@ export default function DataCiteForm({
         return null;
     }, [datacenterTouched, mappedValidationErrors, selectedDatacenters.length]);
 
+    const clearDatacenterValidationErrors = useCallback(() => {
+        const nextMappedValidationErrors = mappedValidationErrors.filter((error) => !isDatacenterErrorKey(error.backendKey));
+
+        if (nextMappedValidationErrors.length === mappedValidationErrors.length) {
+            return;
+        }
+
+        setMappedValidationErrors(nextMappedValidationErrors);
+
+        if (nextMappedValidationErrors.length === 0) {
+            setValidationAlertHeader(undefined);
+            setErrorMessage(null);
+        }
+    }, [mappedValidationErrors]);
+
     /**
      * Shared handler for 422 backend validation errors.
      * Maps errors to sections, injects inline field errors, opens relevant accordion sections,
@@ -2199,6 +2214,7 @@ export default function DataCiteForm({
                                 onChange={(ids) => {
                                     setSelectedDatacenters(ids);
                                     setDatacenterTouched(true);
+                                    clearDatacenterValidationErrors();
                                 }}
                                 className="min-w-0 md:col-span-3"
                                 required

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -983,7 +983,6 @@ export default function DataCiteForm({
     const [isSaving, setIsSaving] = useState(false);
     const [isSavingDraft, setIsSavingDraft] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
-    const [validationErrors, setValidationErrors] = useState<string[]>([]);
     const [mappedValidationErrors, setMappedValidationErrors] = useState<MappedError[]>([]);
     const [validationAlertHeader, setValidationAlertHeader] = useState<string | undefined>(undefined);
     const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
@@ -1840,7 +1839,6 @@ export default function DataCiteForm({
         setHasAttemptedSubmit(true);
         setIsSaving(true);
         setErrorMessage(null);
-        setValidationErrors([]);
         setMappedValidationErrors([]);
         clearBackendErrors();
 
@@ -1963,7 +1961,6 @@ export default function DataCiteForm({
                     if (parsed?.errors) {
                         applyBackendValidationErrors(parsed.errors, parsed.message, defaultError);
                     } else {
-                        setValidationErrors([]);
                         setErrorMessage(parsed?.message || defaultError);
                     }
 
@@ -1984,7 +1981,6 @@ export default function DataCiteForm({
 
         setIsSavingDraft(true);
         setErrorMessage(null);
-        setValidationErrors([]);
         setMappedValidationErrors([]);
         clearBackendErrors();
 
@@ -2038,7 +2034,6 @@ export default function DataCiteForm({
                     if (parsed?.errors) {
                         applyBackendValidationErrors(parsed.errors, parsed.message, defaultError);
                     } else {
-                        setValidationErrors([]);
                         setErrorMessage(parsed?.message || defaultError);
                     }
 
@@ -2066,15 +2061,14 @@ export default function DataCiteForm({
         return <Circle className="h-4 w-4 text-gray-400" aria-label="Optional section" />;
     };
 
-    // Build global error messages array for ValidationAlert (client-side preflight errors only)
+    // Build global error messages array for ValidationAlert when no mapped navigation errors are present.
     const globalErrorMessages = useMemo(() => {
-        const messages: string[] = [];
         if (errorMessage && mappedValidationErrors.length === 0) {
-            messages.push(errorMessage);
+            return [errorMessage];
         }
-        messages.push(...validationErrors);
-        return messages;
-    }, [errorMessage, validationErrors, mappedValidationErrors]);
+
+        return [];
+    }, [errorMessage, mappedValidationErrors]);
 
     // Handle click on an error in the ClickableValidationAlert (Issue #605)
     const handleErrorClick = useCallback(

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -98,6 +98,10 @@ function isDatacenterErrorKey(backendKey: string): boolean {
     return backendKey === 'datacenters' || backendKey.startsWith('datacenters.');
 }
 
+function isDatacenterElementErrorKey(backendKey: string): boolean {
+    return backendKey.startsWith('datacenters.');
+}
+
 export default function DataCiteForm({
     resourceTypes,
     titleTypes,
@@ -1830,12 +1834,17 @@ export default function DataCiteForm({
             return null;
         }
 
-        const mappedDatacenterError = mappedValidationErrors.find((error) => isDatacenterErrorKey(error.backendKey));
-        if (mappedDatacenterError) {
-            return mappedDatacenterError.message;
+        const mappedDatacenterElementError = mappedValidationErrors.find((error) => isDatacenterElementErrorKey(error.backendKey));
+        if (mappedDatacenterElementError) {
+            return mappedDatacenterElementError.message;
         }
 
         if (selectedDatacenters.length === 0) {
+            const mappedDatacenterCollectionError = mappedValidationErrors.find((error) => error.backendKey === 'datacenters');
+            if (mappedDatacenterCollectionError) {
+                return mappedDatacenterCollectionError.message;
+            }
+
             return 'At least one datacenter is required.';
         }
 

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -80,6 +80,17 @@ export type { DataCiteFormProps, InitialAuthor, InitialContributor } from './typ
 // Re-export helper functions for backward compatibility
 export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
 
+function appendValidationMessage(errors: Record<string, string[]>, backendKey: string, message: string): void {
+    const existing = errors[backendKey];
+
+    if (existing) {
+        existing.push(message);
+        return;
+    }
+
+    errors[backendKey] = [message];
+}
+
 export default function DataCiteForm({
     resourceTypes,
     titleTypes,
@@ -144,17 +155,7 @@ export default function DataCiteForm({
     );
 
     const errorRef = useRef<HTMLDivElement | null>(null);
-
-    // Refs for accordion sections (for auto-scroll on validation errors)
-    const resourceInfoRef = useRef<HTMLDivElement | null>(null);
-    const licensesRef = useRef<HTMLDivElement | null>(null);
-    const authorsRef = useRef<HTMLDivElement | null>(null);
-    const descriptionsRef = useRef<HTMLDivElement | null>(null);
-    const datesRef = useRef<HTMLDivElement | null>(null);
     const controlledVocabulariesRef = useRef<HTMLDivElement | null>(null);
-
-    // Ref to track pending validation scroll timeout (prevents race conditions on rapid save clicks)
-    const validationScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Tracking refs for MSL notification
     const hasNotifiedMslUnlock = useRef<boolean>(false);
@@ -1058,30 +1059,6 @@ export default function DataCiteForm({
         return issues;
     }, [dates]);
 
-    const areRequiredFieldsFilled = useMemo(() => {
-        const mainTitleEntry = titles.find((entry) => entry.titleType === 'main-title');
-        const mainTitleFilled = Boolean(mainTitleEntry?.title.trim());
-        const yearFilled = Boolean(form.year?.trim());
-        const resourceTypeSelected = Boolean(form.resourceType);
-        const languageSelected = Boolean(form.language);
-        const primaryLicenseFilled = Boolean(licenseEntries[0]?.license?.trim());
-        const authorsValid =
-            authors.length > 0 &&
-            authors.every((author) => {
-                if (author.type === 'person') {
-                    const hasLastName = Boolean(author.lastName.trim());
-                    const contactValid = !author.isContact || Boolean(author.email.trim());
-                    return hasLastName && contactValid;
-                }
-
-                return Boolean(author.institutionName.trim());
-            });
-        const abstractFilled = descriptions.some((desc) => desc.type === 'Abstract' && desc.value.trim() !== '');
-        // Note: 'Created' date is no longer required from user - it's auto-managed by the backend
-
-        return mainTitleFilled && yearFilled && resourceTypeSelected && languageSelected && primaryLicenseFilled && authorsValid && abstractFilled && selectedDatacenters.length > 0;
-    }, [authors, descriptions, form.language, form.resourceType, form.year, licenseEntries, selectedDatacenters, titles]);
-
     // Draft save only requires a Main Title (Issue #548)
     const isDraftSaveable = useMemo(() => {
         const mainTitleEntry = titles.find((entry) => entry.titleType === 'main-title');
@@ -1093,70 +1070,62 @@ export default function DataCiteForm({
         return gcmdKeywords.some((kw) => kw.isLegacy === true);
     }, [gcmdKeywords]);
 
-    // Collect all missing required fields for Save button tooltip
-    const missingRequiredFields = useMemo(() => {
-        const missing: string[] = [];
-
-        // Check main title
+    const clientSubmitValidationErrors = useMemo(() => {
+        const errors: Record<string, string[]> = {};
         const mainTitleEntry = titles.find((entry) => entry.titleType === 'main-title');
+
         if (!mainTitleEntry?.title.trim()) {
-            missing.push('Main Title is required');
+            appendValidationMessage(errors, 'titles.0.title', 'Main Title is required.');
         }
 
-        // Check year
         if (!form.year?.trim()) {
-            missing.push('Publication Year is required');
+            appendValidationMessage(errors, 'year', 'Publication Year is required.');
         }
 
-        // Check resource type
         if (!form.resourceType) {
-            missing.push('Resource Type is required');
+            appendValidationMessage(errors, 'resourceType', 'Resource Type is required.');
         }
 
-        // Check language
         if (!form.language) {
-            missing.push('Language is required');
+            appendValidationMessage(errors, 'language', 'Language is required.');
         }
 
-        // Check primary license
         if (!licenseEntries[0]?.license?.trim()) {
-            missing.push('Primary License is required');
+            appendValidationMessage(errors, 'licenses.0.license', 'Primary License is required.');
         }
 
-        // Check authors
         if (authors.length === 0) {
-            missing.push('At least one Author is required');
+            appendValidationMessage(errors, 'authors', 'At least one author is required.');
         } else {
-            const invalidAuthors = authors.filter((author) => {
+            authors.forEach((author, index) => {
                 if (author.type === 'person') {
-                    const hasLastName = Boolean(author.lastName.trim());
-                    const contactValid = !author.isContact || Boolean(author.email.trim());
-                    return !hasLastName || !contactValid;
-                }
-                return !author.institutionName.trim();
-            });
+                    if (!author.lastName.trim()) {
+                        appendValidationMessage(errors, `authors.${index}.lastName`, `Author ${index + 1}: Last name is required.`);
+                    }
 
-            if (invalidAuthors.length > 0) {
-                missing.push(`${invalidAuthors.length} Author(s) with missing required fields`);
-            }
+                    if (author.isContact && !author.email.trim()) {
+                        appendValidationMessage(errors, `authors.${index}.email`, `Author ${index + 1}: Email is required for contact person.`);
+                    }
+
+                    return;
+                }
+
+                if (!author.institutionName.trim()) {
+                    appendValidationMessage(errors, `authors.${index}.institutionName`, `Author ${index + 1}: Institution name is required.`);
+                }
+            });
         }
 
-        // Check abstract
         const abstractEntry = descriptions.find((desc) => desc.type === 'Abstract');
         if (!abstractEntry?.value.trim()) {
-            missing.push('Abstract is required');
-        } else if (abstractEntry.value.trim().length < 50) {
-            missing.push('Abstract must be at least 50 characters');
+            appendValidationMessage(errors, 'descriptions.0.description', 'Abstract is required.');
         }
 
-        // Note: 'Created' date is no longer required from user - it's auto-managed by the backend
-
-        // Check datacenters
         if (selectedDatacenters.length === 0) {
-            missing.push('At least one Datacenter is required');
+            appendValidationMessage(errors, 'datacenters', 'At least one datacenter is required.');
         }
 
-        return missing;
+        return errors;
     }, [authors, descriptions, form.language, form.resourceType, form.year, licenseEntries, selectedDatacenters, titles]);
 
     // ===================================================================
@@ -1341,80 +1310,6 @@ export default function DataCiteForm({
         return 'valid';
     }, [instruments]);
 
-    // ===================================================================
-    // Auto-Scroll to First Invalid Section
-    // ===================================================================
-    // Scrolls to the first accordion section with validation errors
-    // Opens the section automatically and focuses the first problematic field
-    const scrollToFirstInvalidSection = () => {
-        // Define priority order of sections to check
-        // Note: Dates section is excluded as it's now optional (Created/Updated are auto-managed)
-        const sectionsToCheck: Array<{
-            status: 'valid' | 'invalid' | 'optional-empty';
-            ref: React.RefObject<HTMLDivElement | null>;
-            accordionValue: string;
-            focusSelector?: string; // CSS selector for first field to focus
-        }> = [
-            {
-                status: resourceInfoStatus,
-                ref: resourceInfoRef,
-                accordionValue: 'resource-info',
-                focusSelector: '[data-testid="main-title-input"]', // Focus main title if invalid
-            },
-            {
-                status: licensesStatus,
-                ref: licensesRef,
-                accordionValue: 'licenses-rights',
-                focusSelector: '[data-testid="license-select-0"]', // Focus primary license
-            },
-            {
-                status: authorsStatus,
-                ref: authorsRef,
-                accordionValue: 'authors',
-                // Authors is complex, just scroll to section
-            },
-            {
-                status: descriptionsStatus,
-                ref: descriptionsRef,
-                accordionValue: 'descriptions',
-                focusSelector: '[data-testid="abstract-textarea"]', // Focus abstract
-            },
-        ];
-
-        // Find first invalid section
-        const firstInvalidSection = sectionsToCheck.find((section) => section.status === 'invalid');
-
-        if (firstInvalidSection) {
-            // Open the accordion section
-            setOpenAccordionItems((prev) => {
-                if (!prev.includes(firstInvalidSection.accordionValue)) {
-                    return [...prev, firstInvalidSection.accordionValue];
-                }
-                return prev;
-            });
-
-            // Scroll to the section after a brief delay to allow accordion to open
-            setTimeout(() => {
-                if (firstInvalidSection.ref.current) {
-                    firstInvalidSection.ref.current.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'start',
-                    });
-
-                    // Focus the first field if selector provided
-                    if (firstInvalidSection.focusSelector) {
-                        setTimeout(() => {
-                            const fieldToFocus = document.querySelector(firstInvalidSection.focusSelector!) as HTMLElement;
-                            if (fieldToFocus) {
-                                fieldToFocus.focus();
-                            }
-                        }, 400); // Additional delay for smooth scroll to complete
-                    }
-                }
-            }, 100); // Brief delay for accordion animation
-        }
-    };
-
     const handleChange = (field: keyof DataCiteFormData, value: string) => {
         setForm((prev) => ({ ...prev, [field]: value }));
 
@@ -1593,16 +1488,6 @@ export default function DataCiteForm({
         }
 
     }, [errorMessage]);
-
-    // Cleanup pending validation scroll timeout on unmount
-    useEffect(() => {
-        return () => {
-            if (validationScrollTimeoutRef.current) {
-                clearTimeout(validationScrollTimeoutRef.current);
-                validationScrollTimeoutRef.current = null;
-            }
-        };
-    }, []);
 
     const [resolvedResourceId, setResolvedResourceId] = useState<number | null>(() => {
         if (!initialResourceId) {
@@ -1890,16 +1775,15 @@ export default function DataCiteForm({
         titles,
     ]);
 
-    /**
-     * Shared handler for 422 backend validation errors.
-     * Maps errors to sections, injects inline field errors, opens relevant accordion sections,
-     * and scrolls/focuses the first errored field or section trigger.
-     */
-    const applyBackendValidationErrors = useCallback(
-        (errors: Record<string, string[]>, serverMessage: string | undefined, defaultHeader: string) => {
+    const revealValidationErrors = useCallback(
+        (errors: Record<string, string[]>, headerMessage: string) => {
             const mapped = mapBackendErrors(errors);
             setMappedValidationErrors(mapped);
-            setValidationAlertHeader(serverMessage ?? defaultHeader);
+            setValidationAlertHeader(headerMessage);
+
+            if (Object.hasOwn(errors, 'datacenters')) {
+                setDatacenterTouched(true);
+            }
 
             // Inject errors into individual field states for inline display
             const fieldErrors = mapped
@@ -1919,9 +1803,21 @@ export default function DataCiteForm({
                 scheduleScrollToError(firstError.fieldSelector, firstError.sectionId);
             }
 
-            setErrorMessage(serverMessage ?? defaultHeader);
+            setErrorMessage(headerMessage);
         },
         [setFieldErrors, setOpenAccordionItems],
+    );
+
+    /**
+     * Shared handler for 422 backend validation errors.
+     * Maps errors to sections, injects inline field errors, opens relevant accordion sections,
+     * and scrolls/focuses the first errored field or section trigger.
+     */
+    const applyBackendValidationErrors = useCallback(
+        (errors: Record<string, string[]>, serverMessage: string | undefined, defaultHeader: string) => {
+            revealValidationErrors(errors, serverMessage ?? defaultHeader);
+        },
+        [revealValidationErrors],
     );
 
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -1934,38 +1830,22 @@ export default function DataCiteForm({
         setMappedValidationErrors([]);
         clearBackendErrors();
 
-        // Check if required fields are filled - if not, show error list and scroll to first invalid section
-        if (!areRequiredFieldsFilled) {
-            // Clear any pending scroll timeout from a previous save attempt
-            if (validationScrollTimeoutRef.current) {
-                clearTimeout(validationScrollTimeoutRef.current);
-                validationScrollTimeoutRef.current = null;
-            }
-
-            setValidationErrors(missingRequiredFields);
-            setErrorMessage('Please complete all required fields before saving.');
+        // Check client-side submit blockers before sending the request.
+        if (Object.keys(clientSubmitValidationErrors).length > 0) {
+            revealValidationErrors(clientSubmitValidationErrors, 'Please complete all required fields before saving.');
             setIsSaving(false);
-
-            // Scroll to error list first (via useEffect on errorMessage), then to first invalid section.
-            // Use requestAnimationFrame to wait for the DOM update + a short delay for the scroll animation.
-            requestAnimationFrame(() => {
-                validationScrollTimeoutRef.current = setTimeout(() => {
-                    validationScrollTimeoutRef.current = null;
-                    scrollToFirstInvalidSection();
-                }, 600);
-            });
             return;
         }
 
         // Client-side validation for funding references
         if (!validateAllFundingReferences(fundingReferences)) {
-            setValidationErrors(['Please fix the validation errors in the Funding References section before submitting.']);
+            revealValidationErrors(
+                {
+                    fundingReferences: ['Please fix the validation errors in the Funding References section before submitting.'],
+                },
+                'Please review the highlighted funding reference issues before saving.',
+            );
             setIsSaving(false);
-            // Scroll to funding references section
-            const fundingSection = document.getElementById('funding-references-section');
-            if (fundingSection) {
-                fundingSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
             return;
         }
 
@@ -2209,7 +2089,7 @@ export default function DataCiteForm({
                             {renderStatusBadge(resourceInfoStatus)}
                         </div>
                     </AccordionTrigger>
-                    <AccordionContent ref={resourceInfoRef} className="space-y-6">
+                    <AccordionContent className="space-y-6">
                         <SectionHeader
                             label="Resource Information"
                             description="Basic metadata about your dataset including identifiers and type."
@@ -2349,7 +2229,7 @@ export default function DataCiteForm({
                             {renderStatusBadge(licensesStatus)}
                         </div>
                     </AccordionTrigger>
-                    <AccordionContent ref={licensesRef}>
+                    <AccordionContent>
                         <SectionHeader
                             label="Licenses and Rights"
                             description="Specify usage rights and restrictions for your dataset."
@@ -2389,7 +2269,7 @@ export default function DataCiteForm({
                             {renderStatusBadge(authorsStatus)}
                         </div>
                     </AccordionTrigger>
-                    <AccordionContent ref={authorsRef}>
+                    <AccordionContent>
                         <SectionHeader
                             label="Authors"
                             description="People or institutions who created this work."
@@ -2437,7 +2317,7 @@ export default function DataCiteForm({
                             {renderStatusBadge(descriptionsStatus)}
                         </div>
                     </AccordionTrigger>
-                    <AccordionContent ref={descriptionsRef}>
+                    <AccordionContent>
                         <SectionHeader
                             label="Descriptions"
                             description="Detailed information about your dataset."
@@ -2559,7 +2439,7 @@ export default function DataCiteForm({
                             {renderStatusBadge(datesStatus)}
                         </div>
                     </AccordionTrigger>
-                    <AccordionContent ref={datesRef}>
+                    <AccordionContent>
                         <SectionHeader
                             label="Dates"
                             description="Important dates for your dataset."

--- a/resources/js/components/curation/fields/datacenter-field.tsx
+++ b/resources/js/components/curation/fields/datacenter-field.tsx
@@ -22,9 +22,10 @@ interface DatacenterFieldProps {
     className?: string;
     required?: boolean;
     hasError?: boolean;
+    errorMessage?: string;
 }
 
-export function DatacenterField({ id, label, options, selected, onChange, className, required = false, hasError = false }: DatacenterFieldProps) {
+export function DatacenterField({ id, label, options, selected, onChange, className, required = false, hasError = false, errorMessage }: DatacenterFieldProps) {
     const [open, setOpen] = useState(false);
 
     const selectedOptions = options.filter((o) => selected.includes(o.id));
@@ -100,7 +101,7 @@ export function DatacenterField({ id, label, options, selected, onChange, classN
                     </Command>
                 </PopoverContent>
             </Popover>
-            {hasError && selected.length === 0 && <p className="text-destructive text-sm">At least one datacenter is required.</p>}
+            {hasError && errorMessage && <p className="text-destructive text-sm">{errorMessage}</p>}
         </div>
     );
 }

--- a/resources/js/components/curation/utils/error-field-mapper.ts
+++ b/resources/js/components/curation/utils/error-field-mapper.ts
@@ -138,7 +138,7 @@ function resolveFieldSelector(backendKey: string): string | null {
         return '[data-testid="abstract-textarea"]';
     }
 
-    // For "licenses" without index, return null (no stable testid on license selects)
+    // For "licenses" without index, point to the first license select via its stable data-testid
     if (backendKey === 'licenses') {
         return '[data-testid="license-select-0"]';
     }

--- a/resources/js/components/curation/utils/error-field-mapper.ts
+++ b/resources/js/components/curation/utils/error-field-mapper.ts
@@ -66,6 +66,7 @@ const SIMPLE_FIELD_MAP: Record<string, string> = {
     resourceType: '#resourceType',
     version: '#version',
     language: '#language',
+    datacenters: '#datacenter',
 };
 
 /**
@@ -139,7 +140,7 @@ function resolveFieldSelector(backendKey: string): string | null {
 
     // For "licenses" without index, return null (no stable testid on license selects)
     if (backendKey === 'licenses') {
-        return null;
+        return '[data-testid="license-select-0"]';
     }
 
     // For "authors" without index, return null to trigger accordion section fallback
@@ -170,9 +171,10 @@ function resolveFieldSelector(backendKey: string): string | null {
                 return index === '0' ? '[data-testid="abstract-textarea"]' : null;
             case 'datacenters':
                 return '#datacenter';
+            case 'licenses':
+                return `[data-testid="license-select-${index}"]`;
             // The following field components do not have stable data-testid attributes yet.
             // Return null to fall back to opening the correct accordion section.
-            case 'licenses':
             case 'fundingReferences':
             case 'relatedIdentifiers':
             case 'spatialTemporalCoverages':
@@ -197,6 +199,38 @@ function resolveFieldId(backendKey: string): string | null {
     if (backendKey in FIELD_ID_MAP) {
         return FIELD_ID_MAP[backendKey];
     }
+
+    if (backendKey === 'titles') {
+        return 'title-0';
+    }
+
+    if (backendKey === 'licenses') {
+        return 'license-0';
+    }
+
+    if (backendKey === 'descriptions') {
+        return 'abstract';
+    }
+
+    const arrayMatch = backendKey.match(/^(\w+)\.(\d+)(?:\.(\w+))?$/);
+    if (!arrayMatch) {
+        return null;
+    }
+
+    const [, prefix, index, subfield] = arrayMatch;
+
+    if (prefix === 'titles' && subfield === 'title' && index === '0') {
+        return 'title-0';
+    }
+
+    if (prefix === 'licenses' && index === '0') {
+        return 'license-0';
+    }
+
+    if (prefix === 'descriptions' && index === '0') {
+        return 'abstract';
+    }
+
     return null;
 }
 

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -808,6 +808,11 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                         (title, year, resource type, datacenter, language, license, authors, abstract) must be filled.
                                     </li>
                                 </ul>
+                                <p className="mt-3">
+                                    After <strong>"Save &amp; Validate"</strong>, ERNIE shows blocking validation issues in a clickable summary
+                                    above the form. Select any entry to reopen the relevant accordion section and jump directly to the affected
+                                    field.
+                                </p>
                             </WorkflowSteps.Step>
                         </WorkflowSteps>
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2958,7 +2958,7 @@ describe('DataCiteForm', () => {
         },
     );
 
-    it('marks the datacenter field invalid for backend datacenter element errors', async () => {
+    it('marks the datacenter field invalid for backend datacenter element errors', { timeout: 20000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 
         const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
@@ -3065,7 +3065,7 @@ describe('DataCiteForm', () => {
         });
     });
 
-    it('clears the inline required datacenter error after a datacenter is selected', async () => {
+    it('clears the inline required datacenter error after a datacenter is selected', { timeout: 20000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 
         render(

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2958,6 +2958,59 @@ describe('DataCiteForm', () => {
         },
     );
 
+    it('marks the datacenter field invalid for backend datacenter element errors', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+        mockedAxios.post.mockRejectedValue({
+            response: {
+                status: 422,
+                data: {
+                    message: 'Validation failed',
+                    errors: {
+                        'datacenters.0': ['Selected datacenter is invalid.'],
+                    },
+                },
+            },
+            isAxiosError: true,
+        });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Dataset', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user);
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /^Selected datacenter is invalid\.$/i })).toBeInTheDocument();
+        });
+
+        const datacenterSelect = screen.getByTestId('datacenter-select');
+        expect(datacenterSelect).toHaveAttribute('aria-invalid', 'true');
+        expect(datacenterSelect.parentElement).not.toBeNull();
+        expect(within(datacenterSelect.parentElement!).getByText('Selected datacenter is invalid.')).toBeInTheDocument();
+    });
+
     it('renders client-side submit blockers as clickable navigation errors for datacenter selection', { timeout: 20000 }, async () => {
         vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
             cb(performance.now());

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -923,10 +923,10 @@ describe('DataCiteForm', () => {
             });
 
             // Individual missing field messages should be listed
-            expect(screen.getByText('Main Title is required')).toBeInTheDocument();
-            expect(screen.getByText('Publication Year is required')).toBeInTheDocument();
-            expect(screen.getByText('Resource Type is required')).toBeInTheDocument();
-            expect(screen.getByText('Primary License is required')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Resource Type is required\.$/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Primary License is required\.$/i })).toBeInTheDocument();
         },
     );
 
@@ -958,7 +958,7 @@ describe('DataCiteForm', () => {
             await waitFor(() => {
                 expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
             });
-            expect(screen.getByText('Main Title is required')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
 
             // Second save attempt — error list must still appear
             await act(async () => {
@@ -967,8 +967,8 @@ describe('DataCiteForm', () => {
             await waitFor(() => {
                 expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
             });
-            expect(screen.getByText('Main Title is required')).toBeInTheDocument();
-            expect(screen.getByText('Publication Year is required')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
         },
     );
 
@@ -2952,11 +2952,182 @@ describe('DataCiteForm', () => {
         await screen.findByText('Validation failed');
         const alert = screen.getByTestId('global-validation-alert');
         expect(alert).not.toBeNull();
-        expect(screen.getByText('A main title is required.')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^A main title is required\.$/i })).toBeInTheDocument();
         // Should NOT redirect on validation failure (Issue #624)
         expect(mockRouterVisit).not.toHaveBeenCalled();
         },
     );
+
+    it('renders client-side submit blockers as clickable navigation errors for datacenter selection', { timeout: 20000 }, async () => {
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            cb(performance.now());
+            return 1;
+        });
+
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+                availableDatacenters={availableDatacenters}
+            />,
+        );
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user, 'This is a sufficiently long abstract for client-side validation coverage.');
+
+        const datacenterSelect = screen.getByTestId('datacenter-select');
+        const datacenterScrollSpy = vi.spyOn(datacenterSelect, 'scrollIntoView');
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /^At least one datacenter is required\.$/i })).toBeInTheDocument();
+        });
+        expect(axios.post).not.toHaveBeenCalled();
+        expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(datacenterScrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+        });
+
+        datacenterScrollSpy.mockClear();
+
+        await user.click(screen.getByRole('button', { name: /^At least one datacenter is required\.$/i }));
+
+        await waitFor(() => {
+            expect(datacenterScrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+        });
+    });
+
+    it('reopens and scrolls to the authors section when a client-side author error is clicked', { timeout: 20000 }, async () => {
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            cb(performance.now());
+            return 1;
+        });
+
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+                availableDatacenters={availableDatacenters}
+            />,
+        );
+
+        await fillRequiredAbstract(user, 'This is a sufficiently long abstract for author navigation coverage.');
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /^At least one author is required\.$/i })).toBeInTheDocument();
+        });
+        expect(axios.post).not.toHaveBeenCalled();
+
+        const authorsTrigger = getAccordionTrigger(/Authors/i);
+        await user.click(authorsTrigger);
+        expect(authorsTrigger).toHaveAttribute('aria-expanded', 'false');
+
+        const authorsScrollSpy = vi.spyOn(authorsTrigger, 'scrollIntoView');
+
+        await user.click(screen.getByRole('button', { name: /^At least one author is required\.$/i }));
+
+        await waitFor(() => {
+            expect(authorsTrigger).toHaveAttribute('aria-expanded', 'true');
+            expect(authorsScrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+        });
+    });
+
+    it('shows clickable funding reference navigation errors before submit reaches the backend', { timeout: 20000 }, async () => {
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            cb(performance.now());
+            return 1;
+        });
+
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                initialDatacenters={[1]}
+                initialFundingReferences={[
+                    {
+                        id: 'funding-1',
+                        funderName: '',
+                        funderIdentifier: '',
+                        funderIdentifierType: null,
+                        awardNumber: '',
+                        awardUri: '',
+                        awardTitle: '',
+                        isExpanded: false,
+                    },
+                ]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+                availableDatacenters={availableDatacenters}
+            />,
+        );
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user, 'This is a sufficiently long abstract for funding validation coverage.');
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /^Please fix the validation errors in the Funding References section before submitting\.$/i })).toBeInTheDocument();
+        });
+        expect(axios.post).not.toHaveBeenCalled();
+
+        const fundingTrigger = getAccordionTrigger(/Funding References/i);
+        await user.click(fundingTrigger);
+        expect(fundingTrigger).toHaveAttribute('aria-expanded', 'false');
+
+        const fundingScrollSpy = vi.spyOn(fundingTrigger, 'scrollIntoView');
+
+        await user.click(screen.getByRole('button', { name: /^Please fix the validation errors in the Funding References section before submitting\.$/i }));
+
+        await waitFor(() => {
+            expect(fundingTrigger).toHaveAttribute('aria-expanded', 'true');
+            expect(fundingScrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+        });
+    });
 
     it(
         'shows a network error message when saving throws',
@@ -3072,7 +3243,7 @@ describe('DataCiteForm', () => {
             fireEvent.submit(formElement);
         });
         await waitFor(() => {
-            expect(screen.getByText('Abstract is required')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^Abstract is required\.$/i })).toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -266,7 +266,7 @@ describe('DataCiteForm', () => {
 
     const fillRequiredAbstract = async (
         user: ReturnType<typeof userEvent.setup>,
-        abstract = 'This is a test abstract for the dataset.',
+        abstract = 'This is a sufficiently long abstract for the dataset validation flow.',
     ) => {
         await ensureDescriptionsOpen(user);
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
@@ -3274,10 +3274,47 @@ describe('DataCiteForm', () => {
 
         // Fill Abstract
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'This is a test abstract');
+        await user.type(abstractTextarea, 'This is a sufficiently long abstract for save button coverage.');
 
         const saveButton = screen.getByRole('button', { name: /save & validate/i });
         await waitFor(() => expect(saveButton).toBeEnabled());
+    });
+
+    it('blocks Save & Validate when Abstract is shorter than 50 characters', async () => {
+        const user = userEvent.setup();
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        await fillRequiredAuthor(user);
+        await fillRequiredContributor(user);
+
+        const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
+        await user.type(abstractTextarea, 'Short abstract');
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /^Abstract must be at least 50 characters \(current: 14\)$/i })).toBeInTheDocument();
+        });
+        expect(axios.post).not.toHaveBeenCalled();
     });
 
     it(
@@ -3316,7 +3353,7 @@ describe('DataCiteForm', () => {
 
         // Fill Abstract (required)
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'This is a test abstract');
+        await user.type(abstractTextarea, 'This is a sufficiently long abstract for payload submission tests.');
 
         // Fill Methods (optional)
         const methodsTab = screen.getByRole('tab', { name: /^Methods$/i });
@@ -3343,7 +3380,7 @@ describe('DataCiteForm', () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     descriptionType: 'Abstract',
-                    description: 'This is a test abstract',
+                    description: 'This is a sufficiently long abstract for payload submission tests.',
                 }),
                 expect.objectContaining({
                     descriptionType: 'Methods',
@@ -3387,7 +3424,7 @@ describe('DataCiteForm', () => {
 
         // Fill only Abstract
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'This is a test abstract');
+        await user.type(abstractTextarea, 'This is a sufficiently long abstract for payload submission tests.');
 
         const saveButton = screen.getByRole('button', { name: /save & validate/i });
         await waitFor(() => expect(saveButton).toBeEnabled());
@@ -3406,7 +3443,7 @@ describe('DataCiteForm', () => {
         expect(requestBody.descriptions).toHaveLength(1);
         expect(requestBody.descriptions[0]).toEqual({
             descriptionType: 'Abstract',
-            description: 'This is a test abstract',
+            description: 'This is a sufficiently long abstract for payload submission tests.',
             language: null,
         });
     });
@@ -3444,7 +3481,7 @@ describe('DataCiteForm', () => {
 
         // Fill Abstract with whitespace
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, '   Test abstract with spaces   ');
+        await user.type(abstractTextarea, '   This is a sufficiently long abstract with spaces for trimming tests.   ');
 
         const saveButton = screen.getByRole('button', { name: /save & validate/i });
         await waitFor(() => expect(saveButton).toBeEnabled());
@@ -3459,7 +3496,7 @@ describe('DataCiteForm', () => {
         expect(fetchCall).toBeDefined();
         const requestBody = JSON.parse(fetchCall![1].body);
 
-        expect(requestBody.descriptions[0].description).toBe('Test abstract with spaces');
+        expect(requestBody.descriptions[0].description).toBe('This is a sufficiently long abstract with spaces for trimming tests.');
     });
     });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -3065,6 +3065,51 @@ describe('DataCiteForm', () => {
         });
     });
 
+    it('clears the inline required datacenter error after a datacenter is selected', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+                availableDatacenters={availableDatacenters}
+            />,
+        );
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user, 'This is a sufficiently long abstract for datacenter inline error clearing.');
+
+        const datacenterSelect = screen.getByTestId('datacenter-select');
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        await waitFor(() => {
+            expect(datacenterSelect).toHaveAttribute('aria-invalid', 'true');
+        });
+        expect(datacenterSelect.parentElement).not.toBeNull();
+        expect(within(datacenterSelect.parentElement!).getByText('At least one datacenter is required.')).toBeInTheDocument();
+
+        await user.click(datacenterSelect);
+        await user.click(screen.getByText('Test Datacenter'));
+
+        await waitFor(() => {
+            expect(datacenterSelect).toHaveAttribute('aria-invalid', 'false');
+            expect(within(datacenterSelect.parentElement!).queryByText('At least one datacenter is required.')).not.toBeInTheDocument();
+        });
+    });
+
     it('reopens and scrolls to the authors section when a client-side author error is clicked', { timeout: 20000 }, async () => {
         vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
             cb(performance.now());

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2960,6 +2960,10 @@ describe('DataCiteForm', () => {
 
     it('marks the datacenter field invalid for backend datacenter element errors', { timeout: 20000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const backendErrorDatacenters = [
+            { id: 1, name: 'Invalid Datacenter' },
+            { id: 2, name: 'Replacement Datacenter' },
+        ];
 
         const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
         mockedAxios.post.mockRejectedValue({
@@ -2989,7 +2993,7 @@ describe('DataCiteForm', () => {
                 initialResourceType="1"
                 initialTitles={[{ title: 'Primary Dataset', titleType: 'main-title' }]}
                 initialLicenses={['MIT']}
-                availableDatacenters={availableDatacenters}
+                availableDatacenters={backendErrorDatacenters}
                 initialDatacenters={[1]}
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
@@ -3009,6 +3013,16 @@ describe('DataCiteForm', () => {
         expect(datacenterSelect).toHaveAttribute('aria-invalid', 'true');
         expect(datacenterSelect.parentElement).not.toBeNull();
         expect(within(datacenterSelect.parentElement!).getByText('Selected datacenter is invalid.')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Remove datacenter "Invalid Datacenter"' }));
+        await user.click(datacenterSelect);
+        await user.click(screen.getByText('Replacement Datacenter'));
+
+        await waitFor(() => {
+            expect(datacenterSelect).toHaveAttribute('aria-invalid', 'false');
+            expect(within(datacenterSelect.parentElement!).queryByText('Selected datacenter is invalid.')).not.toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: /^Selected datacenter is invalid\.$/i })).not.toBeInTheDocument();
+        });
     });
 
     it('renders client-side submit blockers as clickable navigation errors for datacenter selection', { timeout: 20000 }, async () => {

--- a/tests/vitest/components/curation/utils/__tests__/error-field-mapper.test.ts
+++ b/tests/vitest/components/curation/utils/__tests__/error-field-mapper.test.ts
@@ -104,6 +104,19 @@ describe('mapBackendErrors', () => {
         expect(mapped).toHaveLength(1);
         expect(mapped[0].sectionId).toBe('licenses-rights');
         expect(mapped[0].sectionName).toBe('Licenses & Rights');
+        expect(mapped[0].fieldSelector).toBe('[data-testid="license-select-0"]');
+    });
+
+    it('maps datacenters to the datacenter selector', () => {
+        const errors: Record<string, string[]> = {
+            datacenters: ['[Resource Information] At least one datacenter is required.'],
+        };
+
+        const mapped = mapBackendErrors(errors);
+
+        expect(mapped).toHaveLength(1);
+        expect(mapped[0].sectionId).toBe('resource-info');
+        expect(mapped[0].fieldSelector).toBe('#datacenter');
     });
 
     it('maps contributor roles to roles field selector', () => {
@@ -293,6 +306,18 @@ describe('mapBackendErrors', () => {
         const mapped = mapBackendErrors(errors);
 
         expect(mapped[0].fieldSelector).toBe('[data-testid="main-title-input"]');
+        expect(mapped[0].fieldId).toBe('title-0');
+    });
+
+    it('resolves indexed license selector', () => {
+        const errors: Record<string, string[]> = {
+            'licenses.0.license': ['[Licenses & Rights] License #1 is required.'],
+        };
+
+        const mapped = mapBackendErrors(errors);
+
+        expect(mapped[0].fieldSelector).toBe('[data-testid="license-select-0"]');
+        expect(mapped[0].fieldId).toBe('license-0');
     });
 
     it('resolves "titles" (no index) to main title input', () => {
@@ -303,16 +328,29 @@ describe('mapBackendErrors', () => {
         const mapped = mapBackendErrors(errors);
 
         expect(mapped[0].fieldSelector).toBe('[data-testid="main-title-input"]');
+        expect(mapped[0].fieldId).toBe('title-0');
     });
 
-    it('resolves "licenses" (no index) to null (accordion section fallback)', () => {
+    it('resolves "licenses" (no index) to the primary license selector', () => {
         const errors: Record<string, string[]> = {
             licenses: ['[Licenses & Rights] At least one license is required.'],
         };
 
         const mapped = mapBackendErrors(errors);
 
-        expect(mapped[0].fieldSelector).toBeNull();
+        expect(mapped[0].fieldSelector).toBe('[data-testid="license-select-0"]');
+        expect(mapped[0].fieldId).toBe('license-0');
+    });
+
+    it('resolves descriptions to the abstract field feedback state', () => {
+        const errors: Record<string, string[]> = {
+            'descriptions.0.description': ['[Descriptions] Abstract is required.'],
+        };
+
+        const mapped = mapBackendErrors(errors);
+
+        expect(mapped[0].fieldSelector).toBe('[data-testid="abstract-textarea"]');
+        expect(mapped[0].fieldId).toBe('abstract');
     });
 
     it('resolves "authors" (no index) to null (accordion section fallback)', () => {


### PR DESCRIPTION
This pull request enhances the Data Editor's validation experience by introducing a grouped, clickable summary for Save & Validate errors. It refactors the validation logic to provide more actionable feedback, streamlines the handling of required fields, and improves the user experience by allowing curators to jump directly to problematic fields. Additionally, the codebase sees improved modularity and maintainability in its validation and error-handling logic.

**User experience improvements:**

* Save & Validate blocking messages are now shown as a grouped, clickable summary, allowing curators to jump directly to the relevant field or accordion section that needs attention, instead of manually scanning the form.
* The Data Editor now provides more specific, field-level validation messages for required fields such as title, datacenter, authors, abstract, licenses, and funding references. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1096-R1149) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1922-L1968) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1893-R1807)

**Validation logic refactoring:**

* Refactored client-side validation to collect errors in a structured object keyed by backend field names, allowing for more granular error mapping and display.
* Abstract validation logic (such as minimum and maximum lengths) is now centralized using constants, and its warnings/errors are consistently applied. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R83-R104) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L609-R633) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1240-R1230)

**Codebase simplification and maintainability:**

* Removed legacy logic for auto-scrolling to the first invalid section and related refs/timeouts, in favor of the new clickable error summary. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L147-L158) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1344-L1417) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1597-L1606)
* Consolidated error handling for backend and client-side validation errors, improving clarity and reducing duplicated logic. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1893-R1807) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1922-L1968) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2072)