### PR TITLE
Feature: Hover Preview in Search Results of Portal

### DIFF
--- a/app/Services/PortalSearchService.php
+++ b/app/Services/PortalSearchService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\CacheKey;
+use App\Models\Description;
 use App\Models\Datacenter;
 use App\Models\DateType;
 use App\Models\GeoLocation;
@@ -20,6 +21,7 @@ use App\Models\Title;
 use App\Support\Traits\ChecksCacheTagging;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -90,7 +92,7 @@ class PortalSearchService
      */
     public function search(array $filters = []): LengthAwarePaginator
     {
-        $query = $this->buildQuery($filters);
+        $query = $this->buildQuery($filters, includeAbstractPreview: true);
 
         $perPage = min(
             $filters['per_page'] ?? self::DEFAULT_PER_PAGE,
@@ -126,7 +128,6 @@ class PortalSearchService
     {
         return $this->buildQuery($filters, applyBounds: false)
             ->whereHas('geoLocations')
-            ->with(['geoLocations', 'titles.titleType', 'creators.creatorable', 'resourceType', 'descriptions.descriptionType'])
             ->get();
     }
 
@@ -146,13 +147,12 @@ class PortalSearchService
      * }  $filters
      * @return Builder<Resource>
      */
-    private function buildQuery(array $filters, bool $applyBounds = true): Builder
+    private function buildQuery(array $filters, bool $applyBounds = true, bool $includeAbstractPreview = false): Builder
     {
         $query = Resource::query()
             ->with([
                 'titles.titleType',
                 'creators.creatorable',
-                'descriptions.descriptionType',
                 'resourceType',
                 'geoLocations',
                 'landingPage',
@@ -168,6 +168,10 @@ class PortalSearchService
                     ->limit(1)
             )
             ->orderByDesc('created_at');
+
+        if ($includeAbstractPreview) {
+            $this->withAbstractPreview($query);
+        }
 
         // Apply type filter
         $type = $filters['type'] ?? null;
@@ -952,8 +956,12 @@ class PortalSearchService
 
     private function extractAbstract(Resource $resource): ?string
     {
+        if (! $resource->relationLoaded('descriptions')) {
+            return null;
+        }
+
         $abstract = $resource->descriptions
-            ->first(fn ($description): bool => strcasecmp((string) $description->descriptionType->slug, 'Abstract') === 0);
+            ->first(fn (Description $description): bool => $description->isAbstract());
 
         if ($abstract === null) {
             return null;
@@ -962,6 +970,25 @@ class PortalSearchService
         $value = trim((string) $abstract->value);
 
         return $value !== '' ? $value : null;
+    }
+
+    /**
+     * @param  Builder<Resource>  $query
+     */
+    private function withAbstractPreview(Builder $query): void
+    {
+        $query->with([
+            'descriptions' => function (Relation $descriptionRelation): void {
+                $descriptionQuery = $descriptionRelation->getQuery();
+
+                $descriptionQuery
+                    ->select(['id', 'resource_id', 'value', 'description_type_id'])
+                    ->whereHas('descriptionType', function (Builder $typeQuery): void {
+                        $typeQuery->where('slug', 'Abstract');
+                    })
+                    ->with(['descriptionType:id,slug']);
+            },
+        ]);
     }
 
     /**

--- a/app/Services/PortalSearchService.php
+++ b/app/Services/PortalSearchService.php
@@ -126,7 +126,7 @@ class PortalSearchService
     {
         return $this->buildQuery($filters, applyBounds: false)
             ->whereHas('geoLocations')
-            ->with(['geoLocations', 'titles.titleType', 'creators.creatorable', 'resourceType'])
+            ->with(['geoLocations', 'titles.titleType', 'creators.creatorable', 'resourceType', 'descriptions.descriptionType'])
             ->get();
     }
 
@@ -152,6 +152,7 @@ class PortalSearchService
             ->with([
                 'titles.titleType',
                 'creators.creatorable',
+                'descriptions.descriptionType',
                 'resourceType',
                 'geoLocations',
                 'landingPage',
@@ -917,6 +918,7 @@ class PortalSearchService
             'id' => $resource->id,
             'doi' => $resource->doi,
             'title' => $mainTitle,
+            'abstract' => $this->extractAbstract($resource),
             'creators' => $creators,
             'year' => $resource->publication_year,
             'resourceType' => $resourceType !== null ? $resourceType->name : 'Unknown',
@@ -946,6 +948,20 @@ class PortalSearchService
         }
 
         return 'Untitled';
+    }
+
+    private function extractAbstract(Resource $resource): ?string
+    {
+        $abstract = $resource->descriptions
+            ->first(fn ($description): bool => strcasecmp((string) $description->descriptionType->slug, 'Abstract') === 0);
+
+        if ($abstract === null) {
+            return null;
+        }
+
+        $value = trim((string) $abstract->value);
+
+        return $value !== '' ? $value : null;
     }
 
     /**

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -98,6 +98,10 @@
         ],
         "improvements": [
             {
+                "title": "Portal Navigation and Search Result Preview",
+                "description": "Authenticated users now get a dedicated Portal entry in the Data Curation section of the main menu, opening the public /portal search in a new browser tab. Inside the portal result list, long titles now truncate more predictably so author and year metadata remain visible in the row. Hovering or focusing a result opens a richer preview with the full main title, the full creator list, and the abstract when one is available, allowing faster triage before opening the landing page."
+            },
+            {
                 "title": "Clickable Save & Validate Error Navigation",
                 "description": "The Data Editor now turns Save & Validate blocking messages into a grouped clickable summary. When required fields such as title, datacenter, authors, abstract, licenses, or funding references need attention, curators can select the matching entry to reopen the relevant accordion section and jump directly to the affected field instead of scanning the entire form manually."
             },

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
     LayoutTemplate,
     MapPin,
     ScrollText,
+    Search,
     Settings,
     Sparkles,
     Users,
@@ -97,6 +98,14 @@ export function AppSidebar() {
             showZeroBadge: true,
             badgeTone: 'primary',
             tourId: 'sidebar-resources',
+        },
+        {
+            title: 'Portal',
+            href: '/portal',
+            icon: Search,
+            openInNewTab: true,
+            rel: 'noopener noreferrer',
+            tourId: 'sidebar-portal',
         },
     ];
 

--- a/resources/js/components/nav-footer.tsx
+++ b/resources/js/components/nav-footer.tsx
@@ -18,16 +18,29 @@ export function NavFooter({
                 <SidebarMenu>
                     {items.map((item) => {
                         const href = typeof item.href === 'string' ? item.href : item.href.url;
+
+                        const linkContent = (
+                            <>
+                                {item.icon && <Icon iconNode={item.icon} className="h-5 w-5" />}
+                                <span>{item.title}</span>
+                            </>
+                        );
+
                         return (
                             <SidebarMenuItem key={item.title}>
                                 <SidebarMenuButton
                                     asChild
                                     className="text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100"
                                 >
-                                    <Link href={href} prefetch data-tour={item.tourId}>
-                                        {item.icon && <Icon iconNode={item.icon} className="h-5 w-5" />}
-                                        <span>{item.title}</span>
-                                    </Link>
+                                    {item.openInNewTab ? (
+                                        <a href={href} target="_blank" rel={item.rel ?? 'noopener noreferrer'} data-tour={item.tourId}>
+                                            {linkContent}
+                                        </a>
+                                    ) : (
+                                        <Link href={href} prefetch data-tour={item.tourId}>
+                                            {linkContent}
+                                        </Link>
+                                    )}
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
                         );

--- a/resources/js/components/nav-footer.tsx
+++ b/resources/js/components/nav-footer.tsx
@@ -3,6 +3,7 @@ import { type ComponentPropsWithoutRef } from 'react';
 
 import { Icon } from '@/components/icon';
 import { SidebarGroup, SidebarGroupContent, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { buildExternalLinkRel } from '@/lib/external-link-rel';
 import { type NavItem } from '@/types';
 
 export function NavFooter({
@@ -33,7 +34,7 @@ export function NavFooter({
                                     className="text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100"
                                 >
                                     {item.openInNewTab ? (
-                                        <a href={href} target="_blank" rel={item.rel ?? 'noopener noreferrer'} data-tour={item.tourId}>
+                                        <a href={href} target="_blank" rel={buildExternalLinkRel(item.rel)} data-tour={item.tourId}>
                                             {linkContent}
                                         </a>
                                     ) : (

--- a/resources/js/components/nav-section.tsx
+++ b/resources/js/components/nav-section.tsx
@@ -1,6 +1,7 @@
 import { Link, usePage } from '@inertiajs/react';
 
 import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarSeparator } from '@/components/ui/sidebar';
+import { buildExternalLinkRel } from '@/lib/external-link-rel';
 import { cn } from '@/lib/utils';
 import { type NavItem } from '@/types';
 
@@ -75,7 +76,7 @@ export function NavSection({ label, items, showSeparator = false }: NavSectionPr
                                         <a
                                             href={href}
                                             target="_blank"
-                                            rel={item.rel ?? 'noopener noreferrer'}
+                                            rel={buildExternalLinkRel(item.rel)}
                                             onMouseEnter={item.onPrefetch}
                                             onFocus={item.onPrefetch}
                                             data-tour={item.tourId}

--- a/resources/js/components/nav-section.tsx
+++ b/resources/js/components/nav-section.tsx
@@ -42,11 +42,20 @@ export function NavSection({ label, items, showSeparator = false }: NavSectionPr
             <SidebarMenu>
                 {items.map((item) => {
                     const href = typeof item.href === 'string' ? item.href : item.href.url;
-                    const isActive =
+                    const isActive = !item.openInNewTab && (
                         page.url === href ||
                         page.url.startsWith(href + '/') ||
                         page.url.startsWith(href + '?') ||
-                        page.url.startsWith(href + '#');
+                        page.url.startsWith(href + '#')
+                    );
+
+                    const linkContent = (
+                        <>
+                            {item.icon && <item.icon />}
+                            <span>{item.title}</span>
+                        </>
+                    );
+
                     return (
                         <SidebarMenuItem key={item.title}>
                             {item.disabled ? (
@@ -62,10 +71,22 @@ export function NavSection({ label, items, showSeparator = false }: NavSectionPr
                                     isActive={isActive}
                                     tooltip={{ children: item.title }}
                                 >
-                                    <Link href={href} prefetch onMouseEnter={item.onPrefetch} onFocus={item.onPrefetch} data-tour={item.tourId} aria-current={isActive ? 'page' : undefined}>
-                                        {item.icon && <item.icon />}
-                                        <span>{item.title}</span>
-                                    </Link>
+                                    {item.openInNewTab ? (
+                                        <a
+                                            href={href}
+                                            target="_blank"
+                                            rel={item.rel ?? 'noopener noreferrer'}
+                                            onMouseEnter={item.onPrefetch}
+                                            onFocus={item.onPrefetch}
+                                            data-tour={item.tourId}
+                                        >
+                                            {linkContent}
+                                        </a>
+                                    ) : (
+                                        <Link href={href} prefetch onMouseEnter={item.onPrefetch} onFocus={item.onPrefetch} data-tour={item.tourId} aria-current={isActive ? 'page' : undefined}>
+                                            {linkContent}
+                                        </Link>
+                                    )}
                                 </SidebarMenuButton>
                             )}
                             {shouldRenderBadge(item) && (

--- a/resources/js/components/portal/PortalResultCard.tsx
+++ b/resources/js/components/portal/PortalResultCard.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/ui/badge';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { cn } from '@/lib/utils';
 import type { PortalCreator, PortalResource } from '@/types/portal';
 
@@ -32,6 +33,16 @@ function formatAuthors(creators: PortalCreator[]): string {
     return `${formatName(creators[0])} et al.`;
 }
 
+function formatCreatorDisplayName(creator: PortalCreator): string {
+    const name = creator.name || 'Unknown';
+
+    if (creator.givenName && creator.givenName.trim() !== '') {
+        return `${creator.givenName} ${name}`;
+    }
+
+    return name;
+}
+
 /**
  * Get badge variant based on resource type.
  */
@@ -45,11 +56,12 @@ function getTypeBadgeVariant(isIgsn: boolean): 'default' | 'secondary' | 'outlin
 export function PortalResultCard({ resource }: PortalResultCardProps) {
     const authors = formatAuthors(resource.creators);
     const hasLandingPage = resource.landingPageUrl !== null;
+    const previewCreators = resource.creators.length > 0 ? resource.creators.map(formatCreatorDisplayName) : ['Unknown'];
 
     const rowContent = (
         <div
             className={cn(
-                'flex items-center gap-3 rounded-md border bg-card px-3 py-2 transition-all duration-200',
+                'flex min-w-0 items-center gap-3 rounded-md border bg-card px-3 py-2 transition-all duration-200',
                 hasLandingPage && 'cursor-pointer hover:border-primary hover:bg-accent/50',
             )}
         >
@@ -65,39 +77,71 @@ export function PortalResultCard({ resource }: PortalResultCardProps) {
                 </span>
             )}
 
-            {/* Title - takes remaining space */}
-            <span
-                className={cn(
-                    'min-w-0 flex-1 truncate text-sm font-medium',
-                    hasLandingPage && 'group-hover:text-primary',
-                )}
-            >
-                {resource.title}
-            </span>
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+                {/* Title - takes remaining space and truncates first */}
+                <span
+                    data-testid="portal-result-title"
+                    className={cn(
+                        'min-w-0 flex-1 truncate text-sm font-medium',
+                        hasLandingPage && 'group-hover:text-primary',
+                    )}
+                >
+                    {resource.title}
+                </span>
 
-            {/* Authors */}
-            <span className="hidden shrink-0 text-sm text-muted-foreground md:block lg:max-w-[200px] lg:truncate">
-                {authors}
-            </span>
+                <div data-testid="portal-result-meta" className="flex shrink-0 items-center gap-2">
+                    {/* Authors */}
+                    <span className="hidden max-w-[220px] truncate text-sm text-muted-foreground md:block">
+                        {authors}
+                    </span>
 
-            {/* Year */}
-            {resource.year && (
-                <span className="shrink-0 text-sm text-muted-foreground">{resource.year}</span>
-            )}
+                    {/* Year */}
+                    {resource.year && (
+                        <span className="shrink-0 text-sm text-muted-foreground">{resource.year}</span>
+                    )}
+                </div>
+            </div>
         </div>
     );
 
     if (hasLandingPage) {
         return (
-            <a
-                href={resource.landingPageUrl!}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`View ${resource.title} (opens in new tab)`}
-                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-md"
-            >
-                {rowContent}
-            </a>
+            <HoverCard openDelay={0} closeDelay={0}>
+                <HoverCardTrigger asChild>
+                    <a
+                        href={resource.landingPageUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={`View ${resource.title} (opens in new tab)`}
+                        className="group block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                        {rowContent}
+                    </a>
+                </HoverCardTrigger>
+                <HoverCardContent
+                    align="start"
+                    className="w-[min(32rem,calc(100vw-2rem))] max-h-[min(70vh,32rem)] overflow-y-auto"
+                >
+                    <div className="space-y-3" data-testid="portal-result-preview">
+                        <div className="space-y-1">
+                            <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">Title</p>
+                            <p className="text-sm font-semibold leading-snug text-foreground">{resource.title}</p>
+                        </div>
+
+                        <div className="space-y-1">
+                            <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">Creators</p>
+                            <p className="text-sm leading-snug text-foreground">{previewCreators.join(', ')}</p>
+                        </div>
+
+                        {resource.abstract && (
+                            <div className="space-y-1">
+                                <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">Abstract</p>
+                                <p className="text-sm leading-relaxed text-muted-foreground">{resource.abstract}</p>
+                            </div>
+                        )}
+                    </div>
+                </HoverCardContent>
+            </HoverCard>
         );
     }
 

--- a/resources/js/components/portal/PortalResultCard.tsx
+++ b/resources/js/components/portal/PortalResultCard.tsx
@@ -55,7 +55,8 @@ function getTypeBadgeVariant(isIgsn: boolean): 'default' | 'secondary' | 'outlin
  */
 export function PortalResultCard({ resource }: PortalResultCardProps) {
     const authors = formatAuthors(resource.creators);
-    const hasLandingPage = resource.landingPageUrl !== null;
+    const landingPageUrl = resource.landingPageUrl;
+    const hasLandingPage = landingPageUrl !== null;
     const previewCreators = resource.creators.length > 0 ? resource.creators.map(formatCreatorDisplayName) : ['Unknown'];
 
     const rowContent = (
@@ -109,7 +110,7 @@ export function PortalResultCard({ resource }: PortalResultCardProps) {
             <HoverCard openDelay={0} closeDelay={0}>
                 <HoverCardTrigger asChild>
                     <a
-                        href={resource.landingPageUrl}
+                        href={landingPageUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label={`View ${resource.title} (opens in new tab)`}

--- a/resources/js/lib/external-link-rel.ts
+++ b/resources/js/lib/external-link-rel.ts
@@ -1,0 +1,21 @@
+export function buildExternalLinkRel(rel?: string): string {
+    const tokens = new Map<string, string>();
+
+    for (const token of rel?.split(/\s+/) ?? []) {
+        const trimmedToken = token.trim();
+
+        if (trimmedToken === '') {
+            continue;
+        }
+
+        tokens.set(trimmedToken.toLowerCase(), trimmedToken);
+    }
+
+    for (const requiredToken of ['noopener', 'noreferrer']) {
+        if (!tokens.has(requiredToken)) {
+            tokens.set(requiredToken, requiredToken);
+        }
+    }
+
+    return Array.from(tokens.values()).join(' ');
+}

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -137,6 +137,14 @@ export default function Docs({ userRole, editorSettings }: DocsProps) {
                                 <strong>Header Navigation:</strong> The authenticated page header keeps the main navigation visible and provides quick access to Editor Settings, the changelog, the user documentation, the API documentation, and the user menu. When a page defines breadcrumbs, ERNIE shows them directly below the header so your current location stays clear.
                             </p>
                         </div>
+
+                        <div className="mt-4 rounded-lg border border-cyan-200 bg-cyan-50 p-4 dark:border-cyan-900 dark:bg-cyan-950">
+                            <p className="text-sm text-cyan-900 dark:text-cyan-100">
+                                <strong>Portal Shortcut:</strong> The authenticated sidebar now includes a <strong>Portal</strong> entry in the{' '}
+                                <strong>Data Curation</strong> section. It opens the public Data Portal in a new browser tab, so you can switch
+                                quickly from internal curation to published-record discovery without losing your current ERNIE workspace.
+                            </p>
+                        </div>
                     </>
                 ),
             },
@@ -947,6 +955,17 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             Resource type, datacenter, temporal range, and spatial map filters continue to work together with the split keyword
                             filters. When the result set refreshes, the current results stay visible until the new response arrives.
                         </p>
+
+                        <h4>Result Preview</h4>
+                        <p>
+                            Portal result rows stay compact for faster scanning. If a title is too long for the available row width, ERNIE truncates
+                            it responsively so author and year metadata stay visible.
+                        </p>
+                        <ul className="list-inside list-disc space-y-1">
+                            <li>Hover a result row with the mouse to open a metadata preview</li>
+                            <li>Tab to a result link to open the same preview from the keyboard</li>
+                            <li>The preview shows the full main title, the full creator list, and the abstract when one is available</li>
+                        </ul>
                     </>
                 ),
             },

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -27,6 +27,8 @@ export interface NavItem {
     icon?: LucideIcon | null;
     isActive?: boolean;
     disabled?: boolean;
+    openInNewTab?: boolean;
+    rel?: string;
     separator?: boolean;
     badge?: number | string;
     showZeroBadge?: boolean;

--- a/resources/js/types/portal.ts
+++ b/resources/js/types/portal.ts
@@ -46,6 +46,7 @@ export interface PortalResource {
     id: number;
     doi: string | null;
     title: string;
+    abstract: string | null;
     creators: PortalCreator[];
     year: number | null;
     resourceType: string;

--- a/tests/pest/Feature/PortalTest.php
+++ b/tests/pest/Feature/PortalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\GeoLocation;
 use App\Models\LandingPage;
 use App\Models\Person;
+use App\Models\DescriptionType;
 use App\Models\Resource;
 use App\Models\ResourceCreator;
 use App\Models\ResourceType;
@@ -289,9 +290,29 @@ describe('Portal Resource Transformation', function () {
                 ->has('resources', 1)
                 ->where('resources.0.title', 'Test Dataset')
                 ->where('resources.0.doi', '10.5880/test.2024.001')
+                ->where('resources.0.abstract', null)
                 ->where('resources.0.year', 2024)
                 ->where('resources.0.resourceType', 'Dataset')
                 ->where('resources.0.isIgsn', false)
+            );
+    });
+
+    it('includes the abstract description when present', function () {
+        $resource = createPublishedResource($this->datasetType, 'Test Dataset');
+        $abstractType = DescriptionType::firstOrCreate(
+            ['slug' => 'Abstract'],
+            ['name' => 'Abstract']
+        );
+
+        $resource->descriptions()->create([
+            'description_type_id' => $abstractType->id,
+            'value' => 'A concise abstract for portal preview testing.',
+        ]);
+
+        $this->get(route('portal'))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('resources.0.abstract', 'A concise abstract for portal preview testing.')
             );
     });
 

--- a/tests/pest/Feature/PortalTest.php
+++ b/tests/pest/Feature/PortalTest.php
@@ -309,10 +309,17 @@ describe('Portal Resource Transformation', function () {
             'value' => 'A concise abstract for portal preview testing.',
         ]);
 
+        GeoLocation::factory()->create([
+            'resource_id' => $resource->id,
+            'point_latitude' => 52.5,
+            'point_longitude' => 13.4,
+        ]);
+
         $this->get(route('portal'))
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
                 ->where('resources.0.abstract', 'A concise abstract for portal preview testing.')
+                ->where('mapData.0.abstract', null)
             );
     });
 

--- a/tests/vitest/components/__tests__/app-sidebar.test.tsx
+++ b/tests/vitest/components/__tests__/app-sidebar.test.tsx
@@ -189,7 +189,9 @@ describe('AppSidebar', () => {
         expect(sectionCalls[0][0].label).toBeUndefined();
         expect(sectionCalls[0][0].items.map((item: NavItem) => item.title)).toEqual(['Dashboard']);
         expect(sectionCalls[1][0].label).toBe('Data Curation');
-        expect(sectionCalls[1][0].items.map((item: NavItem) => item.title)).toEqual(['Data Editor', 'Resources']);
+        expect(sectionCalls[1][0].items.map((item: NavItem) => item.title)).toEqual(['Data Editor', 'Resources', 'Portal']);
+        expect(sectionCalls[1][0].items[2].href).toBe('/portal');
+        expect(sectionCalls[1][0].items[2].openInNewTab).toBe(true);
         expect(sectionCalls[2][0].label).toBe('IGSN Curation');
         expect(sectionCalls[2][0].items.map((item: NavItem) => item.title)).toEqual(['IGSNs List', 'IGSNs Map', 'IGSN Editor']);
 
@@ -397,7 +399,9 @@ describe('AppSidebar', () => {
 
         const toolsSection = NavSectionMock.mock.calls.find((call) => call[0].label === 'Tools');
         const administrationSection = NavSectionMock.mock.calls.find((call) => call[0].label === 'Administration');
+        const dataCurationSection = NavSectionMock.mock.calls.find((call) => call[0].label === 'Data Curation');
 
+        expect(dataCurationSection?.[0].items.map((item: NavItem) => item.title)).toEqual(['Data Editor', 'Resources', 'Portal']);
         expect(toolsSection?.[0].items.map((item: NavItem) => item.title)).toEqual(['Assistance', 'Assessment']);
         expect(administrationSection?.[0].items.map((item: NavItem) => item.title)).toEqual(['Logs', 'Editor Settings', 'Landing Pages']);
     });

--- a/tests/vitest/components/__tests__/nav-footer.test.tsx
+++ b/tests/vitest/components/__tests__/nav-footer.test.tsx
@@ -62,5 +62,14 @@ describe('NavFooter', () => {
 
         expect(screen.getByRole('link', { name: /docs/i })).toHaveAttribute('data-tour', 'sidebar-documentation');
     });
+
+    it('supports footer items that open in a new tab', () => {
+        render(<NavFooter items={[{ title: 'Portal', href: '/portal', icon: Book, openInNewTab: true }]} />);
+
+        const link = screen.getByRole('link', { name: /portal/i });
+        expect(link).toHaveAttribute('href', '/portal');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
 });
 

--- a/tests/vitest/components/__tests__/nav-footer.test.tsx
+++ b/tests/vitest/components/__tests__/nav-footer.test.tsx
@@ -71,5 +71,11 @@ describe('NavFooter', () => {
         expect(link).toHaveAttribute('target', '_blank');
         expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
+
+    it('preserves custom rel tokens while enforcing new-tab protections', () => {
+        render(<NavFooter items={[{ title: 'Portal', href: '/portal', icon: Book, openInNewTab: true, rel: 'nofollow' }]} />);
+
+        expect(screen.getByRole('link', { name: /portal/i })).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+    });
 });
 

--- a/tests/vitest/components/__tests__/nav-section.test.tsx
+++ b/tests/vitest/components/__tests__/nav-section.test.tsx
@@ -157,6 +157,14 @@ describe('NavSection', () => {
         expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
+    it('preserves custom rel tokens while enforcing new-tab protections', () => {
+        const items: NavItem[] = [{ title: 'Portal', href: '/portal', icon: Home, openInNewTab: true, rel: 'nofollow' }];
+
+        render(<NavSection items={items} />);
+
+        expect(screen.getByRole('link', { name: /portal/i })).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+    });
+
     it('renders data-tour attributes for guided tour anchors', () => {
         const items: NavItem[] = [{ title: 'Dashboard', href: '/dashboard', icon: Home, tourId: 'sidebar-dashboard' }];
 

--- a/tests/vitest/components/__tests__/nav-section.test.tsx
+++ b/tests/vitest/components/__tests__/nav-section.test.tsx
@@ -146,6 +146,17 @@ describe('NavSection', () => {
         expect(link).toHaveAttribute('href', '/dashboard');
     });
 
+    it('renders native new-tab links when configured', () => {
+        const items: NavItem[] = [{ title: 'Portal', href: '/portal', icon: Home, openInNewTab: true }];
+
+        render(<NavSection items={items} />);
+
+        const link = screen.getByRole('link', { name: /portal/i });
+        expect(link).toHaveAttribute('href', '/portal');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
     it('renders data-tour attributes for guided tour anchors', () => {
         const items: NavItem[] = [{ title: 'Dashboard', href: '/dashboard', icon: Home, tourId: 'sidebar-dashboard' }];
 

--- a/tests/vitest/components/portal/portal-map.test.tsx
+++ b/tests/vitest/components/portal/portal-map.test.tsx
@@ -100,6 +100,7 @@ function createMockResourceWithGeo(
         id,
         title: `Resource ${id}`,
         doi: `10.5880/GFZ.TEST.${id}`,
+        abstract: null,
         resourceType: 'Dataset',
         resourceTypeSlug: 'dataset',
         isIgsn: false,

--- a/tests/vitest/components/portal/portal-result-card.test.tsx
+++ b/tests/vitest/components/portal/portal-result-card.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
 import { PortalResultCard } from '@/components/portal/PortalResultCard';
@@ -14,6 +15,7 @@ function createMockResource(overrides: Partial<PortalResource> = {}): PortalReso
         id: 1,
         title: 'Test Resource Title',
         doi: '10.5880/GFZ.TEST.2024.001',
+        abstract: null,
         resourceType: 'Dataset',
         resourceTypeSlug: 'dataset',
         isIgsn: false,
@@ -53,7 +55,6 @@ describe('PortalResultCard', () => {
             const resource = createMockResource({ year: 2023, creators: [{ name: 'Test' }] });
             render(<PortalResultCard resource={resource} />);
 
-            // Year is displayed in same paragraph with authors
             expect(screen.getByText(/2023/)).toBeInTheDocument();
         });
 
@@ -68,8 +69,18 @@ describe('PortalResultCard', () => {
             const resource = createMockResource({ year: null });
             render(<PortalResultCard resource={resource} />);
 
-            // Should not show year or bullet point
             expect(screen.queryByText('•')).not.toBeInTheDocument();
+        });
+
+        it('keeps the title flexible and the metadata cluster fixed for long titles', () => {
+            const resource = createMockResource({
+                title: 'A very long dataset title that should truncate visually before pushing authors and publication year out of the visible result row area',
+            });
+
+            render(<PortalResultCard resource={resource} />);
+
+            expect(screen.getByTestId('portal-result-title')).toHaveClass('min-w-0', 'flex-1', 'truncate');
+            expect(screen.getByTestId('portal-result-meta')).toHaveClass('shrink-0');
         });
     });
 
@@ -155,6 +166,8 @@ describe('PortalResultCard', () => {
 
             const link = screen.getByRole('link');
             expect(link).toHaveAttribute('href', '/landing/my-resource');
+            expect(link).toHaveAttribute('target', '_blank');
+            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
         });
 
         it('renders without link when landingPageUrl is null', () => {
@@ -170,6 +183,57 @@ describe('PortalResultCard', () => {
 
             const link = screen.getByRole('link');
             expect(link).toHaveClass('group');
+        });
+
+        it('shows full title, creators, and abstract in the hover preview', async () => {
+            const user = userEvent.setup();
+            const resource = createMockResource({
+                title: 'A much longer full title than the row can comfortably show',
+                abstract: 'This abstract gives searchers more context without opening the landing page.',
+                creators: [
+                    { name: 'Smith', givenName: 'Jane' },
+                    { name: 'Jones', givenName: 'Max' },
+                    { name: 'GFZ Data Services' },
+                ],
+            });
+
+            render(<PortalResultCard resource={resource} />);
+
+            await user.hover(screen.getByRole('link'));
+
+            const preview = await screen.findByTestId('portal-result-preview');
+            const scoped = within(preview);
+
+            expect(scoped.getByText('A much longer full title than the row can comfortably show')).toBeInTheDocument();
+            expect(scoped.getByText('Jane Smith, Max Jones, GFZ Data Services')).toBeInTheDocument();
+            expect(scoped.getByText('This abstract gives searchers more context without opening the landing page.')).toBeInTheDocument();
+        });
+
+        it('shows the same preview on keyboard focus', async () => {
+            const user = userEvent.setup();
+            const resource = createMockResource({
+                abstract: 'Keyboard users should get the same preview.',
+            });
+
+            render(<PortalResultCard resource={resource} />);
+
+            await user.tab();
+
+            const preview = await screen.findByTestId('portal-result-preview');
+            expect(preview).toBeInTheDocument();
+            expect(within(preview).getByText('Keyboard users should get the same preview.')).toBeInTheDocument();
+        });
+
+        it('omits the abstract block from the preview when no abstract is available', async () => {
+            const user = userEvent.setup();
+            const resource = createMockResource({ abstract: null });
+
+            render(<PortalResultCard resource={resource} />);
+
+            await user.hover(screen.getByRole('link'));
+
+            const preview = await screen.findByTestId('portal-result-preview');
+            expect(within(preview).queryByText('Abstract')).not.toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/components/portal/portal-result-list.test.tsx
+++ b/tests/vitest/components/portal/portal-result-list.test.tsx
@@ -15,6 +15,7 @@ function createMockResource(id: number, overrides: Partial<PortalResource> = {})
         id,
         title: `Resource ${id}`,
         doi: `10.5880/GFZ.TEST.${id}`,
+        abstract: null,
         resourceType: 'Dataset',
         resourceTypeSlug: 'dataset',
         isIgsn: false,

--- a/tests/vitest/lib/__tests__/portal-map-config.test.ts
+++ b/tests/vitest/lib/__tests__/portal-map-config.test.ts
@@ -324,6 +324,7 @@ describe('renderPopupHtml', () => {
         id: 1,
         doi: '10.5880/test.2026.001',
         title: 'Test Dataset',
+        abstract: null,
         creators: [{ name: 'Doe, John' }],
         year: 2026,
         resourceType: 'Dataset',

--- a/tests/vitest/pages/__tests__/portal.test.tsx
+++ b/tests/vitest/pages/__tests__/portal.test.tsx
@@ -198,11 +198,11 @@ vi.mock('@/components/ui/resizable', () => ({
 
 const defaultProps: PortalPageProps = {
     resources: [
-        { id: 1, doi: '10.1234/test1', title: 'Dataset 1', creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [], landingPageUrl: null },
-        { id: 2, doi: '10.1234/test2', title: 'Dataset 2', creators: [], year: 2023, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [], landingPageUrl: null },
+        { id: 1, doi: '10.1234/test1', title: 'Dataset 1', abstract: null, creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [], landingPageUrl: null },
+        { id: 2, doi: '10.1234/test2', title: 'Dataset 2', abstract: null, creators: [], year: 2023, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [], landingPageUrl: null },
     ],
     mapData: [
-        { id: 1, doi: '10.1234/test1', title: 'Dataset 1', creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [{ id: 1, type: 'point', point: { lat: 52, lng: 13 }, bounds: null, polygon: null }], landingPageUrl: null },
+        { id: 1, doi: '10.1234/test1', title: 'Dataset 1', abstract: null, creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [{ id: 1, type: 'point', point: { lat: 52, lng: 13 }, bounds: null, polygon: null }], landingPageUrl: null },
     ],
     pagination: {
         current_page: 1,
@@ -422,13 +422,13 @@ describe('Portal', () => {
             ...defaultProps,
             mapData: [
                 {
-                    id: 1, doi: '10.1234/a', title: 'A', creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, landingPageUrl: null,
+                    id: 1, doi: '10.1234/a', title: 'A', abstract: null, creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, landingPageUrl: null,
                     geoLocations: [
                         { id: 1, type: 'point' as const, point: { lat: 1, lng: 1 }, bounds: null, polygon: null },
                         { id: 2, type: 'point' as const, point: { lat: 2, lng: 2 }, bounds: null, polygon: null },
                     ],
                 },
-                { id: 2, doi: '10.1234/b', title: 'B', creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [], landingPageUrl: null },
+                { id: 2, doi: '10.1234/b', title: 'B', abstract: null, creators: [], year: 2024, resourceType: 'Dataset', resourceTypeSlug: 'dataset', isIgsn: false, geoLocations: [], landingPageUrl: null },
             ],
         };
         render(<Portal {...propsWithMultipleGeo} />);

--- a/tests/vitest/test-helpers/factories.ts
+++ b/tests/vitest/test-helpers/factories.ts
@@ -261,6 +261,7 @@ export function createMockPortalResource(overrides?: Partial<PortalResource>): P
         id,
         doi: `10.5880/portal.2026.${String(id).padStart(3, '0')}`,
         title: `Portal Resource ${id}`,
+        abstract: null,
         creators: [{ name: 'Doe, John', givenName: 'John' }],
         year: 2026,
         resourceType: 'Dataset',


### PR DESCRIPTION
This pull request introduces significant improvements to the Portal navigation and the search result preview experience for authenticated users. The main changes include adding a dedicated Portal entry in the sidebar, enhancing the search result list to better display metadata, and providing a richer preview of each result with full title, creators, and abstract when available. Additionally, backend changes support the retrieval and display of the abstract in search results.

**Portal Navigation and UI Enhancements:**

* Added a dedicated "Portal" entry to the main sidebar for authenticated users, which opens the public portal search in a new browser tab. (`resources/js/components/app-sidebar.tsx` [[1]](diffhunk://#diff-09845d63b8044b16b013decdd5cc20a182793c1ad93ea10fdbea68d41d4643ecR102-R109) [[2]](diffhunk://#diff-09845d63b8044b16b013decdd5cc20a182793c1ad93ea10fdbea68d41d4643ecR16); `resources/js/components/nav-footer.tsx` [[3]](diffhunk://#diff-3c096477ece7d6924d99a8730aa2ebefb16ef498d7188ff0915fc6a013125050R22-R44) [[4]](diffhunk://#diff-3c096477ece7d6924d99a8730aa2ebefb16ef498d7188ff0915fc6a013125050R6); `resources/js/components/nav-section.tsx` [[5]](diffhunk://#diff-c953f72f6125cb5126bda646a7b2609cfb8bc70afb7374044db3787a9d856c62L45-R59) [[6]](diffhunk://#diff-c953f72f6125cb5126bda646a7b2609cfb8bc70afb7374044db3787a9d856c62R75-R90) [[7]](diffhunk://#diff-c953f72f6125cb5126bda646a7b2609cfb8bc70afb7374044db3787a9d856c62R4)
* Improved the search result row layout so that long titles truncate first, ensuring author and year metadata remain visible. (`resources/js/components/portal/PortalResultCard.tsx` [[1]](diffhunk://#diff-e291ae4d0fef29d0c6308c8ce10b3004f05ff0f1462726357be0eb5d2d0e9107L68-R84) [[2]](diffhunk://#diff-e291ae4d0fef29d0c6308c8ce10b3004f05ff0f1462726357be0eb5d2d0e9107R93-R95)
* Implemented a hover/focus preview for each search result using a hover card, displaying the full main title, complete creator list, and the abstract if available. (`resources/js/components/portal/PortalResultCard.tsx` [[1]](diffhunk://#diff-e291ae4d0fef29d0c6308c8ce10b3004f05ff0f1462726357be0eb5d2d0e9107R104-R145) [[2]](diffhunk://#diff-e291ae4d0fef29d0c6308c8ce10b3004f05ff0f1462726357be0eb5d2d0e9107L47-R65) [[3]](diffhunk://#diff-e291ae4d0fef29d0c6308c8ce10b3004f05ff0f1462726357be0eb5d2d0e9107R36-R45) [[4]](diffhunk://#diff-e291ae4d0fef29d0c6308c8ce10b3004f05ff0f1462726357be0eb5d2d0e9107R2)

**Backend Support for Abstract Preview:**

* Updated the backend service to include the abstract in portal search results by eager-loading the relevant description and extracting the abstract text. (`app/Services/PortalSearchService.php` [[1]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7R8) [[2]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7R24) [[3]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7L93-R95) [[4]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7L129) [[5]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7L149-R150) [[6]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7R172-R175) [[7]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7R925) [[8]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7R957-R993)

**Technical Improvements:**

* Added a utility to ensure all external links in the sidebar and footer include `noopener noreferrer` for security, even if custom rel attributes are provided. (`resources/js/lib/external-link-rel.ts` [[1]](diffhunk://#diff-27a683aaf6507a973d46fa84458e07c9fef1e810112d6a47e628b911abb8ef0bR1-R21); used in sidebar/footer components [[2]](diffhunk://#diff-3c096477ece7d6924d99a8730aa2ebefb16ef498d7188ff0915fc6a013125050R6) [[3]](diffhunk://#diff-c953f72f6125cb5126bda646a7b2609cfb8bc70afb7374044db3787a9d856c62R4)

**Documentation and Changelog:**

* Updated the changelog to reflect the new Portal navigation and richer search result preview features. (`resources/data/changelog.json` [resources/data/changelog.jsonR100-R103](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR100-R103))