### PR TITLE
Feature: Draft Deletion and better UX for Resources List

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -165,10 +165,10 @@ class ResourceController extends Controller
     }
 
     /**
-     * Delete a resource.
+     * Delete a draft resource.
      *
      * Authorization is enforced by DestroyResourceRequest::authorize() (delegates
-     * to ResourcePolicy::delete – Admin / Group Leader only).
+     * to ResourcePolicy::delete – curator / group leader / admin on draft resources only).
      */
     public function destroy(DestroyResourceRequest $request, Resource $resource): RedirectResponse
     {
@@ -176,7 +176,7 @@ class ResourceController extends Controller
 
         return redirect()
             ->route('resources')
-            ->with('success', 'Resource deleted successfully.');
+            ->with('success', 'Draft deleted successfully.');
     }
 
     /**

--- a/app/Policies/ResourcePolicy.php
+++ b/app/Policies/ResourcePolicy.php
@@ -58,6 +58,10 @@ class ResourcePolicy
             return false;
         }
 
+        if (filled($resource->doi)) {
+            return false;
+        }
+
         $resource->loadMissing([
             'titles.titleType',
             'creators',

--- a/app/Policies/ResourcePolicy.php
+++ b/app/Policies/ResourcePolicy.php
@@ -50,6 +50,14 @@ class ResourcePolicy
      */
     public function delete(User $user, Resource $resource): bool
     {
+        $canDeleteDrafts = $user->role === UserRole::ADMIN
+            || $user->role === UserRole::GROUP_LEADER
+            || $user->role === UserRole::CURATOR;
+
+        if (! $canDeleteDrafts) {
+            return false;
+        }
+
         $resource->loadMissing([
             'titles.titleType',
             'creators',
@@ -58,11 +66,7 @@ class ResourcePolicy
             'landingPage',
         ]);
 
-        $canDeleteDrafts = $user->role === UserRole::ADMIN
-            || $user->role === UserRole::GROUP_LEADER
-            || $user->role === UserRole::CURATOR;
-
-        return $canDeleteDrafts && $resource->publicStatus() === 'draft';
+        return $resource->publicStatus() === 'draft';
     }
 
     /**

--- a/app/Policies/ResourcePolicy.php
+++ b/app/Policies/ResourcePolicy.php
@@ -50,9 +50,19 @@ class ResourcePolicy
      */
     public function delete(User $user, Resource $resource): bool
     {
-        // Only admins and group leaders can delete resources
-        return $user->role === UserRole::ADMIN
-            || $user->role === UserRole::GROUP_LEADER;
+        $resource->loadMissing([
+            'titles.titleType',
+            'creators',
+            'rights',
+            'descriptions.descriptionType',
+            'landingPage',
+        ]);
+
+        $canDeleteDrafts = $user->role === UserRole::ADMIN
+            || $user->role === UserRole::GROUP_LEADER
+            || $user->role === UserRole::CURATOR;
+
+        return $canDeleteDrafts && $resource->publicStatus() === 'draft';
     }
 
     /**

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-29",
+        "date": "2026-05-31",
         "features": [
             {
                 "title": "Landing Page and Portal Statistics Dashboard",
@@ -255,6 +255,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "Resources List Actions Stay in Sync",
+                "description": "The /resources page now refreshes immediately after successful legacy imports, draft resources can again be deleted from the per-row trash action by authorized curator, group leader, and admin users, and reopening the landing page setup modal in the same browser tab no longer drops unsaved Download URL or Additional Links input."
+            },
             {
                 "title": "Changelog Navigation and Expansion Stay Predictable",
                 "description": "The /changelog page now keeps release expansion under explicit user control: only clicking a release, using timeline navigation, keyboard navigation, or opening a hash URL changes which version is open. Scroll-based viewport tracking no longer auto-expands other releases, the desktop timeline uses larger click targets so navigation feels reliable again, and the surrounding motion was toned down to reduce distracting transitions while preserving orientation cues."

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -251,13 +251,11 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const initialTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, existingConfig?.template);
     const storageKey = resource.id ? `${LANDING_PAGE_DRAFT_STORAGE_PREFIX}:${resource.id}` : null;
     const hydratedDraftStateKeyRef = useRef<string | null>(null);
-    const previousDraftScopeRef = useRef<string | null>(null);
     const currentDraftScope = isOpen ? storageKey : null;
 
-    if (previousDraftScopeRef.current !== currentDraftScope) {
+    useEffect(() => {
         hydratedDraftStateKeyRef.current = null;
-        previousDraftScopeRef.current = currentDraftScope;
-    }
+    }, [currentDraftScope]);
 
     const readPersistedDraftState = useCallback((): PersistedLandingPageDraftState | null => {
         if (typeof window === 'undefined' || storageKey === null) {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -4,7 +4,7 @@ import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, v
 import { CSS } from '@dnd-kit/utilities';
 import axios from 'axios';
 import { Copy, Eye, Globe, GripVertical, Plus, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { ExternalLandingPageFields } from '@/components/landing-pages/modals/ExternalLandingPageFields';
@@ -227,6 +227,14 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     // else uses the standard `default_gfz` template.
     const initialTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, existingConfig?.template);
     const storageKey = resource.id ? `${LANDING_PAGE_DRAFT_STORAGE_PREFIX}:${resource.id}` : null;
+    const hydratedDraftStateKeyRef = useRef<string | null>(null);
+    const previousDraftScopeRef = useRef<string | null>(null);
+    const currentDraftScope = isOpen ? storageKey : null;
+
+    if (previousDraftScopeRef.current !== currentDraftScope) {
+        hydratedDraftStateKeyRef.current = null;
+        previousDraftScopeRef.current = currentDraftScope;
+    }
 
     const readPersistedDraftState = useCallback((): PersistedLandingPageDraftState | null => {
         if (typeof window === 'undefined' || storageKey === null) {
@@ -357,14 +365,15 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         const baseDraftState = buildDraftStateFromConfig(config);
         const persistedDraftState = readPersistedDraftState();
 
+        hydratedDraftStateKeyRef.current = storageKey;
         setCurrentConfig(config);
         setPreviewUrl(config?.preview_url ?? '');
         applyDraftState(persistedDraftState ?? baseDraftState);
         setHasHydratedDraftState(true);
-    }, [applyDraftState, buildDraftStateFromConfig, readPersistedDraftState]);
+    }, [applyDraftState, buildDraftStateFromConfig, readPersistedDraftState, storageKey]);
 
     useEffect(() => {
-        if (!isOpen || !hasHydratedDraftState) {
+        if (!isOpen || !hasHydratedDraftState || hydratedDraftStateKeyRef.current !== storageKey) {
             return;
         }
 
@@ -387,6 +396,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         landingPageTemplateId,
         links,
         persistDraftState,
+        storageKey,
         template,
     ]);
 
@@ -440,16 +450,12 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             } else {
                 console.error('Failed to load landing page config:', error);
                 toast.error('Failed to load landing page configuration');
-                const persistedDraftState = readPersistedDraftState();
-                if (persistedDraftState) {
-                    applyDraftState(persistedDraftState);
-                }
-                setHasHydratedDraftState(true);
+                applyConfigState(null);
             }
         } finally {
             setIsLoading(false);
         }
-    }, [applyConfigState, applyDraftState, readPersistedDraftState, resource.id]);
+    }, [applyConfigState, resource.id]);
 
     // Load existing config when modal opens
     useEffect(() => {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -57,11 +57,81 @@ const EMPTY_DOWNLOAD_URL_SUGGESTIONS: LandingPageDownloadUrlSuggestions = {
     urls: [],
 };
 
+const LANDING_PAGE_DRAFT_STORAGE_PREFIX = 'setup-landing-page-modal:draft';
+
 type DownloadUrlSuggestionEntry = {
     id: string;
     value: string;
     usageCount: number;
 };
+
+type PersistedLandingPageDraftState = {
+    template: string;
+    ftpUrl: string;
+    isPublished: boolean;
+    externalDomainId: string;
+    externalPath: string;
+    landingPageTemplateId: number | null;
+    links: LandingPageLink[];
+};
+
+function cloneLandingPageLinks(links: LandingPageLink[] = []): LandingPageLink[] {
+    return links.map((link, index) => ({
+        id: link.id,
+        _clientId: link._clientId,
+        url: link.url,
+        label: link.label,
+        position: typeof link.position === 'number' ? link.position : index,
+    }));
+}
+
+function parsePersistedLandingPageDraftState(rawValue: string | null): PersistedLandingPageDraftState | null {
+    if (!rawValue) {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(rawValue) as Partial<PersistedLandingPageDraftState> | null;
+
+        if (!parsed || typeof parsed !== 'object' || typeof parsed.template !== 'string') {
+            return null;
+        }
+
+        const links = Array.isArray(parsed.links)
+            ? parsed.links.map((link, index) => {
+                if (!link || typeof link !== 'object') {
+                    return {
+                        url: '',
+                        label: '',
+                        position: index,
+                    } satisfies LandingPageLink;
+                }
+
+                const candidate = link as Partial<LandingPageLink>;
+
+                return {
+                    id: typeof candidate.id === 'number' ? candidate.id : undefined,
+                    _clientId: typeof candidate._clientId === 'string' ? candidate._clientId : undefined,
+                    url: typeof candidate.url === 'string' ? candidate.url : '',
+                    label: typeof candidate.label === 'string' ? candidate.label : '',
+                    position: typeof candidate.position === 'number' ? candidate.position : index,
+                } satisfies LandingPageLink;
+            })
+            : [];
+
+        return {
+            template: parsed.template,
+            ftpUrl: typeof parsed.ftpUrl === 'string' ? parsed.ftpUrl : '',
+            isPublished: parsed.isPublished === true,
+            externalDomainId: typeof parsed.externalDomainId === 'string' ? parsed.externalDomainId : '',
+            externalPath: typeof parsed.externalPath === 'string' ? parsed.externalPath : '',
+            landingPageTemplateId: typeof parsed.landingPageTemplateId === 'number' ? parsed.landingPageTemplateId : null,
+            links,
+        };
+    } catch {
+        return null;
+    }
+}
 
 function SortableLinkItem({
     link,
@@ -118,12 +188,70 @@ function SortableLinkItem({
 
 export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig }: SetupLandingPageModalProps) {
     // PhysicalObject resources (IGSNs) default to the IGSN renderer; everything
-    // else uses the standard `default_gfz` template. This is reused for the
-    // initial state, the reset-on-close branch, and the 404 fallback inside
-    // `loadLandingPageConfig` so a freshly opened IGSN modal always points at
-    // the correct built-in template.
-    const defaultTemplateForResource = getPreferredTemplateForResource(resource.resourcetypegeneral);
+    // else uses the standard `default_gfz` template.
     const initialTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, existingConfig?.template);
+    const storageKey = resource.id ? `${LANDING_PAGE_DRAFT_STORAGE_PREFIX}:${resource.id}` : null;
+
+    const readPersistedDraftState = useCallback((): PersistedLandingPageDraftState | null => {
+        if (typeof window === 'undefined' || storageKey === null) {
+            return null;
+        }
+
+        const persistedDraft = parsePersistedLandingPageDraftState(window.sessionStorage.getItem(storageKey));
+
+        if (!persistedDraft) {
+            return null;
+        }
+
+        return {
+            ...persistedDraft,
+            template: getPreferredTemplateForResource(resource.resourcetypegeneral, persistedDraft.template),
+            links: cloneLandingPageLinks(persistedDraft.links),
+        };
+    }, [resource.resourcetypegeneral, storageKey]);
+
+    const persistDraftState = useCallback((draftState: PersistedLandingPageDraftState) => {
+        if (typeof window === 'undefined' || storageKey === null) {
+            return;
+        }
+
+        window.sessionStorage.setItem(storageKey, JSON.stringify({
+            ...draftState,
+            links: cloneLandingPageLinks(draftState.links),
+        }));
+    }, [storageKey]);
+
+    const clearPersistedDraftState = useCallback(() => {
+        if (typeof window === 'undefined' || storageKey === null) {
+            return;
+        }
+
+        window.sessionStorage.removeItem(storageKey);
+    }, [storageKey]);
+
+    const buildDraftStateFromConfig = useCallback((config: LandingPageConfig | null): PersistedLandingPageDraftState => {
+        const preferredTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, config?.template);
+
+        return {
+            template: preferredTemplate,
+            ftpUrl: config?.ftp_url ?? '',
+            isPublished: (config?.status ?? 'draft') === 'published',
+            externalDomainId: String(config?.external_domain_id ?? ''),
+            externalPath: config?.external_path ?? '',
+            landingPageTemplateId: getHydratedLandingPageTemplateId(preferredTemplate, config),
+            links: cloneLandingPageLinks(config?.links ?? []),
+        };
+    }, [resource.resourcetypegeneral]);
+
+    const applyDraftState = useCallback((draftState: PersistedLandingPageDraftState) => {
+        setTemplate(draftState.template);
+        setFtpUrl(draftState.ftpUrl);
+        setIsPublished(draftState.isPublished);
+        setExternalDomainId(draftState.externalDomainId);
+        setExternalPath(draftState.externalPath);
+        setLinks(cloneLandingPageLinks(draftState.links));
+        setLandingPageTemplateId(draftState.landingPageTemplateId);
+    }, []);
 
     const [template, setTemplate] = useState<string>(initialTemplate);
     const [ftpUrl, setFtpUrl] = useState<string>(existingConfig?.ftp_url ?? '');
@@ -148,6 +276,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const [downloadUrlSuggestionsOpen, setDownloadUrlSuggestionsOpen] = useState(false);
     const [downloadUrlSuggestionQuery, setDownloadUrlSuggestionQuery] = useState('');
     const [activeDownloadUrlSuggestionIndex, setActiveDownloadUrlSuggestionIndex] = useState<number | null>(null);
+    const [hasHydratedDraftState, setHasHydratedDraftState] = useState(false);
 
     // Landing page template ID (for custom templates)
     const [landingPageTemplateId, setLandingPageTemplateId] = useState<number | null>(
@@ -188,49 +317,42 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const importedDownloadFiles = currentConfig?.files ?? existingConfig?.files ?? [];
     const hasImportedFiles = importedDownloadFiles.length > 0;
 
-    const applyConfigState = useCallback((config: LandingPageConfig) => {
-        const preferredTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, config.template);
+    const applyConfigState = useCallback((config: LandingPageConfig | null) => {
+        const baseDraftState = buildDraftStateFromConfig(config);
+        const persistedDraftState = readPersistedDraftState();
 
         setCurrentConfig(config);
-        setTemplate(preferredTemplate);
-        setFtpUrl(config.ftp_url ?? '');
-        setIsPublished(config.status === 'published');
-        setPreviewUrl(config.preview_url ?? '');
-        setExternalDomainId(String(config.external_domain_id ?? ''));
-        setExternalPath(config.external_path ?? '');
-        setLinks(config.links ?? []);
-        setLandingPageTemplateId(getHydratedLandingPageTemplateId(preferredTemplate, config));
-    }, [resource.resourcetypegeneral]);
+        setPreviewUrl(config?.preview_url ?? '');
+        applyDraftState(persistedDraftState ?? baseDraftState);
+        setHasHydratedDraftState(true);
+    }, [applyDraftState, buildDraftStateFromConfig, readPersistedDraftState]);
 
-    // Load existing config when modal opens
     useEffect(() => {
-        if (isOpen && resource.id) {
-            if (existingConfig) {
-                applyConfigState(existingConfig);
-            } else {
-                loadLandingPageConfig();
-            }
-            loadAvailableDomains();
-            loadCustomTemplates();
-        } else if (!isOpen) {
-            setCurrentConfig(null);
-            setTemplate(defaultTemplateForResource);
-            setFtpUrl('');
-            setIsPublished(false);
-            setPreviewUrl('');
-            setExternalDomainId('');
-            setExternalPath('');
-            setLinks([]);
-            setLandingPageTemplateId(null);
-            setDownloadUrlSuggestions(EMPTY_DOWNLOAD_URL_SUGGESTIONS);
-            setDownloadUrlSuggestionsLoaded(false);
-            setDownloadUrlSuggestionsLoading(false);
-            setDownloadUrlSuggestionsOpen(false);
-            setDownloadUrlSuggestionQuery('');
-            setActiveDownloadUrlSuggestionIndex(null);
+        if (!isOpen || !hasHydratedDraftState) {
+            return;
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [applyConfigState, defaultTemplateForResource, existingConfig, isOpen, resource.id]);
+
+        persistDraftState({
+            template,
+            ftpUrl,
+            isPublished,
+            externalDomainId,
+            externalPath,
+            landingPageTemplateId,
+            links: cloneLandingPageLinks(links),
+        });
+    }, [
+        externalDomainId,
+        externalPath,
+        ftpUrl,
+        hasHydratedDraftState,
+        isOpen,
+        isPublished,
+        landingPageTemplateId,
+        links,
+        persistDraftState,
+        template,
+    ]);
 
     const loadAvailableDomains = async () => {
         try {
@@ -271,30 +393,52 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         }
     };
 
-    const loadLandingPageConfig = async () => {
+    const loadLandingPageConfig = useCallback(async () => {
         setIsLoading(true);
         try {
             const response = await axios.get<{ landing_page: LandingPageConfig }>(`/resources/${resource.id}/landing-page`);
             applyConfigState(response.data.landing_page);
         } catch (error) {
             if (isLandingPageNotFoundError(error)) {
-                setCurrentConfig(null);
-                setTemplate(defaultTemplateForResource);
-                setFtpUrl('');
-                setIsPublished(false);
-                setPreviewUrl('');
-                setExternalDomainId('');
-                setExternalPath('');
-                setLinks([]);
-                setLandingPageTemplateId(null);
+                applyConfigState(null);
             } else {
                 console.error('Failed to load landing page config:', error);
                 toast.error('Failed to load landing page configuration');
+                const persistedDraftState = readPersistedDraftState();
+                if (persistedDraftState) {
+                    applyDraftState(persistedDraftState);
+                }
+                setHasHydratedDraftState(true);
             }
         } finally {
             setIsLoading(false);
         }
-    };
+    }, [applyConfigState, applyDraftState, readPersistedDraftState, resource.id]);
+
+    // Load existing config when modal opens
+    useEffect(() => {
+        if (isOpen && resource.id) {
+            setHasHydratedDraftState(false);
+            if (existingConfig) {
+                applyConfigState(existingConfig);
+            } else {
+                void loadLandingPageConfig();
+            }
+            void loadAvailableDomains();
+            void loadCustomTemplates();
+        } else if (!isOpen) {
+            setHasHydratedDraftState(false);
+            setCurrentConfig(null);
+            setPreviewUrl('');
+            applyDraftState(buildDraftStateFromConfig(null));
+            setDownloadUrlSuggestions(EMPTY_DOWNLOAD_URL_SUGGESTIONS);
+            setDownloadUrlSuggestionsLoaded(false);
+            setDownloadUrlSuggestionsLoading(false);
+            setDownloadUrlSuggestionsOpen(false);
+            setDownloadUrlSuggestionQuery('');
+            setActiveDownloadUrlSuggestionIndex(null);
+        }
+    }, [applyConfigState, applyDraftState, buildDraftStateFromConfig, existingConfig, isOpen, loadLandingPageConfig, resource.id]);
 
     useEffect(() => {
         if (!supportsFtpUrl || hasImportedFiles) {
@@ -343,6 +487,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             toast.success(response.data.message);
 
             if (response.data.landing_page) {
+                clearPersistedDraftState();
                 applyConfigState(response.data.landing_page);
             }
 
@@ -384,8 +529,10 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
         try {
             await axios.delete(`/resources/${resource.id}/landing-page`);
+            clearPersistedDraftState();
             setCurrentConfig(null);
             setPreviewUrl('');
+            applyDraftState(buildDraftStateFromConfig(null));
             toast.success('Landing page preview removed successfully');
             onSuccess?.();
             onClose();
@@ -782,7 +929,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                         {/* FTP URL (hidden for external landing pages, disabled when imported files exist) */}
                         {supportsFtpUrl && (
                             <div className="space-y-2">
-                                <Label htmlFor="ftp-url">Download URL (FTP)</Label>
+                                <Label htmlFor="ftp-url">Download URL</Label>
                                 <div
                                     className="relative"
                                     onFocusCapture={openDownloadUrlSuggestions}

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -85,6 +85,29 @@ function cloneLandingPageLinks(links: LandingPageLink[] = []): LandingPageLink[]
     }));
 }
 
+function normalizePersistedLandingPageDraftState(draftState: PersistedLandingPageDraftState) {
+    return {
+        template: draftState.template,
+        ftpUrl: draftState.ftpUrl,
+        isPublished: draftState.isPublished,
+        externalDomainId: draftState.externalDomainId,
+        externalPath: draftState.externalPath,
+        landingPageTemplateId: draftState.landingPageTemplateId,
+        links: cloneLandingPageLinks(draftState.links).map((link, index) => ({
+            url: link.url,
+            label: link.label,
+            position: typeof link.position === 'number' ? link.position : index,
+        })),
+    };
+}
+
+function arePersistedLandingPageDraftStatesEqual(
+    left: PersistedLandingPageDraftState,
+    right: PersistedLandingPageDraftState,
+): boolean {
+    return JSON.stringify(normalizePersistedLandingPageDraftState(left)) === JSON.stringify(normalizePersistedLandingPageDraftState(right));
+}
+
 function parsePersistedLandingPageDraftState(rawValue: string | null): PersistedLandingPageDraftState | null {
     if (!rawValue) {
         return null;
@@ -360,6 +383,19 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     );
     const importedDownloadFiles = currentConfig?.files ?? existingConfig?.files ?? [];
     const hasImportedFiles = importedDownloadFiles.length > 0;
+    const currentDraftState = useMemo<PersistedLandingPageDraftState>(() => ({
+        template,
+        ftpUrl,
+        isPublished,
+        externalDomainId,
+        externalPath,
+        landingPageTemplateId,
+        links: cloneLandingPageLinks(links),
+    }), [externalDomainId, externalPath, ftpUrl, isPublished, landingPageTemplateId, links, template]);
+    const baselineDraftState = useMemo(
+        () => buildDraftStateFromConfig(currentConfig),
+        [buildDraftStateFromConfig, currentConfig],
+    );
 
     const applyConfigState = useCallback((config: LandingPageConfig | null) => {
         const baseDraftState = buildDraftStateFromConfig(config);
@@ -377,27 +413,20 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             return;
         }
 
-        persistDraftState({
-            template,
-            ftpUrl,
-            isPublished,
-            externalDomainId,
-            externalPath,
-            landingPageTemplateId,
-            links: cloneLandingPageLinks(links),
-        });
+        if (arePersistedLandingPageDraftStatesEqual(currentDraftState, baselineDraftState)) {
+            clearPersistedDraftState();
+            return;
+        }
+
+        persistDraftState(currentDraftState);
     }, [
-        externalDomainId,
-        externalPath,
-        ftpUrl,
+        baselineDraftState,
+        clearPersistedDraftState,
+        currentDraftState,
         hasHydratedDraftState,
         isOpen,
-        isPublished,
-        landingPageTemplateId,
-        links,
         persistDraftState,
         storageKey,
-        template,
     ]);
 
     const loadAvailableDomains = async () => {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -133,6 +133,42 @@ function parsePersistedLandingPageDraftState(rawValue: string | null): Persisted
     }
 }
 
+function readSessionStorageItem(key: string): string | null {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    try {
+        return window.sessionStorage.getItem(key);
+    } catch {
+        return null;
+    }
+}
+
+function writeSessionStorageItem(key: string, value: string): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.sessionStorage.setItem(key, value);
+    } catch {
+        // Ignore storage errors so the modal remains usable.
+    }
+}
+
+function removeSessionStorageItem(key: string): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.sessionStorage.removeItem(key);
+    } catch {
+        // Ignore storage errors so the modal remains usable.
+    }
+}
+
 function SortableLinkItem({
     link,
     index,
@@ -197,7 +233,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             return null;
         }
 
-        const persistedDraft = parsePersistedLandingPageDraftState(window.sessionStorage.getItem(storageKey));
+        const persistedDraft = parsePersistedLandingPageDraftState(readSessionStorageItem(storageKey));
 
         if (!persistedDraft) {
             return null;
@@ -215,7 +251,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             return;
         }
 
-        window.sessionStorage.setItem(storageKey, JSON.stringify({
+        writeSessionStorageItem(storageKey, JSON.stringify({
             ...draftState,
             links: cloneLandingPageLinks(draftState.links),
         }));
@@ -226,7 +262,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             return;
         }
 
-        window.sessionStorage.removeItem(storageKey);
+        removeSessionStorageItem(storageKey);
     }, [storageKey]);
 
     const buildDraftStateFromConfig = useCallback((config: LandingPageConfig | null): PersistedLandingPageDraftState => {

--- a/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
+++ b/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
@@ -1,7 +1,7 @@
 import { router } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
 import { AlertCircle, CheckCircle2, Download, XCircle } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { DataCiteIcon } from '@/components/icons/datacite-icon';
@@ -43,6 +43,7 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
     const [error, setError] = useState<string | null>(null);
     const [showSkippedDois, setShowSkippedDois] = useState(false);
     const [showFailedDois, setShowFailedDois] = useState(false);
+    const hasNotifiedSuccessRef = useRef(false);
 
     // Reset state when modal opens/closes
     useEffect(() => {
@@ -54,8 +55,18 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
             setError(null);
             setShowSkippedDois(false);
             setShowFailedDois(false);
+            hasNotifiedSuccessRef.current = false;
         }
     }, [isOpen]);
+
+    useEffect(() => {
+        if (modalState !== 'completed' || (progress?.imported ?? 0) < 1 || hasNotifiedSuccessRef.current) {
+            return;
+        }
+
+        hasNotifiedSuccessRef.current = true;
+        onSuccess?.();
+    }, [modalState, onSuccess, progress?.imported]);
 
     // Poll for progress updates with adaptive interval using setTimeout chains.
     // This approach avoids race conditions that can occur with setInterval + clearInterval,
@@ -117,6 +128,7 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
     const startImport = useCallback(async () => {
         setIsStarting(true);
         setError(null);
+        hasNotifiedSuccessRef.current = false;
 
         try {
             const response = await axios.post<{ import_id: string; message: string }>('/datacite/import/start', {}, { headers: buildCsrfHeaders() });
@@ -164,16 +176,8 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
     }, []);
 
     const handleClose = useCallback(() => {
-        if (modalState === 'completed') {
-            // Call onSuccess callback to refresh the resources list.
-            // Note: The onSuccess callback (from resources.tsx) already handles
-            // page reload, so we don't call router.reload() here to avoid duplicates.
-            if (onSuccess) {
-                onSuccess();
-            }
-        }
         onClose();
-    }, [modalState, onClose, onSuccess]);
+    }, [onClose]);
 
     const progressPercent = progress && progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
 

--- a/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
+++ b/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
@@ -60,13 +60,13 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
     }, [isOpen]);
 
     useEffect(() => {
-        if (modalState !== 'completed' || (progress?.imported ?? 0) < 1 || hasNotifiedSuccessRef.current) {
+        if (!isOpen || modalState !== 'completed' || (progress?.imported ?? 0) < 1 || hasNotifiedSuccessRef.current) {
             return;
         }
 
         hasNotifiedSuccessRef.current = true;
         onSuccess?.();
-    }, [modalState, onSuccess, progress?.imported]);
+    }, [isOpen, modalState, onSuccess, progress?.imported]);
 
     // Poll for progress updates with adaptive interval using setTimeout chains.
     // This approach avoids race conditions that can occur with setInterval + clearInterval,

--- a/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
+++ b/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
@@ -1,7 +1,7 @@
 import { router } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
 import { AlertCircle, CheckCircle2, Download, Search, XCircle } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { DataCiteIcon } from '@/components/icons/datacite-icon';
@@ -54,6 +54,7 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
     const [progress, setProgress] = useState<ImportProgress | null>(null);
     const [isStarting, setIsStarting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const hasNotifiedSuccessRef = useRef(false);
 
     useEffect(() => {
         if (!isOpen) {
@@ -65,8 +66,18 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
             setProgress(null);
             setIsStarting(false);
             setError(null);
+            hasNotifiedSuccessRef.current = false;
         }
     }, [isOpen]);
+
+    useEffect(() => {
+        if (modalState !== 'completed' || progress?.imported !== 1 || hasNotifiedSuccessRef.current) {
+            return;
+        }
+
+        hasNotifiedSuccessRef.current = true;
+        onSuccess?.();
+    }, [modalState, onSuccess, progress?.imported]);
 
     useEffect(() => {
         if (!importId || modalState !== 'running') {
@@ -137,6 +148,7 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
         setError(null);
         setSubmittedDoi(normalizedDoi);
         setDoiInput(normalizedDoi);
+        hasNotifiedSuccessRef.current = false;
 
         try {
             const response = await axios.post<{ import_id: string; message: string }>(
@@ -194,12 +206,8 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
     }, [doiInput]);
 
     const handleClose = useCallback(() => {
-        if (modalState === 'completed' && progress?.imported === 1) {
-            onSuccess?.();
-        }
-
         onClose();
-    }, [modalState, onClose, onSuccess, progress?.imported]);
+    }, [onClose]);
 
     const progressPercent = progress && progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
     const isAlreadyImported = progress?.skipped === 1;

--- a/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
+++ b/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
@@ -71,13 +71,13 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
     }, [isOpen]);
 
     useEffect(() => {
-        if (modalState !== 'completed' || progress?.imported !== 1 || hasNotifiedSuccessRef.current) {
+        if (!isOpen || modalState !== 'completed' || progress?.imported !== 1 || hasNotifiedSuccessRef.current) {
             return;
         }
 
         hasNotifiedSuccessRef.current = true;
         onSuccess?.();
-    }, [modalState, onSuccess, progress?.imported]);
+    }, [isOpen, modalState, onSuccess, progress?.imported]);
 
     useEffect(() => {
         if (!importId || modalState !== 'running') {

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1,7 +1,7 @@
 import { Head, router, usePage } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
 import { ArrowDown, ArrowUp, ArrowUpDown, Braces, Eye, PencilLine, Quote, Trash2 } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -810,13 +810,15 @@ function ResourcesPage({
     );
 
     const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
-        if (!open && !isDeletingResource) {
+        if (!open && !isDeletingResourceRef.current && !isDeletingResource) {
             isDeletingResourceRef.current = false;
             setResourcePendingDelete(null);
         }
     }, [isDeletingResource]);
 
-    const handleConfirmDelete = useCallback(() => {
+    const handleConfirmDelete = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+
         if (isDeletingResourceRef.current || !resourcePendingDelete?.id) {
             return;
         }

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -764,9 +764,18 @@ function ResourcesPage({
     const isDeletingResourceRef = useRef(false);
     const { vocabularies: citationVocabularies, isLoading: citationVocabulariesLoading } = useCitationVocabularies();
 
+    const hasPersistentIdentifier = useCallback((resource: Resource): boolean => {
+        return typeof resource.doi === 'string' && resource.doi.trim().length > 0;
+    }, []);
+
     const canDeleteResource = useCallback(
-        (resource: Resource): boolean => canDeleteDraftResources && resource.publicstatus === 'draft' && typeof resource.id === 'number',
-        [canDeleteDraftResources],
+        (resource: Resource): boolean => {
+            return canDeleteDraftResources
+                && resource.publicstatus === 'draft'
+                && typeof resource.id === 'number'
+                && !hasPersistentIdentifier(resource);
+        },
+        [canDeleteDraftResources, hasPersistentIdentifier],
     );
 
     const getDeleteButtonTitle = useCallback(
@@ -779,9 +788,13 @@ function ResourcesPage({
                 return 'Only draft resources can be deleted';
             }
 
+            if (hasPersistentIdentifier(resource)) {
+                return 'Resources with persistent identifiers cannot be deleted';
+            }
+
             return 'Delete draft resource';
         },
-        [canDeleteDraftResources],
+        [canDeleteDraftResources, hasPersistentIdentifier],
     );
 
     const handleRequestDelete = useCallback(

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -761,6 +761,7 @@ function ResourcesPage({
     const [citationManagerResourceId, setCitationManagerResourceId] = useState<number | null>(null);
     const [resourcePendingDelete, setResourcePendingDelete] = useState<Resource | null>(null);
     const [isDeletingResource, setIsDeletingResource] = useState(false);
+    const isDeletingResourceRef = useRef(false);
     const { vocabularies: citationVocabularies, isLoading: citationVocabulariesLoading } = useCitationVocabularies();
 
     const canDeleteResource = useCallback(
@@ -789,6 +790,7 @@ function ResourcesPage({
                 return;
             }
 
+            isDeletingResourceRef.current = false;
             setResourcePendingDelete(resource);
         },
         [canDeleteResource],
@@ -796,17 +798,19 @@ function ResourcesPage({
 
     const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
         if (!open && !isDeletingResource) {
+            isDeletingResourceRef.current = false;
             setResourcePendingDelete(null);
         }
     }, [isDeletingResource]);
 
     const handleConfirmDelete = useCallback(() => {
-        if (!resourcePendingDelete?.id) {
+        if (isDeletingResourceRef.current || !resourcePendingDelete?.id) {
             return;
         }
 
         const resourceToDelete = resourcePendingDelete;
 
+        isDeletingResourceRef.current = true;
         setIsDeletingResource(true);
 
         router.delete(`/resources/${resourceToDelete.id}`, {
@@ -824,6 +828,7 @@ function ResourcesPage({
                 toast.error('Failed to delete draft resource.');
             },
             onFinish: () => {
+                isDeletingResourceRef.current = false;
                 setIsDeletingResource(false);
             },
         });

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -18,6 +18,16 @@ import ImportSingleOldResourceModal from '@/components/resources/modals/ImportSi
 import RegisterDoiModal from '@/components/resources/modals/RegisterDoiModal';
 import { ResourcesFilters } from '@/components/resources-filters';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -282,6 +292,9 @@ function ResourcesPage({
     const { auth } = usePage<{ auth: { user: AuthUser } }>().props;
     const canManageLandingPages = auth.user?.can_manage_landing_pages ?? false;
     const canRegisterDoi = auth.user?.can_register_production_doi ?? false;
+    const canDeleteDraftResources = auth.user?.role === 'admin'
+        || auth.user?.role === 'group_leader'
+        || auth.user?.role === 'curator';
 
     const [resources, setResources] = useState<Resource[]>(initialResources);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -304,6 +317,14 @@ function ResourcesPage({
 
     const lastResourceElementRef = useRef<HTMLTableRowElement | null>(null);
     const observerRef = useRef<IntersectionObserver | null>(null);
+
+    useEffect(() => {
+        setResources(initialResources);
+    }, [initialResources]);
+
+    useEffect(() => {
+        setPagination(initialPagination);
+    }, [initialPagination]);
 
     // Load more resources for infinite scrolling
     const loadMore = useCallback(async () => {
@@ -738,7 +759,75 @@ function ResourcesPage({
     const [isValidationModalOpen, setIsValidationModalOpen] = useState(false);
     const [validationSchemaVersion, setValidationSchemaVersion] = useState<string>('4.6');
     const [citationManagerResourceId, setCitationManagerResourceId] = useState<number | null>(null);
+    const [resourcePendingDelete, setResourcePendingDelete] = useState<Resource | null>(null);
+    const [isDeletingResource, setIsDeletingResource] = useState(false);
     const { vocabularies: citationVocabularies, isLoading: citationVocabulariesLoading } = useCitationVocabularies();
+
+    const canDeleteResource = useCallback(
+        (resource: Resource): boolean => canDeleteDraftResources && resource.publicstatus === 'draft' && typeof resource.id === 'number',
+        [canDeleteDraftResources],
+    );
+
+    const getDeleteButtonTitle = useCallback(
+        (resource: Resource): string => {
+            if (!canDeleteDraftResources) {
+                return 'You do not have permission to delete draft resources';
+            }
+
+            if (resource.publicstatus !== 'draft') {
+                return 'Only draft resources can be deleted';
+            }
+
+            return 'Delete draft resource';
+        },
+        [canDeleteDraftResources],
+    );
+
+    const handleRequestDelete = useCallback(
+        (resource: Resource) => {
+            if (!canDeleteResource(resource)) {
+                return;
+            }
+
+            setResourcePendingDelete(resource);
+        },
+        [canDeleteResource],
+    );
+
+    const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
+        if (!open && !isDeletingResource) {
+            setResourcePendingDelete(null);
+        }
+    }, [isDeletingResource]);
+
+    const handleConfirmDelete = useCallback(() => {
+        if (!resourcePendingDelete?.id) {
+            return;
+        }
+
+        const resourceToDelete = resourcePendingDelete;
+
+        setIsDeletingResource(true);
+
+        router.delete(`/resources/${resourceToDelete.id}`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setSelectedIds((prev) => {
+                    const next = new Set(prev);
+                    next.delete(resourceToDelete.id);
+                    return next;
+                });
+                setResourcePendingDelete(null);
+                toast.success('Draft deleted successfully.');
+            },
+            onError: () => {
+                toast.error('Failed to delete draft resource.');
+            },
+            onFinish: () => {
+                setIsDeletingResource(false);
+            },
+        });
+    }, [resourcePendingDelete]);
 
     const handleExportDataCiteJson = useCallback(async (resource: Resource) => {
         if (!resource.id) {
@@ -1524,10 +1613,11 @@ function ResourcesPage({
                                                                         type="button"
                                                                         variant="ghost"
                                                                         size="icon"
-                                                                        disabled
-                                                                        aria-label={`Delete resource ${resourceLabel} (not yet implemented)`}
-                                                                        title="Delete resource (not yet implemented)"
-                                                                        className="cursor-not-allowed opacity-40"
+                                                                        onClick={canDeleteResource(resource) ? () => handleRequestDelete(resource) : undefined}
+                                                                        disabled={!canDeleteResource(resource) || isDeletingResource}
+                                                                        aria-label={`Delete resource ${resourceLabel}`}
+                                                                        title={getDeleteButtonTitle(resource)}
+                                                                        className={!canDeleteResource(resource) ? 'cursor-not-allowed opacity-40' : undefined}
                                                                     >
                                                                         <Trash2 aria-hidden="true" className="size-4" />
                                                                     </Button>
@@ -1592,6 +1682,29 @@ function ResourcesPage({
                 onClose={() => setShowSingleImportModal(false)}
                 onSuccess={handleImportSuccess}
             />
+
+            <AlertDialog open={resourcePendingDelete !== null} onOpenChange={handleDeleteDialogOpenChange}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete draft resource?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {resourcePendingDelete?.title
+                                ? `This will permanently remove the draft resource "${resourcePendingDelete.title}" from ERNIE.`
+                                : 'This will permanently remove the selected draft resource from ERNIE.'}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={isDeletingResource}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            variant="destructive"
+                            onClick={handleConfirmDelete}
+                            disabled={isDeletingResource}
+                        >
+                            {isDeletingResource ? 'Deleting...' : 'Delete Draft'}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
 
             {/* JSON Validation Error Modal */}
             <ValidationErrorModal

--- a/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
@@ -197,7 +197,9 @@ describe('ResourceController destroy authorization', function () {
     });
 
     it('denies beginner from deleting draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create();
+        $resource = \App\Models\Resource::factory()->create([
+            'doi' => null,
+        ]);
 
         $response = $this->actingAs($this->beginner)
             ->delete("/resources/{$resource->id}");

--- a/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
@@ -160,7 +160,7 @@ describe('ResourceController canImportFromDataCite', function () {
 });
 
 describe('ResourceController destroy authorization', function () {
-    it('allows admin to delete resources', function () {
+    it('allows admin to delete draft resources', function () {
         $resource = \App\Models\Resource::factory()->create();
 
         $response = $this->actingAs($this->adminUser)
@@ -170,7 +170,7 @@ describe('ResourceController destroy authorization', function () {
         expect(\App\Models\Resource::find($resource->id))->toBeNull();
     });
 
-    it('allows group leader to delete resources', function () {
+    it('allows group leader to delete draft resources', function () {
         $resource = \App\Models\Resource::factory()->create();
 
         $response = $this->actingAs($this->groupLeader)
@@ -180,18 +180,17 @@ describe('ResourceController destroy authorization', function () {
         expect(\App\Models\Resource::find($resource->id))->toBeNull();
     });
 
-    it('denies curator from deleting resources', function () {
+    it('allows curator to delete draft resources', function () {
         $resource = \App\Models\Resource::factory()->create();
 
         $response = $this->actingAs($this->curator)
             ->delete("/resources/{$resource->id}");
 
-        $response->assertForbidden();
-        // Resource should still exist
-        expect(\App\Models\Resource::find($resource->id))->not->toBeNull();
+        $response->assertRedirect('/resources');
+        expect(\App\Models\Resource::find($resource->id))->toBeNull();
     });
 
-    it('denies beginner from deleting resources', function () {
+    it('denies beginner from deleting draft resources', function () {
         $resource = \App\Models\Resource::factory()->create();
 
         $response = $this->actingAs($this->beginner)

--- a/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
@@ -161,7 +161,9 @@ describe('ResourceController canImportFromDataCite', function () {
 
 describe('ResourceController destroy authorization', function () {
     it('allows admin to delete draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create();
+        $resource = \App\Models\Resource::factory()->create([
+            'doi' => null,
+        ]);
 
         $response = $this->actingAs($this->adminUser)
             ->delete("/resources/{$resource->id}");
@@ -171,7 +173,9 @@ describe('ResourceController destroy authorization', function () {
     });
 
     it('allows group leader to delete draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create();
+        $resource = \App\Models\Resource::factory()->create([
+            'doi' => null,
+        ]);
 
         $response = $this->actingAs($this->groupLeader)
             ->delete("/resources/{$resource->id}");
@@ -181,7 +185,9 @@ describe('ResourceController destroy authorization', function () {
     });
 
     it('allows curator to delete draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create();
+        $resource = \App\Models\Resource::factory()->create([
+            'doi' => null,
+        ]);
 
         $response = $this->actingAs($this->curator)
             ->delete("/resources/{$resource->id}");

--- a/tests/pest/Feature/Policies/ResourcePolicyTest.php
+++ b/tests/pest/Feature/Policies/ResourcePolicyTest.php
@@ -16,7 +16,9 @@ use App\Policies\ResourcePolicy;
 
 function createNonDraftResourceForPolicy(): Resource
 {
-    $resource = Resource::factory()->create();
+    $resource = Resource::factory()->create([
+        'doi' => null,
+    ]);
 
     $titleType = TitleType::firstOrCreate([
         'slug' => 'MainTitle',

--- a/tests/pest/Feature/Policies/ResourcePolicyTest.php
+++ b/tests/pest/Feature/Policies/ResourcePolicyTest.php
@@ -164,6 +164,34 @@ describe('ResourcePolicy', function () {
     });
 
     describe('delete', function () {
+        it('short-circuits before loading relations for users who cannot delete drafts', function () {
+            $user = User::factory()->create(['role' => UserRole::BEGINNER]);
+
+            /** @var Resource&\Mockery\MockInterface $resource */
+            $resource = \Mockery::mock(Resource::class);
+            $resource->shouldNotReceive('loadMissing');
+            $resource->shouldNotReceive('publicStatus');
+
+            expect($this->policy->delete($user, $resource))->toBeFalse();
+        });
+
+        it('loads relations only after the role check passes', function () {
+            $user = User::factory()->create(['role' => UserRole::ADMIN]);
+
+            /** @var Resource&\Mockery\MockInterface $resource */
+            $resource = \Mockery::mock(Resource::class);
+            $resource->shouldReceive('loadMissing')->once()->with([
+                'titles.titleType',
+                'creators',
+                'rights',
+                'descriptions.descriptionType',
+                'landingPage',
+            ])->andReturnSelf();
+            $resource->shouldReceive('publicStatus')->once()->andReturn('draft');
+
+            expect($this->policy->delete($user, $resource))->toBeTrue();
+        });
+
         it('allows admin to delete a draft resource', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
             expect($this->policy->delete($user, $this->resource))->toBeTrue();

--- a/tests/pest/Feature/Policies/ResourcePolicyTest.php
+++ b/tests/pest/Feature/Policies/ResourcePolicyTest.php
@@ -3,10 +3,71 @@
 declare(strict_types=1);
 
 use App\Enums\UserRole;
+use App\Models\Description;
+use App\Models\DescriptionType;
 use App\Models\LandingPage;
+use App\Models\Person;
 use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\Right;
+use App\Models\TitleType;
 use App\Models\User;
 use App\Policies\ResourcePolicy;
+
+function createNonDraftResourceForPolicy(): Resource
+{
+    $resource = Resource::factory()->create();
+
+    $titleType = TitleType::firstOrCreate([
+        'slug' => 'MainTitle',
+    ], [
+        'name' => 'Main Title',
+    ]);
+
+    $resource->titles()->create([
+        'value' => 'Complete resource',
+        'title_type_id' => $titleType->id,
+    ]);
+
+    $creator = Person::create([
+        'family_name' => 'Example',
+        'given_name' => 'Author',
+    ]);
+
+    ResourceCreator::create([
+        'resource_id' => $resource->id,
+        'creatorable_type' => Person::class,
+        'creatorable_id' => $creator->id,
+        'position' => 0,
+    ]);
+
+    $right = Right::firstOrCreate([
+        'identifier' => 'cc-by-4.0',
+    ], [
+        'name' => 'CC-BY 4.0',
+    ]);
+    $resource->rights()->attach($right->id);
+
+    $abstractType = DescriptionType::firstOrCreate([
+        'slug' => 'Abstract',
+    ], [
+        'name' => 'Abstract',
+    ]);
+
+    Description::create([
+        'resource_id' => $resource->id,
+        'value' => 'Abstract',
+        'description_type_id' => $abstractType->id,
+    ]);
+
+    return $resource->fresh([
+        'titles.titleType',
+        'creators',
+        'rights',
+        'descriptions.descriptionType',
+        'landingPage',
+    ]);
+}
 
 describe('ResourcePolicy', function () {
     beforeEach(function () {
@@ -103,19 +164,43 @@ describe('ResourcePolicy', function () {
     });
 
     describe('delete', function () {
-        it('allows admin to delete a resource', function () {
+        it('allows admin to delete a draft resource', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
             expect($this->policy->delete($user, $this->resource))->toBeTrue();
         });
 
-        it('allows group leader to delete a resource', function () {
+        it('allows group leader to delete a draft resource', function () {
             $user = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
             expect($this->policy->delete($user, $this->resource))->toBeTrue();
         });
 
-        it('denies curator from deleting a resource', function () {
+        it('allows curator to delete a draft resource', function () {
             $user = User::factory()->create(['role' => UserRole::CURATOR]);
-            expect($this->policy->delete($user, $this->resource))->toBeFalse();
+            expect($this->policy->delete($user, $this->resource))->toBeTrue();
+        });
+
+        it('denies admin from deleting a non-draft resource', function () {
+            $user = User::factory()->create(['role' => UserRole::ADMIN]);
+            $resource = createNonDraftResourceForPolicy();
+
+            expect($resource->publicStatus())->not->toBe('draft');
+            expect($this->policy->delete($user, $resource))->toBeFalse();
+        });
+
+        it('denies group leader from deleting a non-draft resource', function () {
+            $user = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
+            $resource = createNonDraftResourceForPolicy();
+
+            expect($resource->publicStatus())->not->toBe('draft');
+            expect($this->policy->delete($user, $resource))->toBeFalse();
+        });
+
+        it('denies curator from deleting a non-draft resource', function () {
+            $user = User::factory()->create(['role' => UserRole::CURATOR]);
+            $resource = createNonDraftResourceForPolicy();
+
+            expect($resource->publicStatus())->not->toBe('draft');
+            expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
         it('denies beginner from deleting a resource', function () {

--- a/tests/pest/Feature/Policies/ResourcePolicyTest.php
+++ b/tests/pest/Feature/Policies/ResourcePolicyTest.php
@@ -72,7 +72,9 @@ function createNonDraftResourceForPolicy(): Resource
 describe('ResourcePolicy', function () {
     beforeEach(function () {
         $this->policy = new ResourcePolicy;
-        $this->resource = Resource::factory()->create();
+        $this->resource = Resource::factory()->create([
+            'doi' => null,
+        ]);
     });
 
     describe('viewAny', function () {
@@ -180,6 +182,7 @@ describe('ResourcePolicy', function () {
 
             /** @var Resource&\Mockery\MockInterface $resource */
             $resource = \Mockery::mock(Resource::class);
+            $resource->shouldReceive('getAttribute')->with('doi')->once()->andReturn(null);
             $resource->shouldReceive('loadMissing')->once()->with([
                 'titles.titleType',
                 'creators',
@@ -195,6 +198,16 @@ describe('ResourcePolicy', function () {
         it('allows admin to delete a draft resource', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
             expect($this->policy->delete($user, $this->resource))->toBeTrue();
+        });
+
+        it('denies admin from deleting a draft resource with a persistent identifier', function () {
+            $user = User::factory()->create(['role' => UserRole::ADMIN]);
+            $resource = Resource::factory()->create([
+                'doi' => '10.5880/test.2026.001',
+            ]);
+
+            expect($resource->publicStatus())->toBe('draft');
+            expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
         it('allows group leader to delete a draft resource', function () {

--- a/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
+++ b/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
@@ -17,7 +17,9 @@ uses(RefreshDatabase::class);
 
 function createNonDraftResource(): Resource
 {
-    $resource = Resource::factory()->create();
+    $resource = Resource::factory()->create([
+        'doi' => null,
+    ]);
 
     $titleType = TitleType::firstOrCreate([
         'slug' => 'MainTitle',

--- a/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
+++ b/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
@@ -72,7 +72,9 @@ function createNonDraftResource(): Resource
 
 it('allows admins to delete draft resources', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $resource = Resource::factory()->create();
+    $resource = Resource::factory()->create([
+        'doi' => null,
+    ]);
 
     $this->actingAs($admin)
         ->delete(route('resources.destroy', $resource))
@@ -82,9 +84,26 @@ it('allows admins to delete draft resources', function (): void {
     expect(Resource::find($resource->id))->toBeNull();
 });
 
+it('forbids admins from deleting draft resources with persistent identifiers', function (): void {
+    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+    $resource = Resource::factory()->create([
+        'doi' => '10.5880/test.2026.002',
+    ]);
+
+    expect($resource->publicStatus())->toBe('draft');
+
+    $this->actingAs($admin)
+        ->delete(route('resources.destroy', $resource))
+        ->assertStatus(403);
+
+    expect(Resource::find($resource->id))->not->toBeNull();
+});
+
 it('allows group leaders to delete draft resources', function (): void {
     $leader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
-    $resource = Resource::factory()->create();
+    $resource = Resource::factory()->create([
+        'doi' => null,
+    ]);
 
     $this->actingAs($leader)
         ->delete(route('resources.destroy', $resource))
@@ -95,7 +114,9 @@ it('allows group leaders to delete draft resources', function (): void {
 
 it('allows curators to delete draft resources', function (): void {
     $curator = User::factory()->create(['role' => UserRole::CURATOR]);
-    $resource = Resource::factory()->create();
+    $resource = Resource::factory()->create([
+        'doi' => null,
+    ]);
 
     $this->actingAs($curator)
         ->delete(route('resources.destroy', $resource))

--- a/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
+++ b/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
@@ -3,25 +3,86 @@
 declare(strict_types=1);
 
 use App\Enums\UserRole;
+use App\Models\Description;
+use App\Models\DescriptionType;
+use App\Models\Person;
 use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\Right;
+use App\Models\TitleType;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-it('allows admins to delete resources', function (): void {
+function createNonDraftResource(): Resource
+{
+    $resource = Resource::factory()->create();
+
+    $titleType = TitleType::firstOrCreate([
+        'slug' => 'MainTitle',
+    ], [
+        'name' => 'Main Title',
+    ]);
+
+    $resource->titles()->create([
+        'value' => 'Delete me later',
+        'title_type_id' => $titleType->id,
+    ]);
+
+    $creator = Person::create([
+        'family_name' => 'Example',
+        'given_name' => 'Curator',
+    ]);
+
+    ResourceCreator::create([
+        'resource_id' => $resource->id,
+        'creatorable_type' => Person::class,
+        'creatorable_id' => $creator->id,
+        'position' => 0,
+    ]);
+
+    $right = Right::firstOrCreate([
+        'identifier' => 'cc-by-4.0',
+    ], [
+        'name' => 'CC-BY 4.0',
+    ]);
+    $resource->rights()->attach($right->id);
+
+    $abstractType = DescriptionType::firstOrCreate([
+        'slug' => 'Abstract',
+    ], [
+        'name' => 'Abstract',
+    ]);
+
+    Description::create([
+        'resource_id' => $resource->id,
+        'value' => 'Complete enough to leave draft status.',
+        'description_type_id' => $abstractType->id,
+    ]);
+
+    return $resource->fresh([
+        'titles.titleType',
+        'creators',
+        'rights',
+        'descriptions.descriptionType',
+        'landingPage',
+    ]);
+}
+
+it('allows admins to delete draft resources', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
     $resource = Resource::factory()->create();
 
     $this->actingAs($admin)
         ->delete(route('resources.destroy', $resource))
         ->assertRedirect(route('resources'))
-        ->assertSessionHas('success', 'Resource deleted successfully.');
+        ->assertSessionHas('success', 'Draft deleted successfully.');
 
     expect(Resource::find($resource->id))->toBeNull();
 });
 
-it('allows group leaders to delete resources', function (): void {
+it('allows group leaders to delete draft resources', function (): void {
     $leader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
     $resource = Resource::factory()->create();
 
@@ -32,9 +93,48 @@ it('allows group leaders to delete resources', function (): void {
     expect(Resource::find($resource->id))->toBeNull();
 });
 
-it('forbids curators from deleting resources', function (): void {
+it('allows curators to delete draft resources', function (): void {
     $curator = User::factory()->create(['role' => UserRole::CURATOR]);
     $resource = Resource::factory()->create();
+
+    $this->actingAs($curator)
+        ->delete(route('resources.destroy', $resource))
+        ->assertRedirect(route('resources'));
+
+    expect(Resource::find($resource->id))->toBeNull();
+});
+
+it('forbids admins from deleting non-draft resources', function (): void {
+    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+    $resource = createNonDraftResource();
+
+    expect($resource->publicStatus())->not->toBe('draft');
+
+    $this->actingAs($admin)
+        ->delete(route('resources.destroy', $resource))
+        ->assertStatus(403);
+
+    expect(Resource::find($resource->id))->not->toBeNull();
+});
+
+it('forbids group leaders from deleting non-draft resources', function (): void {
+    $leader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
+    $resource = createNonDraftResource();
+
+    expect($resource->publicStatus())->not->toBe('draft');
+
+    $this->actingAs($leader)
+        ->delete(route('resources.destroy', $resource))
+        ->assertStatus(403);
+
+    expect(Resource::find($resource->id))->not->toBeNull();
+});
+
+it('forbids curators from deleting non-draft resources', function (): void {
+    $curator = User::factory()->create(['role' => UserRole::CURATOR]);
+    $resource = createNonDraftResource();
+
+    expect($resource->publicStatus())->not->toBe('draft');
 
     $this->actingAs($curator)
         ->delete(route('resources.destroy', $resource))

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1436,6 +1436,104 @@ describe('SetupLandingPageModal', () => {
             expect(screen.queryByDisplayValue('https://example.org/temp')).not.toBeInTheDocument();
         });
 
+        it('ignores sessionStorage read errors and falls back to the server state', async () => {
+            const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+                throw new DOMException('sessionStorage is unavailable', 'QuotaExceededError');
+            });
+
+            try {
+                mockModalGetRequests({ landingPage: mockExistingConfig });
+
+                render(
+                    <SetupLandingPageModal
+                        resource={mockResource}
+                        isOpen={true}
+                        onClose={mockOnClose}
+                    />,
+                );
+
+                const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+                expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
+            } finally {
+                getItemSpy.mockRestore();
+            }
+        });
+
+        it('ignores sessionStorage write errors while the user edits the modal', async () => {
+            const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new DOMException('sessionStorage is unavailable', 'QuotaExceededError');
+            });
+
+            try {
+                mockModalGetRequests({ landingPage: null });
+
+                const user = userEvent.setup();
+                render(
+                    <SetupLandingPageModal
+                        resource={mockResource}
+                        isOpen={true}
+                        onClose={mockOnClose}
+                    />,
+                );
+
+                const ftpInput = await screen.findByLabelText(/^Download URL$/i);
+                await user.clear(ftpInput);
+                await user.type(ftpInput, 'https://downloads.example.org/storage-safe.zip');
+
+                expect((ftpInput as HTMLInputElement).value).toBe('https://downloads.example.org/storage-safe.zip');
+            } finally {
+                setItemSpy.mockRestore();
+            }
+        });
+
+        it('ignores sessionStorage removal errors after a successful save', async () => {
+            const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+                throw new DOMException('sessionStorage is unavailable', 'QuotaExceededError');
+            });
+
+            try {
+                mockModalGetRequests({ landingPage: null });
+
+                const savedConfig: LandingPageConfig = {
+                    ...mockExistingConfig,
+                    status: 'draft',
+                    ftp_url: 'https://saved.example.org/final-file.zip',
+                    links: [],
+                };
+
+                mockedAxiosPost.mockResolvedValue({
+                    data: {
+                        message: 'Landing page saved',
+                        landing_page: savedConfig,
+                        preview_url: savedConfig.preview_url,
+                    },
+                });
+
+                const user = userEvent.setup();
+                render(
+                    <SetupLandingPageModal
+                        resource={mockResource}
+                        isOpen={true}
+                        onClose={mockOnClose}
+                    />,
+                );
+
+                const ftpInput = await screen.findByLabelText(/^Download URL$/i);
+                await user.clear(ftpInput);
+                await user.type(ftpInput, savedConfig.ftp_url ?? '');
+                await user.click(screen.getByRole('button', { name: /create preview/i }));
+
+                await waitFor(() => {
+                    expect(mockedAxiosPost).toHaveBeenCalled();
+                });
+
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            } finally {
+                removeItemSpy.mockRestore();
+            }
+        });
+
         it('ignores malformed persisted draft data and falls back to the server state', async () => {
             window.sessionStorage.setItem('setup-landing-page-modal:draft:123', '{not-valid-json');
             mockModalGetRequests({ landingPage: mockExistingConfig });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -2339,6 +2339,71 @@ describe('SetupLandingPageModal', () => {
             expect(toast.error).toHaveBeenCalledWith('Failed to load landing page configuration');
         });
 
+        it('resets to clean defaults when a new resource fails to load and no persisted draft exists', async () => {
+            const firstResource = mockResource;
+            const secondResource = {
+                ...mockResource,
+                id: 456,
+                doi: '10.5880/GFZ.TEST.2025.002',
+                title: 'Second Resource Title',
+            };
+            const firstConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                ftp_url: 'https://downloads.example.org/first-resource.zip',
+                links: [
+                    {
+                        label: 'First resource link',
+                        url: 'https://example.org/first-resource',
+                        position: 0,
+                    },
+                ],
+            };
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                if (url.includes(`/resources/${firstResource.id}/landing-page`)) {
+                    return Promise.resolve({ data: { landing_page: firstConfig } });
+                }
+
+                return Promise.reject({
+                    isAxiosError: true,
+                    response: { status: 500, data: { message: 'Server error' } },
+                });
+            });
+
+            const { rerender } = render(
+                <SetupLandingPageModal
+                    resource={firstResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/^Download URL$/i)).toHaveValue('https://downloads.example.org/first-resource.zip');
+            });
+            expect(screen.getByDisplayValue('First resource link')).toBeInTheDocument();
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={secondResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByLabelText(/^Download URL$/i)).toHaveValue('');
+            });
+            expect(screen.queryByDisplayValue('First resource link')).not.toBeInTheDocument();
+            expect(mockedToastError).toHaveBeenCalledWith('Failed to load landing page configuration');
+        });
+
         it('prevents removal of published landing page with error toast', async () => {
             // Published config cannot be removed
             mockedAxiosGet.mockImplementation((url: string) => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1370,6 +1370,7 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('clears persisted unsaved values after a successful save', async () => {
+            const draftStorageKey = 'setup-landing-page-modal:draft:123';
             mockModalGetRequests({ landingPage: null });
 
             const savedConfig: LandingPageConfig = {
@@ -1411,6 +1412,10 @@ describe('SetupLandingPageModal', () => {
                 expect(mockedAxiosPost).toHaveBeenCalled();
             });
 
+            await waitFor(() => {
+                expect(window.sessionStorage.getItem(draftStorageKey)).toBeNull();
+            });
+
             mockModalGetRequests({ landingPage: savedConfig });
 
             rerender(
@@ -1434,6 +1439,26 @@ describe('SetupLandingPageModal', () => {
             expect(reopenedFtpInput.value).toBe('https://saved.example.org/final-file.zip');
             expect(screen.queryByDisplayValue('Temporary Link')).not.toBeInTheDocument();
             expect(screen.queryByDisplayValue('https://example.org/temp')).not.toBeInTheDocument();
+        });
+
+        it('does not persist a draft when the hydrated state matches the server config', async () => {
+            mockModalGetRequests({ landingPage: mockExistingConfig });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
+
+            await waitFor(() => {
+                expect(window.sessionStorage.getItem('setup-landing-page-modal:draft:123')).toBeNull();
+            });
         });
 
         it('ignores sessionStorage read errors and falls back to the server state', async () => {
@@ -1576,6 +1601,7 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('clears a persisted draft after removing a preview and reopens with empty defaults', async () => {
+            const draftStorageKey = 'setup-landing-page-modal:draft:123';
             const draftConfig: LandingPageConfig = {
                 ...mockExistingConfig,
                 status: 'draft',
@@ -1619,6 +1645,10 @@ describe('SetupLandingPageModal', () => {
 
             await waitFor(() => {
                 expect(mockedAxiosDelete).toHaveBeenCalledWith(`/resources/${mockResource.id}/landing-page`);
+            });
+
+            await waitFor(() => {
+                expect(window.sessionStorage.getItem(draftStorageKey)).toBeNull();
             });
 
             mockModalGetRequests({ landingPage: null });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1435,6 +1435,120 @@ describe('SetupLandingPageModal', () => {
             expect(screen.queryByDisplayValue('Temporary Link')).not.toBeInTheDocument();
             expect(screen.queryByDisplayValue('https://example.org/temp')).not.toBeInTheDocument();
         });
+
+        it('ignores malformed persisted draft data and falls back to the server state', async () => {
+            window.sessionStorage.setItem('setup-landing-page-modal:draft:123', '{not-valid-json');
+            mockModalGetRequests({ landingPage: mockExistingConfig });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
+        });
+
+        it('ignores persisted draft entries without a template and falls back to the server state', async () => {
+            window.sessionStorage.setItem(
+                'setup-landing-page-modal:draft:123',
+                JSON.stringify({
+                    ftpUrl: 'https://downloads.example.org/invalid.zip',
+                    links: [{ label: 'Invalid persisted link', url: 'https://example.org/invalid', position: 0 }],
+                }),
+            );
+            mockModalGetRequests({ landingPage: mockExistingConfig });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
+            expect(screen.queryByDisplayValue('Invalid persisted link')).not.toBeInTheDocument();
+        });
+
+        it('clears a persisted draft after removing a preview and reopens with empty defaults', async () => {
+            const draftConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft',
+                ftp_url: 'https://saved.example.org/current.zip',
+            };
+
+            window.sessionStorage.setItem(
+                'setup-landing-page-modal:draft:123',
+                JSON.stringify({
+                    template: 'default_gfz',
+                    ftpUrl: 'https://downloads.example.org/stale.zip',
+                    isPublished: false,
+                    externalDomainId: '',
+                    externalPath: '',
+                    landingPageTemplateId: null,
+                    links: [
+                        {
+                            label: 'Stale link',
+                            url: 'https://example.org/stale',
+                            position: 0,
+                        },
+                    ],
+                }),
+            );
+
+            mockModalGetRequests({ landingPage: draftConfig });
+            mockedAxiosDelete.mockResolvedValue({ data: { message: 'Landing page deleted successfully' } });
+            vi.stubGlobal('confirm', vi.fn(() => true));
+
+            const user = userEvent.setup();
+            const { rerender } = render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await screen.findByRole('dialog');
+            await user.click(screen.getByRole('button', { name: /remove preview/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosDelete).toHaveBeenCalledWith(`/resources/${mockResource.id}/landing-page`);
+            });
+
+            mockModalGetRequests({ landingPage: null });
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={false}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const reopenedFtpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(reopenedFtpInput.value).toBe('');
+            expect(screen.queryByDisplayValue('Stale link')).not.toBeInTheDocument();
+            expect(screen.queryByDisplayValue('https://example.org/stale')).not.toBeInTheDocument();
+
+            vi.unstubAllGlobals();
+        });
     });
 
     describe('Custom Templates', () => {
@@ -2073,6 +2187,58 @@ describe('SetupLandingPageModal', () => {
             await waitFor(() => {
                 expect(toast.error).toHaveBeenCalledWith('Failed to load landing page configuration');
             });
+        });
+
+        it('restores a persisted draft when loading the server config fails with a non-404 error', async () => {
+            const { toast } = await import('sonner');
+
+            window.sessionStorage.setItem(
+                'setup-landing-page-modal:draft:123',
+                JSON.stringify({
+                    template: 'default_gfz',
+                    ftpUrl: 'https://downloads.example.org/persisted.zip',
+                    isPublished: false,
+                    externalDomainId: '',
+                    externalPath: '',
+                    landingPageTemplateId: null,
+                    links: [
+                        {
+                            label: 'Persisted link',
+                            url: 'https://example.org/persisted',
+                            position: 0,
+                        },
+                    ],
+                }),
+            );
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+
+                return Promise.reject({
+                    isAxiosError: true,
+                    response: { status: 500, data: { message: 'Server error' } },
+                });
+            });
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(ftpInput.value).toBe('https://downloads.example.org/persisted.zip');
+            expect(screen.getByDisplayValue('Persisted link')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('https://example.org/persisted')).toBeInTheDocument();
+            expect(toast.error).toHaveBeenCalledWith('Failed to load landing page configuration');
         });
 
         it('prevents removal of published landing page with error toast', async () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -96,6 +96,7 @@ describe('SetupLandingPageModal', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        window.sessionStorage.clear();
     });
 
     const mockModalGetRequests = ({
@@ -218,7 +219,7 @@ describe('SetupLandingPageModal', () => {
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/Landing Page Template/i)).toBeInTheDocument();
-                expect(screen.getByLabelText(/Download URL \(FTP\)/i)).toBeInTheDocument();
+                expect(screen.getByLabelText(/^Download URL$/i)).toBeInTheDocument();
                 expect(screen.getByLabelText(/Publish Landing Page/i)).toBeInTheDocument();
             });
         });
@@ -269,7 +270,7 @@ describe('SetupLandingPageModal', () => {
             expect(optionsList).toHaveTextContent('Default GFZ IGSN Template');
             expect(optionsList).toHaveTextContent('External Landing Page');
             expect(optionsList).not.toHaveTextContent('Default GFZ Data Services');
-            expect(screen.queryByLabelText(/Download URL \(FTP\)/i)).not.toBeInTheDocument();
+            expect(screen.queryByLabelText(/^Download URL$/i)).not.toBeInTheDocument();
         });
 
         it('loads existing configuration', async () => {
@@ -284,7 +285,7 @@ describe('SetupLandingPageModal', () => {
             );
 
             await waitFor(() => {
-                const ftpInput = screen.getByLabelText(/Download URL \(FTP\)/i) as HTMLInputElement;
+                const ftpInput = screen.getByLabelText(/^Download URL$/i) as HTMLInputElement;
                 expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
             });
         });
@@ -302,7 +303,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.click(ftpInput);
 
             await waitFor(() => {
@@ -326,7 +327,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
             expect(ftpInput).toHaveAttribute('role', 'combobox');
             expect(ftpInput).toHaveAttribute('aria-autocomplete', 'list');
@@ -345,7 +346,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
             await user.click(ftpInput);
             await user.type(ftpInput, 'archive');
@@ -376,7 +377,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
             await user.click(ftpInput);
             await user.click(screen.getByText('https://datapub.gfz.de/download/10.5880.DIGIS.E.2025.002-aYVBW'));
@@ -397,7 +398,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
             await user.click(ftpInput);
 
@@ -449,7 +450,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             expect(ftpInput).toBeDisabled();
 
             await user.click(ftpInput);
@@ -472,7 +473,7 @@ describe('SetupLandingPageModal', () => {
                 />,
             );
 
-            const ftpInput = await screen.findByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.click(ftpInput);
 
             await waitFor(() => {
@@ -517,7 +518,7 @@ describe('SetupLandingPageModal', () => {
                 expect(screen.getByRole('combobox', { name: /landing page template/i })).toHaveTextContent('Default GFZ IGSN Template');
             });
 
-            expect(screen.queryByLabelText(/Download URL \(FTP\)/i)).not.toBeInTheDocument();
+            expect(screen.queryByLabelText(/^Download URL$/i)).not.toBeInTheDocument();
 
             await user.click(screen.getByRole('button', { name: /Update/i }));
 
@@ -716,7 +717,7 @@ describe('SetupLandingPageModal', () => {
             });
 
             // Fill FTP URL (use full label text)
-            const ftpInput = screen.getByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = screen.getByLabelText(/^Download URL$/i);
             await user.clear(ftpInput);
             await user.type(ftpInput, 'https://datapub.gfz-potsdam.de/download/new-data');
 
@@ -799,7 +800,7 @@ describe('SetupLandingPageModal', () => {
             });
 
             // Change FTP URL (use full label text)
-            const ftpInput = screen.getByLabelText(/Download URL \(FTP\)/i);
+            const ftpInput = screen.getByLabelText(/^Download URL$/i);
             await user.clear(ftpInput);
             await user.type(ftpInput, 'https://datapub.gfz-potsdam.de/download/updated-data');
 
@@ -1323,6 +1324,116 @@ describe('SetupLandingPageModal', () => {
             await user.click(cancelButton);
 
             expect(mockOnClose).toHaveBeenCalled();
+        });
+
+        it('retains unsaved download url and additional links after closing and reopening', async () => {
+            mockModalGetRequests({ landingPage: null });
+
+            const user = userEvent.setup();
+            const { rerender } = render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
+            await user.clear(ftpInput);
+            await user.type(ftpInput, 'https://downloads.example.org/draft-file.zip');
+
+            await user.click(screen.getByRole('button', { name: /add link/i }));
+            await user.type(screen.getByPlaceholderText(/display text/i), 'Project Website');
+            await user.type(screen.getByPlaceholderText('https://...'), 'https://example.org/project');
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={false}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const reopenedFtpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(reopenedFtpInput.value).toBe('https://downloads.example.org/draft-file.zip');
+            expect(screen.getByDisplayValue('Project Website')).toBeInTheDocument();
+            expect(screen.getByDisplayValue('https://example.org/project')).toBeInTheDocument();
+        });
+
+        it('clears persisted unsaved values after a successful save', async () => {
+            mockModalGetRequests({ landingPage: null });
+
+            const savedConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft',
+                ftp_url: 'https://saved.example.org/final-file.zip',
+                links: [],
+            };
+
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page saved',
+                    landing_page: savedConfig,
+                    preview_url: savedConfig.preview_url,
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+            const { rerender } = render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const ftpInput = await screen.findByLabelText(/^Download URL$/i);
+            await user.clear(ftpInput);
+            await user.type(ftpInput, 'https://downloads.example.org/unsaved-file.zip');
+
+            await user.click(screen.getByRole('button', { name: /add link/i }));
+            await user.type(screen.getByPlaceholderText(/display text/i), 'Temporary Link');
+            await user.type(screen.getByPlaceholderText('https://...'), 'https://example.org/temp');
+
+            await user.click(screen.getByRole('button', { name: /create preview/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalled();
+            });
+
+            mockModalGetRequests({ landingPage: savedConfig });
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={false}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            rerender(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            const reopenedFtpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+
+            expect(reopenedFtpInput.value).toBe('https://saved.example.org/final-file.zip');
+            expect(screen.queryByDisplayValue('Temporary Link')).not.toBeInTheDocument();
+            expect(screen.queryByDisplayValue('https://example.org/temp')).not.toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/components/resources/modals/ImportFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportFromDataCiteModal.test.tsx
@@ -36,7 +36,7 @@ vi.mock('sonner', () => ({
 
 describe('ImportFromDataCiteModal', () => {
     const mockOnClose = vi.fn();
-     
+
     const mockOnSuccess = vi.fn();
 
     beforeEach(() => {

--- a/tests/vitest/components/resources/modals/ImportFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportFromDataCiteModal.test.tsx
@@ -216,6 +216,44 @@ describe('ImportFromDataCiteModal', () => {
         expect(mockOnClose).not.toHaveBeenCalled();
     });
 
+    it('does not call onSuccess again when the parent closes the modal after completion', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+        (axios.post as Mock).mockResolvedValueOnce({
+            data: { import_id: 'test-import-123', message: 'Import started' },
+        });
+
+        (axios.get as Mock).mockResolvedValue({
+            data: {
+                status: 'completed',
+                total: 5,
+                processed: 5,
+                imported: 2,
+                skipped: 3,
+                failed: 0,
+                skipped_dois: [],
+                failed_dois: [],
+            },
+        });
+
+        const { rerender } = render(
+            <ImportFromDataCiteModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(await screen.findByText('Import Complete')).toBeInTheDocument();
+        expect(mockOnSuccess).toHaveBeenCalledOnce();
+
+        rerender(
+            <ImportFromDataCiteModal isOpen={false} onClose={mockOnClose} onSuccess={mockOnSuccess} />,
+        );
+
+        await waitFor(() => {
+            expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+        });
+    });
+
     it('does not call onSuccess when the import completed without new resources', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 

--- a/tests/vitest/components/resources/modals/ImportFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportFromDataCiteModal.test.tsx
@@ -36,7 +36,7 @@ vi.mock('sonner', () => ({
 
 describe('ImportFromDataCiteModal', () => {
     const mockOnClose = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     const mockOnSuccess = vi.fn();
 
     beforeEach(() => {
@@ -183,6 +183,67 @@ describe('ImportFromDataCiteModal', () => {
         await waitFor(() => {
             expect(screen.getByRole('progressbar')).toBeInTheDocument();
         });
+    });
+
+    it('calls onSuccess as soon as at least one resource was imported', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+        (axios.post as Mock).mockResolvedValue({
+            data: { import_id: 'test-import-123', message: 'Import started' },
+        });
+
+        (axios.get as Mock).mockResolvedValue({
+            data: {
+                status: 'completed',
+                total: 5,
+                processed: 5,
+                imported: 2,
+                skipped: 3,
+                failed: 0,
+                skipped_dois: [],
+                failed_dois: [],
+            },
+        });
+
+        render(
+            <ImportFromDataCiteModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(await screen.findByText('Import Complete')).toBeInTheDocument();
+        expect(mockOnSuccess).toHaveBeenCalledOnce();
+        expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('does not call onSuccess when the import completed without new resources', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+        (axios.post as Mock).mockResolvedValue({
+            data: { import_id: 'test-import-123', message: 'Import started' },
+        });
+
+        (axios.get as Mock).mockResolvedValue({
+            data: {
+                status: 'completed',
+                total: 5,
+                processed: 5,
+                imported: 0,
+                skipped: 5,
+                failed: 0,
+                skipped_dois: ['10.5880/test.1'],
+                failed_dois: [],
+            },
+        });
+
+        render(
+            <ImportFromDataCiteModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />,
+        );
+
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(await screen.findByText('Import Complete')).toBeInTheDocument();
+        expect(mockOnSuccess).not.toHaveBeenCalled();
     });
 
     it('handles API error gracefully', async () => {

--- a/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
@@ -175,4 +175,42 @@ describe('ImportSingleOldResourceModal', () => {
         expect(mockOnSuccess).toHaveBeenCalledOnce();
         expect(mockOnClose).not.toHaveBeenCalled();
     });
+
+    it('does not call onSuccess again when the parent closes the modal after completion', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+        (axios.post as Mock).mockResolvedValue({
+            data: { import_id: 'single-import-123', message: 'Import started' },
+        });
+        (axios.get as Mock).mockResolvedValue({
+            data: {
+                status: 'completed',
+                total: 1,
+                processed: 1,
+                imported: 1,
+                skipped: 0,
+                failed: 0,
+                skipped_dois: [],
+                failed_dois: [],
+            },
+        });
+
+        const { rerender } = render(
+            <ImportSingleOldResourceModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />,
+        );
+
+        await user.type(screen.getByLabelText('DOI'), '10.5880/gfz.ojsj.2026.001');
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(await screen.findByText('Import complete')).toBeInTheDocument();
+        expect(mockOnSuccess).toHaveBeenCalledOnce();
+
+        rerender(
+            <ImportSingleOldResourceModal isOpen={false} onClose={mockOnClose} onSuccess={mockOnSuccess} />,
+        );
+
+        await waitFor(() => {
+            expect(mockOnSuccess).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
@@ -147,7 +147,7 @@ describe('ImportSingleOldResourceModal', () => {
         expect(mockOnSuccess).not.toHaveBeenCalled();
     });
 
-    it('calls onSuccess when a new resource was imported and the modal closes', async () => {
+    it('calls onSuccess as soon as a new resource was imported', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
         (axios.post as Mock).mockResolvedValue({
@@ -172,13 +172,7 @@ describe('ImportSingleOldResourceModal', () => {
         await user.click(screen.getByRole('button', { name: /start import/i }));
 
         expect(await screen.findByText('Import complete')).toBeInTheDocument();
-
-        const closeButton = screen.getAllByText('Close')[0].closest('button');
-        expect(closeButton).not.toBeNull();
-
-        await user.click(closeButton!);
-
         expect(mockOnSuccess).toHaveBeenCalledOnce();
-        expect(mockOnClose).toHaveBeenCalledOnce();
+        expect(mockOnClose).not.toHaveBeenCalled();
     });
 });

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -88,6 +88,7 @@ interface TestResource {
     title?: string;
     first_author?: { givenName?: string | null; familyName?: string | null; name?: string } | null;
     landingPage?: { id: number; is_published: boolean; public_url: string } | null;
+    [key: string]: unknown;
 }
 
 function makeResource(overrides: Partial<TestResource> = {}): TestResource {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -143,6 +143,15 @@ describe('ResourcesPage – extended', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         localStorage.clear();
+        Object.assign(mockUser, {
+            role: 'group_leader',
+            can_manage_landing_pages: true,
+            can_access_old_datasets: false,
+            can_access_statistics: false,
+            can_access_users: false,
+            can_access_logs: false,
+            can_access_editor_settings: false,
+        });
         Object.defineProperty(window, 'location', { writable: true, value: { href: '', search: '' } });
 
         // IntersectionObserver stub – does not auto-trigger
@@ -602,8 +611,6 @@ describe('ResourcesPage – extended', () => {
             const deleteBtn = screen.getByRole('button', { name: /delete resource/i });
             expect(deleteBtn).toBeDisabled();
             expect(deleteBtn).toHaveAttribute('title', 'You do not have permission to delete draft resources');
-
-            mockUser.role = 'group_leader';
         });
 
         it('opens editor when edit button is clicked', async () => {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -545,6 +545,20 @@ describe('ResourcesPage – extended', () => {
             expect(routerMock.delete).toHaveBeenCalledTimes(1);
         });
 
+        it('keeps the confirmation dialog open while the delete request is in flight', async () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', { name: /delete draft/i }));
+            });
+
+            expect(routerMock.delete).toHaveBeenCalledTimes(1);
+            expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /deleting\.\.\./i })).toBeDisabled();
+        });
+
         it('closes the delete confirmation dialog when the user cancels', () => {
             renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
 
@@ -556,7 +570,7 @@ describe('ResourcesPage – extended', () => {
             expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
         });
 
-        it('re-enables the row delete action after a failed delete finishes', async () => {
+        it('re-enables the delete confirmation after a failed delete finishes', async () => {
             renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
 
             fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
@@ -565,7 +579,7 @@ describe('ResourcesPage – extended', () => {
             });
 
             await waitFor(() => {
-                expect(screen.getByRole('button', { name: /delete resource.*disposable draft/i })).toBeDisabled();
+                expect(screen.getByRole('button', { name: /deleting\.\.\./i })).toBeDisabled();
             });
 
             const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
@@ -578,10 +592,11 @@ describe('ResourcesPage – extended', () => {
                 deleteOptions.onFinish();
             });
 
-            expect(screen.getByRole('button', { name: /delete resource.*disposable draft/i })).toBeEnabled();
+            expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /delete draft/i })).toBeEnabled();
         });
 
-        it('allows a new delete request after the previous one finishes', async () => {
+        it('allows a retry after the previous delete request finishes', async () => {
             renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
 
             fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
@@ -597,7 +612,6 @@ describe('ResourcesPage – extended', () => {
                 firstDeleteOptions.onFinish();
             });
 
-            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
             fireEvent.click(screen.getByRole('button', { name: /delete draft/i }));
 
             expect(routerMock.delete).toHaveBeenCalledTimes(2);

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -12,6 +12,7 @@ const editorRouteMock = vi.hoisted(() =>
     })),
 );
 const mockUser = vi.hoisted(() => ({
+    role: 'group_leader',
     can_manage_landing_pages: true,
     can_access_old_datasets: false,
     can_access_statistics: false,
@@ -357,6 +358,32 @@ describe('ResourcesPage – extended', () => {
             expect(screen.queryByRole('button', { name: /import all old resources/i })).not.toBeInTheDocument();
             expect(screen.queryByRole('button', { name: /import old single resource/i })).not.toBeInTheDocument();
         });
+
+        it('syncs refreshed resources and pagination props into local state after reloads', () => {
+            const initialProps = {
+                resources: [makeResource({ id: 1, title: 'Old Resource Title', doi: '10.5880/test.2024.001' })],
+                pagination: makePagination({ total: 1, to: 1 }),
+                sort: defaultSort,
+                canImportFromDataCite: true,
+            };
+
+            const { rerender } = render(<ResourcesPage {...initialProps} />);
+
+            expect(screen.getByText('Old Resource Title')).toBeInTheDocument();
+            expect(screen.getByText(/all resources have been loaded.*1 total/i)).toBeInTheDocument();
+
+            rerender(
+                <ResourcesPage
+                    {...initialProps}
+                    resources={[makeResource({ id: 2, title: 'Imported Resource Title', doi: '10.5880/test.2024.002' })]}
+                    pagination={makePagination({ total: 2, to: 1 })}
+                />,
+            );
+
+            expect(screen.queryByText('Old Resource Title')).not.toBeInTheDocument();
+            expect(screen.getByText('Imported Resource Title')).toBeInTheDocument();
+            expect(screen.getByText(/all resources have been loaded.*2 total/i)).toBeInTheDocument();
+        });
     });
 
     // ── Landing page management button ───────────────────────────────
@@ -442,8 +469,50 @@ describe('ResourcesPage – extended', () => {
 
         it('renders disabled delete button', () => {
             renderPage();
-            const deleteBtn = screen.getByRole('button', { name: /delete resource.*not yet implemented/i });
+            const deleteBtn = screen.getByRole('button', { name: /delete resource/i });
             expect(deleteBtn).toBeDisabled();
+            expect(deleteBtn).toHaveAttribute('title', 'Only draft resources can be deleted');
+        });
+
+        it('enables delete button for draft resources when the user can delete drafts', () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', landingPage: null })] });
+
+            const deleteBtn = screen.getByRole('button', { name: /delete resource/i });
+            expect(deleteBtn).toBeEnabled();
+            expect(deleteBtn).toHaveAttribute('title', 'Delete draft resource');
+        });
+
+        it('opens a confirmation dialog and submits the delete request for draft resources', async () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+
+            expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+            expect(screen.getByText(/delete draft resource\?/i)).toBeInTheDocument();
+
+            fireEvent.click(screen.getByRole('button', { name: /delete draft/i }));
+
+            expect(routerMock.delete).toHaveBeenCalledWith(
+                '/resources/1',
+                expect.objectContaining({
+                    preserveScroll: true,
+                    onSuccess: expect.any(Function),
+                    onError: expect.any(Function),
+                    onFinish: expect.any(Function),
+                }),
+            );
+        });
+
+        it('keeps the delete button disabled for draft resources when the user lacks permission', () => {
+            mockUser.role = 'beginner';
+
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', landingPage: null })] });
+
+            const deleteBtn = screen.getByRole('button', { name: /delete resource/i });
+            expect(deleteBtn).toBeDisabled();
+            expect(deleteBtn).toHaveAttribute('title', 'You do not have permission to delete draft resources');
+
+            mockUser.role = 'group_leader';
         });
 
         it('opens editor when edit button is clicked', async () => {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoisted mocks
@@ -502,6 +502,54 @@ describe('ResourcesPage – extended', () => {
                     onFinish: expect.any(Function),
                 }),
             );
+
+            const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
+                onSuccess: () => void;
+                onFinish: () => void;
+            };
+
+            await act(async () => {
+                deleteOptions.onSuccess();
+                deleteOptions.onFinish();
+            });
+
+            expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+        });
+
+        it('closes the delete confirmation dialog when the user cancels', () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+            expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+            expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+        });
+
+        it('re-enables the row delete action after a failed delete finishes', async () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+            await act(async () => {
+                fireEvent.click(screen.getByRole('button', { name: /delete draft/i }));
+            });
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /delete resource.*disposable draft/i })).toBeDisabled();
+            });
+
+            const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
+                onError: () => void;
+                onFinish: () => void;
+            };
+
+            await act(async () => {
+                deleteOptions.onError();
+                deleteOptions.onFinish();
+            });
+
+            expect(screen.getByRole('button', { name: /delete resource.*disposable draft/i })).toBeEnabled();
         });
 
         it('keeps the delete button disabled for draft resources when the user lacks permission', () => {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -476,11 +476,19 @@ describe('ResourcesPage – extended', () => {
         });
 
         it('enables delete button for draft resources when the user can delete drafts', () => {
-            renderPage({ resources: [makeResource({ publicstatus: 'draft', landingPage: null })] });
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, landingPage: null })] });
 
             const deleteBtn = screen.getByRole('button', { name: /delete resource/i });
             expect(deleteBtn).toBeEnabled();
             expect(deleteBtn).toHaveAttribute('title', 'Delete draft resource');
+        });
+
+        it('keeps the delete button disabled for draft resources with persistent identifiers', () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', title: 'Registered Draft', landingPage: null })] });
+
+            const deleteBtn = screen.getByRole('button', { name: /delete resource.*10\.5880\/test\.2024\.001/i });
+            expect(deleteBtn).toBeDisabled();
+            expect(deleteBtn).toHaveAttribute('title', 'Resources with persistent identifiers cannot be deleted');
         });
 
         it('opens a confirmation dialog and submits the delete request for draft resources', async () => {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -516,6 +516,18 @@ describe('ResourcesPage – extended', () => {
             expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
         });
 
+        it('ignores rapid repeated delete confirmations within the same dialog open', () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+
+            const confirmDeleteButton = screen.getByRole('button', { name: /delete draft/i });
+            fireEvent.click(confirmDeleteButton);
+            fireEvent.click(confirmDeleteButton);
+
+            expect(routerMock.delete).toHaveBeenCalledTimes(1);
+        });
+
         it('closes the delete confirmation dialog when the user cancels', () => {
             renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
 
@@ -550,6 +562,28 @@ describe('ResourcesPage – extended', () => {
             });
 
             expect(screen.getByRole('button', { name: /delete resource.*disposable draft/i })).toBeEnabled();
+        });
+
+        it('allows a new delete request after the previous one finishes', async () => {
+            renderPage({ resources: [makeResource({ publicstatus: 'draft', doi: null, title: 'Disposable Draft', landingPage: null })] });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+            fireEvent.click(screen.getByRole('button', { name: /delete draft/i }));
+
+            const firstDeleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
+                onError: () => void;
+                onFinish: () => void;
+            };
+
+            await act(async () => {
+                firstDeleteOptions.onError();
+                firstDeleteOptions.onFinish();
+            });
+
+            fireEvent.click(screen.getByRole('button', { name: /delete resource.*disposable draft/i }));
+            fireEvent.click(screen.getByRole('button', { name: /delete draft/i }));
+
+            expect(routerMock.delete).toHaveBeenCalledTimes(2);
         });
 
         it('keeps the delete button disabled for draft resources when the user lacks permission', () => {

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -27,6 +27,7 @@ vi.mock('@inertiajs/react', () => ({
             auth: {
                 user: {
                     can_manage_landing_pages: true,
+                    role: 'group_leader',
                 },
             },
         },
@@ -116,9 +117,9 @@ describe('ResourcesPage', () => {
         expect(
             screen.getByRole('button', { name: /open resource.*10\.9999\/example.*in.*editor/i }),
         ).toBeInTheDocument();
-        // Delete functionality is not yet implemented (disabled button)
-        const deleteButton = screen.getByRole('button', { name: /delete resource.*10\.9999\/example.*not yet implemented/i });
+        const deleteButton = screen.getByRole('button', { name: /delete resource.*10\.9999\/example/i });
         expect(deleteButton).toBeDisabled();
+        expect(deleteButton).toHaveAttribute('title', 'Only draft resources can be deleted');
     });
 
     it('shows a friendly empty state when there are no resources', () => {
@@ -171,8 +172,7 @@ describe('ResourcesPage', () => {
         const dataRows = screen.getAllByRole('row').slice(1);
         expect(within(dataRows[0]).getByText('Not registered')).toBeInTheDocument();
 
-        // Delete functionality is not yet implemented - skip dialog test
-        // fireEvent.click(screen.getByRole('button', { name: /delete.*placeholder title.*from ernie/i }));
+        expect(screen.getByRole('button', { name: /delete resource.*placeholder title/i })).toBeDisabled();
     });
 
     it('opens the curation editor with prefilled metadata when the action is triggered', async () => {


### PR DESCRIPTION
This pull request introduces several improvements and fixes across resource management, draft handling, and landing page modals, with a focus on enhancing user experience and ensuring state consistency. The most significant changes include stricter authorization and clearer messaging for deleting draft resources, robust session-based draft persistence in the landing page setup modal to prevent accidental data loss, and immediate UI updates after legacy imports or draft deletions. The changelog and UI text have also been updated for clarity.

**Resource Deletion Authorization and Messaging**
- Updated the `ResourcePolicy` so that only curators, group leaders, and admins can delete draft resources, and only if the resource has not been assigned a DOI and is in draft status. This prevents published resources from being deleted by mistake.
- Clarified controller and UI messages to indicate that only draft resources are being deleted, and updated success messages accordingly.

**Landing Page Modal: Draft Persistence and Restoration**
- Implemented robust session storage logic in `SetupLandingPageModal.tsx` to persist unsaved draft state (including links and fields) on a per-resource basis. This ensures that reopening the modal in the same tab restores any unsaved changes, preventing accidental data loss. [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R60-R194) [[2]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950L121-R319) [[3]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R344)
- Automatically clears persisted draft state when changes are saved or reverted to the baseline, keeping the session storage clean and in sync with the backend. [[1]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R559) [[2]](diffhunk://#diff-71d2bc0d8f279b0432e78a56221f61e2731f113f15d720233ba83559c4ca4950R601-R604)

**UI Consistency and Usability**
- The landing page modal now properly resets and hydrates state when opened or closed, ensuring no stale or orphaned data remains.
- Updated the download URL label in the modal for clarity.

**Resource Import and List Refresh**
- Added logic to immediately refresh the `/resources` list after successful legacy imports, ensuring the UI stays in sync with backend changes. [[1]](diffhunk://#diff-acda986becf8e7f7ab246831bba2de3a63f59f3e990a401d738c598e78058014L4-R4) [[2]](diffhunk://#diff-acda986becf8e7f7ab246831bba2de3a63f59f3e990a401d738c598e78058014R46)

**Changelog and Documentation**
- Updated the changelog date and added a detailed entry summarizing these fixes and improvements for better project tracking. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR258-R261)