### PR TITLE
Fix: Unwanted Brackets in Affiliation Names when Data editor is used with Firefox

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-05-31",
+        "date": "2026-06-02",
         "features": [
             {
                 "title": "Landing Page and Portal Statistics Dashboard",

--- a/resources/js/components/curation/fields/tag-input-field.tsx
+++ b/resources/js/components/curation/fields/tag-input-field.tsx
@@ -47,7 +47,12 @@ export function TagInputField<T extends TagInputItem = TagInputItem>({
     const tagifyRef = useRef<Tagify<TagData> | null>(null);
     const changeHandlerRef = useRef(onChange);
     const editingRorIdRef = useRef<string | null>(null);
-    const originalDelimitersRef = useRef<string | RegExp | null>(null);
+    const originalDelimitersRef = useRef<string | RegExp>(',');
+    const delimitersWereSuspendedRef = useRef(false);
+    const originalDropdownEnabledRef = useRef<number | false>(0);
+    const dropdownWasSuspendedRef = useRef(false);
+    const originalAutoCompleteEnabledRef = useRef(true);
+    const autoCompleteWasSuspendedRef = useRef(false);
 
     useEffect(() => {
         changeHandlerRef.current = onChange;
@@ -130,11 +135,50 @@ export function TagInputField<T extends TagInputItem = TagInputItem>({
             changeHandlerRef.current({ raw: rawValue, tags });
         };
 
-        const restoreDelimiters = () => {
-            if (originalDelimitersRef.current !== null) {
-                tagify.settings.delimiters = originalDelimitersRef.current;
-                originalDelimitersRef.current = null;
+        const suspendAffiliationEditFormatting = () => {
+            if (!delimitersWereSuspendedRef.current) {
+                originalDelimitersRef.current = tagify.settings.delimiters;
+                delimitersWereSuspendedRef.current = true;
             }
+
+            tagify.settings.delimiters = /(?!)/;
+
+            if (tagify.settings.dropdown && !dropdownWasSuspendedRef.current) {
+                originalDropdownEnabledRef.current = tagify.settings.dropdown.enabled;
+                dropdownWasSuspendedRef.current = true;
+            }
+
+            if (tagify.settings.dropdown) {
+                tagify.settings.dropdown.enabled = false;
+                tagify.dropdown.hide(true);
+            }
+
+            if (tagify.settings.autoComplete && !autoCompleteWasSuspendedRef.current) {
+                originalAutoCompleteEnabledRef.current = tagify.settings.autoComplete.enabled;
+                autoCompleteWasSuspendedRef.current = true;
+            }
+
+            if (tagify.settings.autoComplete) {
+                tagify.settings.autoComplete.enabled = false;
+            }
+        };
+
+        const restoreAffiliationEditFormatting = () => {
+            if (delimitersWereSuspendedRef.current) {
+                tagify.settings.delimiters = originalDelimitersRef.current;
+                delimitersWereSuspendedRef.current = false;
+            }
+
+            if (dropdownWasSuspendedRef.current && tagify.settings.dropdown) {
+                tagify.settings.dropdown.enabled = originalDropdownEnabledRef.current;
+                dropdownWasSuspendedRef.current = false;
+            }
+
+            if (autoCompleteWasSuspendedRef.current && tagify.settings.autoComplete) {
+                tagify.settings.autoComplete.enabled = originalAutoCompleteEnabledRef.current;
+                autoCompleteWasSuspendedRef.current = false;
+            }
+
             editingRorIdRef.current = null;
         };
 
@@ -142,11 +186,9 @@ export function TagInputField<T extends TagInputItem = TagInputItem>({
             const tagData = event.detail?.data as Record<string, unknown> | undefined;
             const rorId = typeof tagData?.rorId === 'string' ? tagData.rorId : null;
             editingRorIdRef.current = rorId;
-            // Only suspend delimiters for tags with a ROR ID (affiliation tags)
-            // to avoid changing comma-separator behavior in other fields (e.g. Free Keywords)
+
             if (rorId) {
-                originalDelimitersRef.current = tagify.settings.delimiters;
-                tagify.settings.delimiters = /(?!)/;
+                suspendAffiliationEditFormatting();
             }
         };
 
@@ -155,13 +197,13 @@ export function TagInputField<T extends TagInputItem = TagInputItem>({
             if (tagData && editingRorIdRef.current) {
                 tagData.rorId = editingRorIdRef.current;
             }
-            restoreDelimiters();
+            restoreAffiliationEditFormatting();
         };
 
         const handleEditKeydown = (event: CustomEvent) => {
             const keyboardEvent = (event.detail as { event?: KeyboardEvent })?.event;
             if (keyboardEvent?.key === 'Escape') {
-                restoreDelimiters();
+                restoreAffiliationEditFormatting();
             }
         };
 
@@ -215,6 +257,22 @@ export function TagInputField<T extends TagInputItem = TagInputItem>({
                 ...tagify.settings.dropdown,
                 ...tagifySettings.dropdown,
             };
+        }
+
+        if (editingRorIdRef.current) {
+            if (tagifySettings.dropdown && 'enabled' in tagifySettings.dropdown && tagifySettings.dropdown.enabled !== undefined) {
+                originalDropdownEnabledRef.current = tagifySettings.dropdown.enabled;
+                dropdownWasSuspendedRef.current = true;
+            }
+
+            if (tagify.settings.dropdown) {
+                tagify.settings.dropdown.enabled = false;
+                tagify.dropdown.hide(true);
+            }
+
+            if (tagify.settings.autoComplete) {
+                tagify.settings.autoComplete.enabled = false;
+            }
         }
     }, [tagifySettings]);
 

--- a/resources/js/pages/changelog.tsx
+++ b/resources/js/pages/changelog.tsx
@@ -206,6 +206,7 @@ export default function Changelog() {
 
         // Listen for hash changes triggered outside navigateToRelease()
         window.addEventListener('hashchange', processHash);
+        processHash();
 
         return () => {
             window.removeEventListener('hashchange', processHash);

--- a/tests/playwright/workflows/13-affiliation-tag-editing.spec.ts
+++ b/tests/playwright/workflows/13-affiliation-tag-editing.spec.ts
@@ -91,7 +91,16 @@ async function startInlineTagEdit(page: Page, section: AffiliationSection, field
   await tagText.scrollIntoViewIfNeeded();
   await tagText.dblclick();
 
-  const editableTagText = field.locator('.tagify__tag [contenteditable], .tagify__tag[contenteditable]').first();
+  const editableTagText = field
+    .locator(
+      [
+        '.tagify__tag [contenteditable="true"]',
+        '.tagify__tag[contenteditable="true"]',
+        '.tagify__tag [contenteditable="plaintext-only"]',
+        '.tagify__tag[contenteditable="plaintext-only"]',
+      ].join(', '),
+    )
+    .first();
   try {
     await editableTagText.waitFor({ state: 'visible', timeout: 1500 });
   } catch {

--- a/tests/playwright/workflows/13-affiliation-tag-editing.spec.ts
+++ b/tests/playwright/workflows/13-affiliation-tag-editing.spec.ts
@@ -1,0 +1,155 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { loginAsTestUser } from '../helpers/test-helpers';
+
+const ORIGINAL_AFFILIATION = 'GFZ Helmholtz Centre for Geosciences';
+const EDITED_AFFILIATION = 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany';
+const GFZ_ROR_ID = 'https://ror.org/04z8jg394';
+
+interface AffiliationSection {
+  addButtonName: RegExp;
+  fieldTestId: string;
+  inputTestId: string;
+  label: string;
+  rorBadgeTestId: string;
+  triggerName: RegExp;
+}
+
+const sections: AffiliationSection[] = [
+  {
+    addButtonName: /Add First Author/i,
+    fieldTestId: 'author-0-affiliations-field',
+    inputTestId: 'author-0-affiliations-input',
+    label: 'author',
+    rorBadgeTestId: 'author-0-affiliations-ror-ids',
+    triggerName: /Authors/i,
+  },
+  {
+    addButtonName: /Add First Contributor/i,
+    fieldTestId: 'contributor-0-affiliations-field',
+    inputTestId: 'contributor-0-affiliations-input',
+    label: 'contributor',
+    rorBadgeTestId: 'contributor-0-affiliations-ror-ids',
+    triggerName: /Contributors/i,
+  },
+];
+
+async function mockRorAffiliations(page: Page) {
+  await page.route('**/api/v1/ror-affiliations', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      status: 200,
+      body: JSON.stringify([
+        {
+          prefLabel: ORIGINAL_AFFILIATION,
+          rorId: GFZ_ROR_ID,
+          otherLabel: ['GFZ', 'GeoForschungsZentrum Potsdam'],
+        },
+      ]),
+    });
+  });
+}
+
+async function expandAccordion(page: Page, triggerName: RegExp) {
+  const trigger = page.locator('[data-slot="accordion-trigger"]', { hasText: triggerName }).first();
+  await trigger.waitFor({ state: 'visible', timeout: 10000 });
+
+  if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+    await trigger.scrollIntoViewIfNeeded();
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  }
+}
+
+async function addFirstEntry(page: Page, section: AffiliationSection): Promise<Locator> {
+  await expandAccordion(page, section.triggerName);
+
+  const addButton = page.getByRole('button', { name: section.addButtonName }).first();
+  await addButton.scrollIntoViewIfNeeded();
+  await addButton.click();
+
+  const field = page.getByTestId(section.fieldTestId);
+  await field.waitFor({ state: 'visible', timeout: 10000 });
+  return field;
+}
+
+async function selectGfzAffiliation(page: Page, field: Locator) {
+  const tagInput = field.locator('.tagify__input').first();
+  await tagInput.scrollIntoViewIfNeeded();
+  await tagInput.click();
+  await tagInput.fill('GFZ');
+
+  const suggestion = page.locator('.tagify__dropdown__item', { hasText: ORIGINAL_AFFILIATION }).first();
+  await suggestion.waitFor({ state: 'visible', timeout: 10000 });
+  await suggestion.click();
+
+  await expect(field.locator('.tagify__tag-text').first()).toHaveText(ORIGINAL_AFFILIATION);
+}
+
+async function startInlineTagEdit(page: Page, section: AffiliationSection, field: Locator): Promise<Locator> {
+  const tagText = field.locator('.tagify__tag-text').first();
+  await tagText.scrollIntoViewIfNeeded();
+  await tagText.dblclick();
+
+  const editableTagText = field.locator('.tagify__tag [contenteditable], .tagify__tag[contenteditable]').first();
+  try {
+    await editableTagText.waitFor({ state: 'visible', timeout: 1500 });
+  } catch {
+    await page.getByTestId(section.inputTestId).evaluate((input) => {
+      const tagify = (input as HTMLInputElement & {
+        tagify?: {
+          editTag?: (tagElement: HTMLElement) => void;
+          getTagElms?: () => HTMLElement[];
+        };
+      }).tagify;
+      const tagElement = tagify?.getTagElms?.()[0] ?? input.parentElement?.querySelector<HTMLElement>('.tagify__tag');
+
+      if (!tagify?.editTag || !tagElement) {
+        throw new Error('Unable to start Tagify inline editing for the affiliation tag.');
+      }
+
+      tagify.editTag(tagElement);
+    });
+    await editableTagText.waitFor({ state: 'visible', timeout: 5000 });
+  }
+
+  return editableTagText;
+}
+
+async function editGfzAffiliation(page: Page, section: AffiliationSection, field: Locator) {
+  const editableTagText = await startInlineTagEdit(page, section, field);
+  await editableTagText.fill(EDITED_AFFILIATION);
+  await editableTagText.press('Enter');
+}
+
+async function expectEditedAffiliation(page: Page, section: AffiliationSection, field: Locator) {
+  const tagText = field.locator('.tagify__tag-text').first();
+  await expect(tagText).toHaveText(EDITED_AFFILIATION);
+  await expect(page.getByTestId(section.inputTestId)).toHaveValue(EDITED_AFFILIATION);
+
+  const visibleLabel = (await tagText.textContent())?.trim() ?? '';
+  expect(visibleLabel).toBe(EDITED_AFFILIATION);
+  expect(visibleLabel.startsWith('(')).toBe(false);
+
+  const rorBadge = page.getByTestId(section.rorBadgeTestId);
+  await expect(rorBadge).toContainText(EDITED_AFFILIATION);
+  await expect(rorBadge).toContainText(GFZ_ROR_ID);
+}
+
+test.describe('Affiliation tag editing', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRorAffiliations(page);
+    await loginAsTestUser(page);
+    await page.goto('/editor');
+  });
+
+  for (const section of sections) {
+    test(`keeps the edited GFZ ROR affiliation exact for ${section.label}s`, async ({ page }) => {
+      const field = await addFirstEntry(page, section);
+
+      await selectGfzAffiliation(page, field);
+      await editGfzAffiliation(page, section, field);
+      await expectEditedAffiliation(page, section, field);
+    });
+  }
+});

--- a/tests/vitest/components/curation/fields/tag-input-field-edit.test.tsx
+++ b/tests/vitest/components/curation/fields/tag-input-field-edit.test.tsx
@@ -21,6 +21,22 @@ function getTagifyInstance(inputId: string): MockTagify {
     return input.tagify;
 }
 
+function getDropdownSettings(tagify: MockTagify): { enabled: number | boolean } {
+    const dropdown = tagify.settings.dropdown;
+    if (!dropdown || typeof dropdown !== 'object') {
+        throw new Error('Expected dropdown settings to exist');
+    }
+    return dropdown as { enabled: number | boolean };
+}
+
+function getAutoCompleteSettings(tagify: MockTagify): { enabled: boolean } {
+    const autoComplete = tagify.settings.autoComplete;
+    if (!autoComplete || typeof autoComplete !== 'object') {
+        throw new Error('Expected autoComplete settings to exist');
+    }
+    return autoComplete as { enabled: boolean };
+}
+
 describe('TagInputField — edit mode rorId preservation', () => {
     afterEach(() => {
         cleanup();
@@ -76,10 +92,14 @@ describe('TagInputField — edit mode rorId preservation', () => {
         tagify.emit('edit:start', { data: { value: 'GFZ Helmholtz Centre for Geosciences', rorId } });
         expect(tagify.settings.delimiters).toBeInstanceOf(RegExp);
         expect(','.match(tagify.settings.delimiters as RegExp)).toBeNull();
+        expect(getDropdownSettings(tagify).enabled).toBe(false);
+        expect(getAutoCompleteSettings(tagify).enabled).toBe(false);
 
         // Simulate edit:updated — delimiter should be restored
         tagify.emit('edit:updated', { data: { value: 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany' } });
         expect(tagify.settings.delimiters).toBe(',');
+        expect(getDropdownSettings(tagify).enabled).toBe(0);
+        expect(getAutoCompleteSettings(tagify).enabled).toBe(true);
     });
 
     it('does not suspend delimiter when editing a tag without rorId', () => {
@@ -150,5 +170,90 @@ describe('TagInputField — edit mode rorId preservation', () => {
 
         // rorId should NOT be set since the original had none
         expect(editedTagData.rorId).toBeUndefined();
+    });
+
+    it('keeps an edited ROR affiliation label exactly as typed and preserves rorId', () => {
+        const onChange = vi.fn();
+        const rorId = 'https://ror.org/04z8jg394';
+        const editedValue = 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany';
+
+        render(
+            <TagInputField
+                id="affiliations"
+                label="Affiliations"
+                value={[{ value: 'GFZ Helmholtz Centre for Geosciences', rorId }]}
+                onChange={onChange}
+                tagifySettings={{
+                    whitelist: [{ value: 'GFZ Helmholtz Centre for Geosciences', rorId, searchTerms: ['GFZ'] }],
+                    dropdown: {
+                        enabled: 1,
+                        maxItems: 20,
+                        closeOnSelect: true,
+                        searchKeys: ['value', 'searchTerms'],
+                    },
+                }}
+            />,
+        );
+
+        const tagify = getTagifyInstance('affiliations');
+        expect(getDropdownSettings(tagify).enabled).toBe(1);
+
+        tagify.emit('edit:start', { data: { value: 'GFZ Helmholtz Centre for Geosciences', rorId } });
+        expect(getDropdownSettings(tagify).enabled).toBe(false);
+        expect(getAutoCompleteSettings(tagify).enabled).toBe(false);
+
+        const editedTagData: Record<string, unknown> = { value: editedValue };
+        tagify.value = [{ value: editedValue, rorId, data: { rorId } }];
+        tagify.emit('edit:updated', { data: editedTagData });
+        tagify.emit('change', { value: editedValue, tagify });
+
+        expect(editedTagData).toEqual({ value: editedValue, rorId });
+        expect(editedValue.startsWith('(')).toBe(false);
+        expect(onChange).toHaveBeenLastCalledWith({
+            raw: editedValue,
+            tags: [{ value: editedValue, rorId }],
+        });
+        expect(getDropdownSettings(tagify).enabled).toBe(1);
+        expect(getAutoCompleteSettings(tagify).enabled).toBe(true);
+    });
+
+    it('keeps dropdown suspended if affiliation suggestions load while a ROR tag is being edited', () => {
+        const onChange = vi.fn();
+        const rorId = 'https://ror.org/04z8jg394';
+        const initialValue = [{ value: 'GFZ Helmholtz Centre for Geosciences', rorId }];
+
+        const { rerender } = render(
+            <TagInputField
+                id="affiliations"
+                label="Affiliations"
+                value={initialValue}
+                onChange={onChange}
+                tagifySettings={{
+                    whitelist: [],
+                    dropdown: { enabled: 0 },
+                }}
+            />,
+        );
+
+        const tagify = getTagifyInstance('affiliations');
+        tagify.emit('edit:start', { data: { value: 'GFZ Helmholtz Centre for Geosciences', rorId } });
+
+        rerender(
+            <TagInputField
+                id="affiliations"
+                label="Affiliations"
+                value={initialValue}
+                onChange={onChange}
+                tagifySettings={{
+                    whitelist: [{ value: 'GFZ Helmholtz Centre for Geosciences', rorId, searchTerms: ['GFZ'] }],
+                    dropdown: { enabled: 1 },
+                }}
+            />,
+        );
+
+        expect(getDropdownSettings(tagify).enabled).toBe(false);
+
+        tagify.emit('edit:updated', { data: { value: 'GFZ Helmholtz Centre for Geosciences, Potsdam, Germany' } });
+        expect(getDropdownSettings(tagify).enabled).toBe(1);
     });
 });

--- a/tests/vitest/pages/__tests__/changelog.test.tsx
+++ b/tests/vitest/pages/__tests__/changelog.test.tsx
@@ -349,13 +349,19 @@ describe('Changelog', () => {
         const firstButton = await screen.findByRole('button', { name: /version 0.1.0/i });
         const targetButton = screen.getByRole('button', { name: /version 0.2.0/i });
 
+        await vi.waitFor(() => {
+            expect(firstButton).toHaveAttribute('aria-expanded', 'true');
+        });
+
         await act(async () => {
             window.history.pushState(null, '', '/changelog#v0.2.0');
             window.dispatchEvent(new HashChangeEvent('hashchange'));
         });
 
-        expect(targetButton).toHaveAttribute('aria-expanded', 'true');
-        expect(firstButton).toHaveAttribute('aria-expanded', 'false');
+        await vi.waitFor(() => {
+            expect(targetButton).toHaveAttribute('aria-expanded', 'true');
+            expect(firstButton).toHaveAttribute('aria-expanded', 'false');
+        });
     });
 
     it('keeps the open release stable when scroll-based highlighting changes', async () => {

--- a/tests/vitest/test-helpers/tagify-mock.ts
+++ b/tests/vitest/test-helpers/tagify-mock.ts
@@ -40,7 +40,7 @@ export class MockTagify {
     public whitelist: Array<Record<string, unknown>> = [];
     public dropdownHideCalls = 0;
     public dropdown = {
-        hide: (_force?: boolean) => {
+        hide: () => {
             this.dropdownHideCalls += 1;
         },
     };

--- a/tests/vitest/test-helpers/tagify-mock.ts
+++ b/tests/vitest/test-helpers/tagify-mock.ts
@@ -38,12 +38,18 @@ export class MockTagify {
     public value: MockTagifyValue[] = [];
     public settings: Record<string, unknown> = {};
     public whitelist: Array<Record<string, unknown>> = [];
+    public dropdownHideCalls = 0;
+    public dropdown = {
+        hide: (_force?: boolean) => {
+            this.dropdownHideCalls += 1;
+        },
+    };
     private inputElement: HTMLInputElement;
     private handlers = new Map<string, Set<ChangeHandler>>();
 
     constructor(inputElement: HTMLInputElement, settings?: Record<string, unknown>) {
         this.inputElement = inputElement;
-        this.settings = { delimiters: ',', editTags: 1, ...settings };
+        this.settings = { delimiters: ',', editTags: 1, dropdown: { enabled: 0 }, autoComplete: { enabled: true }, ...settings };
 
         const scope = document.createElement('div');
         scope.className = 'tagify';


### PR DESCRIPTION
This pull request introduces significant improvements to the affiliation tag editing experience in the `TagInputField` component, ensuring that editing ROR affiliation tags preserves formatting, disables disruptive UI features during editing, and maintains data integrity. It also adds comprehensive automated tests to validate these behaviors and makes minor updates elsewhere.

**Key changes:**

### Tag Editing Behavior Improvements

* Refactored the `TagInputField` component to suspend delimiters, dropdown suggestions, and autocomplete while editing affiliation tags with a ROR ID, restoring the original settings after editing. This prevents accidental tag splitting and unwanted UI interference during inline editing. (`resources/js/components/curation/fields/tag-input-field.tsx`) [[1]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL50-R55) [[2]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL133-R191) [[3]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL158-R206) [[4]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fR261-R276)
* Ensured that, when editing a ROR affiliation, the label is kept exactly as typed and the ROR ID is preserved, avoiding unwanted formatting changes or data loss. (`resources/js/components/curation/fields/tag-input-field.tsx`) [[1]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL133-R191) [[2]](diffhunk://#diff-31f88b04644ce88464fca6099f565cd3da4c71a1ffd147c8f33bb03c98746a8fL158-R206)

### Automated Testing

* Added a comprehensive Playwright end-to-end test suite for affiliation tag editing, covering both authors and contributors, to verify correct label handling, ROR ID preservation, and UI behavior. (`tests/playwright/workflows/13-affiliation-tag-editing.spec.ts`)
* Enhanced unit tests for tag editing to check that dropdown and autocomplete settings are correctly suspended and restored, and to ensure the edited label and ROR ID are handled as expected. (`tests/vitest/components/curation/fields/tag-input-field-edit.test.tsx`, `tests/vitest/test-helpers/tagify-mock.ts`) [[1]](diffhunk://#diff-7f7000e65f52e7c2b01abaf6c861e7143c35c4101aa4bf1cfb82f385c6fcd06aR24-R39) [[2]](diffhunk://#diff-7f7000e65f52e7c2b01abaf6c861e7143c35c4101aa4bf1cfb82f385c6fcd06aR95-R102) [[3]](diffhunk://#diff-7f7000e65f52e7c2b01abaf6c861e7143c35c4101aa4bf1cfb82f385c6fcd06aR174-R258) [[4]](diffhunk://#diff-2b9630bf5f45ff9a61218cb65ae5c154dffc584d48ac8d574caf13d8b3741088R41-R52)

### Minor Fixes

* Updated the changelog date in `changelog.json` to reflect the new release date. (`resources/data/changelog.json`)
* Fixed a bug in the changelog page to ensure the correct release is highlighted on page load. (`resources/js/pages/changelog.tsx`, `tests/vitest/pages/__tests__/changelog.test.tsx`) [[1]](diffhunk://#diff-4b8dd37df23c47fa47be184dbd30b84cab83d7b9a24d2aee1ed68bfe0672fdbbR209) [[2]](diffhunk://#diff-aeb97b0d86e17eb437fee8cf37fa6db0f889da5cc3544bce7faff645ab54dd5aR352-R365)