### PR TITLE
Fix: Name of unique indexes too long

### DIFF
--- a/database/migrations/2026_05_27_000001_create_landing_page_daily_statistics_table.php
+++ b/database/migrations/2026_05_27_000001_create_landing_page_daily_statistics_table.php
@@ -23,7 +23,7 @@ return new class extends Migration
             $table->unsignedInteger('file_download_click_count')->default(0);
             $table->timestamps();
 
-            $table->unique(['landing_page_id', 'statistic_date']);
+            $table->unique(['landing_page_id', 'statistic_date'], 'lp_daily_stats_page_date_unique');
             $table->index('statistic_date');
         });
     }

--- a/database/migrations/2026_05_27_000002_create_portal_search_daily_statistics_table.php
+++ b/database/migrations/2026_05_27_000002_create_portal_search_daily_statistics_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->unsignedInteger('search_count')->default(0);
             $table->timestamps();
 
-            $table->unique(['statistic_date', 'normalized_term']);
+            $table->unique(['statistic_date', 'normalized_term'], 'portal_search_stats_date_term_unique');
             $table->index('normalized_term');
             $table->index('statistic_date');
         });


### PR DESCRIPTION
This pull request updates the database migration files to explicitly name unique constraints, which improves maintainability and makes future schema changes or troubleshooting easier.

**Database migration improvements:**

* Added an explicit name (`lp_daily_stats_page_date_unique`) to the unique constraint on the `landing_page_id` and `statistic_date` columns in `create_landing_page_daily_statistics_table.php`.
* Added an explicit name (`portal_search_stats_date_term_unique`) to the unique constraint on the `statistic_date` and `normalized_term` columns in `create_portal_search_daily_statistics_table.php`.