### PR TITLE
Fix: Exclude global coverage from maps and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,11 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 
+# Optional tolerance for detecting whole-world geographic boxes.
+# Keep the backend and Vite values in sync when overriding the default.
+GEO_GLOBAL_COVERAGE_TOLERANCE=
+VITE_GEO_GLOBAL_COVERAGE_TOLERANCE="${GEO_GLOBAL_COVERAGE_TOLERANCE}"
+
 # Google Maps API Key for geocoding and map display
 GM_API_KEY=
 

--- a/app/Models/GeoLocation.php
+++ b/app/Models/GeoLocation.php
@@ -41,6 +41,8 @@ class GeoLocation extends Model
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
     use HasFactory;
 
+    public const GLOBAL_COVERAGE_TOLERANCE = 0.000001;
+
     protected $casts = [
         'point_longitude' => 'decimal:8',
         'point_latitude' => 'decimal:8',
@@ -84,6 +86,25 @@ class GeoLocation extends Model
     }
 
     /**
+     * Check if this bounding box covers the whole world.
+     */
+    public function isGlobalCoverage(): bool
+    {
+        if (! $this->hasBox()) {
+            return false;
+        }
+
+        if ($this->geo_type !== null && $this->geo_type !== 'box') {
+            return false;
+        }
+
+        return $this->isNear((float) $this->west_bound_longitude, -180.0)
+            && $this->isNear((float) $this->east_bound_longitude, 180.0)
+            && $this->isNear((float) $this->south_bound_latitude, -90.0)
+            && $this->isNear((float) $this->north_bound_latitude, 90.0);
+    }
+
+    /**
      * Check if this has a place name defined.
      */
     public function hasPlace(): bool
@@ -121,5 +142,10 @@ class GeoLocation extends Model
     public function hasElevation(): bool
     {
         return $this->elevation !== null;
+    }
+
+    private function isNear(float $actual, float $expected): bool
+    {
+        return abs($actual - $expected) <= self::GLOBAL_COVERAGE_TOLERANCE;
     }
 }

--- a/app/Models/GeoLocation.php
+++ b/app/Models/GeoLocation.php
@@ -146,6 +146,11 @@ class GeoLocation extends Model
 
     private function isNear(float $actual, float $expected): bool
     {
-        return abs($actual - $expected) <= self::GLOBAL_COVERAGE_TOLERANCE;
+        $configuredTolerance = config('app.geo.global_coverage_tolerance');
+        $tolerance = is_numeric($configuredTolerance)
+            ? max(0.0, (float) $configuredTolerance)
+            : self::GLOBAL_COVERAGE_TOLERANCE;
+
+        return abs($actual - $expected) <= $tolerance;
     }
 }

--- a/app/Services/PortalSearchService.php
+++ b/app/Services/PortalSearchService.php
@@ -1028,26 +1028,30 @@ class PortalSearchService
      */
     private function formatGeoLocations(Resource $resource): array
     {
-        return $resource->geoLocations->map(function (GeoLocation $geo): array {
-            return [
-                'id' => $geo->id,
-                'type' => $this->determineGeoType($geo),
-                'point' => $geo->point_latitude !== null && $geo->point_longitude !== null
-                    ? ['lat' => (float) $geo->point_latitude, 'lng' => (float) $geo->point_longitude]
-                    : null,
-                'bounds' => $geo->west_bound_longitude !== null
-                    ? [
-                        'north' => (float) $geo->north_bound_latitude,
-                        'south' => (float) $geo->south_bound_latitude,
-                        'east' => (float) $geo->east_bound_longitude,
-                        'west' => (float) $geo->west_bound_longitude,
-                    ]
-                    : null,
-                'polygon' => $geo->polygon_points !== null
-                    ? array_map(fn (array $p): array => ['lat' => $p['latitude'], 'lng' => $p['longitude']], $geo->polygon_points)
-                    : null,
-            ];
-        })->all();
+        return $resource->geoLocations
+            ->reject(static fn (GeoLocation $geo): bool => $geo->isGlobalCoverage())
+            ->map(function (GeoLocation $geo): array {
+                return [
+                    'id' => $geo->id,
+                    'type' => $this->determineGeoType($geo),
+                    'point' => $geo->point_latitude !== null && $geo->point_longitude !== null
+                        ? ['lat' => (float) $geo->point_latitude, 'lng' => (float) $geo->point_longitude]
+                        : null,
+                    'bounds' => $geo->west_bound_longitude !== null
+                        ? [
+                            'north' => (float) $geo->north_bound_latitude,
+                            'south' => (float) $geo->south_bound_latitude,
+                            'east' => (float) $geo->east_bound_longitude,
+                            'west' => (float) $geo->west_bound_longitude,
+                        ]
+                        : null,
+                    'polygon' => $geo->polygon_points !== null
+                        ? array_map(fn (array $p): array => ['lat' => $p['latitude'], 'lng' => $p['longitude']], $geo->polygon_points)
+                        : null,
+                ];
+            })
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Services/PortalSearchService.php
+++ b/app/Services/PortalSearchService.php
@@ -1037,7 +1037,7 @@ class PortalSearchService
                     'point' => $geo->point_latitude !== null && $geo->point_longitude !== null
                         ? ['lat' => (float) $geo->point_latitude, 'lng' => (float) $geo->point_longitude]
                         : null,
-                    'bounds' => $geo->west_bound_longitude !== null
+                    'bounds' => $geo->hasBox()
                         ? [
                             'north' => (float) $geo->north_bound_latitude,
                             'south' => (float) $geo->south_bound_latitude,
@@ -1069,7 +1069,7 @@ class PortalSearchService
             return 'polygon';
         }
 
-        if ($geo->west_bound_longitude !== null) {
+        if ($geo->hasBox()) {
             return 'box';
         }
 

--- a/config/app.php
+++ b/config/app.php
@@ -74,7 +74,7 @@ return [
     |
     | Configure application-level geographic interpretation. The global coverage
     | tolerance is optional; when unset, GeoLocation falls back to its built-in
-    | default so older deployments keep their existing behaviour.
+    | default for detecting whole-world bounding boxes.
     |
     */
 

--- a/config/app.php
+++ b/config/app.php
@@ -69,6 +69,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Geographic Coverage
+    |--------------------------------------------------------------------------
+    |
+    | Configure application-level geographic interpretation. The global coverage
+    | tolerance is optional; when unset, GeoLocation falls back to its built-in
+    | default so older deployments keep their existing behaviour.
+    |
+    */
+
+    'geo' => [
+        'global_coverage_tolerance' => env('GEO_GLOBAL_COVERAGE_TOLERANCE'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-06-02",
+        "date": "2026-06-03",
         "features": [
             {
                 "title": "Landing Page and Portal Statistics Dashboard",
@@ -255,6 +255,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "Global Coverage Handling on Landing Page and Portal Maps",
+                "description": "Landing Page Location sections now treat exact whole-world bounding boxes as global coverage instead of drawing them as oversized rectangles. Global-only resources show a concise spatial coverage notice, mixed global and local coverage keeps the local geometries visible, and Landing Page maps use a 2:1 layout with Leaflet world wrapping disabled. The public portal map also excludes global coverage shapes so worldwide resources no longer cover more specific results on the map while remaining available in the search result list."
+            },
             {
                 "title": "Resources List Actions Stay in Sync",
                 "description": "The /resources page now refreshes immediately after successful legacy imports, draft resources can again be deleted from the per-row trash action by authorized curator, group leader, and admin users, and reopening the landing page setup modal in the same browser tab no longer drops unsaved Download URL or Additional Links input."

--- a/resources/js/components/portal/PortalMap.tsx
+++ b/resources/js/components/portal/PortalMap.tsx
@@ -10,9 +10,10 @@ import { MapContainer, Polygon, Polyline, Popup, Rectangle, TileLayer, useMap } 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { isGlobalCoverageBounds } from '@/lib/geo-coverage';
 import { formatAuthorsShort, getShapePathOptions } from '@/lib/portal-map-config';
 import { cn } from '@/lib/utils';
-import type { GeoBounds, PortalResource } from '@/types/portal';
+import type { GeoBounds, PortalGeoLocation, PortalResource } from '@/types/portal';
 
 import { ClusterLayer } from './PortalMapCluster';
 import { PortalMapLegend } from './PortalMapLegend';
@@ -70,6 +71,21 @@ function calculateBounds(resources: PortalResource[]): L.LatLngBounds | null {
     }
 
     return L.latLngBounds(allPoints);
+}
+
+function isGlobalPortalLocation(geo: PortalGeoLocation): boolean {
+    if (geo.type !== 'box' || geo.bounds === null) {
+        return false;
+    }
+
+    return isGlobalCoverageBounds(geo.bounds, geo.type);
+}
+
+function withoutGlobalLocations(resource: PortalResource): PortalResource {
+    return {
+        ...resource,
+        geoLocations: resource.geoLocations.filter((geo) => !isGlobalPortalLocation(geo)),
+    };
 }
 
 /**
@@ -370,9 +386,9 @@ export function PortalMap({ resources, className, hideHeader = false, geoFilterE
     const [isCollapsed, setIsCollapsed] = useState(false);
     const skipNextMoveEnd = useRef(false);
 
-    // Filter resources that have geo locations
+    // Filter resources that have non-global geo locations
     const resourcesWithGeo = useMemo(
-        () => resources.filter((r) => r.geoLocations.length > 0),
+        () => resources.map(withoutGlobalLocations).filter((r) => r.geoLocations.length > 0),
         [resources],
     );
 

--- a/resources/js/components/portal/PortalMap.tsx
+++ b/resources/js/components/portal/PortalMap.tsx
@@ -81,10 +81,16 @@ function isGlobalPortalLocation(geo: PortalGeoLocation): boolean {
     return isGlobalCoverageBounds(geo.bounds, geo.type);
 }
 
-function withoutGlobalLocations(resource: PortalResource): PortalResource {
+export function withoutGlobalLocations(resource: PortalResource): PortalResource {
+    const geoLocations = resource.geoLocations.filter((geo) => !isGlobalPortalLocation(geo));
+
+    if (geoLocations.length === resource.geoLocations.length) {
+        return resource;
+    }
+
     return {
         ...resource,
-        geoLocations: resource.geoLocations.filter((geo) => !isGlobalPortalLocation(geo)),
+        geoLocations,
     };
 }
 

--- a/resources/js/lib/geo-coverage.ts
+++ b/resources/js/lib/geo-coverage.ts
@@ -1,0 +1,31 @@
+export const GLOBAL_COVERAGE_MESSAGE = 'This dataset has global spatial coverage.';
+
+export const GLOBAL_COVERAGE_TOLERANCE = 0.000001;
+
+interface BoundsLike {
+    north: number | null;
+    south: number | null;
+    east: number | null;
+    west: number | null;
+}
+
+function isNear(actual: number, expected: number): boolean {
+    return Math.abs(actual - expected) <= GLOBAL_COVERAGE_TOLERANCE;
+}
+
+export function isGlobalCoverageBounds(bounds: BoundsLike, geoType?: string | null): boolean {
+    if (geoType !== null && geoType !== undefined && geoType !== 'box') {
+        return false;
+    }
+
+    if (bounds.west === null || bounds.east === null || bounds.south === null || bounds.north === null) {
+        return false;
+    }
+
+    return (
+        isNear(bounds.west, -180) &&
+        isNear(bounds.east, 180) &&
+        isNear(bounds.south, -90) &&
+        isNear(bounds.north, 90)
+    );
+}

--- a/resources/js/lib/geo-coverage.ts
+++ b/resources/js/lib/geo-coverage.ts
@@ -1,6 +1,6 @@
 export const GLOBAL_COVERAGE_MESSAGE = 'This dataset has global spatial coverage.';
 
-export const GLOBAL_COVERAGE_TOLERANCE = 0.000001;
+export const DEFAULT_GLOBAL_COVERAGE_TOLERANCE = 0.000001;
 
 interface BoundsLike {
     north: number | null;
@@ -9,8 +9,24 @@ interface BoundsLike {
     west: number | null;
 }
 
-function isNear(actual: number, expected: number): boolean {
-    return Math.abs(actual - expected) <= GLOBAL_COVERAGE_TOLERANCE;
+export function getGlobalCoverageTolerance(): number {
+    const configuredTolerance = import.meta.env.VITE_GEO_GLOBAL_COVERAGE_TOLERANCE;
+
+    if (typeof configuredTolerance !== 'string' || configuredTolerance.trim() === '') {
+        return DEFAULT_GLOBAL_COVERAGE_TOLERANCE;
+    }
+
+    const tolerance = Number(configuredTolerance);
+
+    if (!Number.isFinite(tolerance) || tolerance < 0) {
+        return DEFAULT_GLOBAL_COVERAGE_TOLERANCE;
+    }
+
+    return tolerance;
+}
+
+function isNear(actual: number, expected: number, tolerance: number): boolean {
+    return Math.abs(actual - expected) <= tolerance;
 }
 
 export function isGlobalCoverageBounds(bounds: BoundsLike, geoType?: string | null): boolean {
@@ -22,10 +38,10 @@ export function isGlobalCoverageBounds(bounds: BoundsLike, geoType?: string | nu
         return false;
     }
 
-    return (
-        isNear(bounds.west, -180) &&
-        isNear(bounds.east, 180) &&
-        isNear(bounds.south, -90) &&
-        isNear(bounds.north, 90)
-    );
+    const tolerance = getGlobalCoverageTolerance();
+
+    return isNear(bounds.west, -180, tolerance)
+        && isNear(bounds.east, 180, tolerance)
+        && isNear(bounds.south, -90, tolerance)
+        && isNear(bounds.north, 90, tolerance);
 }

--- a/resources/js/pages/LandingPages/components/LocationSection.tsx
+++ b/resources/js/pages/LandingPages/components/LocationSection.tsx
@@ -10,6 +10,7 @@ import { MapContainer, Marker, Polygon, Polyline, Rectangle, TileLayer, useMap }
 
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { GLOBAL_COVERAGE_MESSAGE, isGlobalCoverageBounds } from '@/lib/geo-coverage';
 
 import { LandingPageCard } from './LandingPageCard';
 
@@ -48,6 +49,11 @@ interface LocationSectionProps {
 // GFZ Corporate Blue
 const GFZ_BLUE = '#0C2A63';
 
+const WORLD_BOUNDS: L.LatLngBoundsExpression = [
+    [-90, -180],
+    [90, 180],
+];
+
 /**
  * Check if a GeoLocation has a valid point defined
  */
@@ -64,6 +70,21 @@ function hasBox(geo: GeoLocation): boolean {
         geo.east_bound_longitude !== null &&
         geo.south_bound_latitude !== null &&
         geo.north_bound_latitude !== null
+    );
+}
+
+/**
+ * Check if a GeoLocation box covers the whole world.
+ */
+function isGlobalCoverage(geo: GeoLocation): boolean {
+    return isGlobalCoverageBounds(
+        {
+            west: geo.west_bound_longitude,
+            east: geo.east_bound_longitude,
+            south: geo.south_bound_latitude,
+            north: geo.north_bound_latitude,
+        },
+        geo.geo_type,
     );
 }
 
@@ -341,6 +362,17 @@ function GeoLocationLayer({ geoLocation }: { geoLocation: GeoLocation }) {
     );
 }
 
+function GlobalCoverageNotice() {
+    return (
+        <p
+            className="mb-4 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-gray-700 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-gray-200"
+            data-testid="global-coverage-message"
+        >
+            {GLOBAL_COVERAGE_MESSAGE}
+        </p>
+    );
+}
+
 /**
  * LocationSection Component
  *
@@ -363,8 +395,13 @@ export function LocationSection({ geoLocations, isDark = false }: LocationSectio
         [geoLocations],
     );
 
+    const globalLocations = useMemo(() => validLocations.filter((geo) => isGlobalCoverage(geo)), [validLocations]);
+    const mappableLocations = useMemo(() => validLocations.filter((geo) => !isGlobalCoverage(geo)), [validLocations]);
+
     // Calculate bounds for auto-zoom
-    const bounds = useMemo(() => calculateBounds(validLocations), [validLocations]);
+    const bounds = useMemo(() => calculateBounds(mappableLocations), [mappableLocations]);
+    const hasGlobalCoverage = globalLocations.length > 0;
+    const hasMappableLocations = mappableLocations.length > 0;
 
     // Don't render if no valid locations
     if (validLocations.length === 0) {
@@ -379,13 +416,14 @@ export function LocationSection({ geoLocations, isDark = false }: LocationSectio
         : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
     // Show loading placeholder during SSR — always visible (no fade-in gating)
-    if (!isMounted) {
+    if (!isMounted && hasMappableLocations) {
         return (
             <LandingPageCard disableFadeIn aria-labelledby="heading-location">
                 <h2 id="heading-location" className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
                     Location
                 </h2>
-                <Skeleton className="h-[300px] w-full rounded-lg" />
+                {hasGlobalCoverage && <GlobalCoverageNotice />}
+                <Skeleton className="aspect-[2/1] w-full rounded-lg" />
             </LandingPageCard>
         );
     }
@@ -395,21 +433,32 @@ export function LocationSection({ geoLocations, isDark = false }: LocationSectio
             <h2 id="heading-location" className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
                 Location
             </h2>
-            <div
-                className="relative z-0 h-[300px] w-full overflow-hidden rounded-lg"
-                data-testid="map-container"
-                aria-label="Map showing the geographic location of the dataset"
-            >
-                <MapContainer bounds={bounds} className="h-full w-full" scrollWheelZoom={true} style={{ height: '100%', width: '100%' }}>
-                    <TileLayer attribution={tileAttribution} url={tileUrl} />
-                    <FitBoundsControl bounds={bounds} />
-                    <FullscreenControl />
+            {hasGlobalCoverage && <GlobalCoverageNotice />}
+            {hasMappableLocations && (
+                <div
+                    className="relative z-0 aspect-[2/1] w-full overflow-hidden rounded-lg"
+                    data-testid="map-container"
+                    aria-label="Map showing the geographic location of the dataset"
+                >
+                    <MapContainer
+                        bounds={bounds}
+                        className="h-full w-full"
+                        maxBounds={WORLD_BOUNDS}
+                        maxBoundsViscosity={1}
+                        scrollWheelZoom={true}
+                        style={{ height: '100%', width: '100%' }}
+                        worldCopyJump={false}
+                    >
+                        <TileLayer attribution={tileAttribution} noWrap={true} url={tileUrl} />
+                        <FitBoundsControl bounds={bounds} />
+                        <FullscreenControl />
 
-                    {validLocations.map((geo) => (
-                        <GeoLocationLayer key={geo.id} geoLocation={geo} />
-                    ))}
-                </MapContainer>
-            </div>
+                        {mappableLocations.map((geo) => (
+                            <GeoLocationLayer key={geo.id} geoLocation={geo} />
+                        ))}
+                    </MapContainer>
+                </div>
+            )}
         </LandingPageCard>
     );
 }

--- a/tests/pest/Feature/Models/GeoLocationTest.php
+++ b/tests/pest/Feature/Models/GeoLocationTest.php
@@ -27,6 +27,8 @@ beforeEach(function () {
         'resource_type_id' => $resourceType->id,
         'language_id' => $language->id,
     ]);
+
+    config()->set('app.geo.global_coverage_tolerance', null);
 });
 
 describe('Point locations', function () {
@@ -121,6 +123,16 @@ describe('Box locations', function () {
         ]);
 
         expect($geoLocation->fresh()->isGlobalCoverage())->toBeFalse();
+    });
+
+    it('uses the configured global coverage tolerance when detecting world boxes', function () {
+        config()->set('app.geo.global_coverage_tolerance', 0.02);
+
+        $geoLocation = GeoLocation::factory()->withBox(-179.99, 179.99, -89.99, 89.99)->create([
+            'resource_id' => $this->resource->id,
+        ]);
+
+        expect($geoLocation->fresh()->isGlobalCoverage())->toBeTrue();
     });
 
     it('rejects non-box geometry types even when box columns contain world bounds', function () {

--- a/tests/pest/Feature/Models/GeoLocationTest.php
+++ b/tests/pest/Feature/Models/GeoLocationTest.php
@@ -86,6 +86,51 @@ describe('Box locations', function () {
 
         expect($geoLocation->hasBox())->toBeTrue();
     });
+
+    it('detects an exact global coverage box', function () {
+        $geoLocation = GeoLocation::factory()->withBox(-180, 180, -90, 90)->create([
+            'resource_id' => $this->resource->id,
+        ]);
+
+        expect($geoLocation->fresh()->isGlobalCoverage())->toBeTrue();
+    });
+
+    it('detects legacy global coverage boxes without explicit geo type', function () {
+        $geoLocation = GeoLocation::create([
+            'resource_id' => $this->resource->id,
+            'west_bound_longitude' => -180,
+            'east_bound_longitude' => 180,
+            'south_bound_latitude' => -90,
+            'north_bound_latitude' => 90,
+        ]);
+
+        expect($geoLocation->fresh()->isGlobalCoverage())->toBeTrue();
+    });
+
+    it('allows tiny coordinate drift for global coverage boxes', function () {
+        $geoLocation = GeoLocation::factory()->withBox(-179.9999995, 179.9999995, -89.9999995, 89.9999995)->create([
+            'resource_id' => $this->resource->id,
+        ]);
+
+        expect($geoLocation->fresh()->isGlobalCoverage())->toBeTrue();
+    });
+
+    it('rejects near-world boxes outside the global coverage tolerance', function () {
+        $geoLocation = GeoLocation::factory()->withBox(-179.99, 180, -90, 90)->create([
+            'resource_id' => $this->resource->id,
+        ]);
+
+        expect($geoLocation->fresh()->isGlobalCoverage())->toBeFalse();
+    });
+
+    it('rejects non-box geometry types even when box columns contain world bounds', function () {
+        $geoLocation = GeoLocation::factory()->withBox(-180, 180, -90, 90)->create([
+            'resource_id' => $this->resource->id,
+            'geo_type' => 'polygon',
+        ]);
+
+        expect($geoLocation->fresh()->isGlobalCoverage())->toBeFalse();
+    });
 });
 
 describe('Place locations', function () {

--- a/tests/pest/Feature/Services/PortalSearchServiceTest.php
+++ b/tests/pest/Feature/Services/PortalSearchServiceTest.php
@@ -719,6 +719,22 @@ describe('transformForPortal', function () {
             ->and(array_column($result['geoLocations'], 'type'))
             ->toEqualCanonicalizing(['point', 'box']);
     });
+
+    it('does not cast incomplete legacy boxes to portal bounds', function () {
+        $resource = createPublishedResourceForSearch('Incomplete Box Dataset', $this->titleType);
+        GeoLocation::create([
+            'resource_id' => $resource->id,
+            'west_bound_longitude' => 13.0,
+        ]);
+        $resource->load(['titles.titleType', 'creators.creatorable', 'resourceType', 'geoLocations', 'landingPage']);
+
+        $result = $this->service->transformForPortal($resource);
+
+        expect($result['geoLocations'])
+            ->toHaveCount(1)
+            ->and($result['geoLocations'][0]['type'])->toBe('unknown')
+            ->and($result['geoLocations'][0]['bounds'])->toBeNull();
+    });
 });
 
 // =========================================================================

--- a/tests/pest/Feature/Services/PortalSearchServiceTest.php
+++ b/tests/pest/Feature/Services/PortalSearchServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\Datacenter;
 use App\Models\Description;
+use App\Models\GeoLocation;
 use App\Models\Institution;
 use App\Models\LandingPage;
 use App\Models\Person;
@@ -684,6 +685,39 @@ describe('transformForPortal', function () {
 
         expect($result['isIgsn'])->toBeTrue()
             ->and($result['resourceTypeSlug'])->toBe('physical-object');
+    });
+
+    it('omits global-only coverage from portal geo locations', function () {
+        $resource = createPublishedResourceForSearch('Global Dataset', $this->titleType);
+        GeoLocation::factory()->withBox(-180, 180, -90, 90)->create([
+            'resource_id' => $resource->id,
+        ]);
+        $resource->load(['titles.titleType', 'creators.creatorable', 'resourceType', 'geoLocations', 'landingPage']);
+
+        $result = $this->service->transformForPortal($resource);
+
+        expect($result['geoLocations'])->toBeEmpty();
+    });
+
+    it('keeps local portal geo locations when global coverage is mixed with local coverage', function () {
+        $resource = createPublishedResourceForSearch('Mixed Coverage Dataset', $this->titleType);
+        GeoLocation::factory()->withBox(-180, 180, -90, 90)->create([
+            'resource_id' => $resource->id,
+        ]);
+        GeoLocation::factory()->withPoint(13.0661, 52.3806)->create([
+            'resource_id' => $resource->id,
+        ]);
+        GeoLocation::factory()->withBox(5.87, 15.04, 47.27, 55.06)->create([
+            'resource_id' => $resource->id,
+        ]);
+        $resource->load(['titles.titleType', 'creators.creatorable', 'resourceType', 'geoLocations', 'landingPage']);
+
+        $result = $this->service->transformForPortal($resource);
+
+        expect($result['geoLocations'])
+            ->toHaveCount(2)
+            ->and(array_column($result['geoLocations'], 'type'))
+            ->toEqualCanonicalizing(['point', 'box']);
     });
 });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -3393,7 +3393,7 @@ describe('DataCiteForm', () => {
     });
 
     it('blocks Save & Validate when Abstract is shorter than 50 characters', async () => {
-        const user = userEvent.setup();
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
@@ -3410,13 +3410,16 @@ describe('DataCiteForm', () => {
                 initialLicenses={['MIT']}
                 availableDatacenters={availableDatacenters}
                 initialDatacenters={[1]}
+                initialAuthors={[
+                    {
+                        type: 'person',
+                        lastName: 'Curator',
+                    },
+                ]}
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
         );
-
-        await fillRequiredAuthor(user);
-        await fillRequiredContributor(user);
 
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
         await user.type(abstractTextarea, 'Short abstract');

--- a/tests/vitest/components/landing-pages/__tests__/LocationSection.test.tsx
+++ b/tests/vitest/components/landing-pages/__tests__/LocationSection.test.tsx
@@ -7,10 +7,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock react-leaflet components since they require browser APIs
 vi.mock('react-leaflet', () => ({
-    MapContainer: vi.fn(({ children }) => (
-        <div data-testid="leaflet-map">{children}</div>
+    MapContainer: vi.fn(({ children, maxBounds, maxBoundsViscosity, worldCopyJump }) => (
+        <div
+            data-testid="leaflet-map"
+            data-max-bounds={JSON.stringify(maxBounds)}
+            data-max-bounds-viscosity={String(maxBoundsViscosity)}
+            data-world-copy-jump={String(worldCopyJump)}
+        >
+            {children}
+        </div>
     )),
-    TileLayer: vi.fn(({ url }) => <div data-testid="tile-layer" data-url={url} />),
+    TileLayer: vi.fn(({ noWrap, url }) => <div data-testid="tile-layer" data-no-wrap={String(noWrap)} data-url={url} />),
     Marker: vi.fn(({ position }) => (
         <div data-testid="marker" data-position={JSON.stringify(position)} />
     )),
@@ -142,6 +149,33 @@ describe('LocationSection', () => {
             );
 
             expect(screen.getByTestId('map-container')).toBeInTheDocument();
+        });
+
+        it('should render maps with a 2:1 aspect ratio and bounded world tiles', () => {
+            render(
+                <LocationSection
+                    geoLocations={[
+                        {
+                            id: 1,
+                            place: 'GFZ Potsdam',
+                            point_longitude: 13.0661,
+                            point_latitude: 52.3806,
+                            west_bound_longitude: null,
+                            east_bound_longitude: null,
+                            south_bound_latitude: null,
+                            north_bound_latitude: null,
+                            polygon_points: null,
+                            geo_type: 'point',
+                        },
+                    ]}
+                />,
+            );
+
+            expect(screen.getByTestId('map-container')).toHaveClass('aspect-[2/1]');
+            expect(screen.getByTestId('leaflet-map').dataset.maxBounds).toBe('[[-90,-180],[90,180]]');
+            expect(screen.getByTestId('leaflet-map').dataset.maxBoundsViscosity).toBe('1');
+            expect(screen.getByTestId('leaflet-map').dataset.worldCopyJump).toBe('false');
+            expect(screen.getByTestId('tile-layer').dataset.noWrap).toBe('true');
         });
     });
 
@@ -364,6 +398,109 @@ describe('LocationSection', () => {
             expect(screen.getByTestId('marker')).toBeInTheDocument();
             expect(screen.getByTestId('rectangle')).toBeInTheDocument();
             expect(screen.getByTestId('polygon')).toBeInTheDocument();
+        });
+
+        it('should show a global coverage message without rendering a map for global-only coverage', () => {
+            render(
+                <LocationSection
+                    geoLocations={[
+                        {
+                            id: 1,
+                            place: 'World',
+                            point_longitude: null,
+                            point_latitude: null,
+                            west_bound_longitude: -180,
+                            east_bound_longitude: 180,
+                            south_bound_latitude: -90,
+                            north_bound_latitude: 90,
+                            polygon_points: null,
+                            geo_type: 'box',
+                        },
+                    ]}
+                />,
+            );
+
+            expect(screen.getByText('Location')).toBeInTheDocument();
+            expect(screen.getByTestId('global-coverage-message')).toHaveTextContent('This dataset has global spatial coverage.');
+            expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('rectangle')).not.toBeInTheDocument();
+        });
+
+        it('should render local point geometry and the message for mixed global and point coverage', () => {
+            render(
+                <LocationSection
+                    geoLocations={[
+                        {
+                            id: 1,
+                            place: 'World',
+                            point_longitude: null,
+                            point_latitude: null,
+                            west_bound_longitude: -180,
+                            east_bound_longitude: 180,
+                            south_bound_latitude: -90,
+                            north_bound_latitude: 90,
+                            polygon_points: null,
+                            geo_type: 'box',
+                        },
+                        {
+                            id: 2,
+                            place: 'Potsdam',
+                            point_longitude: 13.0661,
+                            point_latitude: 52.3806,
+                            west_bound_longitude: null,
+                            east_bound_longitude: null,
+                            south_bound_latitude: null,
+                            north_bound_latitude: null,
+                            polygon_points: null,
+                            geo_type: 'point',
+                        },
+                    ]}
+                />,
+            );
+
+            expect(screen.getByTestId('global-coverage-message')).toBeInTheDocument();
+            expect(screen.getByTestId('marker')).toBeInTheDocument();
+            expect(screen.queryByTestId('rectangle')).not.toBeInTheDocument();
+        });
+
+        it('should render only local rectangles for mixed global and local box coverage', () => {
+            render(
+                <LocationSection
+                    geoLocations={[
+                        {
+                            id: 1,
+                            place: 'World',
+                            point_longitude: null,
+                            point_latitude: null,
+                            west_bound_longitude: -180,
+                            east_bound_longitude: 180,
+                            south_bound_latitude: -90,
+                            north_bound_latitude: 90,
+                            polygon_points: null,
+                            geo_type: 'box',
+                        },
+                        {
+                            id: 2,
+                            place: 'Germany',
+                            point_longitude: null,
+                            point_latitude: null,
+                            west_bound_longitude: 5.87,
+                            east_bound_longitude: 15.04,
+                            south_bound_latitude: 47.27,
+                            north_bound_latitude: 55.06,
+                            polygon_points: null,
+                            geo_type: 'box',
+                        },
+                    ]}
+                />,
+            );
+
+            const rectangles = screen.getAllByTestId('rectangle');
+            expect(rectangles).toHaveLength(1);
+            expect(JSON.parse(rectangles[0].dataset.bounds || '[]')).toEqual([
+                [47.27, 5.87],
+                [55.06, 15.04],
+            ]);
         });
     });
 

--- a/tests/vitest/components/portal/portal-map.test.tsx
+++ b/tests/vitest/components/portal/portal-map.test.tsx
@@ -87,7 +87,7 @@ vi.mock('leaflet/dist/images/marker-icon-2x.png', () => ({ default: 'marker-icon
 vi.mock('leaflet/dist/images/marker-shadow.png', () => ({ default: 'marker-shadow.png' }));
 
 // Import after mocks
-import { PortalMap } from '@/components/portal/PortalMap';
+import { PortalMap, withoutGlobalLocations } from '@/components/portal/PortalMap';
 
 /**
  * Factory to create a mock PortalResource with geo location
@@ -114,6 +114,48 @@ function createMockResourceWithGeo(
 describe('PortalMap', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+    });
+
+    describe('withoutGlobalLocations', () => {
+        it('returns the original resource when no global locations are removed', () => {
+            const resource = createMockResourceWithGeo(1, [
+                { id: 1, type: 'point', point: { lat: 52.5, lng: 13.4 }, bounds: null, polygon: null },
+                {
+                    id: 2,
+                    type: 'box',
+                    point: null,
+                    bounds: { north: 53, south: 52, east: 14, west: 13 },
+                    polygon: null,
+                },
+            ]);
+
+            expect(withoutGlobalLocations(resource)).toBe(resource);
+        });
+
+        it('clones the resource only when global locations are removed', () => {
+            const resource = createMockResourceWithGeo(1, [
+                {
+                    id: 1,
+                    type: 'box',
+                    point: null,
+                    bounds: { north: 90, south: -90, east: 180, west: -180 },
+                    polygon: null,
+                },
+                {
+                    id: 2,
+                    type: 'box',
+                    point: null,
+                    bounds: { north: 53, south: 52, east: 14, west: 13 },
+                    polygon: null,
+                },
+            ]);
+
+            const filteredResource = withoutGlobalLocations(resource);
+
+            expect(filteredResource).not.toBe(resource);
+            expect(filteredResource.geoLocations).toHaveLength(1);
+            expect(filteredResource.geoLocations[0]).toBe(resource.geoLocations[1]);
+        });
     });
 
     describe('Collapsible Behavior', () => {

--- a/tests/vitest/components/portal/portal-map.test.tsx
+++ b/tests/vitest/components/portal/portal-map.test.tsx
@@ -216,6 +216,49 @@ describe('PortalMap', () => {
             expect(screen.getAllByTestId('map-rectangle').length).toBeGreaterThan(0);
         });
 
+        it('does not render global bounding boxes as map shapes', () => {
+            const resources = [
+                createMockResourceWithGeo(1, [
+                    {
+                        id: 1,
+                        type: 'box',
+                        point: null,
+                        bounds: { north: 90, south: -90, east: 180, west: -180 },
+                        polygon: null,
+                    },
+                ]),
+            ];
+            render(<PortalMap resources={resources} />);
+
+            expect(screen.queryAllByTestId('map-rectangle')).toHaveLength(0);
+            expect(screen.getAllByText(/no geographic data available/i).length).toBeGreaterThan(0);
+        });
+
+        it('keeps local geometries when a resource also has global coverage', () => {
+            const resources = [
+                createMockResourceWithGeo(1, [
+                    {
+                        id: 1,
+                        type: 'box',
+                        point: null,
+                        bounds: { north: 90, south: -90, east: 180, west: -180 },
+                        polygon: null,
+                    },
+                    {
+                        id: 2,
+                        type: 'box',
+                        point: null,
+                        bounds: { north: 53, south: 52, east: 14, west: 13 },
+                        polygon: null,
+                    },
+                ]),
+            ];
+            render(<PortalMap resources={resources} />);
+
+            expect(screen.getAllByTestId('map-rectangle').length).toBeGreaterThan(0);
+            expect(screen.getAllByText('(1 location)').length).toBeGreaterThan(0);
+        });
+
         it('renders polygons for polygon geo locations', () => {
             const resources = [
                 createMockResourceWithGeo(1, [

--- a/tests/vitest/lib/geo-coverage.test.ts
+++ b/tests/vitest/lib/geo-coverage.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isGlobalCoverageBounds } from '@/lib/geo-coverage';
+import {
+    DEFAULT_GLOBAL_COVERAGE_TOLERANCE,
+    getGlobalCoverageTolerance,
+    isGlobalCoverageBounds,
+} from '@/lib/geo-coverage';
 
 describe('isGlobalCoverageBounds', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
     it('detects an exact world bounding box', () => {
         expect(isGlobalCoverageBounds({ west: -180, east: 180, south: -90, north: 90 }, 'box')).toBe(true);
     });
@@ -13,6 +21,23 @@ describe('isGlobalCoverageBounds', () => {
 
     it('rejects near-world boxes outside the exact tolerance', () => {
         expect(isGlobalCoverageBounds({ west: -179.99, east: 180, south: -90, north: 90 }, 'box')).toBe(false);
+    });
+
+    it('uses the configured Vite tolerance for near-world boxes', () => {
+        vi.stubEnv('VITE_GEO_GLOBAL_COVERAGE_TOLERANCE', '0.02');
+
+        expect(isGlobalCoverageBounds({ west: -179.99, east: 179.99, south: -89.99, north: 89.99 }, 'box')).toBe(true);
+    });
+
+    it('falls back to the safe default for empty, invalid, or negative Vite tolerance values', () => {
+        vi.stubEnv('VITE_GEO_GLOBAL_COVERAGE_TOLERANCE', '');
+        expect(getGlobalCoverageTolerance()).toBe(DEFAULT_GLOBAL_COVERAGE_TOLERANCE);
+
+        vi.stubEnv('VITE_GEO_GLOBAL_COVERAGE_TOLERANCE', 'not-a-number');
+        expect(getGlobalCoverageTolerance()).toBe(DEFAULT_GLOBAL_COVERAGE_TOLERANCE);
+
+        vi.stubEnv('VITE_GEO_GLOBAL_COVERAGE_TOLERANCE', '-1');
+        expect(getGlobalCoverageTolerance()).toBe(DEFAULT_GLOBAL_COVERAGE_TOLERANCE);
     });
 
     it('rejects non-box geometry types', () => {

--- a/tests/vitest/lib/geo-coverage.test.ts
+++ b/tests/vitest/lib/geo-coverage.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { isGlobalCoverageBounds } from '@/lib/geo-coverage';
+
+describe('isGlobalCoverageBounds', () => {
+    it('detects an exact world bounding box', () => {
+        expect(isGlobalCoverageBounds({ west: -180, east: 180, south: -90, north: 90 }, 'box')).toBe(true);
+    });
+
+    it('allows tiny coordinate drift within tolerance', () => {
+        expect(isGlobalCoverageBounds({ west: -179.9999995, east: 179.9999995, south: -89.9999995, north: 89.9999995 }, 'box')).toBe(true);
+    });
+
+    it('rejects near-world boxes outside the exact tolerance', () => {
+        expect(isGlobalCoverageBounds({ west: -179.99, east: 180, south: -90, north: 90 }, 'box')).toBe(false);
+    });
+
+    it('rejects non-box geometry types', () => {
+        expect(isGlobalCoverageBounds({ west: -180, east: 180, south: -90, north: 90 }, 'polygon')).toBe(false);
+    });
+
+    it('rejects incomplete bounds', () => {
+        expect(isGlobalCoverageBounds({ west: -180, east: 180, south: null, north: 90 }, 'box')).toBe(false);
+    });
+});


### PR DESCRIPTION
This pull request implements robust, configurable handling of global (whole-world) geographic coverage for resources, ensuring that datasets with global coverage are treated distinctly in both backend and frontend. The changes prevent global bounding boxes from being visualized as oversized rectangles on maps, improve the clarity of spatial coverage notices, and allow for a configurable tolerance in detecting "global" coverage. This results in more accurate and user-friendly map displays and search results.

**Global Coverage Detection and Configuration:**

- Added a new method `isGlobalCoverage()` to the `GeoLocation` model to detect whole-world bounding boxes, with an optional configurable tolerance (`GEO_GLOBAL_COVERAGE_TOLERANCE`) set via environment variable and exposed to the frontend. The default tolerance is `0.000001`. [[1]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1R44-R45) [[2]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1R88-R106) [[3]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1R146-R155) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR75-R79) [[5]](diffhunk://#diff-950397cc5ef29707b54d0c774bd94af85836bab1a27f2f86533d832d25caf224R70-R84) [[6]](diffhunk://#diff-4da0550524c770ec0a9f2ef66065632b599f6df16da0b367d4c85d31f367d0abR1-R47)

**Backend Filtering and Search Improvements:**

- Updated the `PortalSearchService` to exclude global-coverage geo locations from map displays and search results, ensuring that worldwide resources do not obscure more specific results. [[1]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7L1031-R1040) [[2]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7L1050-R1054) [[3]](diffhunk://#diff-cc3abd216be92a406aad7b75c29bdfdb5879253dd6aa035891cfb47d5b1ebbf7L1068-R1072)

**Frontend Map and UI Enhancements:**

- Implemented frontend logic (in both Portal and Landing Page maps) to filter out global-coverage locations from map rendering, display a concise global coverage notice, and adjust map layout to a 2:1 aspect ratio with world wrapping disabled for clarity. [[1]](diffhunk://#diff-7a0bac4cbd80067c3e1a07fa53366c79f2ab3d1ada0be9e849560ce9d68841d3R13-R16) [[2]](diffhunk://#diff-7a0bac4cbd80067c3e1a07fa53366c79f2ab3d1ada0be9e849560ce9d68841d3R76-R96) [[3]](diffhunk://#diff-7a0bac4cbd80067c3e1a07fa53366c79f2ab3d1ada0be9e849560ce9d68841d3L373-R397) [[4]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957R13) [[5]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957R52-R56) [[6]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957R76-R90) [[7]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957R365-R375) [[8]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957R398-R404) [[9]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957L382-R426) [[10]](diffhunk://#diff-83cc5961d051197614042358e341bab0371df9eca00a55f874894765bcaac957R436-R461)

**Testing and Documentation:**

- Added comprehensive tests for global coverage detection, including edge cases for tolerance and geometry types. [[1]](diffhunk://#diff-8302dc4289e642ddfa11d7f2c101dab26371be3843075536bfda728a054822a8R30-R31) [[2]](diffhunk://#diff-8302dc4289e642ddfa11d7f2c101dab26371be3843075536bfda728a054822a8R91-R145) [[3]](diffhunk://#diff-6df57efb07580df10edeed97b4d3f2805c409ae22b0aedb879737811a7dfa0cdR7)
- Updated the changelog with a summary of these improvements and their impact on map and search behavior. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR258-R261)