### PR TITLE
Fix: Data Loss of Legacy Data Attributes

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -388,8 +388,19 @@ class ImportFromDataCiteJob implements ShouldQueue
 
     private function handleSinglePendingFallback(string $doi, string $startedAt): void
     {
-        $result = app(SumarioPendingResourceImportService::class)
-            ->importPendingByDoi($doi, $this->userId);
+        try {
+            $result = app(SumarioPendingResourceImportService::class)
+                ->importPendingByDoi($doi, $this->userId);
+        } catch (\Throwable $exception) {
+            Log::warning('SUMARIO pending lookup failed during single DOI fallback', [
+                'doi' => $doi,
+                'error' => $exception->getMessage(),
+            ]);
+
+            $this->markSingleImportAsFailed($doi, 'SUMARIO pending lookup is unavailable.', $startedAt);
+
+            return;
+        }
 
         if ($result['status'] === 'imported') {
             $this->updateProgress([

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
-use App\Enums\CacheKey;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteImportService;
+use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
+use App\Services\LegacyLandingPageImportService;
+use App\Services\LegacyMetaworksDatacenterLookupService;
 use App\Services\MetaworksDownloadUrlService;
+use App\Services\SumarioPendingResourceImportService;
+use App\Services\SumarioPmdContactEnrichmentService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -96,8 +100,23 @@ class ImportFromDataCiteJob implements ShouldQueue
                 return;
             }
 
+            $pendingImportService = app(SumarioPendingResourceImportService::class);
+            $pendingImportUnavailable = false;
+
+            try {
+                $pendingTotal = $pendingImportService->countImportablePending();
+            } catch (\Throwable $exception) {
+                $pendingTotal = 0;
+                $pendingImportUnavailable = true;
+
+                Log::warning('SUMARIO pending import count failed; skipping pending resources', [
+                    'import_id' => $this->importId,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
+
             // Get total count for progress calculation
-            $total = $importService->getTotalDoiCount();
+            $total = $importService->getTotalDoiCount() + $pendingTotal;
 
             $this->updateProgress([
                 'status' => 'running',
@@ -206,6 +225,27 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $this->updateProgressCounts($processed, $imported, $skipped, $failed, $skippedDois, $failedDois, $total);
             }
 
+            if (! $pendingImportUnavailable && $this->determineFinalStatus() !== 'cancelled') {
+                $pendingSummary = $pendingImportService->importAllPending($this->userId, $maxStoredDois);
+
+                $processed += $pendingSummary['processed'];
+                $imported += $pendingSummary['imported'];
+                $skipped += $pendingSummary['skipped'];
+                $failed += $pendingSummary['failed'];
+                $skippedDois = array_slice(
+                    array_merge($skippedDois, $pendingSummary['skipped_dois']),
+                    0,
+                    $maxStoredDois,
+                );
+                $failedDois = array_slice(
+                    array_merge($failedDois, $pendingSummary['failed_dois']),
+                    0,
+                    $maxStoredDois,
+                );
+
+                $this->updateProgressCounts($processed, $imported, $skipped, $failed, $skippedDois, $failedDois, $total);
+            }
+
             // Determine final status - preserve 'cancelled' if user cancelled during processing
             $finalStatus = $this->determineFinalStatus();
 
@@ -280,7 +320,7 @@ class ImportFromDataCiteJob implements ShouldQueue
         $doiRecord = $importService->fetchSingleDoi($doi);
 
         if ($doiRecord === null) {
-            $this->markSingleImportAsFailed($doi, 'The DOI was not found in DataCite.', $startedAt);
+            $this->handleSinglePendingFallback($doi, $startedAt);
 
             return;
         }
@@ -345,6 +385,53 @@ class ImportFromDataCiteJob implements ShouldQueue
         ]);
     }
 
+    private function handleSinglePendingFallback(string $doi, string $startedAt): void
+    {
+        $result = app(SumarioPendingResourceImportService::class)
+            ->importPendingByDoi($doi, $this->userId);
+
+        if ($result['status'] === 'imported') {
+            $this->updateProgress([
+                'status' => $this->determineFinalStatus(),
+                'total' => 1,
+                'processed' => 1,
+                'imported' => 1,
+                'skipped' => 0,
+                'failed' => 0,
+                'skipped_dois' => [],
+                'failed_dois' => [],
+                'started_at' => $startedAt,
+                'completed_at' => now()->toIso8601String(),
+                'current_prefix' => null,
+            ]);
+
+            return;
+        }
+
+        if ($result['status'] === 'skipped') {
+            $this->updateProgress([
+                'status' => $this->determineFinalStatus(),
+                'total' => 1,
+                'processed' => 1,
+                'imported' => 0,
+                'skipped' => 1,
+                'failed' => 0,
+                'skipped_dois' => [$result['doi']],
+                'failed_dois' => [],
+                'started_at' => $startedAt,
+                'completed_at' => now()->toIso8601String(),
+                'current_prefix' => null,
+            ]);
+
+            return;
+        }
+
+        $error = $result['error']
+            ?? 'The DOI was not found in DataCite or SUMARIO pending resources.';
+
+        $this->markSingleImportAsFailed($result['doi'], $error, $startedAt);
+    }
+
     /**
      * @param  array<string, mixed>  $doiRecord
      * @return array{status: 'imported'|'skipped', metaworks_unavailable: bool}
@@ -399,12 +486,14 @@ class ImportFromDataCiteJob implements ShouldQueue
 
             $metaworksUnavailable = false;
 
+            $this->enrichImportedResourceFromLegacyDatabases($importedResource, $doi);
+
             if ($shouldLookupMetaworks && ! LandingPage::where('resource_id', $importedResource->id)->exists()) {
-                /** @var array{urls: array<int, string>, allPublic: bool} $fileResult */
-                $fileResult = ['urls' => [], 'allPublic' => false];
+                /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool} $fileResult */
+                $fileResult = ['files' => [], 'allPublic' => false];
 
                 try {
-                    $fileResult = $metaworksService->lookupFileUrls($doi);
+                    $fileResult = $metaworksService->lookupFileEntries($doi);
                 } catch (\Throwable $exception) {
                     Log::warning('Metaworks DB unavailable, disabling lookups for remaining DOIs', [
                         'doi' => $doi,
@@ -413,11 +502,15 @@ class ImportFromDataCiteJob implements ShouldQueue
                     $metaworksUnavailable = true;
                 }
 
-                if ($fileResult['urls'] !== []) {
+                if ($fileResult['files'] !== []) {
                     try {
-                        $this->createLandingPageWithFiles($importedResource, $fileResult['urls'], $fileResult['allPublic']);
+                        app(LegacyLandingPageImportService::class)->createForResource(
+                            resource: $importedResource,
+                            fileEntries: $fileResult['files'],
+                            isPublished: $fileResult['allPublic'],
+                        );
                     } catch (\Throwable $exception) {
-                        Log::warning('Failed to create landing page with download files', [
+                        Log::warning('Failed to create landing page with download links', [
                             'doi' => $doi,
                             'resource_id' => $importedResource->id,
                             'error' => $exception->getMessage(),
@@ -425,6 +518,8 @@ class ImportFromDataCiteJob implements ShouldQueue
                     }
                 }
             }
+
+            $this->syncDataCiteMetadataIfAllowed($importedResource);
 
             Log::debug('Imported DOI', ['doi' => $doi]);
 
@@ -452,6 +547,25 @@ class ImportFromDataCiteJob implements ShouldQueue
 
             throw $exception;
         }
+    }
+
+    private function enrichImportedResourceFromLegacyDatabases(Resource $resource, string $doi): void
+    {
+        if (! $resource->exists) {
+            return;
+        }
+
+        app(SumarioPmdContactEnrichmentService::class)->enrich($resource, $doi);
+        app(LegacyMetaworksDatacenterLookupService::class)->syncDatacenters($resource, $doi);
+    }
+
+    private function syncDataCiteMetadataIfAllowed(Resource $resource): void
+    {
+        if (config('datacite.test_mode') !== false || ! $resource->exists) {
+            return;
+        }
+
+        app(DataCiteSyncService::class)->syncIfRegistered($resource->fresh() ?? $resource);
     }
 
     /**
@@ -572,59 +686,6 @@ class ImportFromDataCiteJob implements ShouldQueue
         return (isset($currentStatus['status']) && $currentStatus['status'] === 'cancelled')
             ? 'cancelled'
             : 'completed';
-    }
-
-    /**
-     * Create a landing page with file entries for a newly imported resource.
-     *
-     * The landing page is created with the default_gfz template. Its published status
-     * depends on the file visibility in the legacy metaworks database:
-     * - All files public -> landing page is published immediately
-     * - Any file non-public -> landing page is created as draft
-     *
-     * The slug, preview_token, and doi_prefix are auto-generated by the
-     * LandingPage model's boot event. The resource relation is set before save()
-     * so boot() can derive doi_prefix and slug without extra queries.
-     *
-     * The resource's titles.titleType are preloaded to avoid N+1 queries during
-     * slug generation in the boot event.
-     *
-     * The landing page and all files are wrapped in a transaction for atomicity.
-     *
-     * @param  Resource  $resource  The newly imported resource
-     * @param  array<int, string>  $fileUrls  Download URLs from the metaworks database
-     * @param  bool  $isPublished  Whether the landing page should be published
-     */
-    private function createLandingPageWithFiles(Resource $resource, array $fileUrls, bool $isPublished): void
-    {
-        // Preload titles.titleType so LandingPage::boot() slug generation
-        // doesn't trigger additional queries per resource in the import loop.
-        $resource->loadMissing('titles.titleType');
-
-        // Wrap in transaction for atomicity: either all files are created or none.
-        DB::transaction(function () use ($resource, $fileUrls, $isPublished): void {
-            $landingPage = new LandingPage([
-                'resource_id' => $resource->id,
-                'template' => 'default_gfz',
-                'ftp_url' => $fileUrls[0], // Backward compat: first URL as ftp_url
-                'is_published' => $isPublished,
-                'published_at' => $isPublished ? now() : null,
-            ]);
-
-            // Set relation so boot() auto-populates doi_prefix and generates
-            // the slug from the in-memory resource without extra queries.
-            $landingPage->setRelation('resource', $resource);
-            $landingPage->save();
-
-            foreach ($fileUrls as $position => $url) {
-                $landingPage->files()->create([
-                    'url' => $url,
-                    'position' => $position,
-                ]);
-            }
-        });
-
-        CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->forget();
     }
 
     /**

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -227,22 +227,40 @@ class ImportFromDataCiteJob implements ShouldQueue
             }
 
             if (! $pendingImportUnavailable && $this->determineFinalStatus() !== 'cancelled') {
-                $pendingSummary = $pendingImportService->importAllPending($this->userId, $maxStoredDois);
+                try {
+                    $pendingSummary = $pendingImportService->importAllPending($this->userId, $maxStoredDois);
 
-                $processed += $pendingSummary['processed'];
-                $imported += $pendingSummary['imported'];
-                $skipped += $pendingSummary['skipped'];
-                $failed += $pendingSummary['failed'];
-                $skippedDois = array_slice(
-                    array_merge($skippedDois, $pendingSummary['skipped_dois']),
-                    0,
-                    $maxStoredDois,
-                );
-                $failedDois = array_slice(
-                    array_merge($failedDois, $pendingSummary['failed_dois']),
-                    0,
-                    $maxStoredDois,
-                );
+                    $processed += $pendingSummary['processed'];
+                    $imported += $pendingSummary['imported'];
+                    $skipped += $pendingSummary['skipped'];
+                    $failed += $pendingSummary['failed'];
+                    $skippedDois = array_slice(
+                        array_merge($skippedDois, $pendingSummary['skipped_dois']),
+                        0,
+                        $maxStoredDois,
+                    );
+                    $failedDois = array_slice(
+                        array_merge($failedDois, $pendingSummary['failed_dois']),
+                        0,
+                        $maxStoredDois,
+                    );
+                } catch (\Throwable $exception) {
+                    $processed += $pendingTotal;
+                    $failed += $pendingTotal;
+
+                    if ($pendingTotal > 0 && count($failedDois) < $maxStoredDois) {
+                        $failedDois[] = [
+                            'doi' => 'sumario-pending',
+                            'error' => 'SUMARIO pending import is unavailable.',
+                        ];
+                    }
+
+                    Log::warning('SUMARIO pending import failed; continuing DataCite import job', [
+                        'import_id' => $this->importId,
+                        'pending_total' => $pendingTotal,
+                        'error' => $exception->getMessage(),
+                    ]);
+                }
 
                 $this->updateProgressCounts($processed, $imported, $skipped, $failed, $skippedDois, $failedDois, $total);
             }

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -17,6 +17,7 @@ use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -527,7 +528,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                 'status' => 'imported',
                 'metaworks_unavailable' => $metaworksUnavailable,
             ];
-        } catch (\Illuminate\Database\QueryException $exception) {
+        } catch (QueryException $exception) {
             $isDuplicateEntry = false;
             if (isset($exception->errorInfo[1])) {
                 $isDuplicateEntry = $exception->errorInfo[1] === 1062;
@@ -561,7 +562,11 @@ class ImportFromDataCiteJob implements ShouldQueue
 
     private function syncDataCiteMetadataIfAllowed(Resource $resource): void
     {
-        if (config('datacite.test_mode') !== false || ! $resource->exists) {
+        if (
+            config('datacite.test_mode') !== false
+            || ! (bool) config('datacite.sync_after_import', false)
+            || ! $resource->exists
+        ) {
             return;
         }
 

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @property int $id
+ * @property string|null $publicstatus
  * @property string|null $identifier
  * @property int|null $publicationyear
  * @property string|null $version

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
 
 /**
  * Resource Model (DataCite Metadata)
@@ -31,8 +34,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int|null $legacy_source_id
  * @property string|null $legacy_source_status
  * @property bool $force_review_status
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read ResourceType|null $resourceType
  * @property-read Language|null $language
  * @property-read Publisher|null $publisher
@@ -41,32 +44,32 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property-read LandingPage|null $landingPage
  * @property-read ResourceAssessment|null $resourceAssessment
  * @property-read IgsnMetadata|null $igsnMetadata
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Title> $titles
- * @property-read \Illuminate\Database\Eloquent\Collection<int, ResourceCreator> $creators
- * @property-read \Illuminate\Database\Eloquent\Collection<int, ResourceContributor> $contributors
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Description> $descriptions
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Subject> $subjects
- * @property-read \Illuminate\Database\Eloquent\Collection<int, ResourceDate> $dates
- * @property-read \Illuminate\Database\Eloquent\Collection<int, GeoLocation> $geoLocations
- * @property-read \Illuminate\Database\Eloquent\Collection<int, RelatedIdentifier> $relatedIdentifiers
- * @property-read \Illuminate\Database\Eloquent\Collection<int, RelatedItem> $relatedItems
- * @property-read \Illuminate\Database\Eloquent\Collection<int, FundingReference> $fundingReferences
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Right> $rights
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Size> $sizes
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Format> $formats
- * @property-read \Illuminate\Database\Eloquent\Collection<int, IgsnClassification> $igsnClassifications
- * @property-read \Illuminate\Database\Eloquent\Collection<int, IgsnGeologicalAge> $igsnGeologicalAges
- * @property-read \Illuminate\Database\Eloquent\Collection<int, IgsnGeologicalUnit> $igsnGeologicalUnits
- * @property-read \Illuminate\Database\Eloquent\Collection<int, AlternateIdentifier> $alternateIdentifiers
- * @property-read \Illuminate\Database\Eloquent\Collection<int, ResourceInstrument> $instruments
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Datacenter> $datacenters
+ * @property-read Collection<int, Title> $titles
+ * @property-read Collection<int, ResourceCreator> $creators
+ * @property-read Collection<int, ResourceContributor> $contributors
+ * @property-read Collection<int, Description> $descriptions
+ * @property-read Collection<int, Subject> $subjects
+ * @property-read Collection<int, ResourceDate> $dates
+ * @property-read Collection<int, GeoLocation> $geoLocations
+ * @property-read Collection<int, RelatedIdentifier> $relatedIdentifiers
+ * @property-read Collection<int, RelatedItem> $relatedItems
+ * @property-read Collection<int, FundingReference> $fundingReferences
+ * @property-read Collection<int, Right> $rights
+ * @property-read Collection<int, Size> $sizes
+ * @property-read Collection<int, Format> $formats
+ * @property-read Collection<int, IgsnClassification> $igsnClassifications
+ * @property-read Collection<int, IgsnGeologicalAge> $igsnGeologicalAges
+ * @property-read Collection<int, IgsnGeologicalUnit> $igsnGeologicalUnits
+ * @property-read Collection<int, AlternateIdentifier> $alternateIdentifiers
+ * @property-read Collection<int, ResourceInstrument> $instruments
+ * @property-read Collection<int, Datacenter> $datacenters
  *
  * @see https://datacite-metadata-schema.readthedocs.io/en/4.7/
  */
 #[Fillable(['doi', 'publication_year', 'resource_type_id', 'version', 'language_id', 'publisher_id', 'created_by_user_id', 'updated_by_user_id', 'legacy_source', 'legacy_source_id', 'legacy_source_status', 'force_review_status'])]
 class Resource extends Model
 {
-    /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $casts = [
@@ -406,9 +409,9 @@ class Resource extends Model
     /**
      * Get all free-text subjects.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, Subject>
+     * @return Collection<int, Subject>
      */
-    public function getFreeTextSubjectsAttribute(): \Illuminate\Database\Eloquent\Collection
+    public function getFreeTextSubjectsAttribute(): Collection
     {
         return $this->subjects->filter(fn (Subject $s) => $s->isFreeText());
     }
@@ -416,9 +419,9 @@ class Resource extends Model
     /**
      * Get all controlled vocabulary subjects.
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, Subject>
+     * @return Collection<int, Subject>
      */
-    public function getControlledSubjectsAttribute(): \Illuminate\Database\Eloquent\Collection
+    public function getControlledSubjectsAttribute(): Collection
     {
         return $this->subjects->filter(fn (Subject $s) => $s->isControlled());
     }
@@ -426,9 +429,9 @@ class Resource extends Model
     /**
      * Get temporal coverage dates (dateType = 'Collected').
      *
-     * @return \Illuminate\Database\Eloquent\Collection<int, ResourceDate>
+     * @return Collection<int, ResourceDate>
      */
-    public function getTemporalCoverageAttribute(): \Illuminate\Database\Eloquent\Collection
+    public function getTemporalCoverageAttribute(): Collection
     {
         return $this->dates->filter(fn (ResourceDate $d) => $d->isCollected());
     }
@@ -502,8 +505,8 @@ class Resource extends Model
      * Determine the publication status of this resource (Issue #548).
      *
      * Status hierarchy:
-     * - 'review': legacy SUMARIO pending imports marked with force_review_status
-     * - 'draft': missing any mandatory field (takes precedence)
+     * - 'review'/'published': legacy SUMARIO pending imports marked with force_review_status override completeness checks
+     * - 'draft': non-legacy resources missing any mandatory field
      * - 'curation': all mandatory fields present, no DOI or no landing page
      * - 'review': has DOI + landing page with is_published = false
      * - 'published': has DOI + landing page with is_published = true

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -27,6 +27,10 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int|null $publisher_id
  * @property int|null $created_by_user_id
  * @property int|null $updated_by_user_id
+ * @property string|null $legacy_source
+ * @property int|null $legacy_source_id
+ * @property string|null $legacy_source_status
+ * @property bool $force_review_status
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read ResourceType|null $resourceType
@@ -59,7 +63,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  *
  * @see https://datacite-metadata-schema.readthedocs.io/en/4.7/
  */
-#[Fillable(['doi', 'publication_year', 'resource_type_id', 'version', 'language_id', 'publisher_id', 'created_by_user_id', 'updated_by_user_id'])]
+#[Fillable(['doi', 'publication_year', 'resource_type_id', 'version', 'language_id', 'publisher_id', 'created_by_user_id', 'updated_by_user_id', 'legacy_source', 'legacy_source_id', 'legacy_source_status', 'force_review_status'])]
 class Resource extends Model
 {
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
@@ -67,6 +71,8 @@ class Resource extends Model
 
     protected $casts = [
         'publication_year' => 'integer',
+        'legacy_source_id' => 'integer',
+        'force_review_status' => 'boolean',
     ];
 
     /**
@@ -496,6 +502,7 @@ class Resource extends Model
      * Determine the publication status of this resource (Issue #548).
      *
      * Status hierarchy:
+     * - 'review': legacy SUMARIO pending imports marked with force_review_status
      * - 'draft': missing any mandatory field (takes precedence)
      * - 'curation': all mandatory fields present, no DOI or no landing page
      * - 'review': has DOI + landing page with is_published = false
@@ -503,6 +510,14 @@ class Resource extends Model
      */
     public function publicStatus(): string
     {
+        if ($this->force_review_status) {
+            if ($this->doi && $this->landingPage) {
+                return $this->landingPage->is_published ? 'published' : 'review';
+            }
+
+            return 'review';
+        }
+
         if (! $this->isComplete()) {
             return 'draft';
         }

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CacheKey;
+use App\Models\LandingPage;
+use App\Models\Resource;
+use Illuminate\Support\Facades\DB;
+
+class LegacyLandingPageImportService
+{
+    /**
+     * Create a default landing page from legacy file entries.
+     *
+     * The first URL becomes the primary download URL. Subsequent URLs are stored
+     * as landing page links with legacy names/descriptions as labels.
+     *
+     * @param  list<array{url: string, label?: string|null, visible?: string|null}>  $fileEntries
+     */
+    public function createForResource(
+        Resource $resource,
+        array $fileEntries,
+        bool $isPublished,
+        bool $createWhenEmpty = false,
+    ): ?LandingPage {
+        if (LandingPage::where('resource_id', $resource->id)->exists()) {
+            return LandingPage::where('resource_id', $resource->id)->first();
+        }
+
+        $fileEntries = $this->normaliseFileEntries($fileEntries);
+
+        if ($fileEntries === [] && ! $createWhenEmpty) {
+            return null;
+        }
+
+        $resource->loadMissing('titles.titleType');
+
+        $landingPage = DB::transaction(function () use ($resource, $fileEntries, $isPublished): LandingPage {
+            $primaryFile = $fileEntries[0] ?? null;
+            $shouldPublish = $isPublished && $primaryFile !== null;
+
+            $landingPage = new LandingPage([
+                'resource_id' => $resource->id,
+                'template' => 'default_gfz',
+                'ftp_url' => $primaryFile['url'] ?? null,
+                'is_published' => $shouldPublish,
+                'published_at' => $shouldPublish ? now() : null,
+            ]);
+
+            $landingPage->setRelation('resource', $resource);
+            $landingPage->save();
+
+            foreach (array_slice($fileEntries, 1) as $position => $fileEntry) {
+                $landingPage->links()->create([
+                    'url' => $fileEntry['url'],
+                    'label' => $fileEntry['label'] ?? 'Download '.($position + 2),
+                    'position' => $position,
+                ]);
+            }
+
+            return $landingPage;
+        });
+
+        CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->forget();
+
+        return $landingPage;
+    }
+
+    /**
+     * @param  list<array{url: string, label?: string|null, visible?: string|null}>  $fileEntries
+     * @return list<array{url: string, label: string|null, visible: string|null}>
+     */
+    private function normaliseFileEntries(array $fileEntries): array
+    {
+        $normalised = [];
+        $seenUrls = [];
+
+        foreach ($fileEntries as $entry) {
+            $url = trim($entry['url'] ?? '');
+
+            if ($url === '' || isset($seenUrls[$url])) {
+                continue;
+            }
+
+            $seenUrls[$url] = true;
+
+            $label = isset($entry['label']) ? trim((string) $entry['label']) : '';
+
+            $normalised[] = [
+                'url' => $url,
+                'label' => $label !== '' ? mb_substr($label, 0, 255) : null,
+                'visible' => isset($entry['visible']) ? (string) $entry['visible'] : null,
+            ];
+        }
+
+        return $normalised;
+    }
+}

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -25,8 +25,10 @@ class LegacyLandingPageImportService
         bool $isPublished,
         bool $createWhenEmpty = false,
     ): ?LandingPage {
-        if (LandingPage::where('resource_id', $resource->id)->exists()) {
-            return LandingPage::where('resource_id', $resource->id)->first();
+        $existingLandingPage = LandingPage::where('resource_id', $resource->id)->first();
+
+        if ($existingLandingPage !== null) {
+            return $existingLandingPage;
         }
 
         $fileEntries = $this->normaliseFileEntries($fileEntries);

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -78,7 +78,7 @@ class LegacyLandingPageImportService
         $seenUrls = [];
 
         foreach ($fileEntries as $entry) {
-            $url = trim($entry['url'] ?? '');
+            $url = trim($entry['url']);
 
             if ($url === '' || isset($seenUrls[$url])) {
                 continue;

--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Datacenter;
+use App\Models\Resource;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class LegacyMetaworksDatacenterLookupService
+{
+    public const DEFAULT_DATACENTER = 'GFZ German Research Centre for Geosciences';
+    public const GIPP_DATACENTER = 'GIPP Geophysical Instrument Pool Potsdam';
+    public const SDDB_DATACENTER = 'SDDB Scientific Drilling Database';
+
+    private const CONNECTION = 'legacy_metaworks';
+
+    /**
+     * @return list<string>
+     */
+    public function resolveDatacenterNames(string $doi): array
+    {
+        try {
+            $datacenters = [];
+
+            if ($this->doiExistsInTable('gipp_dataset', $doi)) {
+                $datacenters[] = self::GIPP_DATACENTER;
+            }
+
+            if ($this->doiExistsInTable('sddb_dataset', $doi)) {
+                $datacenters[] = self::SDDB_DATACENTER;
+            }
+
+            return $datacenters !== [] ? $datacenters : [self::DEFAULT_DATACENTER];
+        } catch (\Throwable $exception) {
+            Log::warning('Legacy Metaworks datacenter lookup failed; using default datacenter', [
+                'doi' => $doi,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [self::DEFAULT_DATACENTER];
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function resolveDatacenterIds(string $doi): array
+    {
+        $names = $this->resolveDatacenterNames($doi);
+
+        return Datacenter::query()
+            ->whereIn('name', $names)
+            ->pluck('id')
+            ->map(static fn (mixed $id): int => (int) $id)
+            ->values()
+            ->all();
+    }
+
+    public function syncDatacenters(Resource $resource, string $doi): void
+    {
+        $datacenterIds = $this->resolveDatacenterIds($doi);
+
+        if ($datacenterIds === []) {
+            Log::warning('No matching ERNIE datacenter found for legacy import', [
+                'doi' => $doi,
+                'expected_datacenters' => $this->resolveDatacenterNames($doi),
+            ]);
+
+            return;
+        }
+
+        $changes = $resource->datacenters()->sync($datacenterIds);
+
+        if (array_filter($changes)) {
+            $resource->touch();
+        }
+    }
+
+    private function doiExistsInTable(string $table, string $doi): bool
+    {
+        return DB::connection(self::CONNECTION)
+            ->table($table)
+            ->where('doi', $doi)
+            ->exists();
+    }
+}

--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -51,12 +51,13 @@ class LegacyMetaworksDatacenterLookupService
     {
         $names = $this->resolveDatacenterNames($doi);
 
-        return Datacenter::query()
+        $ids = Datacenter::query()
             ->whereIn('name', $names)
             ->pluck('id')
             ->map(static fn (mixed $id): int => (int) $id)
-            ->values()
             ->all();
+
+        return array_values($ids);
     }
 
     public function syncDatacenters(Resource $resource, string $doi): void

--- a/app/Services/MetaworksDownloadUrlService.php
+++ b/app/Services/MetaworksDownloadUrlService.php
@@ -36,10 +36,10 @@ class MetaworksDownloadUrlService
         $result = $this->lookupFileEntries($doi);
 
         return [
-            'urls' => array_values(array_map(
+            'urls' => array_map(
                 static fn (array $file): string => $file['url'],
                 $result['files'],
-            )),
+            ),
             'allPublic' => $result['allPublic'],
         ];
     }

--- a/app/Services/MetaworksDownloadUrlService.php
+++ b/app/Services/MetaworksDownloadUrlService.php
@@ -33,6 +33,28 @@ class MetaworksDownloadUrlService
      */
     public function lookupFileUrls(string $doi): array
     {
+        $result = $this->lookupFileEntries($doi);
+
+        return [
+            'urls' => array_values(array_map(
+                static fn (array $file): string => $file['url'],
+                $result['files'],
+            )),
+            'allPublic' => $result['allPublic'],
+        ];
+    }
+
+    /**
+     * Look up file download entries with labels for a given DOI.
+     *
+     * The first entry becomes the landing page's primary download URL. Remaining
+     * entries are imported as landing page additional links, using the legacy
+     * file name first and the description as fallback label.
+     *
+     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool}
+     */
+    public function lookupFileEntries(string $doi): array
+    {
         // Find old resource_id by DOI
         $oldResource = DB::connection(self::CONNECTION)
             ->table('resource')
@@ -41,7 +63,7 @@ class MetaworksDownloadUrlService
             ->first();
 
         if ($oldResource === null) {
-            return ['urls' => [], 'allPublic' => false];
+            return ['files' => [], 'allPublic' => false];
         }
 
         // Get all file records for that resource (public and non-public)
@@ -49,10 +71,10 @@ class MetaworksDownloadUrlService
             ->table('file')
             ->where('resource_id', $oldResource->id)
             ->orderBy('id')
-            ->get(['url', 'visible']);
+            ->get(['url', 'name', 'description', 'visible']);
 
         if ($files->isEmpty()) {
-            return ['urls' => [], 'allPublic' => false];
+            return ['files' => [], 'allPublic' => false];
         }
 
         // Determine if all files are publicly visible
@@ -61,29 +83,70 @@ class MetaworksDownloadUrlService
         // Deduplicate URLs and filter to valid absolute HTTP(S) links (max 2048 chars)
         // to prevent XSS from legacy data containing javascript:, data: or other unsafe schemes,
         // and reject malformed URLs like "http:foo" that lack a host component.
-        $urls = $files->pluck('url')
-            ->unique()
-            ->values()
-            ->filter(function (string $url) use ($doi): bool {
-                if (mb_strlen($url) > 2048) {
-                    Log::warning('Skipping overly long metaworks URL', ['doi' => $doi, 'length' => mb_strlen($url)]);
+        $seenUrls = [];
+        $entries = [];
 
-                    return false;
-                }
+        foreach ($files as $file) {
+            $url = trim((string) ($file->url ?? ''));
 
-                $uri = UriHelper::parse($url);
-                $scheme = $uri?->getScheme();
-                $isHttp = $scheme !== null && in_array(strtolower($scheme), ['http', 'https'], true);
+            if ($url === '') {
+                continue;
+            }
 
-                if ($uri === null || ! $isHttp || $uri->getHost() === null || $uri->getHost() === '') {
-                    Log::warning('Skipping invalid metaworks URL', ['doi' => $doi, 'url' => $url]);
+            if (isset($seenUrls[$url])) {
+                continue;
+            }
 
-                    return false;
-                }
+            if (! $this->isValidDownloadUrl($doi, $url)) {
+                continue;
+            }
 
-                return true;
-            })->values()->all();
+            $seenUrls[$url] = true;
+            $entries[] = [
+                'url' => $url,
+                'label' => $this->resolveLabel($file->name ?? null, $file->description ?? null),
+                'visible' => isset($file->visible) ? (string) $file->visible : null,
+            ];
+        }
 
-        return ['urls' => $urls, 'allPublic' => $allPublic];
+        return ['files' => $entries, 'allPublic' => $allPublic];
+    }
+
+    private function isValidDownloadUrl(string $doi, string $url): bool
+    {
+        if (mb_strlen($url) > 2048) {
+            Log::warning('Skipping overly long metaworks URL', ['doi' => $doi, 'length' => mb_strlen($url)]);
+
+            return false;
+        }
+
+        $uri = UriHelper::parse($url);
+        $scheme = $uri?->getScheme();
+        $isHttp = $scheme !== null && in_array(strtolower($scheme), ['http', 'https'], true);
+
+        if ($uri === null || ! $isHttp || $uri->getHost() === null || $uri->getHost() === '') {
+            Log::warning('Skipping invalid metaworks URL', ['doi' => $doi, 'url' => $url]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function resolveLabel(mixed $name, mixed $description): ?string
+    {
+        foreach ([$name, $description] as $candidate) {
+            if (! is_string($candidate)) {
+                continue;
+            }
+
+            $label = trim($candidate);
+
+            if ($label !== '') {
+                return mb_substr($label, 0, 255);
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -19,12 +19,13 @@ use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\Right;
 use App\Models\TitleType;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\Citations\RelatedItemStorageService;
 use App\Services\Entities\AffiliationService;
 use App\Services\Entities\InstitutionService;
 use App\Services\Entities\PersonService;
-use App\Services\Citations\RelatedIdentifierCitationLabelService;
-use App\Services\Citations\RelatedItemStorageService;
 use App\Support\SubjectBreadcrumbPath;
+use App\Support\UriHelper;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -33,6 +34,8 @@ use Illuminate\Validation\ValidationException;
 
 class ResourceStorageService
 {
+    private const CONTACT_FIELD_MAX_LENGTH = 255;
+
     /** @var array<string>|null Cached Contact Person name/slug for role matching */
     private ?array $contactPersonNames = null;
 
@@ -341,6 +344,7 @@ class ResourceStorageService
     {
         $person = $this->personService->findOrCreate($data);
         $isContact = (bool) ($data['isContact'] ?? false);
+        $contactInfo = $this->validatedContactInfo($data);
 
         return ResourceCreator::query()->create([
             'resource_id' => $resource->id,
@@ -348,8 +352,8 @@ class ResourceStorageService
             'creatorable_type' => Person::class,
             'position' => $position,
             'is_contact' => $isContact,
-            'email' => $isContact ? ($data['email'] ?? null) : null,
-            'website' => $isContact ? ($data['website'] ?? null) : null,
+            'email' => $isContact ? $contactInfo['email'] : null,
+            'website' => $isContact ? $contactInfo['website'] : null,
         ]);
     }
 
@@ -435,14 +439,15 @@ class ResourceStorageService
         $person = $this->personService->findOrCreate($data);
 
         $hasContactPersonRole = $this->hasContactPersonRole($data);
+        $contactInfo = $this->validatedContactInfo($data);
 
         return ResourceContributor::query()->create([
             'resource_id' => $resource->id,
             'contributorable_id' => $person->id,
             'contributorable_type' => Person::class,
             'position' => $position,
-            'email' => $hasContactPersonRole ? ($data['email'] ?? null) : null,
-            'website' => $hasContactPersonRole ? ($data['website'] ?? null) : null,
+            'email' => $hasContactPersonRole ? $contactInfo['email'] : null,
+            'website' => $hasContactPersonRole ? $contactInfo['website'] : null,
         ]);
     }
 
@@ -503,6 +508,74 @@ class ResourceStorageService
             'contributorable_type' => Institution::class,
             'position' => $position,
         ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{email: string|null, website: string|null}
+     */
+    private function validatedContactInfo(array $data): array
+    {
+        return [
+            'email' => $this->validatedContactEmail($data['email'] ?? null),
+            'website' => $this->validatedContactWebsite($data['website'] ?? null),
+        ];
+    }
+
+    private function validatedContactEmail(mixed $value): ?string
+    {
+        $email = $this->filledContactString($value);
+
+        if ($email === null) {
+            return null;
+        }
+
+        if (
+            mb_strlen($email) > self::CONTACT_FIELD_MAX_LENGTH
+            || filter_var($email, FILTER_VALIDATE_EMAIL) === false
+        ) {
+            Log::warning('Skipping invalid contact email while storing resource');
+
+            return null;
+        }
+
+        return $email;
+    }
+
+    private function validatedContactWebsite(mixed $value): ?string
+    {
+        $website = $this->filledContactString($value);
+
+        if ($website === null) {
+            return null;
+        }
+
+        $uri = UriHelper::parse($website);
+        $scheme = strtolower($uri?->getScheme() ?? '');
+        $host = trim($uri?->getHost() ?? '');
+
+        if (
+            mb_strlen($website) > self::CONTACT_FIELD_MAX_LENGTH
+            || ! in_array($scheme, ['http', 'https'], true)
+            || $host === ''
+        ) {
+            Log::warning('Skipping invalid contact website while storing resource');
+
+            return null;
+        }
+
+        return $website;
+    }
+
+    private function filledContactString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value !== '' ? $value : null;
     }
 
     /**

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -340,12 +340,16 @@ class ResourceStorageService
     private function storePersonCreator(Resource $resource, array $data, int $position): ResourceCreator
     {
         $person = $this->personService->findOrCreate($data);
+        $isContact = (bool) ($data['isContact'] ?? false);
 
         return ResourceCreator::query()->create([
             'resource_id' => $resource->id,
             'creatorable_id' => $person->id,
             'creatorable_type' => Person::class,
             'position' => $position,
+            'is_contact' => $isContact,
+            'email' => $isContact ? ($data['email'] ?? null) : null,
+            'website' => $isContact ? ($data['website'] ?? null) : null,
         ]);
     }
 

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -534,7 +534,7 @@ class ResourceStorageService
             mb_strlen($email) > self::CONTACT_FIELD_MAX_LENGTH
             || filter_var($email, FILTER_VALIDATE_EMAIL) === false
         ) {
-            Log::warning('Skipping invalid contact email while storing resource');
+            Log::debug('Skipping invalid contact email while storing resource');
 
             return null;
         }
@@ -559,7 +559,7 @@ class ResourceStorageService
             || ! in_array($scheme, ['http', 'https'], true)
             || $host === ''
         ) {
-            Log::warning('Skipping invalid contact website while storing resource');
+            Log::debug('Skipping invalid contact website while storing resource');
 
             return null;
         }

--- a/app/Services/SumarioPendingResourceImportService.php
+++ b/app/Services/SumarioPendingResourceImportService.php
@@ -1,0 +1,467 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Datacenter;
+use App\Models\OldDataset;
+use App\Models\Resource;
+use App\Models\ResourceType;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class SumarioPendingResourceImportService
+{
+    public function __construct(
+        private readonly OldDatasetEditorLoader $editorLoader,
+        private readonly ResourceStorageService $resourceStorage,
+        private readonly LegacyMetaworksDatacenterLookupService $datacenterLookup,
+        private readonly MetaworksDownloadUrlService $downloadUrlService,
+        private readonly LegacyLandingPageImportService $landingPageImport,
+        private readonly DoiSuggestionService $doiSuggestionService,
+    ) {}
+
+    public function countImportablePending(): int
+    {
+        return OldDataset::query()
+            ->where('publicstatus', 'pending')
+            ->whereNotNull('identifier')
+            ->where('identifier', '!=', '')
+            ->count();
+    }
+
+    /**
+     * @return array{status: 'imported'|'skipped'|'missing'|'failed', resource: Resource|null, doi: string, error: string|null}
+     */
+    public function importPendingByDoi(string $doi, int $userId): array
+    {
+        $normalisedDoi = $this->normaliseDoi($doi);
+        $oldDataset = $this->findPendingDatasetByDoi($normalisedDoi);
+
+        if ($oldDataset === null) {
+            return [
+                'status' => 'missing',
+                'resource' => null,
+                'doi' => $normalisedDoi,
+                'error' => null,
+            ];
+        }
+
+        if (Resource::where('doi', $normalisedDoi)->exists()) {
+            return [
+                'status' => 'skipped',
+                'resource' => null,
+                'doi' => $normalisedDoi,
+                'error' => null,
+            ];
+        }
+
+        try {
+            return [
+                'status' => 'imported',
+                'resource' => $this->importDataset($oldDataset, $normalisedDoi, $userId),
+                'doi' => $normalisedDoi,
+                'error' => null,
+            ];
+        } catch (\Throwable $exception) {
+            Log::warning('Failed to import SUMARIO pending resource', [
+                'doi' => $normalisedDoi,
+                'old_resource_id' => $oldDataset->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [
+                'status' => 'failed',
+                'resource' => null,
+                'doi' => $normalisedDoi,
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * @return array{processed: int, imported: int, skipped: int, failed: int, skipped_dois: list<string>, failed_dois: list<array{doi: string, error: string}>}
+     */
+    public function importAllPending(int $userId, int $maxStoredDois = 100): array
+    {
+        $summary = [
+            'processed' => 0,
+            'imported' => 0,
+            'skipped' => 0,
+            'failed' => 0,
+            'skipped_dois' => [],
+            'failed_dois' => [],
+        ];
+
+        /** @var iterable<int, OldDataset> $pendingDatasets */
+        $pendingDatasets = OldDataset::query()
+            ->where('publicstatus', 'pending')
+            ->whereNotNull('identifier')
+            ->where('identifier', '!=', '')
+            ->orderBy('id')
+            ->cursor();
+
+        foreach ($pendingDatasets as $oldDataset) {
+            $summary['processed']++;
+            $doi = $this->normaliseDoi((string) $oldDataset->identifier);
+
+            if (Resource::where('doi', $doi)->exists()) {
+                $summary['skipped']++;
+                if (count($summary['skipped_dois']) < $maxStoredDois) {
+                    $summary['skipped_dois'][] = $doi;
+                }
+
+                continue;
+            }
+
+            try {
+                $this->importDataset($oldDataset, $doi, $userId);
+                $summary['imported']++;
+            } catch (\Throwable $exception) {
+                $summary['failed']++;
+
+                if (count($summary['failed_dois']) < $maxStoredDois) {
+                    $summary['failed_dois'][] = [
+                        'doi' => $doi,
+                        'error' => $exception->getMessage(),
+                    ];
+                }
+
+                Log::warning('Failed to import SUMARIO pending resource', [
+                    'doi' => $doi,
+                    'old_resource_id' => $oldDataset->id,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        return $summary;
+    }
+
+    private function findPendingDatasetByDoi(string $doi): ?OldDataset
+    {
+        return OldDataset::query()
+            ->where('publicstatus', 'pending')
+            ->where(function ($query) use ($doi): void {
+                $query->where('identifier', $doi)
+                    ->orWhere('identifier', strtoupper($doi));
+            })
+            ->first();
+    }
+
+    private function importDataset(OldDataset $oldDataset, string $doi, int $userId): Resource
+    {
+        $editorData = $this->editorLoader->loadForEditor((int) $oldDataset->id);
+        $payload = $this->mapEditorPayloadForStorage($editorData, $oldDataset, $doi);
+
+        [$resource] = $this->resourceStorage->store($payload, $userId);
+
+        $resource->forceFill([
+            'legacy_source' => 'sumario-pmd',
+            'legacy_source_id' => $oldDataset->id,
+            'legacy_source_status' => $oldDataset->publicstatus,
+            'force_review_status' => true,
+        ])->save();
+
+        $fileResult = ['files' => [], 'allPublic' => false];
+
+        try {
+            $fileResult = $this->downloadUrlService->lookupFileEntries($doi);
+        } catch (\Throwable $exception) {
+            Log::warning('SUMARIO pending import could not load legacy file URLs', [
+                'doi' => $doi,
+                'old_resource_id' => $oldDataset->id,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+
+        $this->landingPageImport->createForResource(
+            resource: $resource,
+            fileEntries: $fileResult['files'],
+            isPublished: false,
+            createWhenEmpty: true,
+        );
+
+        return $resource->fresh(['landingPage', 'datacenters']) ?? $resource;
+    }
+
+    /**
+     * @param  array<string, mixed>  $editorData
+     * @return array<string, mixed>
+     */
+    private function mapEditorPayloadForStorage(array $editorData, OldDataset $oldDataset, string $doi): array
+    {
+        return [
+            'resourceId' => null,
+            'doi' => $doi,
+            'year' => $this->normaliseYear($editorData['year'] ?? $oldDataset->publicationyear),
+            'version' => $this->filledString($editorData['version'] ?? null),
+            'language' => $this->filledString($editorData['language'] ?? null) ?? 'en',
+            'resourceType' => $this->resolveResourceTypeId($editorData['resourceType'] ?? null),
+            'titles' => $this->normaliseTitles($editorData['titles'] ?? [], $oldDataset, $doi),
+            'licenses' => $this->normaliseStringList($editorData['initialRights'] ?? []),
+            'authors' => $this->normaliseContributors($editorData['authors'] ?? []),
+            'contributors' => $this->normaliseContributors($editorData['contributors'] ?? [], true),
+            'descriptions' => $this->normaliseDescriptions($editorData['descriptions'] ?? []),
+            'dates' => $this->normaliseDates($editorData['dates'] ?? []),
+            'gcmdKeywords' => is_array($editorData['gcmdKeywords'] ?? null) ? array_values($editorData['gcmdKeywords']) : [],
+            'freeKeywords' => $this->normaliseStringList($editorData['freeKeywords'] ?? []),
+            'spatialTemporalCoverages' => is_array($editorData['geoLocations'] ?? null) ? array_values($editorData['geoLocations']) : [],
+            'relatedIdentifiers' => $this->normaliseRelatedIdentifiers($editorData['relatedWorks'] ?? []),
+            'fundingReferences' => is_array($editorData['fundingReferences'] ?? null) ? array_values($editorData['fundingReferences']) : [],
+            'mslLaboratories' => is_array($editorData['mslLaboratories'] ?? null) ? array_values($editorData['mslLaboratories']) : [],
+            'datacenters' => $this->datacenterIdsForDoi($doi),
+        ];
+    }
+
+    /**
+     * @return list<array{title: string, titleType: string, language?: string|null}>
+     */
+    private function normaliseTitles(mixed $titles, OldDataset $oldDataset, string $doi): array
+    {
+        $normalised = [];
+
+        if (is_array($titles)) {
+            foreach ($titles as $title) {
+                if (! is_array($title)) {
+                    continue;
+                }
+
+                $value = $this->filledString($title['title'] ?? null);
+
+                if ($value === null) {
+                    continue;
+                }
+
+                $normalised[] = [
+                    'title' => $value,
+                    'titleType' => $this->filledString($title['titleType'] ?? null) ?? 'main-title',
+                    'language' => $this->filledString($title['language'] ?? null),
+                ];
+            }
+        }
+
+        if ($normalised === []) {
+            $normalised[] = [
+                'title' => $this->filledString($oldDataset->title ?? null) ?? "Legacy dataset {$doi}",
+                'titleType' => 'main-title',
+            ];
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function normaliseContributors(mixed $contributors, bool $mapRoles = false): array
+    {
+        if (! is_array($contributors)) {
+            return [];
+        }
+
+        $normalised = [];
+
+        foreach (array_values($contributors) as $position => $contributor) {
+            if (! is_array($contributor)) {
+                continue;
+            }
+
+            $contributor['position'] = isset($contributor['position']) && is_numeric($contributor['position'])
+                ? (int) $contributor['position']
+                : $position;
+
+            if ($mapRoles) {
+                $contributor['roles'] = $this->normaliseRoles($contributor['roles'] ?? []);
+            }
+
+            $normalised[] = $contributor;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normaliseRoles(mixed $roles): array
+    {
+        if (! is_array($roles)) {
+            return ['Other'];
+        }
+
+        $normalised = [];
+
+        foreach ($roles as $role) {
+            $role = $this->filledString($role);
+
+            if ($role === null) {
+                continue;
+            }
+
+            $normalised[] = Str::studly($role);
+        }
+
+        return $normalised !== [] ? array_values(array_unique($normalised)) : ['Other'];
+    }
+
+    /**
+     * @return list<array{descriptionType: string, description: string, language?: string|null}>
+     */
+    private function normaliseDescriptions(mixed $descriptions): array
+    {
+        if (! is_array($descriptions)) {
+            return [];
+        }
+
+        $normalised = [];
+
+        foreach ($descriptions as $description) {
+            if (! is_array($description)) {
+                continue;
+            }
+
+            $value = $this->filledString($description['description'] ?? null);
+
+            if ($value === null) {
+                continue;
+            }
+
+            $normalised[] = [
+                'descriptionType' => Str::kebab((string) ($description['descriptionType'] ?? $description['type'] ?? 'abstract')),
+                'description' => $value,
+                'language' => $this->filledString($description['language'] ?? null),
+            ];
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function normaliseDates(mixed $dates): array
+    {
+        if (! is_array($dates)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(function (mixed $date): ?array {
+            if (! is_array($date)) {
+                return null;
+            }
+
+            $date['dateType'] = Str::kebab((string) ($date['dateType'] ?? ''));
+
+            return $date['dateType'] !== '' ? $date : null;
+        }, $dates)));
+    }
+
+    /**
+     * @return list<array{identifier: string, identifierType: string, relationType: string, citationLabel: string}>
+     */
+    private function normaliseRelatedIdentifiers(mixed $relatedIdentifiers): array
+    {
+        if (! is_array($relatedIdentifiers)) {
+            return [];
+        }
+
+        $normalised = [];
+
+        foreach ($relatedIdentifiers as $relatedIdentifier) {
+            if (! is_array($relatedIdentifier)) {
+                continue;
+            }
+
+            $identifier = $this->filledString($relatedIdentifier['identifier'] ?? null);
+
+            if ($identifier === null) {
+                continue;
+            }
+
+            $normalised[] = [
+                'identifier' => $identifier,
+                'identifierType' => $this->filledString($relatedIdentifier['identifierType'] ?? $relatedIdentifier['identifier_type'] ?? null) ?? 'DOI',
+                'relationType' => $this->filledString($relatedIdentifier['relationType'] ?? $relatedIdentifier['relation_type'] ?? null) ?? 'References',
+                'citationLabel' => $identifier,
+            ];
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normaliseStringList(mixed $values): array
+    {
+        if (! is_array($values)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(array_map(
+            fn (mixed $value): ?string => $this->filledString($value),
+            $values,
+        ))));
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function datacenterIdsForDoi(string $doi): array
+    {
+        $ids = $this->datacenterLookup->resolveDatacenterIds($doi);
+
+        if ($ids !== []) {
+            return $ids;
+        }
+
+        return [
+            (int) Datacenter::query()->firstOrCreate([
+                'name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+            ])->id,
+        ];
+    }
+
+    private function resolveResourceTypeId(mixed $resourceType): ?int
+    {
+        if (is_numeric($resourceType) && ResourceType::whereKey((int) $resourceType)->exists()) {
+            return (int) $resourceType;
+        }
+
+        return ResourceType::query()
+            ->where('slug', 'dataset')
+            ->value('id')
+            ?? ResourceType::query()->value('id');
+    }
+
+    private function normaliseYear(mixed $year): ?int
+    {
+        if (! is_numeric($year)) {
+            return null;
+        }
+
+        $year = (int) $year;
+
+        return $year >= 1000 && $year <= 9999 ? $year : null;
+    }
+
+    private function normaliseDoi(string $doi): string
+    {
+        $normalised = $this->doiSuggestionService->normalizeDoi($doi);
+
+        return $normalised !== '' ? $normalised : trim($doi);
+    }
+
+    private function filledString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/app/Services/SumarioPmdContactEnrichmentService.php
+++ b/app/Services/SumarioPmdContactEnrichmentService.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Institution;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class SumarioPmdContactEnrichmentService
+{
+    private const CONNECTION = 'metaworks';
+
+    public function enrich(Resource $resource, string $doi): bool
+    {
+        try {
+            $contacts = $this->loadContacts($doi);
+        } catch (\Throwable $exception) {
+            Log::warning('SUMARIO contact lookup failed', [
+                'doi' => $doi,
+                'resource_id' => $resource->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return false;
+        }
+
+        if ($contacts === []) {
+            return false;
+        }
+
+        $resource->loadMissing([
+            'creators.creatorable',
+            'contributors.contributorable',
+        ]);
+
+        $updated = false;
+
+        foreach ($contacts as $contact) {
+            foreach ($resource->creators as $creator) {
+                if (! $this->matchesEntity($creator->creatorable, $contact)) {
+                    continue;
+                }
+
+                $this->updateCreatorContact($creator, $contact);
+                $updated = true;
+            }
+
+            foreach ($resource->contributors as $contributor) {
+                if (! $this->matchesEntity($contributor->contributorable, $contact)) {
+                    continue;
+                }
+
+                $this->updateContributorContact($contributor, $contact);
+                $updated = true;
+            }
+        }
+
+        if ($updated) {
+            $resource->touch();
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @return list<array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}>
+     */
+    private function loadContacts(string $doi): array
+    {
+        $oldResource = DB::connection(self::CONNECTION)
+            ->table('resource')
+            ->where('identifier', $doi)
+            ->select('id')
+            ->first();
+
+        if ($oldResource === null) {
+            return [];
+        }
+
+        $rows = DB::connection(self::CONNECTION)
+            ->table('contactinfo as ci')
+            ->join('resourceagent as ra', function ($join): void {
+                $join->on('ci.resourceagent_resource_id', '=', 'ra.resource_id')
+                    ->on('ci.resourceagent_order', '=', 'ra.order');
+            })
+            ->where('ci.resourceagent_resource_id', $oldResource->id)
+            ->where(function ($query): void {
+                $query->whereNotNull('ci.email')
+                    ->orWhereNotNull('ci.website');
+            })
+            ->orderBy('ci.resourceagent_order')
+            ->get([
+                'ci.resourceagent_order as order',
+                'ra.name',
+                'ra.firstname',
+                'ra.lastname',
+                'ci.email',
+                'ci.website',
+            ]);
+
+        $contacts = [];
+
+        foreach ($rows as $row) {
+            $email = $this->filledString($row->email ?? null);
+            $website = $this->filledString($row->website ?? null);
+
+            if ($email === null && $website === null) {
+                continue;
+            }
+
+            $contacts[] = [
+                'order' => (int) $row->order,
+                'name' => $this->filledString($row->name ?? null),
+                'firstname' => $this->filledString($row->firstname ?? null),
+                'lastname' => $this->filledString($row->lastname ?? null),
+                'email' => $email,
+                'website' => $website,
+            ];
+        }
+
+        return $contacts;
+    }
+
+    /**
+     * @param  array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}  $contact
+     */
+    private function updateCreatorContact(ResourceCreator $creator, array $contact): void
+    {
+        $creator->forceFill([
+            'is_contact' => true,
+            'email' => $contact['email'] ?? $creator->email,
+            'website' => $contact['website'] ?? $creator->website,
+        ])->save();
+    }
+
+    /**
+     * @param  array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}  $contact
+     */
+    private function updateContributorContact(ResourceContributor $contributor, array $contact): void
+    {
+        $contributor->forceFill([
+            'email' => $contact['email'] ?? $contributor->email,
+            'website' => $contact['website'] ?? $contributor->website,
+        ])->save();
+    }
+
+    /**
+     * @param  array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}  $contact
+     */
+    private function matchesEntity(?Model $entity, array $contact): bool
+    {
+        if ($entity instanceof Person) {
+            return $this->namesOverlap($this->personNameCandidates($entity), $this->contactNameCandidates($contact));
+        }
+
+        if ($entity instanceof Institution) {
+            return $this->namesOverlap([$entity->name], $this->contactNameCandidates($contact));
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function personNameCandidates(Person $person): array
+    {
+        $candidates = [];
+
+        if ($person->family_name !== null && $person->given_name !== null) {
+            $candidates[] = "{$person->family_name}, {$person->given_name}";
+            $candidates[] = "{$person->given_name} {$person->family_name}";
+        }
+
+        $candidates[] = $person->full_name;
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}  $contact
+     * @return list<string>
+     */
+    private function contactNameCandidates(array $contact): array
+    {
+        $candidates = [];
+
+        if ($contact['name'] !== null) {
+            $candidates[] = $contact['name'];
+        }
+
+        if ($contact['lastname'] !== null && $contact['firstname'] !== null) {
+            $candidates[] = "{$contact['lastname']}, {$contact['firstname']}";
+            $candidates[] = "{$contact['firstname']} {$contact['lastname']}";
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param  list<string|null>  $left
+     * @param  list<string|null>  $right
+     */
+    private function namesOverlap(array $left, array $right): bool
+    {
+        $normalisedLeft = array_filter(array_map($this->normaliseName(...), $left));
+        $normalisedRight = array_filter(array_map($this->normaliseName(...), $right));
+
+        return array_intersect($normalisedLeft, $normalisedRight) !== [];
+    }
+
+    private function normaliseName(?string $name): string
+    {
+        if ($name === null) {
+            return '';
+        }
+
+        $normalised = mb_strtolower(trim($name), 'UTF-8');
+        $normalised = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalised) ?: $normalised;
+        $normalised = preg_replace('/[^\pL\pN]+/u', ' ', $normalised) ?? '';
+        $normalised = preg_replace('/\s+/', ' ', $normalised) ?? '';
+
+        return trim($normalised);
+    }
+
+    private function filledString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value !== '' ? $value : null;
+    }
+}

--- a/app/Services/SumarioPmdContactEnrichmentService.php
+++ b/app/Services/SumarioPmdContactEnrichmentService.php
@@ -51,8 +51,9 @@ class SumarioPmdContactEnrichmentService
                     continue;
                 }
 
-                $this->updateCreatorContact($creator, $contact);
-                $updated = true;
+                if ($this->updateCreatorContact($creator, $contact)) {
+                    $updated = true;
+                }
             }
 
             foreach ($resource->contributors as $contributor) {
@@ -60,8 +61,9 @@ class SumarioPmdContactEnrichmentService
                     continue;
                 }
 
-                $this->updateContributorContact($contributor, $contact);
-                $updated = true;
+                if ($this->updateContributorContact($contributor, $contact)) {
+                    $updated = true;
+                }
             }
         }
 
@@ -134,24 +136,28 @@ class SumarioPmdContactEnrichmentService
     /**
      * @param  array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}  $contact
      */
-    private function updateCreatorContact(ResourceCreator $creator, array $contact): void
+    private function updateCreatorContact(ResourceCreator $creator, array $contact): bool
     {
         $creator->forceFill([
             'is_contact' => true,
             'email' => $contact['email'] ?? $creator->email,
             'website' => $contact['website'] ?? $creator->website,
         ])->save();
+
+        return $creator->wasChanged(['is_contact', 'email', 'website']);
     }
 
     /**
      * @param  array{order: int, name: string|null, firstname: string|null, lastname: string|null, email: string|null, website: string|null}  $contact
      */
-    private function updateContributorContact(ResourceContributor $contributor, array $contact): void
+    private function updateContributorContact(ResourceContributor $contributor, array $contact): bool
     {
         $contributor->forceFill([
             'email' => $contact['email'] ?? $contributor->email,
             'website' => $contact['website'] ?? $contributor->website,
         ])->save();
+
+        return $contributor->wasChanged(['email', 'website']);
     }
 
     /**

--- a/app/Services/SumarioPmdContactEnrichmentService.php
+++ b/app/Services/SumarioPmdContactEnrichmentService.php
@@ -18,6 +18,8 @@ class SumarioPmdContactEnrichmentService
 {
     private const CONNECTION = 'metaworks';
 
+    private const CONTACT_FIELD_MAX_LENGTH = 255;
+
     public function enrich(Resource $resource, string $doi): bool
     {
         try {
@@ -250,7 +252,10 @@ class SumarioPmdContactEnrichmentService
             return null;
         }
 
-        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+        if (
+            mb_strlen($email) > self::CONTACT_FIELD_MAX_LENGTH
+            || filter_var($email, FILTER_VALIDATE_EMAIL) === false
+        ) {
             Log::warning('Skipping invalid SUMARIO contact email', [
                 'doi' => $doi,
             ]);
@@ -273,7 +278,11 @@ class SumarioPmdContactEnrichmentService
         $scheme = strtolower($uri?->getScheme() ?? '');
         $host = trim($uri?->getHost() ?? '');
 
-        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+        if (
+            mb_strlen($website) > self::CONTACT_FIELD_MAX_LENGTH
+            || ! in_array($scheme, ['http', 'https'], true)
+            || $host === ''
+        ) {
             Log::warning('Skipping invalid SUMARIO contact website', [
                 'doi' => $doi,
             ]);

--- a/app/Services/SumarioPmdContactEnrichmentService.php
+++ b/app/Services/SumarioPmdContactEnrichmentService.php
@@ -9,6 +9,7 @@ use App\Models\Person;
 use App\Models\Resource;
 use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
+use App\Support\UriHelper;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -108,8 +109,8 @@ class SumarioPmdContactEnrichmentService
         $contacts = [];
 
         foreach ($rows as $row) {
-            $email = $this->filledString($row->email ?? null);
-            $website = $this->filledString($row->website ?? null);
+            $email = $this->validatedEmail($row->email ?? null, $doi);
+            $website = $this->validatedWebsite($row->website ?? null, $doi);
 
             if ($email === null && $website === null) {
                 continue;
@@ -239,5 +240,47 @@ class SumarioPmdContactEnrichmentService
         $value = trim($value);
 
         return $value !== '' ? $value : null;
+    }
+
+    private function validatedEmail(mixed $value, string $doi): ?string
+    {
+        $email = $this->filledString($value);
+
+        if ($email === null) {
+            return null;
+        }
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            Log::warning('Skipping invalid SUMARIO contact email', [
+                'doi' => $doi,
+            ]);
+
+            return null;
+        }
+
+        return $email;
+    }
+
+    private function validatedWebsite(mixed $value, string $doi): ?string
+    {
+        $website = $this->filledString($value);
+
+        if ($website === null) {
+            return null;
+        }
+
+        $uri = UriHelper::parse($website);
+        $scheme = strtolower($uri?->getScheme() ?? '');
+        $host = trim($uri?->getHost() ?? '');
+
+        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+            Log::warning('Skipping invalid SUMARIO contact website', [
+                'doi' => $doi,
+            ]);
+
+            return null;
+        }
+
+        return $website;
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -2,12 +2,48 @@
 
 use Illuminate\Support\Str;
 
-$pdoMysqlSslCa = (int) (defined('Pdo\\Mysql::ATTR_SSL_CA')
-    ? constant('Pdo\\Mysql::ATTR_SSL_CA')
-    : constant('PDO::MYSQL_ATTR_SSL_CA'));
-$pdoMysqlSslVerifyServerCert = (int) (defined('Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
-    ? constant('Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
-    : constant('PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'));
+$resolvePdoMysqlAttribute = static function (string $modern, string $legacy): ?int {
+    if (defined($modern)) {
+        return (int) constant($modern);
+    }
+
+    if (defined($legacy)) {
+        return (int) constant($legacy);
+    }
+
+    return null;
+};
+$pdoMysqlSslCa = $resolvePdoMysqlAttribute('Pdo\\Mysql::ATTR_SSL_CA', 'PDO::MYSQL_ATTR_SSL_CA');
+$pdoMysqlSslVerifyServerCert = $resolvePdoMysqlAttribute(
+    'Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT',
+    'PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT',
+);
+$mysqlSslCaOptions = static function (mixed $sslCa) use ($pdoMysqlSslCa): array {
+    if (! extension_loaded('pdo_mysql') || $pdoMysqlSslCa === null) {
+        return [];
+    }
+
+    return array_filter([
+        $pdoMysqlSslCa => $sslCa,
+    ]);
+};
+$legacyMysqlSslOptions = static function (
+    mixed $sslCa,
+    mixed $verifyServerCert
+) use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
+    if (! extension_loaded('pdo_mysql') || $pdoMysqlSslCa === null || $pdoMysqlSslVerifyServerCert === null) {
+        return [];
+    }
+
+    if ($sslCa === null || $sslCa === false || $sslCa === '') {
+        $sslCa = '/etc/ssl/certs/ca-certificates.crt';
+    }
+
+    return [
+        $pdoMysqlSslCa => $sslCa,
+        $pdoMysqlSslVerifyServerCert => $verifyServerCert,
+    ];
+};
 
 return [
 
@@ -64,9 +100,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                $pdoMysqlSslCa => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            'options' => $mysqlSslCaOptions(env('MYSQL_ATTR_SSL_CA')),
         ],
 
         'mariadb' => [
@@ -84,9 +118,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? array_filter([
-                $pdoMysqlSslCa => env('MYSQL_ATTR_SSL_CA'),
-            ]) : [],
+            'options' => $mysqlSslCaOptions(env('MYSQL_ATTR_SSL_CA')),
         ],
 
         'metaworks' => [
@@ -103,18 +135,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? (static function () use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
-                $sslCa = env('DB_SUMARIOPMD_SSL_CA');
-
-                if ($sslCa === null || $sslCa === false || $sslCa === '') {
-                    $sslCa = '/etc/ssl/certs/ca-certificates.crt';
-                }
-
-                return [
-                    $pdoMysqlSslCa => $sslCa,
-                    $pdoMysqlSslVerifyServerCert => false,
-                ];
-            })() : [],
+            'options' => $legacyMysqlSslOptions(env('DB_SUMARIOPMD_SSL_CA'), false),
         ],
 
         'legacy_metaworks' => [
@@ -131,18 +152,10 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? (static function () use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
-                $sslCa = env('DB_METAWORKS_SSL_CA');
-
-                if ($sslCa === null || $sslCa === false || $sslCa === '') {
-                    $sslCa = '/etc/ssl/certs/ca-certificates.crt';
-                }
-
-                return [
-                    $pdoMysqlSslCa => $sslCa,
-                    $pdoMysqlSslVerifyServerCert => env('DB_METAWORKS_SSL_VERIFY_SERVER_CERT', true),
-                ];
-            })() : [],
+            'options' => $legacyMysqlSslOptions(
+                env('DB_METAWORKS_SSL_CA'),
+                env('DB_METAWORKS_SSL_VERIFY_SERVER_CERT', true),
+            ),
         ],
 
         'igsn_legacy' => [
@@ -159,18 +172,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? (static function () use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
-                $sslCa = env('DB_IGSN_SSL_CA');
-
-                if ($sslCa === null || $sslCa === false || $sslCa === '') {
-                    $sslCa = '/etc/ssl/certs/ca-certificates.crt';
-                }
-
-                return [
-                    $pdoMysqlSslCa => $sslCa,
-                    $pdoMysqlSslVerifyServerCert => false,
-                ];
-            })() : [],
+            'options' => $legacyMysqlSslOptions(env('DB_IGSN_SSL_CA'), false),
         ],
 
         'pgsql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
 
 return [
 
@@ -58,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,7 +79,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -104,8 +105,8 @@ return [
                 }
 
                 return [
-                    \Pdo\Mysql::ATTR_SSL_CA => $sslCa,
-                    \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    Mysql::ATTR_SSL_CA => $sslCa,
+                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ];
             })() : [],
         ],
@@ -132,8 +133,8 @@ return [
                 }
 
                 return [
-                    \Pdo\Mysql::ATTR_SSL_CA => $sslCa,
-                    \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    Mysql::ATTR_SSL_CA => $sslCa,
+                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_METAWORKS_SSL_VERIFY_SERVER_CERT', true),
                 ];
             })() : [],
         ],
@@ -160,8 +161,8 @@ return [
                 }
 
                 return [
-                    \Pdo\Mysql::ATTR_SSL_CA => $sslCa,
-                    \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    Mysql::ATTR_SSL_CA => $sslCa,
+                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
                 ];
             })() : [],
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -1,7 +1,13 @@
 <?php
 
 use Illuminate\Support\Str;
-use Pdo\Mysql;
+
+$pdoMysqlSslCa = (int) (defined('Pdo\\Mysql::ATTR_SSL_CA')
+    ? constant('Pdo\\Mysql::ATTR_SSL_CA')
+    : constant('PDO::MYSQL_ATTR_SSL_CA'));
+$pdoMysqlSslVerifyServerCert = (int) (defined('Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
+    ? constant('Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')
+    : constant('PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'));
 
 return [
 
@@ -59,7 +65,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                $pdoMysqlSslCa => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -79,7 +85,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                $pdoMysqlSslCa => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -97,7 +103,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? (static function (): array {
+            'options' => extension_loaded('pdo_mysql') ? (static function () use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
                 $sslCa = env('DB_SUMARIOPMD_SSL_CA');
 
                 if ($sslCa === null || $sslCa === false || $sslCa === '') {
@@ -105,8 +111,8 @@ return [
                 }
 
                 return [
-                    Mysql::ATTR_SSL_CA => $sslCa,
-                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    $pdoMysqlSslCa => $sslCa,
+                    $pdoMysqlSslVerifyServerCert => false,
                 ];
             })() : [],
         ],
@@ -125,7 +131,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? (static function (): array {
+            'options' => extension_loaded('pdo_mysql') ? (static function () use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
                 $sslCa = env('DB_METAWORKS_SSL_CA');
 
                 if ($sslCa === null || $sslCa === false || $sslCa === '') {
@@ -133,8 +139,8 @@ return [
                 }
 
                 return [
-                    Mysql::ATTR_SSL_CA => $sslCa,
-                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_METAWORKS_SSL_VERIFY_SERVER_CERT', true),
+                    $pdoMysqlSslCa => $sslCa,
+                    $pdoMysqlSslVerifyServerCert => env('DB_METAWORKS_SSL_VERIFY_SERVER_CERT', true),
                 ];
             })() : [],
         ],
@@ -153,7 +159,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => extension_loaded('pdo_mysql') ? (static function (): array {
+            'options' => extension_loaded('pdo_mysql') ? (static function () use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
                 $sslCa = env('DB_IGSN_SSL_CA');
 
                 if ($sslCa === null || $sslCa === false || $sslCa === '') {
@@ -161,8 +167,8 @@ return [
                 }
 
                 return [
-                    Mysql::ATTR_SSL_CA => $sslCa,
-                    Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                    $pdoMysqlSslCa => $sslCa,
+                    $pdoMysqlSslVerifyServerCert => false,
                 ];
             })() : [],
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -1,49 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
-
-$resolvePdoMysqlAttribute = static function (string $modern, string $legacy): ?int {
-    if (defined($modern)) {
-        return (int) constant($modern);
-    }
-
-    if (defined($legacy)) {
-        return (int) constant($legacy);
-    }
-
-    return null;
-};
-$pdoMysqlSslCa = $resolvePdoMysqlAttribute('Pdo\\Mysql::ATTR_SSL_CA', 'PDO::MYSQL_ATTR_SSL_CA');
-$pdoMysqlSslVerifyServerCert = $resolvePdoMysqlAttribute(
-    'Pdo\\Mysql::ATTR_SSL_VERIFY_SERVER_CERT',
-    'PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT',
-);
-$mysqlSslCaOptions = static function (mixed $sslCa) use ($pdoMysqlSslCa): array {
-    if (! extension_loaded('pdo_mysql') || $pdoMysqlSslCa === null) {
-        return [];
-    }
-
-    return array_filter([
-        $pdoMysqlSslCa => $sslCa,
-    ]);
-};
-$legacyMysqlSslOptions = static function (
-    mixed $sslCa,
-    mixed $verifyServerCert
-) use ($pdoMysqlSslCa, $pdoMysqlSslVerifyServerCert): array {
-    if (! extension_loaded('pdo_mysql') || $pdoMysqlSslCa === null || $pdoMysqlSslVerifyServerCert === null) {
-        return [];
-    }
-
-    if ($sslCa === null || $sslCa === false || $sslCa === '') {
-        $sslCa = '/etc/ssl/certs/ca-certificates.crt';
-    }
-
-    return [
-        $pdoMysqlSslCa => $sslCa,
-        $pdoMysqlSslVerifyServerCert => $verifyServerCert,
-    ];
-};
+use Pdo\Mysql;
 
 return [
 
@@ -100,7 +58,9 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => $mysqlSslCaOptions(env('MYSQL_ATTR_SSL_CA')),
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
         ],
 
         'mariadb' => [
@@ -118,7 +78,9 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => $mysqlSslCaOptions(env('MYSQL_ATTR_SSL_CA')),
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
         ],
 
         'metaworks' => [
@@ -135,7 +97,10 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => $legacyMysqlSslOptions(env('DB_SUMARIOPMD_SSL_CA'), false),
+            'options' => extension_loaded('pdo_mysql') ? [
+                Mysql::ATTR_SSL_CA => env('DB_SUMARIOPMD_SSL_CA', '/etc/ssl/certs/ca-certificates.crt'),
+                Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+            ] : [],
         ],
 
         'legacy_metaworks' => [
@@ -152,10 +117,10 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => $legacyMysqlSslOptions(
-                env('DB_METAWORKS_SSL_CA'),
-                env('DB_METAWORKS_SSL_VERIFY_SERVER_CERT', true),
-            ),
+            'options' => extension_loaded('pdo_mysql') ? [
+                Mysql::ATTR_SSL_CA => env('DB_METAWORKS_SSL_CA', '/etc/ssl/certs/ca-certificates.crt'),
+                Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+            ] : [],
         ],
 
         'igsn_legacy' => [
@@ -172,7 +137,10 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => $legacyMysqlSslOptions(env('DB_IGSN_SSL_CA'), false),
+            'options' => extension_loaded('pdo_mysql') ? [
+                Mysql::ATTR_SSL_CA => env('DB_IGSN_SSL_CA', '/etc/ssl/certs/ca-certificates.crt'),
+                Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+            ] : [],
         ],
 
         'pgsql' => [

--- a/config/database.php
+++ b/config/database.php
@@ -110,6 +110,34 @@ return [
             })() : [],
         ],
 
+        'legacy_metaworks' => [
+            'driver' => 'mysql',
+            'host' => env('DB_METAWORKS_HOST', '127.0.0.1'),
+            'port' => env('DB_METAWORKS_PORT', '3306'),
+            'database' => env('DB_METAWORKS_NAME', 'metaworks'),
+            'username' => env('DB_METAWORKS_USER', 'root'),
+            'password' => env('DB_METAWORKS_PASSWORD', ''),
+            'unix_socket' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? (static function (): array {
+                $sslCa = env('DB_METAWORKS_SSL_CA');
+
+                if ($sslCa === null || $sslCa === false || $sslCa === '') {
+                    $sslCa = '/etc/ssl/certs/ca-certificates.crt';
+                }
+
+                return [
+                    \Pdo\Mysql::ATTR_SSL_CA => $sslCa,
+                    \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
+                ];
+            })() : [],
+        ],
+
         'igsn_legacy' => [
             'driver' => 'mysql',
             'host' => env('DB_IGSN_HOST', '127.0.0.1'),

--- a/config/datacite.php
+++ b/config/datacite.php
@@ -15,6 +15,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | DataCite Sync After Import
+    |--------------------------------------------------------------------------
+    |
+    | When true and test_mode is false, imported DataCite resources are synced
+    | back to DataCite after legacy enrichment. Keep this opt-in for bulk imports
+    | because direct API updates can add significant runtime and hit rate limits.
+    |
+    */
+    'sync_after_import' => env('DATACITE_SYNC_AFTER_IMPORT', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | DataCite Production API Configuration
     |--------------------------------------------------------------------------
     |

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -267,6 +267,10 @@ entity "resources" as resources {
     language_id : BIGINT <<FK>>
     created_by_user_id : BIGINT <<FK>>
     updated_by_user_id : BIGINT <<FK>>
+    legacy_source : VARCHAR(50) <<nullable>>
+    legacy_source_id : BIGINT <<nullable>>
+    legacy_source_status : VARCHAR(50) <<nullable>>
+    * force_review_status : BOOLEAN = false
     created_at : TIMESTAMP
     updated_at : TIMESTAMP
 }

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -236,6 +236,10 @@ erDiagram
         bigint language_id FK
         bigint created_by_user_id FK
         bigint updated_by_user_id FK
+        varchar legacy_source "50, nullable"
+        bigint legacy_source_id "nullable"
+        varchar legacy_source_status "50, nullable"
+        boolean force_review_status "default false"
         timestamp created_at
         timestamp updated_at
     }

--- a/database/migrations/2026_06_03_000001_add_legacy_import_columns_to_resources.php
+++ b/database/migrations/2026_06_03_000001_add_legacy_import_columns_to_resources.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_06_03_000001_add_legacy_import_columns_to_resources.php
+++ b/database/migrations/2026_06_03_000001_add_legacy_import_columns_to_resources.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('resources', function (Blueprint $table): void {
+            $table->string('legacy_source', 50)->nullable()->after('updated_by_user_id');
+            $table->unsignedBigInteger('legacy_source_id')->nullable()->after('legacy_source');
+            $table->string('legacy_source_status', 50)->nullable()->after('legacy_source_id');
+            $table->boolean('force_review_status')->default(false)->after('legacy_source_status');
+
+            $table->index(['legacy_source', 'legacy_source_id'], 'resources_legacy_source_lookup_idx');
+            $table->index('legacy_source_status');
+            $table->index('force_review_status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('resources', function (Blueprint $table): void {
+            $table->dropIndex('resources_legacy_source_lookup_idx');
+            $table->dropIndex(['legacy_source_status']);
+            $table->dropIndex(['force_review_status']);
+
+            $table->dropColumn([
+                'legacy_source',
+                'legacy_source_id',
+                'legacy_source_status',
+                'force_review_status',
+            ]);
+        });
+    }
+};

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -409,7 +409,7 @@ describe('ImportFromDataCiteJob', function () {
         $this->transformer
             ->shouldReceive('transform')
             ->times(150)
-            ->andThrow(new \Exception('Transform failed'));
+            ->andThrow(new Exception('Transform failed'));
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
@@ -423,7 +423,7 @@ describe('ImportFromDataCiteJob', function () {
 
     it('validates importId is a valid UUID', function () {
         expect(fn () => new ImportFromDataCiteJob($this->user->id, 'invalid-id'))
-            ->toThrow(\InvalidArgumentException::class, 'Invalid importId format');
+            ->toThrow(InvalidArgumentException::class, 'Invalid importId format');
     });
 
     it('accepts valid UUID format for importId', function () {
@@ -706,8 +706,9 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['skipped_dois'])->toBe(['10.5880/pending.skip']);
     });
 
-    it('syncs imported DataCite resources after enrichment when production mode is active', function () {
+    it('syncs imported DataCite resources after enrichment when production sync after import is enabled', function () {
         Config::set('datacite.test_mode', false);
+        Config::set('datacite.sync_after_import', true);
 
         $this->importService
             ->shouldReceive('getTotalDoiCount')
@@ -759,6 +760,49 @@ describe('ImportFromDataCiteJob', function () {
                     && $resource->landingPage->ftp_url === 'https://datapub.gfz.de/download/10.5880/sync.production/data.zip';
             })
             ->andReturn(DataCiteSyncResult::succeeded('10.5880/sync.production'));
+        $this->app->instance(DataCiteSyncService::class, $syncService);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(0);
+    });
+
+    it('does not sync imported DataCite resources when production sync after import is disabled', function () {
+        Config::set('datacite.test_mode', false);
+        Config::set('datacite.sync_after_import', false);
+
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/sync.disabled',
+                    'attributes' => [
+                        'doi' => '10.5880/sync.disabled',
+                        'titles' => [['title' => 'Sync Disabled Dataset']],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/sync.disabled']));
+
+        $syncService = Mockery::mock(DataCiteSyncService::class);
+        $syncService
+            ->shouldReceive('syncIfRegistered')
+            ->never();
         $this->app->instance(DataCiteSyncService::class, $syncService);
 
         $importId = Str::uuid()->toString();
@@ -1096,7 +1140,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
         $metaworksService->shouldReceive('lookupFileEntries')
             ->once()
-            ->andThrow(new \RuntimeException('Connection refused'));
+            ->andThrow(new RuntimeException('Connection refused'));
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -198,6 +198,56 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['failed'])->toBe(0);
     });
 
+    it('keeps the bulk import completed when the SUMARIO pending import phase is unavailable', function () {
+        $this->pendingImportService
+            ->shouldReceive('countImportablePending')
+            ->once()
+            ->andReturn(2);
+
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/datacite.before.pending.failure',
+                    'attributes' => [
+                        'doi' => '10.5880/datacite.before.pending.failure',
+                        'titles' => [['title' => 'DataCite before pending failure']],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturn(Resource::factory()->make(['doi' => '10.5880/datacite.before.pending.failure']));
+
+        $this->pendingImportService
+            ->shouldReceive('importAllPending')
+            ->once()
+            ->with($this->user->id, 100)
+            ->andThrow(new RuntimeException('SUMARIO connection refused'));
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['total'])->toBe(3)
+            ->and($status['processed'])->toBe(3)
+            ->and($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(2)
+            ->and($status['failed_dois'])->toBe([
+                ['doi' => 'sumario-pending', 'error' => 'SUMARIO pending import is unavailable.'],
+            ]);
+    });
+
     it('skips existing DOIs', function () {
         // Create existing resource
         Resource::factory()->create(['doi' => '10.5880/existing']);

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -642,6 +642,37 @@ describe('ImportFromDataCiteJob', function () {
             ]);
     });
 
+    it('marks single SUMARIO pending fallback as failed when the lookup is unavailable', function () {
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/pending.unavailable')
+            ->andReturnNull();
+
+        $this->pendingImportService
+            ->shouldReceive('importPendingByDoi')
+            ->once()
+            ->with('10.5880/pending.unavailable', $this->user->id)
+            ->andThrow(new RuntimeException('Connection refused'));
+
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId, '10.5880/pending.unavailable');
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('failed')
+            ->and($status['total'])->toBe(1)
+            ->and($status['processed'])->toBe(1)
+            ->and($status['imported'])->toBe(0)
+            ->and($status['failed'])->toBe(1)
+            ->and($status['error'])->toBe('SUMARIO pending lookup is unavailable.')
+            ->and($status['failed_dois'])->toBe([
+                ['doi' => '10.5880/pending.unavailable', 'error' => 'SUMARIO pending lookup is unavailable.'],
+            ]);
+    });
+
     it('imports a single SUMARIO pending resource when DataCite has no DOI record', function () {
         $this->importService
             ->shouldReceive('fetchSingleDoi')

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -72,7 +72,7 @@ beforeEach(function () {
     $this->pendingImportService
         ->shouldReceive('importPendingByDoi')
         ->zeroOrMoreTimes()
-        ->andReturnUsing(fn (string $doi): array => [
+        ->andReturnUsing(fn (string $doi, mixed ...$_): array => [
             'status' => 'missing',
             'resource' => null,
             'doi' => $doi,

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -5,13 +5,20 @@ use App\Enums\UserRole;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Models\LandingPage;
 use App\Models\LandingPageFile;
+use App\Models\LandingPageLink;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\DataCiteImportService;
+use App\Services\DataCiteSyncResult;
+use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
+use App\Services\LegacyMetaworksDatacenterLookupService;
 use App\Services\MetaworksDownloadUrlService;
+use App\Services\SumarioPendingResourceImportService;
+use App\Services\SumarioPmdContactEnrichmentService;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 
 beforeEach(function () {
@@ -32,8 +39,63 @@ beforeEach(function () {
 
     // Mock the metaworks service (returns empty result by default)
     $this->metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-    $this->metaworksService->shouldReceive('lookupFileUrls')->andReturn(['urls' => [], 'allPublic' => false]);
+    $this->metaworksService
+        ->shouldReceive('lookupFileUrls')
+        ->zeroOrMoreTimes()
+        ->andReturn(['urls' => [], 'allPublic' => false])
+        ->byDefault();
+    $this->metaworksService
+        ->shouldReceive('lookupFileEntries')
+        ->zeroOrMoreTimes()
+        ->andReturn(['files' => [], 'allPublic' => false])
+        ->byDefault();
     $this->app->instance(MetaworksDownloadUrlService::class, $this->metaworksService);
+
+    $this->pendingImportService = Mockery::mock(SumarioPendingResourceImportService::class);
+    $this->pendingImportService
+        ->shouldReceive('countImportablePending')
+        ->zeroOrMoreTimes()
+        ->andReturn(0)
+        ->byDefault();
+    $this->pendingImportService
+        ->shouldReceive('importAllPending')
+        ->zeroOrMoreTimes()
+        ->andReturn([
+            'processed' => 0,
+            'imported' => 0,
+            'skipped' => 0,
+            'failed' => 0,
+            'skipped_dois' => [],
+            'failed_dois' => [],
+        ])
+        ->byDefault();
+    $this->pendingImportService
+        ->shouldReceive('importPendingByDoi')
+        ->zeroOrMoreTimes()
+        ->andReturnUsing(fn (string $doi): array => [
+            'status' => 'missing',
+            'resource' => null,
+            'doi' => $doi,
+            'error' => null,
+        ])
+        ->byDefault();
+    $this->app->instance(SumarioPendingResourceImportService::class, $this->pendingImportService);
+
+    $this->contactEnrichmentService = Mockery::mock(SumarioPmdContactEnrichmentService::class);
+    $this->contactEnrichmentService
+        ->shouldReceive('enrich')
+        ->zeroOrMoreTimes()
+        ->andReturn(false)
+        ->byDefault();
+    $this->app->instance(SumarioPmdContactEnrichmentService::class, $this->contactEnrichmentService);
+
+    $this->datacenterLookupService = Mockery::mock(LegacyMetaworksDatacenterLookupService::class);
+    $this->datacenterLookupService
+        ->shouldReceive('syncDatacenters')
+        ->zeroOrMoreTimes()
+        ->andReturnNull()
+        ->byDefault();
+    $this->app->instance(LegacyMetaworksDatacenterLookupService::class, $this->datacenterLookupService);
 });
 
 afterEach(function () {
@@ -87,6 +149,53 @@ describe('ImportFromDataCiteJob', function () {
         expect($status['processed'])->toBe(2);
         expect($status['imported'])->toBe(2);
         expect($status['failed'])->toBe(0);
+    });
+
+    it('adds SUMARIO pending import results to the bulk progress summary', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(0);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                if (false) {
+                    yield [];
+                }
+            })());
+
+        $this->pendingImportService
+            ->shouldReceive('countImportablePending')
+            ->once()
+            ->andReturn(1);
+
+        $this->pendingImportService
+            ->shouldReceive('importAllPending')
+            ->once()
+            ->with($this->user->id, 100)
+            ->andReturn([
+                'processed' => 1,
+                'imported' => 1,
+                'skipped' => 0,
+                'failed' => 0,
+                'skipped_dois' => [],
+                'failed_dois' => [],
+            ]);
+
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['total'])->toBe(1)
+            ->and($status['processed'])->toBe(1)
+            ->and($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(0);
     });
 
     it('skips existing DOIs', function () {
@@ -529,8 +638,137 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['imported'])->toBe(0)
             ->and($status['failed'])->toBe(1)
             ->and($status['failed_dois'])->toBe([
-                ['doi' => '10.5880/missing.single', 'error' => 'The DOI was not found in DataCite.'],
+                ['doi' => '10.5880/missing.single', 'error' => 'The DOI was not found in DataCite or SUMARIO pending resources.'],
             ]);
+    });
+
+    it('imports a single SUMARIO pending resource when DataCite has no DOI record', function () {
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/pending.single')
+            ->andReturnNull();
+
+        $this->pendingImportService
+            ->shouldReceive('importPendingByDoi')
+            ->once()
+            ->with('10.5880/pending.single', $this->user->id)
+            ->andReturn([
+                'status' => 'imported',
+                'resource' => Resource::factory()->create([
+                    'doi' => '10.5880/pending.single',
+                    'force_review_status' => true,
+                    'legacy_source_status' => 'pending',
+                ]),
+                'doi' => '10.5880/pending.single',
+                'error' => null,
+            ]);
+
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId, '10.5880/pending.single');
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['processed'])->toBe(1)
+            ->and($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(0);
+    });
+
+    it('marks a single SUMARIO pending fallback as skipped when the resource already exists', function () {
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/pending.skip')
+            ->andReturnNull();
+
+        $this->pendingImportService
+            ->shouldReceive('importPendingByDoi')
+            ->once()
+            ->with('10.5880/pending.skip', $this->user->id)
+            ->andReturn([
+                'status' => 'skipped',
+                'resource' => null,
+                'doi' => '10.5880/pending.skip',
+                'error' => null,
+            ]);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId, '10.5880/pending.skip');
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['imported'])->toBe(0)
+            ->and($status['skipped'])->toBe(1)
+            ->and($status['skipped_dois'])->toBe(['10.5880/pending.skip']);
+    });
+
+    it('syncs imported DataCite resources after enrichment when production mode is active', function () {
+        Config::set('datacite.test_mode', false);
+
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/sync.production',
+                    'attributes' => [
+                        'doi' => '10.5880/sync.production',
+                        'titles' => [['title' => 'Production Sync Dataset']],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/sync.production']));
+
+        $this->metaworksService
+            ->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/sync.production')
+            ->andReturn([
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/download/10.5880/sync.production/data.zip',
+                        'label' => 'Data package',
+                        'visible' => 'public',
+                    ],
+                ],
+                'allPublic' => true,
+            ]);
+
+        $syncService = Mockery::mock(DataCiteSyncService::class);
+        $syncService
+            ->shouldReceive('syncIfRegistered')
+            ->once()
+            ->withArgs(function (Resource $resource): bool {
+                $resource->loadMissing('landingPage');
+
+                return $resource->doi === '10.5880/sync.production'
+                    && $resource->landingPage !== null
+                    && $resource->landingPage->ftp_url === 'https://datapub.gfz.de/download/10.5880/sync.production/data.zip';
+            })
+            ->andReturn(DataCiteSyncResult::succeeded('10.5880/sync.production'));
+        $this->app->instance(DataCiteSyncService::class, $syncService);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(0);
     });
 
     it('marks single import as failed when the DOI transform throws an exception', function () {
@@ -630,7 +868,7 @@ describe('ImportFromDataCiteJob', function () {
 });
 
 describe('ImportFromDataCiteJob download URL enrichment', function () {
-    it('creates landing page with files when metaworks has download URLs', function () {
+    it('creates landing page with primary download and additional links when metaworks has download URLs', function () {
         Cache::put(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key(), [
             'domains' => [['value' => 'https://stale.example.org/', 'usage_count' => 99]],
             'urls' => [['value' => 'https://stale.example.org/download/file.zip', 'usage_count' => 99]],
@@ -664,13 +902,21 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
 
         // Override the default mock: return download URLs (all public)
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldReceive('lookupFileUrls')
+        $metaworksService->shouldReceive('lookupFileEntries')
             ->with('10.5880/lp.test.001')
             ->once()
             ->andReturn([
-                'urls' => [
-                    'https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file1.zip',
-                    'https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip',
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file1.zip',
+                        'label' => 'Archive package',
+                        'visible' => 'public',
+                    ],
+                    [
+                        'url' => 'https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip',
+                        'label' => 'Supplement table',
+                        'visible' => 'public',
+                    ],
                 ],
                 'allPublic' => true,
             ]);
@@ -688,13 +934,13 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($landingPage->published_at)->not->toBeNull()
             ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file1.zip');
 
-        // Verify files were created
-        $files = LandingPageFile::where('landing_page_id', $landingPage->id)->orderBy('position')->get();
-        expect($files)->toHaveCount(2)
-            ->and($files[0]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file1.zip')
-            ->and($files[0]->position)->toBe(0)
-            ->and($files[1]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip')
-            ->and($files[1]->position)->toBe(1);
+        $links = LandingPageLink::where('landing_page_id', $landingPage->id)->orderBy('position')->get();
+        expect($links)->toHaveCount(1)
+            ->and($links[0]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip')
+            ->and($links[0]->label)->toBe('Supplement table')
+            ->and($links[0]->position)->toBe(0);
+
+        expect(LandingPageFile::where('landing_page_id', $landingPage->id)->count())->toBe(0);
 
         expect(Cache::get(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key()))->toBeNull();
     });
@@ -727,11 +973,17 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
 
         // Return URLs with allPublic=false (some files are non-public)
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldReceive('lookupFileUrls')
+        $metaworksService->shouldReceive('lookupFileEntries')
             ->with('10.5880/lp.nonpub.001')
             ->once()
             ->andReturn([
-                'urls' => ['https://datapub.gfz.de/download/internal-file.zip'],
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/download/internal-file.zip',
+                        'label' => 'Internal package',
+                        'visible' => 'internal',
+                    ],
+                ],
                 'allPublic' => false,
             ]);
 
@@ -746,10 +998,9 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($landingPage->is_published)->toBeFalse()
             ->and($landingPage->published_at)->toBeNull();
 
-        // Files should still be created
-        $files = LandingPageFile::where('landing_page_id', $landingPage->id)->get();
-        expect($files)->toHaveCount(1)
-            ->and($files[0]->url)->toBe('https://datapub.gfz.de/download/internal-file.zip');
+        expect($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/internal-file.zip')
+            ->and(LandingPageLink::where('landing_page_id', $landingPage->id)->count())->toBe(0)
+            ->and(LandingPageFile::where('landing_page_id', $landingPage->id)->count())->toBe(0);
     });
 
     it('does not create landing page when metaworks has no files', function () {
@@ -843,7 +1094,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
 
         // MetaworksService throws exception
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldReceive('lookupFileUrls')
+        $metaworksService->shouldReceive('lookupFileEntries')
             ->once()
             ->andThrow(new \RuntimeException('Connection refused'));
 
@@ -896,7 +1147,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ]));
 
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldReceive('lookupFileUrls')
+        $metaworksService->shouldReceive('lookupFileEntries')
             ->once()
             ->with('10.5880/metaworks.first')
             ->andThrow(new RuntimeException('Legacy DB unavailable'));
@@ -946,7 +1197,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
 
         // MetaworksService should NOT be called since landing page already exists
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldNotReceive('lookupFileUrls');
+        $metaworksService->shouldNotReceive('lookupFileEntries');
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
@@ -985,11 +1236,17 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->andReturn(Resource::factory()->make(['doi' => '10.5880/lp.create.fail']));
 
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldReceive('lookupFileUrls')
+        $metaworksService->shouldReceive('lookupFileEntries')
             ->once()
             ->with('10.5880/lp.create.fail')
             ->andReturn([
-                'urls' => ['https://datapub.gfz.de/download/10.5880/lp.create.fail/file.zip'],
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/download/10.5880/lp.create.fail/file.zip',
+                        'label' => 'File',
+                        'visible' => 'public',
+                    ],
+                ],
                 'allPublic' => true,
             ]);
 

--- a/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
@@ -78,6 +78,21 @@ describe('ResourceStorageService – Contributor Contact Person email/website', 
             ->and($contributor->website)->toBe('https://example.org');
     });
 
+    it('stores email and website when a creator is marked as contact person', function () {
+        $data = contributorResourceData();
+        $data['contributors'] = [];
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'author.contact@example.org';
+        $data['authors'][0]['website'] = 'https://author.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $creator = $resource->creators()->first();
+        expect($creator->is_contact)->toBeTrue()
+            ->and($creator->email)->toBe('author.contact@example.org')
+            ->and($creator->website)->toBe('https://author.example.org');
+    });
+
     it('stores null email and website when contributor has no Contact Person role', function () {
         $data = contributorResourceData([
             'roles' => ['DataCollector'],

--- a/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
@@ -93,6 +93,21 @@ describe('ResourceStorageService – Contributor Contact Person email/website', 
             ->and($creator->website)->toBe('https://author.example.org');
     });
 
+    it('drops invalid creator contact email and unsafe website values', function () {
+        $data = contributorResourceData();
+        $data['contributors'] = [];
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'not-an-email';
+        $data['authors'][0]['website'] = 'javascript:alert(1)';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $creator = $resource->creators()->first();
+        expect($creator->is_contact)->toBeTrue()
+            ->and($creator->email)->toBeNull()
+            ->and($creator->website)->toBeNull();
+    });
+
     it('stores null email and website when contributor has no Contact Person role', function () {
         $data = contributorResourceData([
             'roles' => ['DataCollector'],
@@ -105,6 +120,19 @@ describe('ResourceStorageService – Contributor Contact Person email/website', 
             ['slug' => 'DataCollector'],
             ['name' => 'Data Collector', 'category' => 'person'],
         );
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $contributor = $resource->contributors()->first();
+        expect($contributor->email)->toBeNull()
+            ->and($contributor->website)->toBeNull();
+    });
+
+    it('drops invalid contributor contact email and unsafe website values', function () {
+        $data = contributorResourceData([
+            'email' => 'invalid-email',
+            'website' => 'ftp://example.org/profile',
+        ]);
 
         [$resource] = $this->service->store($data, $this->user->id);
 

--- a/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CacheKey;
+use App\Models\LandingPageFile;
+use App\Models\LandingPageLink;
+use App\Models\Resource;
+use App\Services\LegacyLandingPageImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+
+uses(RefreshDatabase::class);
+
+describe('LegacyLandingPageImportService', function () {
+    it('stores the first legacy file as primary download and remaining files as labelled links', function () {
+        Cache::put(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key(), ['urls' => ['stale']]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/landing.links']);
+
+        $landingPage = (new LegacyLandingPageImportService)->createForResource(
+            resource: $resource,
+            fileEntries: [
+                [
+                    'url' => 'https://datapub.gfz.de/primary.zip',
+                    'label' => 'Primary package',
+                    'visible' => 'public',
+                ],
+                [
+                    'url' => 'https://datapub.gfz.de/additional.zip',
+                    'label' => 'Additional table',
+                    'visible' => 'public',
+                ],
+            ],
+            isPublished: true,
+        );
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/primary.zip')
+            ->and($landingPage->is_published)->toBeTrue()
+            ->and($landingPage->published_at)->not->toBeNull();
+
+        $links = LandingPageLink::query()->where('landing_page_id', $landingPage->id)->get();
+        expect($links)->toHaveCount(1)
+            ->and($links[0]->url)->toBe('https://datapub.gfz.de/additional.zip')
+            ->and($links[0]->label)->toBe('Additional table')
+            ->and(LandingPageFile::query()->where('landing_page_id', $landingPage->id)->count())->toBe(0)
+            ->and(Cache::get(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key()))->toBeNull();
+    });
+
+    it('creates an unpublished draft landing page without a download URL when requested for an empty pending import', function () {
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/landing.empty',
+            'force_review_status' => true,
+        ]);
+
+        $landingPage = (new LegacyLandingPageImportService)->createForResource(
+            resource: $resource,
+            fileEntries: [],
+            isPublished: false,
+            createWhenEmpty: true,
+        );
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->is_published)->toBeFalse()
+            ->and($resource->fresh(['landingPage'])->publicStatus())->toBe('review');
+    });
+});

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Datacenter;
+use App\Models\Resource;
+use App\Services\LegacyMetaworksDatacenterLookupService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+describe('LegacyMetaworksDatacenterLookupService', function () {
+    beforeEach(function () {
+        Config::set('database.connections.legacy_metaworks', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+        DB::purge('legacy_metaworks');
+
+        Schema::connection('legacy_metaworks')->create('gipp_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable();
+        });
+
+        Schema::connection('legacy_metaworks')->create('sddb_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable();
+        });
+
+        Datacenter::query()->create(['name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
+        Datacenter::query()->create(['name' => LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
+        Datacenter::query()->create(['name' => LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER]);
+    });
+
+    it('resolves GIPP and SDDB datacenters from true Metaworks tables', function () {
+        DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
+            'doi' => '10.5880/gipp.dataset',
+        ]);
+        DB::connection('legacy_metaworks')->table('sddb_dataset')->insert([
+            'doi' => '10.5880/sddb.dataset',
+        ]);
+
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames('10.5880/gipp.dataset'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER])
+            ->and($service->resolveDatacenterNames('10.5880/sddb.dataset'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER]);
+    });
+
+    it('falls back to the GFZ datacenter when no specialised table contains the DOI', function () {
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames('10.5880/default.dataset'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
+    });
+
+    it('syncs resolved datacenters onto the imported resource', function () {
+        DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
+            'doi' => '10.5880/gipp.sync',
+        ]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/gipp.sync']);
+
+        (new LegacyMetaworksDatacenterLookupService)->syncDatacenters($resource, '10.5880/gipp.sync');
+
+        expect($resource->fresh()->datacenters->pluck('name')->all())
+            ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
+    });
+});

--- a/tests/pest/Unit/Services/MetaworksDownloadUrlServiceTest.php
+++ b/tests/pest/Unit/Services/MetaworksDownloadUrlServiceTest.php
@@ -54,7 +54,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('id')
             ->andReturnSelf();
         $fileQuery->shouldReceive('get')
-            ->with(['url', 'visible'])
+            ->with(['url', 'name', 'description', 'visible'])
             ->andReturn(collect([
                 (object) ['url' => 'https://datapub.gfz.de/download/10.5880/GFZ.1.2.2024.001', 'visible' => 'public'],
             ]));
@@ -98,7 +98,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('id')
             ->andReturnSelf();
         $fileQuery->shouldReceive('get')
-            ->with(['url', 'visible'])
+            ->with(['url', 'name', 'description', 'visible'])
             ->andReturn(collect([
                 (object) ['url' => 'https://datapub.gfz.de/download/10.5880/GFZ.dup.test', 'visible' => 'public'],
                 (object) ['url' => 'https://datapub.gfz.de/download/10.5880/GFZ.dup.test', 'visible' => 'public'],
@@ -144,7 +144,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('id')
             ->andReturnSelf();
         $fileQuery->shouldReceive('get')
-            ->with(['url', 'visible'])
+            ->with(['url', 'name', 'description', 'visible'])
             ->andReturn(collect([
                 (object) ['url' => 'https://datapub.gfz.de/download/10.5880/GFZ.multi.test/file1.zip', 'visible' => 'public'],
                 (object) ['url' => 'https://datapub.gfz.de/download/10.5880/GFZ.multi.test/file2.zip', 'visible' => 'public'],
@@ -171,6 +171,62 @@ describe('MetaworksDownloadUrlService', function () {
             ->and($result['allPublic'])->toBeTrue();
     });
 
+    it('returns structured file entries with labels from name and description', function () {
+        $resourceQuery = Mockery::mock();
+        $resourceQuery->shouldReceive('where')
+            ->with('identifier', '10.5880/GFZ.labels.test')
+            ->andReturnSelf();
+        $resourceQuery->shouldReceive('select')
+            ->with('id')
+            ->andReturnSelf();
+        $resourceQuery->shouldReceive('first')
+            ->andReturn((object) ['id' => 56]);
+
+        $fileQuery = Mockery::mock();
+        $fileQuery->shouldReceive('where')
+            ->with('resource_id', 56)
+            ->andReturnSelf();
+        $fileQuery->shouldReceive('orderBy')
+            ->with('id')
+            ->andReturnSelf();
+        $fileQuery->shouldReceive('get')
+            ->with(['url', 'name', 'description', 'visible'])
+            ->andReturn(collect([
+                (object) [
+                    'url' => 'https://datapub.gfz.de/download/name-label.zip',
+                    'name' => 'Name Label',
+                    'description' => 'Description Label',
+                    'visible' => 'public',
+                ],
+                (object) [
+                    'url' => 'https://datapub.gfz.de/download/description-label.zip',
+                    'name' => '',
+                    'description' => 'Description Fallback',
+                    'visible' => 'public',
+                ],
+            ]));
+
+        $connection = Mockery::mock();
+        $connection->shouldReceive('table')
+            ->with('resource')
+            ->andReturn($resourceQuery);
+        $connection->shouldReceive('table')
+            ->with('file')
+            ->andReturn($fileQuery);
+
+        DB::shouldReceive('connection')
+            ->with('metaworks')
+            ->andReturn($connection);
+
+        $service = new MetaworksDownloadUrlService;
+        $result = $service->lookupFileEntries('10.5880/GFZ.labels.test');
+
+        expect($result['files'])->toHaveCount(2)
+            ->and($result['files'][0]['label'])->toBe('Name Label')
+            ->and($result['files'][1]['label'])->toBe('Description Fallback')
+            ->and($result['allPublic'])->toBeTrue();
+    });
+
     it('filters out non-HTTP URLs from legacy data', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.xss.test')->andReturnSelf();
@@ -180,7 +236,7 @@ describe('MetaworksDownloadUrlService', function () {
         $fileQuery = Mockery::mock();
         $fileQuery->shouldReceive('where')->with('resource_id', 77)->andReturnSelf();
         $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
-        $fileQuery->shouldReceive('get')->with(['url', 'visible'])->andReturn(collect([
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect([
             (object) ['url' => 'https://datapub.gfz.de/download/safe.zip', 'visible' => 'public'],
             (object) ['url' => 'javascript:alert(1)', 'visible' => 'public'],
             (object) ['url' => 'data:text/html,<script>alert(1)</script>', 'visible' => 'public'],
@@ -215,7 +271,7 @@ describe('MetaworksDownloadUrlService', function () {
         $fileQuery = Mockery::mock();
         $fileQuery->shouldReceive('where')->with('resource_id', 88)->andReturnSelf();
         $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
-        $fileQuery->shouldReceive('get')->with(['url', 'visible'])->andReturn(collect([
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect([
             (object) ['url' => $longUrl, 'visible' => 'public'],
             (object) ['url' => 'https://datapub.gfz.de/download/short.zip', 'visible' => 'public'],
         ]));
@@ -244,7 +300,7 @@ describe('MetaworksDownloadUrlService', function () {
         $fileQuery = Mockery::mock();
         $fileQuery->shouldReceive('where')->with('resource_id', 33)->andReturnSelf();
         $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
-        $fileQuery->shouldReceive('get')->with(['url', 'visible'])->andReturn(collect([
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect([
             (object) ['url' => 'https://datapub.gfz.de/download/public-file.zip', 'visible' => 'public'],
             (object) ['url' => 'https://datapub.gfz.de/download/private-file.zip', 'visible' => 'private'],
         ]));
@@ -271,7 +327,7 @@ describe('MetaworksDownloadUrlService', function () {
         $fileQuery = Mockery::mock();
         $fileQuery->shouldReceive('where')->with('resource_id', 44)->andReturnSelf();
         $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
-        $fileQuery->shouldReceive('get')->with(['url', 'visible'])->andReturn(collect([
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect([
             (object) ['url' => 'https://datapub.gfz.de/download/internal.zip', 'visible' => 'internal'],
         ]));
 
@@ -298,7 +354,7 @@ describe('MetaworksDownloadUrlService', function () {
         $fileQuery = Mockery::mock();
         $fileQuery->shouldReceive('where')->with('resource_id', 66)->andReturnSelf();
         $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
-        $fileQuery->shouldReceive('get')->with(['url', 'visible'])->andReturn(collect([
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect([
             (object) ['url' => 'http:foo', 'visible' => 'public'],
             (object) ['url' => 'https://', 'visible' => 'public'],
             (object) ['url' => 'https://datapub.gfz.de/download/valid.zip', 'visible' => 'public'],

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Datacenter;
+use App\Models\Resource;
+use App\Models\User;
+use App\Services\DoiSuggestionService;
+use App\Services\LegacyLandingPageImportService;
+use App\Services\LegacyMetaworksDatacenterLookupService;
+use App\Services\MetaworksDownloadUrlService;
+use App\Services\OldDatasetEditorLoader;
+use App\Services\ResourceStorageService;
+use App\Services\SumarioPendingResourceImportService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+describe('SumarioPendingResourceImportService', function () {
+    beforeEach(function () {
+        Config::set('database.connections.metaworks', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+        DB::purge('metaworks');
+
+        Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+            $table->id();
+            $table->string('publicstatus')->nullable();
+            $table->string('identifier')->nullable();
+            $table->integer('publicationyear')->nullable();
+            $table->string('title')->nullable();
+        });
+    });
+
+    it('imports pending SUMARIO resources as review resources without publishing the landing page', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 55,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/pending.one',
+            'publicationyear' => 2024,
+            'title' => 'Legacy Pending Dataset',
+        ]);
+
+        $user = User::factory()->create();
+        $datacenter = Datacenter::query()->create([
+            'name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+        ]);
+
+        $editorLoader = Mockery::mock(OldDatasetEditorLoader::class);
+        $editorLoader
+            ->shouldReceive('loadForEditor')
+            ->once()
+            ->with(55)
+            ->andReturn([
+                'doi' => '10.5880/pending.one',
+                'year' => '2024',
+                'version' => '1.0',
+                'language' => 'en',
+                'resourceType' => '1',
+                'titles' => [
+                    ['title' => 'Legacy Pending Dataset', 'titleType' => 'main-title'],
+                ],
+                'initialRights' => [],
+                'authors' => [
+                    [
+                        'type' => 'person',
+                        'firstName' => 'Jane',
+                        'lastName' => 'Doe',
+                        'isContact' => true,
+                        'email' => 'jane@example.org',
+                        'position' => 0,
+                    ],
+                ],
+                'contributors' => [],
+                'descriptions' => [],
+                'dates' => [],
+                'gcmdKeywords' => [],
+                'freeKeywords' => [],
+                'geoLocations' => [],
+                'relatedWorks' => [],
+                'fundingReferences' => [],
+                'mslLaboratories' => [],
+            ]);
+
+        $resourceStorage = Mockery::mock(ResourceStorageService::class);
+        $resourceStorage
+            ->shouldReceive('store')
+            ->once()
+            ->andReturnUsing(function (array $payload, int $userId) use ($user, $datacenter): array {
+                expect($userId)->toBe($user->id)
+                    ->and($payload['doi'])->toBe('10.5880/pending.one')
+                    ->and($payload['authors'][0]['isContact'])->toBeTrue()
+                    ->and($payload['authors'][0]['email'])->toBe('jane@example.org')
+                    ->and($payload['datacenters'])->toBe([$datacenter->id]);
+
+                return [
+                    Resource::factory()->create(['doi' => $payload['doi']]),
+                    false,
+                ];
+            });
+
+        $datacenterLookup = Mockery::mock(LegacyMetaworksDatacenterLookupService::class);
+        $datacenterLookup
+            ->shouldReceive('resolveDatacenterIds')
+            ->once()
+            ->with('10.5880/pending.one')
+            ->andReturn([$datacenter->id]);
+
+        $downloadUrlService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $downloadUrlService
+            ->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/pending.one')
+            ->andReturn([
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/pending-one.zip',
+                        'label' => 'Pending package',
+                        'visible' => 'public',
+                    ],
+                ],
+                'allPublic' => true,
+            ]);
+
+        $service = new SumarioPendingResourceImportService(
+            editorLoader: $editorLoader,
+            resourceStorage: $resourceStorage,
+            datacenterLookup: $datacenterLookup,
+            downloadUrlService: $downloadUrlService,
+            landingPageImport: new LegacyLandingPageImportService,
+            doiSuggestionService: app(DoiSuggestionService::class),
+        );
+
+        $result = $service->importPendingByDoi('https://doi.org/10.5880/PENDING.ONE', $user->id);
+
+        $resource = $result['resource']?->fresh(['landingPage']);
+
+        expect($result['status'])->toBe('imported')
+            ->and($resource)->not->toBeNull()
+            ->and($resource->legacy_source)->toBe('sumario-pmd')
+            ->and($resource->legacy_source_id)->toBe(55)
+            ->and($resource->legacy_source_status)->toBe('pending')
+            ->and($resource->force_review_status)->toBeTrue()
+            ->and($resource->publicStatus())->toBe('review')
+            ->and($resource->landingPage)->not->toBeNull()
+            ->and($resource->landingPage->is_published)->toBeFalse()
+            ->and($resource->landingPage->ftp_url)->toBe('https://datapub.gfz.de/pending-one.zip');
+    });
+
+    it('skips a pending SUMARIO resource when the DOI already exists in ERNIE', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 56,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/pending.existing',
+        ]);
+        Resource::factory()->create(['doi' => '10.5880/pending.existing']);
+
+        $service = new SumarioPendingResourceImportService(
+            editorLoader: Mockery::mock(OldDatasetEditorLoader::class),
+            resourceStorage: Mockery::mock(ResourceStorageService::class),
+            datacenterLookup: Mockery::mock(LegacyMetaworksDatacenterLookupService::class),
+            downloadUrlService: Mockery::mock(MetaworksDownloadUrlService::class),
+            landingPageImport: new LegacyLandingPageImportService,
+            doiSuggestionService: app(DoiSuggestionService::class),
+        );
+
+        $result = $service->importPendingByDoi('10.5880/pending.existing', 1);
+
+        expect($result['status'])->toBe('skipped');
+    });
+});

--- a/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
@@ -85,6 +85,84 @@ describe('SumarioPmdContactEnrichmentService', function () {
             ->and($creator->fresh()->website)->toBe('https://jane.example.org');
     });
 
+    it('ignores invalid legacy contact email and unsafe website values', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 44,
+            'identifier' => '10.5880/contact.invalid',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 44,
+            'order' => 1,
+            'name' => 'Risk, Riley',
+            'firstname' => 'Riley',
+            'lastname' => 'Risk',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 44,
+            'resourceagent_order' => 1,
+            'email' => 'not-an-email',
+            'website' => 'javascript:alert(1)',
+        ]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/contact.invalid']);
+        $person = Person::query()->create([
+            'given_name' => 'Riley',
+            'family_name' => 'Risk',
+        ]);
+        $creator = ResourceCreator::query()->create([
+            'resource_id' => $resource->id,
+            'creatorable_type' => Person::class,
+            'creatorable_id' => $person->id,
+            'position' => 0,
+        ]);
+
+        $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.invalid');
+
+        expect($updated)->toBeFalse()
+            ->and($creator->fresh()->is_contact)->toBeFalse()
+            ->and($creator->fresh()->email)->toBeNull()
+            ->and($creator->fresh()->website)->toBeNull();
+    });
+
+    it('persists valid legacy contact fields while dropping invalid companion values', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 45,
+            'identifier' => '10.5880/contact.partial',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 45,
+            'order' => 1,
+            'name' => 'Safe, Sam',
+            'firstname' => 'Sam',
+            'lastname' => 'Safe',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 45,
+            'resourceagent_order' => 1,
+            'email' => 'sam.safe@example.org',
+            'website' => 'ftp://example.org/profile',
+        ]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/contact.partial']);
+        $person = Person::query()->create([
+            'given_name' => 'Sam',
+            'family_name' => 'Safe',
+        ]);
+        $creator = ResourceCreator::query()->create([
+            'resource_id' => $resource->id,
+            'creatorable_type' => Person::class,
+            'creatorable_id' => $person->id,
+            'position' => 0,
+        ]);
+
+        $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.partial');
+
+        expect($updated)->toBeTrue()
+            ->and($creator->fresh()->is_contact)->toBeTrue()
+            ->and($creator->fresh()->email)->toBe('sam.safe@example.org')
+            ->and($creator->fresh()->website)->toBeNull();
+    });
+
     it('enriches matching contributors with legacy contact information', function () {
         DB::connection('metaworks')->table('resource')->insert([
             'id' => 43,

--- a/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
+use App\Services\SumarioPmdContactEnrichmentService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+describe('SumarioPmdContactEnrichmentService', function () {
+    beforeEach(function () {
+        Config::set('database.connections.metaworks', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+        DB::purge('metaworks');
+
+        Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+            $table->id();
+            $table->string('identifier')->nullable();
+        });
+
+        Schema::connection('metaworks')->create('resourceagent', function (Blueprint $table): void {
+            $table->integer('resource_id');
+            $table->integer('order');
+            $table->string('name')->nullable();
+            $table->string('firstname')->nullable();
+            $table->string('lastname')->nullable();
+        });
+
+        Schema::connection('metaworks')->create('contactinfo', function (Blueprint $table): void {
+            $table->integer('resourceagent_resource_id');
+            $table->integer('resourceagent_order');
+            $table->string('email')->nullable();
+            $table->string('website')->nullable();
+        });
+    });
+
+    it('enriches a matching creator with legacy contact email and website', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 42,
+            'identifier' => '10.5880/contact.creator',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 42,
+            'order' => 3,
+            'name' => 'Doe, Jane',
+            'firstname' => 'Jane',
+            'lastname' => 'Doe',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 42,
+            'resourceagent_order' => 3,
+            'email' => 'jane.doe@example.org',
+            'website' => 'https://jane.example.org',
+        ]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/contact.creator']);
+        $person = Person::query()->create([
+            'given_name' => 'Jane',
+            'family_name' => 'Doe',
+        ]);
+        $creator = ResourceCreator::query()->create([
+            'resource_id' => $resource->id,
+            'creatorable_type' => Person::class,
+            'creatorable_id' => $person->id,
+            'position' => 0,
+        ]);
+
+        $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.creator');
+
+        expect($updated)->toBeTrue()
+            ->and($creator->fresh()->is_contact)->toBeTrue()
+            ->and($creator->fresh()->email)->toBe('jane.doe@example.org')
+            ->and($creator->fresh()->website)->toBe('https://jane.example.org');
+    });
+
+    it('enriches matching contributors with legacy contact information', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 43,
+            'identifier' => '10.5880/contact.contributor',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 43,
+            'order' => 1,
+            'name' => 'Smith, Alex',
+            'firstname' => 'Alex',
+            'lastname' => 'Smith',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 43,
+            'resourceagent_order' => 1,
+            'email' => 'alex.smith@example.org',
+            'website' => null,
+        ]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/contact.contributor']);
+        $person = Person::query()->create([
+            'given_name' => 'Alex',
+            'family_name' => 'Smith',
+        ]);
+        $contributor = ResourceContributor::query()->create([
+            'resource_id' => $resource->id,
+            'contributorable_type' => Person::class,
+            'contributorable_id' => $person->id,
+            'position' => 0,
+        ]);
+
+        (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.contributor');
+
+        expect($contributor->fresh()->email)->toBe('alex.smith@example.org')
+            ->and($contributor->fresh()->website)->toBeNull();
+    });
+});

--- a/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
@@ -85,6 +85,51 @@ describe('SumarioPmdContactEnrichmentService', function () {
             ->and($creator->fresh()->website)->toBe('https://jane.example.org');
     });
 
+    it('does not touch the resource when matching creator contact data is unchanged', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 47,
+            'identifier' => '10.5880/contact.creator.unchanged',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 47,
+            'order' => 1,
+            'name' => 'Stable, Casey',
+            'firstname' => 'Casey',
+            'lastname' => 'Stable',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 47,
+            'resourceagent_order' => 1,
+            'email' => 'casey.stable@example.org',
+            'website' => 'https://casey.example.org',
+        ]);
+
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/contact.creator.unchanged',
+            'updated_at' => now()->subDay(),
+        ]);
+        $originalUpdatedAt = $resource->updated_at;
+        $person = Person::query()->create([
+            'given_name' => 'Casey',
+            'family_name' => 'Stable',
+        ]);
+        $creator = ResourceCreator::query()->create([
+            'resource_id' => $resource->id,
+            'creatorable_type' => Person::class,
+            'creatorable_id' => $person->id,
+            'position' => 0,
+            'is_contact' => true,
+            'email' => 'casey.stable@example.org',
+            'website' => 'https://casey.example.org',
+        ]);
+
+        $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.creator.unchanged');
+
+        expect($updated)->toBeFalse()
+            ->and($creator->fresh()->wasChanged(['is_contact', 'email', 'website']))->toBeFalse()
+            ->and($resource->fresh()->updated_at?->equalTo($originalUpdatedAt))->toBeTrue();
+    });
+
     it('ignores invalid legacy contact email and unsafe website values', function () {
         DB::connection('metaworks')->table('resource')->insert([
             'id' => 44,
@@ -237,5 +282,49 @@ describe('SumarioPmdContactEnrichmentService', function () {
 
         expect($contributor->fresh()->email)->toBe('alex.smith@example.org')
             ->and($contributor->fresh()->website)->toBeNull();
+    });
+
+    it('does not touch the resource when matching contributor contact data is unchanged', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 48,
+            'identifier' => '10.5880/contact.contributor.unchanged',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 48,
+            'order' => 1,
+            'name' => 'Still, Alex',
+            'firstname' => 'Alex',
+            'lastname' => 'Still',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 48,
+            'resourceagent_order' => 1,
+            'email' => 'alex.still@example.org',
+            'website' => 'https://alex.example.org',
+        ]);
+
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/contact.contributor.unchanged',
+            'updated_at' => now()->subDay(),
+        ]);
+        $originalUpdatedAt = $resource->updated_at;
+        $person = Person::query()->create([
+            'given_name' => 'Alex',
+            'family_name' => 'Still',
+        ]);
+        $contributor = ResourceContributor::query()->create([
+            'resource_id' => $resource->id,
+            'contributorable_type' => Person::class,
+            'contributorable_id' => $person->id,
+            'position' => 0,
+            'email' => 'alex.still@example.org',
+            'website' => 'https://alex.example.org',
+        ]);
+
+        $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.contributor.unchanged');
+
+        expect($updated)->toBeFalse()
+            ->and($contributor->fresh()->wasChanged(['email', 'website']))->toBeFalse()
+            ->and($resource->fresh()->updated_at?->equalTo($originalUpdatedAt))->toBeTrue();
     });
 });

--- a/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
@@ -163,6 +163,45 @@ describe('SumarioPmdContactEnrichmentService', function () {
             ->and($creator->fresh()->website)->toBeNull();
     });
 
+    it('ignores overlong legacy contact email and website values', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 46,
+            'identifier' => '10.5880/contact.overlong',
+        ]);
+        DB::connection('metaworks')->table('resourceagent')->insert([
+            'resource_id' => 46,
+            'order' => 1,
+            'name' => 'Long, Logan',
+            'firstname' => 'Logan',
+            'lastname' => 'Long',
+        ]);
+        DB::connection('metaworks')->table('contactinfo')->insert([
+            'resourceagent_resource_id' => 46,
+            'resourceagent_order' => 1,
+            'email' => str_repeat('a', 260).'@example.org',
+            'website' => 'https://example.org/'.str_repeat('a', 260),
+        ]);
+
+        $resource = Resource::factory()->create(['doi' => '10.5880/contact.overlong']);
+        $person = Person::query()->create([
+            'given_name' => 'Logan',
+            'family_name' => 'Long',
+        ]);
+        $creator = ResourceCreator::query()->create([
+            'resource_id' => $resource->id,
+            'creatorable_type' => Person::class,
+            'creatorable_id' => $person->id,
+            'position' => 0,
+        ]);
+
+        $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.overlong');
+
+        expect($updated)->toBeFalse()
+            ->and($creator->fresh()->is_contact)->toBeFalse()
+            ->and($creator->fresh()->email)->toBeNull()
+            ->and($creator->fresh()->website)->toBeNull();
+    });
+
     it('enriches matching contributors with legacy contact information', function () {
         DB::connection('metaworks')->table('resource')->insert([
             'id' => 43,

--- a/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPmdContactEnrichmentServiceTest.php
@@ -109,6 +109,7 @@ describe('SumarioPmdContactEnrichmentService', function () {
             'updated_at' => now()->subDay(),
         ]);
         $originalUpdatedAt = $resource->updated_at;
+        $originalCreatorUpdatedAt = now()->subDay()->startOfSecond();
         $person = Person::query()->create([
             'given_name' => 'Casey',
             'family_name' => 'Stable',
@@ -121,12 +122,16 @@ describe('SumarioPmdContactEnrichmentService', function () {
             'is_contact' => true,
             'email' => 'casey.stable@example.org',
             'website' => 'https://casey.example.org',
+            'created_at' => $originalCreatorUpdatedAt,
+            'updated_at' => $originalCreatorUpdatedAt,
         ]);
+        $originalCreatorUpdatedAt = $creator->updated_at;
 
         $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.creator.unchanged');
+        $freshCreator = $creator->fresh();
 
         expect($updated)->toBeFalse()
-            ->and($creator->fresh()->wasChanged(['is_contact', 'email', 'website']))->toBeFalse()
+            ->and($freshCreator?->updated_at?->equalTo($originalCreatorUpdatedAt))->toBeTrue()
             ->and($resource->fresh()->updated_at?->equalTo($originalUpdatedAt))->toBeTrue();
     });
 
@@ -308,6 +313,7 @@ describe('SumarioPmdContactEnrichmentService', function () {
             'updated_at' => now()->subDay(),
         ]);
         $originalUpdatedAt = $resource->updated_at;
+        $originalContributorUpdatedAt = now()->subDay()->startOfSecond();
         $person = Person::query()->create([
             'given_name' => 'Alex',
             'family_name' => 'Still',
@@ -319,12 +325,16 @@ describe('SumarioPmdContactEnrichmentService', function () {
             'position' => 0,
             'email' => 'alex.still@example.org',
             'website' => 'https://alex.example.org',
+            'created_at' => $originalContributorUpdatedAt,
+            'updated_at' => $originalContributorUpdatedAt,
         ]);
+        $originalContributorUpdatedAt = $contributor->updated_at;
 
         $updated = (new SumarioPmdContactEnrichmentService)->enrich($resource, '10.5880/contact.contributor.unchanged');
+        $freshContributor = $contributor->fresh();
 
         expect($updated)->toBeFalse()
-            ->and($contributor->fresh()->wasChanged(['email', 'website']))->toBeFalse()
+            ->and($freshContributor?->updated_at?->equalTo($originalContributorUpdatedAt))->toBeTrue()
             ->and($resource->fresh()->updated_at?->equalTo($originalUpdatedAt))->toBeTrue();
     });
 });


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the DataCite import job and related models, with a focus on improving support for SUMARIO pending resources, legacy data enrichment, and metadata synchronization. The changes also include updates to the `Resource` model for better type safety and new legacy tracking fields.

**Key improvements and changes:**

### SUMARIO Pending Resource Support & Import Robustness

- The import job (`ImportFromDataCiteJob`) now integrates SUMARIO pending resources into the import process. It counts, imports, and handles errors for these pending resources, ensuring they are included in progress calculations and fallback logic if a DOI is not found in DataCite. This improves coverage and resilience of the import workflow. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R104-R120) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R229-R267) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L283-R342) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R407-R464)

### Legacy Data Enrichment & Metadata Sync

- After importing a resource, the job now enriches it with legacy SUMARIO and Metaworks data (contacts, datacenters) and conditionally triggers a DataCite metadata sync if allowed by configuration. This ensures imported resources are as complete and up-to-date as possible. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R519-R526) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R582-R604)

### Landing Page Creation Refactor

- The logic for creating landing pages with download links from legacy Metaworks data has been refactored to use a dedicated service (`LegacyLandingPageImportService`) and now handles richer file entry data instead of just URLs. The old inline method has been removed for clarity and maintainability. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L416-R543) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L577-L629)

### Model Improvements and Type Safety

- The `Resource` model has been updated with new properties for legacy tracking (`legacy_source`, `legacy_source_id`, `legacy_source_status`, `force_review_status`) and improved type annotations, using `Collection` instead of Eloquent collections for related properties and methods. [[1]](diffhunk://#diff-2eeb95c4271950b7d4b77ff1f3760cd13affdf60345ec793f0f93e54ad89803cL7-R17) [[2]](diffhunk://#diff-2eeb95c4271950b7d4b77ff1f3760cd13affdf60345ec793f0f93e54ad89803cL30-R38) [[3]](diffhunk://#diff-2eeb95c4271950b7d4b77ff1f3760cd13affdf60345ec793f0f93e54ad89803cL40-R78) [[4]](diffhunk://#diff-2eeb95c4271950b7d4b77ff1f3760cd13affdf60345ec793f0f93e54ad89803cL403-R434)
- The `publicStatus()` method in `Resource` now prioritizes the `force_review_status` flag for legacy SUMARIO imports, overriding standard completeness checks to reflect their special review/publish status.

### Minor Model Annotation

- The `OldDataset` model docblock now includes the `publicstatus` property for improved clarity and IDE support.