### PR TITLE
Feature: Display Limits for Creators and Contributors on landing Page Templates

### DIFF
--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -301,8 +301,10 @@ class LandingPagePublicController extends Controller
             $effectiveLandingPageTemplate = LandingPageController::templateSupportsCustomTemplateId($effectiveTemplate)
                 ? LandingPageTemplate::resolveCustomTemplate($landingPage->landingPageTemplate, $resourceTypeSlug)
                 : null;
+            $expectedTemplateType = LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug);
             $displayLimitTemplate = $effectiveLandingPageTemplate
-                ?? LandingPageTemplate::defaultForType(LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug));
+                ?? LandingPageTemplate::existingDefaultForType($expectedTemplateType)
+                ?? LandingPageTemplate::defaultForType($expectedTemplateType);
 
             if ($effectiveLandingPageTemplate !== null) {
                 $tmpl = $effectiveLandingPageTemplate;

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -301,6 +301,8 @@ class LandingPagePublicController extends Controller
             $effectiveLandingPageTemplate = LandingPageController::templateSupportsCustomTemplateId($effectiveTemplate)
                 ? LandingPageTemplate::resolveCustomTemplate($landingPage->landingPageTemplate, $resourceTypeSlug)
                 : null;
+            $displayLimitTemplate = $effectiveLandingPageTemplate
+                ?? LandingPageTemplate::defaultForType(LandingPageTemplate::expectedTemplateTypeForResource($resourceTypeSlug));
 
             if ($effectiveLandingPageTemplate !== null) {
                 $tmpl = $effectiveLandingPageTemplate;
@@ -335,6 +337,10 @@ class LandingPagePublicController extends Controller
                     'schemaOrgJsonLd' => $schemaOrgJsonLd,
                     'sectionOrder' => $sectionOrder,
                     'customLogoUrl' => $customLogoUrl,
+                    'displayLimits' => [
+                        'creators' => $displayLimitTemplate->creator_display_limit,
+                        'contributors' => $displayLimitTemplate->contributor_display_limit,
+                    ],
                 ],
             ];
         };

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\LandingPageTemplate\UploadLandingPageTemplateLogoRequest;
 use App\Http\Requests\StoreLandingPageTemplateRequest;
 use App\Http\Requests\UpdateLandingPageTemplateRequest;
 use App\Models\LandingPageTemplate;
+use App\Services\BotProtection\LandingPageRenderDataCacheService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Storage;
@@ -61,6 +62,8 @@ class LandingPageTemplateController extends Controller
             'logo_filename' => null,
             'right_column_order' => $defaultTemplate->right_column_order,
             'left_column_order' => $defaultTemplate->left_column_order,
+            'creator_display_limit' => $defaultTemplate->creator_display_limit,
+            'contributor_display_limit' => $defaultTemplate->contributor_display_limit,
             'created_by' => $request->user()?->id,
         ]);
 
@@ -79,31 +82,45 @@ class LandingPageTemplateController extends Controller
     {
         $this->authorize('update', $landingPageTemplate);
 
-        if ($landingPageTemplate->isDefault()) {
-            return response()->json([
-                'message' => 'The default template cannot be modified.',
-                'error' => 'default_template_immutable',
-            ], 403);
-        }
-
         $validated = $request->validated();
+
+        if ($landingPageTemplate->isDefault()) {
+            $editableDefaultFields = ['creator_display_limit', 'contributor_display_limit'];
+            $unsupportedFields = array_diff(array_keys($validated), $editableDefaultFields);
+
+            if ($unsupportedFields !== []) {
+                return response()->json([
+                    'message' => 'The default template cannot be modified.',
+                    'error' => 'default_template_immutable',
+                ], 403);
+            }
+        }
 
         $updateData = [];
 
-        if (isset($validated['name'])) {
+        if (! $landingPageTemplate->isDefault() && isset($validated['name'])) {
             $updateData['name'] = $validated['name'];
         }
 
-        if (isset($validated['right_column_order'])) {
+        if (! $landingPageTemplate->isDefault() && isset($validated['right_column_order'])) {
             $updateData['right_column_order'] = $validated['right_column_order'];
         }
 
-        if (isset($validated['left_column_order'])) {
+        if (! $landingPageTemplate->isDefault() && isset($validated['left_column_order'])) {
             $updateData['left_column_order'] = $validated['left_column_order'];
+        }
+
+        if (isset($validated['creator_display_limit'])) {
+            $updateData['creator_display_limit'] = $validated['creator_display_limit'];
+        }
+
+        if (isset($validated['contributor_display_limit'])) {
+            $updateData['contributor_display_limit'] = $validated['contributor_display_limit'];
         }
 
         $landingPageTemplate->update($updateData);
         $landingPageTemplate->loadCount('landingPages');
+        app(LandingPageRenderDataCacheService::class)->flush();
 
         return response()->json([
             'message' => 'Template updated successfully',
@@ -181,6 +198,7 @@ class LandingPageTemplateController extends Controller
             'logo_path' => $path,
             'logo_filename' => $file->getClientOriginalName(),
         ]);
+        app(LandingPageRenderDataCacheService::class)->flush();
 
         // Delete old logo only after new one is persisted
         if ($oldLogoPath !== null) {
@@ -215,6 +233,7 @@ class LandingPageTemplateController extends Controller
             'logo_path' => null,
             'logo_filename' => null,
         ]);
+        app(LandingPageRenderDataCacheService::class)->flush();
 
         return response()->json([
             'message' => 'Logo removed successfully',
@@ -244,6 +263,8 @@ class LandingPageTemplateController extends Controller
                 'logo_path',
                 'right_column_order',
                 'left_column_order',
+                'creator_display_limit',
+                'contributor_display_limit',
             ]);
 
         return response()->json([

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -122,7 +122,7 @@ class LandingPageTemplateController extends Controller
 
         if ($landingPageTemplate->isDirty()) {
             $landingPageTemplate->save();
-            app(LandingPageRenderDataCacheService::class)->flush();
+            app(LandingPageRenderDataCacheService::class)->forgetForTemplate($landingPageTemplate);
         }
 
         $landingPageTemplate->loadCount('landingPages');
@@ -203,7 +203,7 @@ class LandingPageTemplateController extends Controller
             'logo_path' => $path,
             'logo_filename' => $file->getClientOriginalName(),
         ]);
-        app(LandingPageRenderDataCacheService::class)->flush();
+        app(LandingPageRenderDataCacheService::class)->forgetForTemplate($landingPageTemplate);
 
         // Delete old logo only after new one is persisted
         if ($oldLogoPath !== null) {
@@ -238,7 +238,7 @@ class LandingPageTemplateController extends Controller
             'logo_path' => null,
             'logo_filename' => null,
         ]);
-        app(LandingPageRenderDataCacheService::class)->flush();
+        app(LandingPageRenderDataCacheService::class)->forgetForTemplate($landingPageTemplate);
 
         return response()->json([
             'message' => 'Logo removed successfully',

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -90,7 +90,7 @@ class LandingPageTemplateController extends Controller
 
             if ($unsupportedFields !== []) {
                 return response()->json([
-                    'message' => 'The default template cannot be modified.',
+                    'message' => 'Only creator and contributor display limits can be updated on default templates.',
                     'error' => 'default_template_immutable',
                 ], 403);
             }

--- a/app/Http/Controllers/LandingPageTemplateController.php
+++ b/app/Http/Controllers/LandingPageTemplateController.php
@@ -118,9 +118,14 @@ class LandingPageTemplateController extends Controller
             $updateData['contributor_display_limit'] = $validated['contributor_display_limit'];
         }
 
-        $landingPageTemplate->update($updateData);
+        $landingPageTemplate->fill($updateData);
+
+        if ($landingPageTemplate->isDirty()) {
+            $landingPageTemplate->save();
+            app(LandingPageRenderDataCacheService::class)->flush();
+        }
+
         $landingPageTemplate->loadCount('landingPages');
-        app(LandingPageRenderDataCacheService::class)->flush();
 
         return response()->json([
             'message' => 'Template updated successfully',

--- a/app/Http/Requests/UpdateLandingPageTemplateRequest.php
+++ b/app/Http/Requests/UpdateLandingPageTemplateRequest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Requests;
 
 use App\Models\LandingPageTemplate;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdateLandingPageTemplateRequest extends FormRequest
 {
@@ -21,7 +23,7 @@ class UpdateLandingPageTemplateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
@@ -35,15 +37,17 @@ class UpdateLandingPageTemplateRequest extends FormRequest
             'right_column_order.*' => ['required', 'string', Rule::in(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)],
             'left_column_order' => ['sometimes', 'array'],
             'left_column_order.*' => ['required', 'string', Rule::in($allowedLeftColumnSections)],
+            'creator_display_limit' => ['sometimes', 'required', 'integer', 'min:'.LandingPageTemplate::MIN_DISPLAY_LIMIT, 'max:'.LandingPageTemplate::MAX_DISPLAY_LIMIT],
+            'contributor_display_limit' => ['sometimes', 'required', 'integer', 'min:'.LandingPageTemplate::MIN_DISPLAY_LIMIT, 'max:'.LandingPageTemplate::MAX_DISPLAY_LIMIT],
         ];
     }
 
     /**
      * Configure the validator instance.
      */
-    public function withValidator(\Illuminate\Validation\Validator $validator): void
+    public function withValidator(Validator $validator): void
     {
-        $validator->after(function (\Illuminate\Validation\Validator $validator): void {
+        $validator->after(function (Validator $validator): void {
             /** @var LandingPageTemplate $template */
             $template = $this->route('landingPageTemplate');
             $allowedLeftColumnSections = LandingPageTemplate::leftColumnSectionsForTemplateType($template->template_type);

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -511,6 +511,21 @@ class LandingPageTemplate extends Model
         };
     }
 
+    public static function existingDefaultForType(string $templateType): ?self
+    {
+        return self::query()
+            ->where('slug', self::defaultSlugForType($templateType))
+            ->where('template_type', $templateType)
+            ->first();
+    }
+
+    private static function defaultSlugForType(string $templateType): string
+    {
+        return $templateType === self::TEMPLATE_TYPE_IGSN
+            ? self::IGSN_DEFAULT_TEMPLATE_SLUG
+            : self::DEFAULT_TEMPLATE_SLUG;
+    }
+
     /**
      * Shared implementation backing {@see self::ensureDefaultTemplateExists()} and
      * {@see self::ensureIgsnDefaultTemplateExists()}.

--- a/app/Models/LandingPageTemplate.php
+++ b/app/Models/LandingPageTemplate.php
@@ -35,6 +35,8 @@ use Illuminate\Support\Str;
  * @property string|null $logo_filename Original filename of the uploaded logo
  * @property array<int, string> $right_column_order Ordered section keys for right column
  * @property array<int, string> $left_column_order Ordered section keys for left column
+ * @property int $creator_display_limit Number of creators shown initially on landing pages
+ * @property int $contributor_display_limit Number of contributors shown initially on landing pages
  * @property int|null $created_by FK to users table
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -58,6 +60,12 @@ class LandingPageTemplate extends Model
     public const TEMPLATE_TYPE_RESOURCE = 'resource';
 
     public const TEMPLATE_TYPE_IGSN = 'igsn';
+
+    public const DEFAULT_DISPLAY_LIMIT = 50;
+
+    public const MIN_DISPLAY_LIMIT = 1;
+
+    public const MAX_DISPLAY_LIMIT = 500;
 
     /**
      * Allowed values for the `template_type` attribute.
@@ -154,6 +162,8 @@ class LandingPageTemplate extends Model
         'logo_filename',
         'right_column_order',
         'left_column_order',
+        'creator_display_limit',
+        'contributor_display_limit',
         'created_by',
     ];
 
@@ -166,6 +176,8 @@ class LandingPageTemplate extends Model
         'is_default' => 'boolean',
         'right_column_order' => 'array',
         'left_column_order' => 'array',
+        'creator_display_limit' => 'integer',
+        'contributor_display_limit' => 'integer',
     ];
 
     /**
@@ -520,6 +532,8 @@ class LandingPageTemplate extends Model
                             'logo_filename' => null,
                             'right_column_order' => self::RIGHT_COLUMN_SECTIONS,
                             'left_column_order' => self::leftColumnSectionsForTemplateType($templateType),
+                            'creator_display_limit' => self::DEFAULT_DISPLAY_LIMIT,
+                            'contributor_display_limit' => self::DEFAULT_DISPLAY_LIMIT,
                             'created_by' => null,
                         ]
                     );

--- a/app/Policies/LandingPageTemplatePolicy.php
+++ b/app/Policies/LandingPageTemplatePolicy.php
@@ -12,7 +12,8 @@ use App\Models\User;
  * Policy for LandingPageTemplate model authorization.
  *
  * Only Admin and Group Leader roles can manage landing page templates.
- * The default template (is_default=true) cannot be updated or deleted.
+ * The default template (is_default=true) can only receive narrowly scoped
+ * display-limit updates; immutable fields remain protected by the controller.
  */
 class LandingPageTemplatePolicy
 {
@@ -44,14 +45,10 @@ class LandingPageTemplatePolicy
 
     /**
      * Determine whether the user can update the template.
-     * Default templates cannot be modified.
+     * Default template field restrictions are enforced by the controller.
      */
     public function update(User $user, LandingPageTemplate $template): bool
     {
-        if ($template->isDefault()) {
-            return false;
-        }
-
         return in_array($user->role, self::MANAGEMENT_ROLES, true);
     }
 

--- a/app/Services/BotProtection/LandingPageRenderDataCacheService.php
+++ b/app/Services/BotProtection/LandingPageRenderDataCacheService.php
@@ -6,9 +6,11 @@ namespace App\Services\BotProtection;
 
 use App\Enums\CacheKey;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Support\Traits\ChecksCacheTagging;
 use Closure;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 class LandingPageRenderDataCacheService
 {
@@ -36,17 +38,41 @@ class LandingPageRenderDataCacheService
         return CacheKey::LANDING_PAGE_RENDER_DATA->forget($landingPage->id);
     }
 
-    public function flush(): void
+    public function forgetById(int $landingPageId): bool
     {
-        $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA;
+        return CacheKey::LANDING_PAGE_RENDER_DATA->forget($landingPageId);
+    }
 
-        if ($this->supportsTagging()) {
-            Cache::tags($cacheKey->tags())->flush();
+    public function forgetForTemplate(LandingPageTemplate $template): void
+    {
+        $query = LandingPage::query()
+            ->select('landing_pages.id')
+            ->where('is_published', true);
 
-            return;
+        if ($template->isDefault()) {
+            $query->whereDoesntHave('landingPageTemplate', function (Builder $query) use ($template): void {
+                $query->where('is_default', false)
+                    ->where('template_type', $template->template_type);
+            });
+
+            if ($template->template_type === LandingPageTemplate::TEMPLATE_TYPE_IGSN) {
+                $query->whereHas('resource.resourceType', function (Builder $query): void {
+                    $query->where('slug', 'physical-object');
+                });
+            } else {
+                $query->whereDoesntHave('resource.resourceType', function (Builder $query): void {
+                    $query->where('slug', 'physical-object');
+                });
+            }
+        } else {
+            $query->where('landing_page_template_id', $template->id);
         }
 
-        Cache::flush();
+        $query->chunkById(500, function (Collection $landingPages): void {
+            foreach ($landingPages as $landingPage) {
+                $this->forgetById((int) $landingPage->id);
+            }
+        }, 'landing_pages.id', 'id');
     }
 
     private function shouldCache(LandingPage $landingPage): bool

--- a/app/Services/BotProtection/LandingPageRenderDataCacheService.php
+++ b/app/Services/BotProtection/LandingPageRenderDataCacheService.php
@@ -8,6 +8,7 @@ use App\Enums\CacheKey;
 use App\Models\LandingPage;
 use App\Support\Traits\ChecksCacheTagging;
 use Closure;
+use Illuminate\Support\Facades\Cache;
 
 class LandingPageRenderDataCacheService
 {
@@ -33,6 +34,19 @@ class LandingPageRenderDataCacheService
     public function forget(LandingPage $landingPage): bool
     {
         return CacheKey::LANDING_PAGE_RENDER_DATA->forget($landingPage->id);
+    }
+
+    public function flush(): void
+    {
+        $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA;
+
+        if ($this->supportsTagging()) {
+            Cache::tags($cacheKey->tags())->flush();
+
+            return;
+        }
+
+        Cache::flush();
     }
 
     private function shouldCache(LandingPage $landingPage): bool

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -599,6 +599,8 @@ entity "landing_page_templates" as landing_page_templates {
     logo_filename : VARCHAR
     * right_column_order : JSON
     * left_column_order : JSON
+    * creator_display_limit : SMALLINT = 50
+    * contributor_display_limit : SMALLINT = 50
     created_by : BIGINT <<FK>>
     created_at : TIMESTAMP
     updated_at : TIMESTAMP

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -534,6 +534,8 @@ erDiagram
         varchar logo_filename "nullable"
         json right_column_order
         json left_column_order
+        smallint creator_display_limit "default 50"
+        smallint contributor_display_limit "default 50"
         bigint created_by FK "nullable"
         timestamp created_at
         timestamp updated_at

--- a/database/factories/LandingPageTemplateFactory.php
+++ b/database/factories/LandingPageTemplateFactory.php
@@ -36,6 +36,8 @@ class LandingPageTemplateFactory extends Factory
             'logo_filename' => null,
             'right_column_order' => LandingPageTemplate::RIGHT_COLUMN_SECTIONS,
             'left_column_order' => LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS,
+            'creator_display_limit' => LandingPageTemplate::DEFAULT_DISPLAY_LIMIT,
+            'contributor_display_limit' => LandingPageTemplate::DEFAULT_DISPLAY_LIMIT,
             'created_by' => User::factory(),
         ];
     }

--- a/database/migrations/2026_06_04_000001_add_display_limits_to_landing_page_templates.php
+++ b/database/migrations/2026_06_04_000001_add_display_limits_to_landing_page_templates.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPageTemplate;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('landing_page_templates', function (Blueprint $table): void {
+            if (! Schema::hasColumn('landing_page_templates', 'creator_display_limit')) {
+                $table->unsignedSmallInteger('creator_display_limit')
+                    ->default(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT)
+                    ->after('left_column_order');
+            }
+
+            if (! Schema::hasColumn('landing_page_templates', 'contributor_display_limit')) {
+                $table->unsignedSmallInteger('contributor_display_limit')
+                    ->default(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT)
+                    ->after('creator_display_limit');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('landing_page_templates', function (Blueprint $table): void {
+            if (Schema::hasColumn('landing_page_templates', 'contributor_display_limit')) {
+                $table->dropColumn('contributor_display_limit');
+            }
+
+            if (Schema::hasColumn('landing_page_templates', 'creator_display_limit')) {
+                $table->dropColumn('creator_display_limit');
+            }
+        });
+    }
+};

--- a/resources/js/pages/LandingPages/components/AbstractSection.tsx
+++ b/resources/js/pages/LandingPages/components/AbstractSection.tsx
@@ -25,6 +25,10 @@ interface AbstractSectionProps {
     /** Public JSON-LD export URL for landing pages (avoids auth-protected routes) */
     jsonLdExportUrl?: string;
     sectionOrder?: MetadataSectionKey[];
+    displayLimits?: {
+        creators: number;
+        contributors: number;
+    };
 }
 
 /**
@@ -42,6 +46,7 @@ export function AbstractSection({
     resourceId,
     jsonLdExportUrl,
     sectionOrder = ['descriptions', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
+    displayLimits = { creators: 50, contributors: 50 },
 }: AbstractSectionProps) {
     const expandedSectionOrder = expandMetadataOrder(sectionOrder);
 
@@ -53,9 +58,9 @@ export function AbstractSection({
 
             switch (sectionKey) {
                 case 'creators':
-                    return <CreatorsSection key="creators" creators={creators} />;
+                    return <CreatorsSection key="creators" creators={creators} displayLimit={displayLimits.creators} />;
                 case 'contributors':
-                    return <ContributorsSection key="contributors" contributors={contributors} />;
+                    return <ContributorsSection key="contributors" contributors={contributors} displayLimit={displayLimits.contributors} />;
                 case 'funders':
                     return <FundersSection key="funders" fundingReferences={fundingReferences} />;
                 case 'keywords':

--- a/resources/js/pages/LandingPages/components/AbstractSection.tsx
+++ b/resources/js/pages/LandingPages/components/AbstractSection.tsx
@@ -2,6 +2,7 @@ import type {
     LandingPageContributor,
     LandingPageCreator,
     LandingPageDescription,
+    LandingPageDisplayLimits,
     LandingPageFundingReference,
     LandingPageSubject,
 } from '@/types/landing-page';
@@ -25,10 +26,7 @@ interface AbstractSectionProps {
     /** Public JSON-LD export URL for landing pages (avoids auth-protected routes) */
     jsonLdExportUrl?: string;
     sectionOrder?: MetadataSectionKey[];
-    displayLimits?: {
-        creators: number;
-        contributors: number;
-    };
+    displayLimits?: LandingPageDisplayLimits;
 }
 
 /**

--- a/resources/js/pages/LandingPages/components/CollapsibleList.tsx
+++ b/resources/js/pages/LandingPages/components/CollapsibleList.tsx
@@ -18,6 +18,8 @@ interface CollapsibleListProps<T> {
     itemLabel: string;
     /** Optional wrapper around the rendered items (e.g. a `<ul>` element). Receives the visible items as children. */
     wrapper?: (children: ReactNode) => ReactNode;
+    /** Show an explicit visible-count summary above the toggle button. */
+    showSummary?: boolean;
     className?: string;
 }
 
@@ -29,7 +31,7 @@ interface CollapsibleListProps<T> {
  *
  * SSR-safe: no client-side measurement needed.
  */
-export function CollapsibleList<T>({ items, renderItem, threshold = DEFAULT_THRESHOLD, itemLabel, wrapper, className }: CollapsibleListProps<T>) {
+export function CollapsibleList<T>({ items, renderItem, threshold = DEFAULT_THRESHOLD, itemLabel, wrapper, showSummary = false, className }: CollapsibleListProps<T>) {
     const [isExpanded, setIsExpanded] = useState(false);
     const regionId = useId();
     const reducedMotion = useReducedMotion();
@@ -57,6 +59,12 @@ export function CollapsibleList<T>({ items, renderItem, threshold = DEFAULT_THRE
             <div id={regionId} role="region" aria-label={`${itemLabel} list`}>
                 {wrapper ? wrapper(rendered) : rendered}
             </div>
+
+            {showSummary && (
+                <p className="mt-2 text-sm text-gray-600 dark:text-gray-400" data-testid="collapsible-list-summary">
+                    {isExpanded ? `Showing all ${items.length} ${itemLabel}` : `Showing ${threshold} of ${items.length} ${itemLabel}`}
+                </p>
+            )}
 
             <Button
                 variant="ghost"

--- a/resources/js/pages/LandingPages/components/ContributorsSection.tsx
+++ b/resources/js/pages/LandingPages/components/ContributorsSection.tsx
@@ -6,13 +6,14 @@ import { OrcidIcon, RorIcon } from './PidIcons';
 
 interface ContributorsSectionProps {
     contributors: LandingPageContributor[];
+    displayLimit?: number;
 }
 
 /**
  * Renders the list of contributors with ORCID/ROR icons and contributor type badges.
- * Collapses when there are more than 10 contributors.
+ * Collapses when there are more contributors than the configured display limit.
  */
-export function ContributorsSection({ contributors }: ContributorsSectionProps) {
+export function ContributorsSection({ contributors, displayLimit = 50 }: ContributorsSectionProps) {
     if (contributors.length === 0) {
         return null;
     }
@@ -22,7 +23,9 @@ export function ContributorsSection({ contributors }: ContributorsSectionProps) 
             <h3 id="heading-contributors" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Contributors</h3>
             <CollapsibleList
                 items={contributors}
+                threshold={displayLimit}
                 itemLabel="contributors"
+                showSummary={true}
                 wrapper={(children) => (
                     <ul className="space-y-2" data-testid="contributors-list">
                         {children}

--- a/resources/js/pages/LandingPages/components/CreatorsSection.tsx
+++ b/resources/js/pages/LandingPages/components/CreatorsSection.tsx
@@ -1,16 +1,18 @@
 import type { LandingPageCreator } from '@/types/landing-page';
 
 import { formatPersonName } from '../lib/formatPersonName';
+import { CollapsibleList } from './CollapsibleList';
 import { OrcidIcon, RorIcon } from './PidIcons';
 
 interface CreatorsSectionProps {
     creators: LandingPageCreator[];
+    displayLimit?: number;
 }
 
 /**
  * Renders the list of creators (authors) with ORCID and ROR icons.
  */
-export function CreatorsSection({ creators }: CreatorsSectionProps) {
+export function CreatorsSection({ creators, displayLimit = 50 }: CreatorsSectionProps) {
     if (creators.length === 0) {
         return null;
     }
@@ -18,8 +20,17 @@ export function CreatorsSection({ creators }: CreatorsSectionProps) {
     return (
         <section className="mt-6" data-testid="creators-section" aria-labelledby="heading-creators">
             <h3 id="heading-creators" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Creators</h3>
-            <ul className="space-y-2" data-testid="creators-list">
-                {creators.map((creator) => {
+            <CollapsibleList
+                items={creators}
+                threshold={displayLimit}
+                itemLabel="creators"
+                showSummary={true}
+                wrapper={(children) => (
+                    <ul className="space-y-2" data-testid="creators-list">
+                        {children}
+                    </ul>
+                )}
+                renderItem={(creator) => {
                     const creatorable = creator.creatorable;
                     const firstAffiliation = creator.affiliations[0];
                     const isPerson = creatorable.type === 'Person';
@@ -63,8 +74,8 @@ export function CreatorsSection({ creators }: CreatorsSectionProps) {
                             )}
                         </li>
                     );
-                })}
-            </ul>
+                }}
+            />
         </section>
     );
 }

--- a/resources/js/pages/LandingPages/default_gfz.tsx
+++ b/resources/js/pages/LandingPages/default_gfz.tsx
@@ -1,7 +1,7 @@
 import { usePage } from '@inertiajs/react';
 import { type ReactNode, useMemo } from 'react';
 
-import type { LandingPageConfig, LandingPageResource, LeftColumnSection, SectionOrder } from '@/types/landing-page';
+import type { LandingPageConfig, LandingPageDisplayLimits, LandingPageResource, LeftColumnSection, SectionOrder } from '@/types/landing-page';
 
 import { AbstractSection } from './components/AbstractSection';
 import { ContactSection } from './components/ContactSection';
@@ -32,13 +32,20 @@ interface DefaultGfzTemplatePageProps {
     schemaOrgJsonLd?: Record<string, unknown>;
     sectionOrder?: SectionOrder | null;
     customLogoUrl?: string | null;
+    displayLimits?: LandingPageDisplayLimits;
     /** Inertia PageProps requires index signature for dynamic SSR props */
     [key: string]: unknown;
 }
 
+const DEFAULT_DISPLAY_LIMITS: LandingPageDisplayLimits = {
+    creators: 50,
+    contributors: 50,
+};
+
 export default function DefaultGfzTemplate() {
-    const { resource, landingPage, isPreview, schemaOrgJsonLd, sectionOrder, customLogoUrl } = usePage<DefaultGfzTemplatePageProps>().props;
+    const { resource, landingPage, isPreview, schemaOrgJsonLd, sectionOrder, customLogoUrl, displayLimits } = usePage<DefaultGfzTemplatePageProps>().props;
     const isDark = useSystemDarkMode();
+    const peopleDisplayLimits = displayLimits ?? DEFAULT_DISPLAY_LIMITS;
 
     const resourceType = resource.resource_type?.name || 'Other';
     const { status, mainTitle, subtitle, citation } = getLandingPageTemplateData(resource, landingPage, isPreview);
@@ -64,11 +71,12 @@ export default function DefaultGfzTemplate() {
                     resourceId={resource.id}
                     jsonLdExportUrl={jsonLdExportUrl}
                     sectionOrder={metadataOrder}
+                    displayLimits={peopleDisplayLimits}
                 />
             ),
             location: <LocationSection key="location" geoLocations={resource.geo_locations || []} isDark={isDark} />,
         };
-    }, [resource, landingPage, isDark, metadataOrder]);
+    }, [resource, landingPage, isDark, metadataOrder, peopleDisplayLimits]);
 
     const leftSectionRegistry = useMemo((): Record<LeftColumnSection, ReactNode> => {
         return {

--- a/resources/js/pages/LandingPages/default_gfz_igsn.tsx
+++ b/resources/js/pages/LandingPages/default_gfz_igsn.tsx
@@ -1,7 +1,7 @@
 import { usePage } from '@inertiajs/react';
 import { type ReactNode, useMemo } from 'react';
 
-import type { LandingPageConfig, LandingPageResource, LeftColumnSection, SectionOrder } from '@/types/landing-page';
+import type { LandingPageConfig, LandingPageDisplayLimits, LandingPageResource, LeftColumnSection, SectionOrder } from '@/types/landing-page';
 
 import { AbstractSection } from './components/AbstractSection';
 import { AcquisitionSection } from './components/AcquisitionSection';
@@ -29,9 +29,15 @@ interface DefaultGfzIgsnTemplatePageProps {
     schemaOrgJsonLd?: Record<string, unknown>;
     sectionOrder?: SectionOrder | null;
     customLogoUrl?: string | null;
+    displayLimits?: LandingPageDisplayLimits;
     /** Inertia PageProps requires index signature for dynamic SSR props */
     [key: string]: unknown;
 }
+
+const DEFAULT_DISPLAY_LIMITS: LandingPageDisplayLimits = {
+    creators: 50,
+    contributors: 50,
+};
 
 /**
  * Default GFZ IGSN Landing Page Template
@@ -41,9 +47,10 @@ interface DefaultGfzIgsnTemplatePageProps {
  * with IGSN-specific General and Acquisition modules in the left column.
  */
 export default function DefaultGfzIgsnTemplate() {
-    const { resource, landingPage, isPreview, schemaOrgJsonLd, sectionOrder, customLogoUrl } =
+    const { resource, landingPage, isPreview, schemaOrgJsonLd, sectionOrder, customLogoUrl, displayLimits } =
         usePage<DefaultGfzIgsnTemplatePageProps>().props;
     const isDark = useSystemDarkMode();
+    const peopleDisplayLimits = displayLimits ?? DEFAULT_DISPLAY_LIMITS;
 
     const { status, mainTitle, subtitle, citation } = getLandingPageTemplateData(resource, landingPage, isPreview);
 
@@ -68,11 +75,12 @@ export default function DefaultGfzIgsnTemplate() {
                     resourceId={resource.id}
                     jsonLdExportUrl={jsonLdExportUrl}
                     sectionOrder={metadataOrder}
+                    displayLimits={peopleDisplayLimits}
                 />
             ),
             location: <LocationSection key="location" geoLocations={resource.geo_locations || []} isDark={isDark} />,
         };
-    }, [resource, landingPage, isDark, metadataOrder]);
+    }, [resource, landingPage, isDark, metadataOrder, peopleDisplayLimits]);
 
     const leftSectionRegistry = useMemo((): Record<LeftColumnSection, ReactNode> => {
         return {

--- a/resources/js/pages/landing-page-templates.tsx
+++ b/resources/js/pages/landing-page-templates.tsx
@@ -29,6 +29,9 @@ import { type BreadcrumbItem, type SharedData } from '@/types';
 import type { LandingPageTemplateConfig, LeftColumnSection, RightColumnSection } from '@/types/landing-page';
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Landing Pages', href: '/landing-pages' }];
+const DISPLAY_LIMIT_MIN = 1;
+const DISPLAY_LIMIT_MAX = 500;
+const DISPLAY_LIMIT_DEFAULT = 50;
 
 interface PageProps extends SharedData {
     templates: LandingPageTemplateConfig[];
@@ -130,6 +133,8 @@ export default function LandingPageTemplatesPage() {
     const [editName, setEditName] = useState('');
     const [editRightOrder, setEditRightOrder] = useState<RightColumnSection[]>([]);
     const [editLeftOrder, setEditLeftOrder] = useState<LeftColumnSection[]>([]);
+    const [editCreatorDisplayLimit, setEditCreatorDisplayLimit] = useState(String(DISPLAY_LIMIT_DEFAULT));
+    const [editContributorDisplayLimit, setEditContributorDisplayLimit] = useState(String(DISPLAY_LIMIT_DEFAULT));
     const [saving, setSaving] = useState(false);
 
     // Delete dialog
@@ -175,18 +180,41 @@ export default function LandingPageTemplatesPage() {
         setEditName(tmpl.name);
         setEditRightOrder(normalizeRightColumnOrder(tmpl.right_column_order));
         setEditLeftOrder(normalizeLeftColumnOrder(tmpl.left_column_order, tmpl.template_type));
+        setEditCreatorDisplayLimit(String(tmpl.creator_display_limit ?? DISPLAY_LIMIT_DEFAULT));
+        setEditContributorDisplayLimit(String(tmpl.contributor_display_limit ?? DISPLAY_LIMIT_DEFAULT));
         setEditOpen(true);
     };
+
+    const isValidDisplayLimit = (value: string) => {
+        if (!/^\d+$/.test(value)) return false;
+
+        const parsed = Number.parseInt(value, 10);
+
+        return parsed >= DISPLAY_LIMIT_MIN && parsed <= DISPLAY_LIMIT_MAX;
+    };
+
+    const areDisplayLimitsValid =
+        isValidDisplayLimit(editCreatorDisplayLimit) &&
+        isValidDisplayLimit(editContributorDisplayLimit);
 
     const handleSave = async () => {
         if (!editTemplate) return;
         setSaving(true);
         try {
-            await axios.put(`/landing-pages/${editTemplate.id}`, {
-                name: editName.trim(),
-                right_column_order: normalizeRightColumnOrder(editRightOrder),
-                left_column_order: normalizeLeftColumnOrder(editLeftOrder, editTemplate.template_type),
-            });
+            const payload = editTemplate.is_default
+                ? {
+                      creator_display_limit: Number.parseInt(editCreatorDisplayLimit, 10),
+                      contributor_display_limit: Number.parseInt(editContributorDisplayLimit, 10),
+                  }
+                : {
+                      name: editName.trim(),
+                      right_column_order: normalizeRightColumnOrder(editRightOrder),
+                      left_column_order: normalizeLeftColumnOrder(editLeftOrder, editTemplate.template_type),
+                      creator_display_limit: Number.parseInt(editCreatorDisplayLimit, 10),
+                      contributor_display_limit: Number.parseInt(editContributorDisplayLimit, 10),
+                  };
+
+            await axios.put(`/landing-pages/${editTemplate.id}`, payload);
             toast.success('Template updated successfully');
             setEditOpen(false);
             router.reload({ only: ['templates'] });
@@ -353,6 +381,17 @@ export default function LandingPageTemplatesPage() {
                                     </div>
                                 )}
 
+                                <div className="grid grid-cols-2 gap-2 rounded-md border bg-muted/20 p-2 text-xs">
+                                    <div>
+                                        <span className="block font-medium text-foreground">Creators shown</span>
+                                        <span className="text-muted-foreground">{tmpl.creator_display_limit ?? DISPLAY_LIMIT_DEFAULT}</span>
+                                    </div>
+                                    <div>
+                                        <span className="block font-medium text-foreground">Contributors shown</span>
+                                        <span className="text-muted-foreground">{tmpl.contributor_display_limit ?? DISPLAY_LIMIT_DEFAULT}</span>
+                                    </div>
+                                </div>
+
                                 {/* Section Order Summary */}
                                 <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
                                     <div>
@@ -379,6 +418,10 @@ export default function LandingPageTemplatesPage() {
                                         <Button variant="outline" size="sm" onClick={() => openClone(tmpl.template_type)}>
                                             <Copy className="mr-1.5 size-3.5" />
                                             Clone this template
+                                        </Button>
+                                        <Button variant="outline" size="sm" onClick={() => openEdit(tmpl)}>
+                                            <Pencil className="mr-1.5 size-3.5" />
+                                            Limits
                                         </Button>
                                     </div>
                                 ) : (
@@ -474,50 +517,91 @@ export default function LandingPageTemplatesPage() {
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2">
                             <Pencil className="size-5" />
-                            Edit Template
+                            {editTemplate?.is_default ? 'Edit Display Limits' : 'Edit Template'}
                         </DialogTitle>
                         <DialogDescription>
-                            Customize the template name and drag sections to reorder them.
+                            {editTemplate?.is_default
+                                ? 'Customize how many creators and contributors are shown initially for this built-in template.'
+                                : 'Customize the template name, section order, and initial creator/contributor display limits.'}
                         </DialogDescription>
                     </DialogHeader>
 
                     <div className="space-y-6 py-2">
-                        <div className="space-y-2">
-                            <Label htmlFor="edit-name">Template Name</Label>
-                            <Input
-                                id="edit-name"
-                                value={editName}
-                                onChange={(e) => setEditName(e.target.value)}
-                            />
+                        {!editTemplate?.is_default && (
+                            <>
+                                <div className="space-y-2">
+                                    <Label htmlFor="edit-name">Template Name</Label>
+                                    <Input
+                                        id="edit-name"
+                                        value={editName}
+                                        onChange={(e) => setEditName(e.target.value)}
+                                    />
+                                </div>
+
+                                <Separator />
+                            </>
+                        )}
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label htmlFor="edit-creator-display-limit">Creators shown initially</Label>
+                                <Input
+                                    id="edit-creator-display-limit"
+                                    type="number"
+                                    inputMode="numeric"
+                                    min={DISPLAY_LIMIT_MIN}
+                                    max={DISPLAY_LIMIT_MAX}
+                                    step={1}
+                                    value={editCreatorDisplayLimit}
+                                    onChange={(e) => setEditCreatorDisplayLimit(e.target.value)}
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="edit-contributor-display-limit">Contributors shown initially</Label>
+                                <Input
+                                    id="edit-contributor-display-limit"
+                                    type="number"
+                                    inputMode="numeric"
+                                    min={DISPLAY_LIMIT_MIN}
+                                    max={DISPLAY_LIMIT_MAX}
+                                    step={1}
+                                    value={editContributorDisplayLimit}
+                                    onChange={(e) => setEditContributorDisplayLimit(e.target.value)}
+                                />
+                            </div>
                         </div>
 
-                        <Separator />
+                        {!editTemplate?.is_default && (
+                            <>
+                                <Separator />
 
-                        <div className="grid gap-6 md:grid-cols-2">
-                            <SectionOrderEditor
-                                title="Right Column (main content)"
-                                items={editRightOrder}
-                                labels={RIGHT_SECTION_LABELS}
-                                description="Description modules render inside one shared metadata card. Location / Map stays outside that card and snaps to the top or bottom position."
-                                onReorder={(items) => setEditRightOrder(normalizeRightColumnOrder(items as RightColumnSection[]))}
-                            />
-                            <SectionOrderEditor
-                                title="Left Column (sidebar)"
-                                items={editLeftOrder}
-                                labels={LEFT_SECTION_LABELS}
-                                description={
-                                    editTemplate?.template_type === 'igsn'
-                                        ? 'IGSN templates use the General and Acquisition modules instead of Files & Downloads.'
-                                        : 'Resource templates render files, contact details, and related material in the sidebar.'
-                                }
-                                onReorder={(items) => setEditLeftOrder(items as LeftColumnSection[])}
-                            />
-                        </div>
+                                <div className="grid gap-6 md:grid-cols-2">
+                                    <SectionOrderEditor
+                                        title="Right Column (main content)"
+                                        items={editRightOrder}
+                                        labels={RIGHT_SECTION_LABELS}
+                                        description="Description modules render inside one shared metadata card. Location / Map stays outside that card and snaps to the top or bottom position."
+                                        onReorder={(items) => setEditRightOrder(normalizeRightColumnOrder(items as RightColumnSection[]))}
+                                    />
+                                    <SectionOrderEditor
+                                        title="Left Column (sidebar)"
+                                        items={editLeftOrder}
+                                        labels={LEFT_SECTION_LABELS}
+                                        description={
+                                            editTemplate?.template_type === 'igsn'
+                                                ? 'IGSN templates use the General and Acquisition modules instead of Files & Downloads.'
+                                                : 'Resource templates render files, contact details, and related material in the sidebar.'
+                                        }
+                                        onReorder={(items) => setEditLeftOrder(items as LeftColumnSection[])}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </div>
 
                     <DialogFooter className="gap-2">
                         <Button variant="outline" onClick={() => setEditOpen(false)}>Cancel</Button>
-                        <LoadingButton loading={saving} disabled={!editName.trim()} onClick={handleSave}>
+                        <LoadingButton loading={saving} disabled={!areDisplayLimitsValid || (!editTemplate?.is_default && !editName.trim())} onClick={handleSave}>
                             Save Changes
                         </LoadingButton>
                     </DialogFooter>

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -70,6 +70,12 @@ export interface LandingPageTemplateConfig {
     /** Ordered left column sections */
     left_column_order: LeftColumnSection[];
 
+    /** Number of creators shown initially on public landing pages */
+    creator_display_limit: number;
+
+    /** Number of contributors shown initially on public landing pages */
+    contributor_display_limit: number;
+
     /** ID of user who created this template */
     created_by: number | null;
 
@@ -99,6 +105,16 @@ export interface LandingPageTemplateSummary {
     logo_url: string | null;
     right_column_order: RightColumnSection[];
     left_column_order: LeftColumnSection[];
+    creator_display_limit?: number;
+    contributor_display_limit?: number;
+}
+
+/**
+ * Initial display limits for long people lists on landing pages.
+ */
+export interface LandingPageDisplayLimits {
+    creators: number;
+    contributors: number;
 }
 
 /**
@@ -652,6 +668,8 @@ export interface LandingPageTemplateProps {
     sectionOrder?: SectionOrder | null;
     /** Custom logo URL from template (null = use default GFZ logo) */
     customLogoUrl?: string | null;
+    /** Initial visible counts for creator/contributor sections */
+    displayLimits?: LandingPageDisplayLimits;
 }
 
 /**

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -733,6 +733,8 @@ describe('Landing Page with Custom Template', function () {
             'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
             'left_column_order' => ['contact', 'files', 'model_description', 'related_work'],
             'logo_path' => 'landing-page-logos/test/custom-logo.png',
+            'creator_display_limit' => 12,
+            'contributor_display_limit' => 34,
         ]);
 
         $landingPage = LandingPage::factory()
@@ -754,11 +756,18 @@ describe('Landing Page with Custom Template', function () {
                     ->has('rightColumn')
                     ->has('leftColumn')
                 )
+                ->where('displayLimits.creators', 12)
+                ->where('displayLimits.contributors', 34)
                 ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/custom-logo.png'))
             );
     });
 
     test('renders landing page without custom template (default)', function () {
+        LandingPageTemplate::ensureDefaultTemplateExists()->update([
+            'creator_display_limit' => 22,
+            'contributor_display_limit' => 44,
+        ]);
+
         $landingPage = LandingPage::factory()
             ->published()
             ->create([
@@ -776,6 +785,8 @@ describe('Landing Page with Custom Template', function () {
                 ->component('LandingPages/default_gfz')
                 ->where('sectionOrder', null)
                 ->where('customLogoUrl', null)
+                ->where('displayLimits.creators', 22)
+                ->where('displayLimits.contributors', 44)
             );
     });
 
@@ -795,6 +806,8 @@ describe('Landing Page with Custom Template', function () {
             'right_column_order' => ['location', 'abstract', 'methods', 'technical_info', 'series_information', 'table_of_contents', 'other', 'creators', 'contributors', 'funders', 'keywords', 'metadata_download'],
             'left_column_order' => ['contact', 'general', 'acquisition', 'model_description', 'related_work'],
             'logo_path' => 'landing-page-logos/test/igsn-logo.png',
+            'creator_display_limit' => 21,
+            'contributor_display_limit' => 31,
         ]);
         $domain = LandingPageDomain::factory()->withDomain('https://legacy.example.org/')->create();
 
@@ -833,6 +846,8 @@ describe('Landing Page with Custom Template', function () {
                     ->has('rightColumn')
                     ->has('leftColumn')
                 )
+                ->where('displayLimits.creators', 21)
+                ->where('displayLimits.contributors', 31)
                 ->where('customLogoUrl', fn ($url) => str_contains($url, 'landing-page-logos/test/igsn-logo.png'))
             );
     });

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -790,6 +790,46 @@ describe('Landing Page with Custom Template', function () {
             );
     });
 
+    test('reads existing default template display limits without normalizing the system template during render', function () {
+        Cache::flush();
+
+        $defaultTemplate = LandingPageTemplate::ensureDefaultTemplateExists();
+        $originalTimestamp = now()->subHour()->startOfSecond();
+
+        LandingPageTemplate::query()
+            ->whereKey($defaultTemplate->id)
+            ->update([
+                'is_default' => false,
+                'creator_display_limit' => 23,
+                'contributor_display_limit' => 43,
+                'updated_at' => $originalTimestamp,
+            ]);
+
+        $landingPage = LandingPage::factory()
+            ->published()
+            ->create([
+                'resource_id' => $this->resource->id,
+                'doi_prefix' => '10.5880/test.public.001',
+                'slug' => 'existing-default-template-read-test',
+                'template' => 'default_gfz',
+                'landing_page_template_id' => null,
+            ]);
+
+        $response = $this->get(landingPageUrl($landingPage));
+
+        $response->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('LandingPages/default_gfz')
+                ->where('displayLimits.creators', 23)
+                ->where('displayLimits.contributors', 43)
+            );
+
+        $freshDefaultTemplate = $defaultTemplate->fresh();
+
+        expect($freshDefaultTemplate?->is_default)->toBeFalse()
+            ->and($freshDefaultTemplate?->updated_at?->equalTo($originalTimestamp))->toBeTrue();
+    });
+
     test('normalizes legacy Physical Object landing pages to the igsn renderer and keeps matching igsn custom templates', function () {
         $physicalObjectType = ResourceType::firstOrCreate(
             ['slug' => 'physical-object'],

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -436,7 +436,7 @@ describe('Update', function (): void {
             ->assertJsonValidationErrors(['creator_display_limit', 'contributor_display_limit']);
     })->with([0, -1, 501, 'abc', 10.5]);
 
-    it('flushes cached public landing page render data after template updates', function (): void {
+    it('forgets affected cached public landing page render data after template updates', function (): void {
         Cache::flush();
 
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
@@ -447,9 +447,12 @@ describe('Update', function (): void {
         ]);
 
         $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id);
+        $schemaOrgCacheKey = CacheKey::SCHEMA_ORG_JSONLD->key($resource->id);
         Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($cacheKey, ['template' => 'default_gfz', 'props' => []], 600);
+        Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->put($schemaOrgCacheKey, ['@context' => 'https://schema.org'], 600);
 
-        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue();
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue()
+            ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgCacheKey))->toBeTrue();
 
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", [
@@ -458,10 +461,11 @@ describe('Update', function (): void {
             ])
             ->assertOk();
 
-        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse();
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse()
+            ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgCacheKey))->toBeTrue();
     });
 
-    it('does not flush cached public landing page render data for empty template updates', function (): void {
+    it('does not forget cached public landing page render data for empty template updates', function (): void {
         Cache::flush();
 
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
@@ -481,7 +485,7 @@ describe('Update', function (): void {
         expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue();
     });
 
-    it('does not flush cached public landing page render data when submitted template values are unchanged', function (): void {
+    it('does not forget cached public landing page render data when submitted template values are unchanged', function (): void {
         Cache::flush();
 
         $template = LandingPageTemplate::factory()->create([

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\CacheKey;
 use App\Http\Controllers\LandingPageTemplateController;
 use App\Http\Requests\StoreLandingPageTemplateRequest;
 use App\Http\Requests\UpdateLandingPageTemplateRequest;
@@ -15,6 +16,7 @@ use Database\Seeders\LandingPageTemplateSeeder;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 
 covers(
@@ -169,7 +171,27 @@ describe('Clone', function (): void {
             ->and($template->is_default)->toBeFalse()
             ->and($template->created_by)->toBe($this->admin->id)
             ->and($template->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
-            ->and($template->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS);
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS)
+            ->and($template->creator_display_limit)->toBe(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT)
+            ->and($template->contributor_display_limit)->toBe(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT);
+    });
+
+    it('copies display limits from the selected default template when cloning', function (): void {
+        $this->defaultTemplate->update([
+            'creator_display_limit' => 25,
+            'contributor_display_limit' => 75,
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->postJson('/landing-pages', ['name' => 'Limited Clone']);
+
+        $response->assertCreated();
+
+        $template = LandingPageTemplate::where('name', 'Limited Clone')->first();
+
+        expect($template)->not->toBeNull()
+            ->and($template?->creator_display_limit)->toBe(25)
+            ->and($template?->contributor_display_limit)->toBe(75);
     });
 
     it('rejects duplicate names', function (): void {
@@ -335,6 +357,8 @@ describe('Update', function (): void {
                 'name' => 'Updated Name',
                 'right_column_order' => $newRightOrder,
                 'left_column_order' => $newLeftOrder,
+                'creator_display_limit' => 40,
+                'contributor_display_limit' => 60,
             ]);
 
         $response->assertOk();
@@ -343,7 +367,9 @@ describe('Update', function (): void {
 
         expect($template->name)->toBe('Updated Name')
             ->and($template->right_column_order)->toBe($newRightOrder)
-            ->and($template->left_column_order)->toBe($newLeftOrder);
+            ->and($template->left_column_order)->toBe($newLeftOrder)
+            ->and($template->creator_display_limit)->toBe(40)
+            ->and($template->contributor_display_limit)->toBe(60);
     });
 
     it('normalizes location to the end when it is submitted in the middle of the right column order', function (): void {
@@ -377,6 +403,58 @@ describe('Update', function (): void {
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$this->defaultTemplate->id}", ['name' => 'Hacked'])
             ->assertForbidden();
+    });
+
+    it('allows updating display limits on default templates', function (): void {
+        $this->actingAs($this->groupLeader)
+            ->putJson("/landing-pages/{$this->defaultTemplate->id}", [
+                'creator_display_limit' => 35,
+                'contributor_display_limit' => 45,
+            ])
+            ->assertOk()
+            ->assertJsonPath('template.creator_display_limit', 35)
+            ->assertJsonPath('template.contributor_display_limit', 45);
+
+        $fresh = $this->defaultTemplate->fresh();
+
+        expect($fresh?->creator_display_limit)->toBe(35)
+            ->and($fresh?->contributor_display_limit)->toBe(45);
+    });
+
+    it('rejects display limits outside the supported range', function (mixed $value): void {
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'creator_display_limit' => $value,
+                'contributor_display_limit' => $value,
+            ])
+            ->assertJsonValidationErrors(['creator_display_limit', 'contributor_display_limit']);
+    })->with([0, -1, 501, 'abc', 10.5]);
+
+    it('flushes cached public landing page render data after template updates', function (): void {
+        Cache::flush();
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+        $resource = Resource::factory()->create();
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id);
+        Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($cacheKey, ['template' => 'default_gfz', 'props' => []], 600);
+
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue();
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'creator_display_limit' => 45,
+                'contributor_display_limit' => 55,
+            ])
+            ->assertOk();
+
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse();
     });
 
     it('rejects invalid section keys in right column', function (): void {
@@ -703,6 +781,18 @@ describe('Model', function (): void {
             ->and($fresh->is_default)->toBeTrue();
     });
 
+    it('does not overwrite customized display limits when normalizing default templates', function (): void {
+        $this->defaultTemplate->update([
+            'creator_display_limit' => 33,
+            'contributor_display_limit' => 44,
+        ]);
+
+        $template = LandingPageTemplate::ensureDefaultTemplateExists();
+
+        expect($template->creator_display_limit)->toBe(33)
+            ->and($template->contributor_display_limit)->toBe(44);
+    });
+
     it('returns null logo_url when no logo is set', function (): void {
         $template = LandingPageTemplate::factory()->create([
             'created_by' => $this->admin->id,
@@ -864,7 +954,9 @@ describe('Factory', function (): void {
             ->and($template->logo_path)->toBeNull()
             ->and($template->logo_filename)->toBeNull()
             ->and($template->right_column_order)->toBe(LandingPageTemplate::RIGHT_COLUMN_SECTIONS)
-            ->and($template->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS);
+            ->and($template->left_column_order)->toBe(LandingPageTemplate::RESOURCE_LEFT_COLUMN_SECTIONS)
+            ->and($template->creator_display_limit)->toBe(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT)
+            ->and($template->contributor_display_limit)->toBe(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT);
     });
 
     it('creates an igsn template with igsn left-column defaults', function (): void {

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -402,7 +402,11 @@ describe('Update', function (): void {
     it('prevents updating the default template', function (): void {
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$this->defaultTemplate->id}", ['name' => 'Hacked'])
-            ->assertForbidden();
+            ->assertForbidden()
+            ->assertJson([
+                'message' => 'Only creator and contributor display limits can be updated on default templates.',
+                'error' => 'default_template_immutable',
+            ]);
     });
 
     it('allows updating display limits on default templates', function (): void {

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -461,6 +461,53 @@ describe('Update', function (): void {
         expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse();
     });
 
+    it('does not flush cached public landing page render data for empty template updates', function (): void {
+        Cache::flush();
+
+        $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
+        $resource = Resource::factory()->create();
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id);
+        Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($cacheKey, ['template' => 'default_gfz', 'props' => []], 600);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [])
+            ->assertOk();
+
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue();
+    });
+
+    it('does not flush cached public landing page render data when submitted template values are unchanged', function (): void {
+        Cache::flush();
+
+        $template = LandingPageTemplate::factory()->create([
+            'created_by' => $this->admin->id,
+            'creator_display_limit' => 45,
+            'contributor_display_limit' => 55,
+        ]);
+        $resource = Resource::factory()->create();
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+            'landing_page_template_id' => $template->id,
+        ]);
+
+        $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id);
+        Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($cacheKey, ['template' => 'default_gfz', 'props' => []], 600);
+
+        $this->actingAs($this->admin)
+            ->putJson("/landing-pages/{$template->id}", [
+                'creator_display_limit' => 45,
+                'contributor_display_limit' => 55,
+            ])
+            ->assertOk();
+
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue();
+    });
+
     it('rejects invalid section keys in right column', function (): void {
         $template = LandingPageTemplate::factory()->create(['created_by' => $this->admin->id]);
 

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateDisplayLimitsMigrationTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateDisplayLimitsMigrationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPageTemplate;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+function loadLandingPageTemplateDisplayLimitsMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_06_04_000001_add_display_limits_to_landing_page_templates.php');
+
+    return $migration;
+}
+
+it('adds and removes landing page template display limit columns', function (): void {
+    $migration = loadLandingPageTemplateDisplayLimitsMigration();
+
+    expect(Schema::hasColumns('landing_page_templates', [
+        'creator_display_limit',
+        'contributor_display_limit',
+    ]))->toBeTrue();
+
+    $migration->down();
+
+    expect(Schema::hasColumn('landing_page_templates', 'creator_display_limit'))->toBeFalse()
+        ->and(Schema::hasColumn('landing_page_templates', 'contributor_display_limit'))->toBeFalse();
+
+    $migration->up();
+
+    expect(Schema::hasColumns('landing_page_templates', [
+        'creator_display_limit',
+        'contributor_display_limit',
+    ]))->toBeTrue();
+
+    $template = LandingPageTemplate::factory()->create();
+
+    expect($template->creator_display_limit)->toBe(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT)
+        ->and($template->contributor_display_limit)->toBe(LandingPageTemplate::DEFAULT_DISPLAY_LIMIT);
+});
+
+it('can be rerun safely when display limit columns already match the desired state', function (): void {
+    $migration = loadLandingPageTemplateDisplayLimitsMigration();
+
+    $migration->up();
+
+    expect(Schema::hasColumns('landing_page_templates', [
+        'creator_display_limit',
+        'contributor_display_limit',
+    ]))->toBeTrue();
+
+    $migration->down();
+    $migration->down();
+
+    expect(Schema::hasColumn('landing_page_templates', 'creator_display_limit'))->toBeFalse()
+        ->and(Schema::hasColumn('landing_page_templates', 'contributor_display_limit'))->toBeFalse();
+
+    $migration->up();
+    $migration->up();
+
+    expect(Schema::hasColumns('landing_page_templates', [
+        'creator_display_limit',
+        'contributor_display_limit',
+    ]))->toBeTrue();
+});

--- a/tests/pest/Unit/BotProtection/LandingPageRenderDataCacheServiceTest.php
+++ b/tests/pest/Unit/BotProtection/LandingPageRenderDataCacheServiceTest.php
@@ -112,3 +112,32 @@ it('forgets cached render data through the tagged cache repository', function ()
         ->and($service->forget($landingPage))->toBeTrue()
         ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse();
 });
+
+it('flushes all tagged landing page render data without clearing unrelated tags', function (): void {
+    $service = new LandingPageRenderDataCacheService;
+    $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA;
+
+    Cache::tags($cacheKey->tags())->put($cacheKey->key(1), ['template' => 'default_gfz', 'props' => []], 600);
+    Cache::tags($cacheKey->tags())->put($cacheKey->key(2), ['template' => 'default_gfz', 'props' => []], 600);
+    Cache::tags(['portal'])->put('portal-payload', ['props' => []], 600);
+
+    expect(Cache::tags($cacheKey->tags())->has($cacheKey->key(1)))->toBeTrue()
+        ->and(Cache::tags($cacheKey->tags())->has($cacheKey->key(2)))->toBeTrue()
+        ->and(Cache::tags(['portal'])->has('portal-payload'))->toBeTrue();
+
+    $service->flush();
+
+    expect(Cache::tags($cacheKey->tags())->has($cacheKey->key(1)))->toBeFalse()
+        ->and(Cache::tags($cacheKey->tags())->has($cacheKey->key(2)))->toBeFalse()
+        ->and(Cache::tags(['portal'])->has('portal-payload'))->toBeTrue();
+});
+
+it('falls back to flushing the whole cache store when tags are unsupported', function (): void {
+    Cache::shouldReceive('getStore')
+        ->once()
+        ->andReturn(new class {});
+    Cache::shouldReceive('flush')
+        ->once();
+
+    (new LandingPageRenderDataCacheService)->flush();
+});

--- a/tests/pest/Unit/BotProtection/LandingPageRenderDataCacheServiceTest.php
+++ b/tests/pest/Unit/BotProtection/LandingPageRenderDataCacheServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\CacheKey;
 use App\Models\LandingPage;
+use App\Models\LandingPageTemplate;
 use App\Models\Resource;
 use App\Services\BotProtection\LandingPageRenderDataCacheService;
 use Illuminate\Support\Facades\Cache;
@@ -113,31 +114,73 @@ it('forgets cached render data through the tagged cache repository', function ()
         ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse();
 });
 
-it('flushes all tagged landing page render data without clearing unrelated tags', function (): void {
+it('forgets cached render data for landing pages using a custom template without clearing same-tag schema cache', function (): void {
     $service = new LandingPageRenderDataCacheService;
-    $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA;
+    $template = LandingPageTemplate::factory()->create();
+    $otherTemplate = LandingPageTemplate::factory()->create();
+    $affectedLandingPage = LandingPage::factory()->published()->create([
+        'resource_id' => Resource::factory()->create()->id,
+        'landing_page_template_id' => $template->id,
+    ]);
+    $unaffectedLandingPage = LandingPage::factory()->published()->create([
+        'resource_id' => Resource::factory()->create()->id,
+        'landing_page_template_id' => $otherTemplate->id,
+    ]);
 
-    Cache::tags($cacheKey->tags())->put($cacheKey->key(1), ['template' => 'default_gfz', 'props' => []], 600);
-    Cache::tags($cacheKey->tags())->put($cacheKey->key(2), ['template' => 'default_gfz', 'props' => []], 600);
-    Cache::tags(['portal'])->put('portal-payload', ['props' => []], 600);
+    $affectedRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($affectedLandingPage->id);
+    $unaffectedRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($unaffectedLandingPage->id);
+    $schemaOrgKey = CacheKey::SCHEMA_ORG_JSONLD->key($affectedLandingPage->resource_id);
 
-    expect(Cache::tags($cacheKey->tags())->has($cacheKey->key(1)))->toBeTrue()
-        ->and(Cache::tags($cacheKey->tags())->has($cacheKey->key(2)))->toBeTrue()
-        ->and(Cache::tags(['portal'])->has('portal-payload'))->toBeTrue();
+    Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($affectedRenderKey, ['template' => 'default_gfz', 'props' => []], 600);
+    Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($unaffectedRenderKey, ['template' => 'default_gfz', 'props' => []], 600);
+    Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->put($schemaOrgKey, ['@context' => 'https://schema.org'], 600);
 
-    $service->flush();
+    expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($affectedRenderKey))->toBeTrue()
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($unaffectedRenderKey))->toBeTrue()
+        ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgKey))->toBeTrue();
 
-    expect(Cache::tags($cacheKey->tags())->has($cacheKey->key(1)))->toBeFalse()
-        ->and(Cache::tags($cacheKey->tags())->has($cacheKey->key(2)))->toBeFalse()
-        ->and(Cache::tags(['portal'])->has('portal-payload'))->toBeTrue();
+    $service->forgetForTemplate($template);
+
+    expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($affectedRenderKey))->toBeFalse()
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($unaffectedRenderKey))->toBeTrue()
+        ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgKey))->toBeTrue();
 });
 
-it('falls back to flushing the whole cache store when tags are unsupported', function (): void {
-    Cache::shouldReceive('getStore')
-        ->once()
-        ->andReturn(new class {});
-    Cache::shouldReceive('flush')
-        ->once();
+it('forgets cached render data for default-template pages without clearing matching custom-template pages', function (): void {
+    $service = new LandingPageRenderDataCacheService;
+    $defaultTemplate = LandingPageTemplate::ensureDefaultTemplateExists();
+    $customTemplate = LandingPageTemplate::factory()->create();
+    $mismatchedTemplate = LandingPageTemplate::factory()->igsn()->create();
+    $nullTemplateLandingPage = LandingPage::factory()->published()->create([
+        'resource_id' => Resource::factory()->create()->id,
+        'landing_page_template_id' => null,
+    ]);
+    $defaultIdLandingPage = LandingPage::factory()->published()->create([
+        'resource_id' => Resource::factory()->create()->id,
+        'landing_page_template_id' => $defaultTemplate->id,
+    ]);
+    $mismatchedTemplateLandingPage = LandingPage::factory()->published()->create([
+        'resource_id' => Resource::factory()->create()->id,
+        'landing_page_template_id' => $mismatchedTemplate->id,
+    ]);
+    $customTemplateLandingPage = LandingPage::factory()->published()->create([
+        'resource_id' => Resource::factory()->create()->id,
+        'landing_page_template_id' => $customTemplate->id,
+    ]);
 
-    (new LandingPageRenderDataCacheService)->flush();
+    $nullTemplateRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($nullTemplateLandingPage->id);
+    $defaultIdRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($defaultIdLandingPage->id);
+    $mismatchedTemplateRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($mismatchedTemplateLandingPage->id);
+    $customTemplateRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($customTemplateLandingPage->id);
+
+    foreach ([$nullTemplateRenderKey, $defaultIdRenderKey, $mismatchedTemplateRenderKey, $customTemplateRenderKey] as $renderKey) {
+        Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($renderKey, ['template' => 'default_gfz', 'props' => []], 600);
+    }
+
+    $service->forgetForTemplate($defaultTemplate);
+
+    expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($nullTemplateRenderKey))->toBeFalse()
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($defaultIdRenderKey))->toBeFalse()
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($mismatchedTemplateRenderKey))->toBeFalse()
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($customTemplateRenderKey))->toBeTrue();
 });

--- a/tests/vitest/pages/LandingPages/__tests__/CollapsibleList.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CollapsibleList.test.tsx
@@ -104,6 +104,25 @@ describe('CollapsibleList', () => {
         expect(allItems.filter((el) => !el.classList.contains('hidden'))).toHaveLength(5);
     });
 
+    it('shows an optional visible-count summary', () => {
+        render(
+            <CollapsibleList
+                items={makeItems(8)}
+                renderItem={(item) => <li key={item}>{item}</li>}
+                threshold={5}
+                itemLabel="creators"
+                showSummary={true}
+                wrapper={(children) => <ul>{children}</ul>}
+            />,
+        );
+
+        expect(screen.getByText('Showing 5 of 8 creators')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /Show all 8 creators/i }));
+
+        expect(screen.getByText('Showing all 8 creators')).toBeInTheDocument();
+    });
+
     it('does not show button when itemCount equals threshold', () => {
         render(
             <CollapsibleList

--- a/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
@@ -68,7 +68,8 @@ describe('ContributorsSection', () => {
 
     it('shows expand button when above threshold', () => {
         const contributors = Array.from({ length: 12 }, (_, i) => mockContributor({ id: i + 1 }));
-        render(<ContributorsSection contributors={contributors} />);
+        render(<ContributorsSection contributors={contributors} displayLimit={10} />);
+        expect(screen.getByText('Showing 10 of 12 contributors')).toBeInTheDocument();
         expect(screen.getByText('Show all 12 contributors')).toBeInTheDocument();
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen } from '@tests/vitest/utils/render';
+import { fireEvent, render, screen } from '@tests/vitest/utils/render';
 import { describe, expect, it } from 'vitest';
 
 import { CreatorsSection } from '@/pages/LandingPages/components/CreatorsSection';
@@ -103,5 +103,32 @@ describe('CreatorsSection', () => {
         render(<CreatorsSection creators={creators} />);
         expect(screen.getByText('Doe, John')).toBeInTheDocument();
         expect(screen.getByText('Smith, Jane')).toBeInTheDocument();
+    });
+
+    it('limits initially visible creators and shows the full list on request', () => {
+        const creators = Array.from({ length: 4 }, (_, i) => mockCreator({
+            id: i + 1,
+            creatorable: {
+                id: i + 1,
+                type: 'Person',
+                name: `Creator, ${i + 1}`,
+                given_name: `${i + 1}`,
+                family_name: 'Creator',
+                name_identifier: null,
+                name_identifier_scheme: null,
+            },
+        }));
+
+        render(<CreatorsSection creators={creators} displayLimit={2} />);
+
+        expect(screen.getByText('Showing 2 of 4 creators')).toBeInTheDocument();
+        const listItems = screen.getAllByRole('listitem');
+        expect(listItems).toHaveLength(4);
+        expect(listItems.filter((item) => !item.classList.contains('hidden'))).toHaveLength(2);
+
+        fireEvent.click(screen.getByRole('button', { name: /Show all 4 creators/i }));
+
+        expect(screen.getByText('Showing all 4 creators')).toBeInTheDocument();
+        expect(screen.getAllByRole('listitem').filter((item) => !item.classList.contains('hidden'))).toHaveLength(4);
     });
 });

--- a/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
+++ b/tests/vitest/pages/__tests__/landing-page-templates.test.tsx
@@ -156,6 +156,8 @@ const defaultTemplate: LandingPageTemplateConfig = {
     logo_url: null,
     right_column_order: defaultRightOrder,
     left_column_order: ['files', 'contact', 'model_description', 'related_work'],
+    creator_display_limit: 50,
+    contributor_display_limit: 50,
     created_by: null,
     creator: null,
     landing_pages_count: 5,
@@ -174,6 +176,8 @@ const customTemplate: LandingPageTemplateConfig = {
     logo_url: 'http://localhost/storage/landing-page-logos/geophysics/logo.png',
     right_column_order: locationFirstRightOrder,
     left_column_order: ['contact', 'files', 'model_description', 'related_work'],
+    creator_display_limit: 25,
+    contributor_display_limit: 75,
     created_by: 1,
     creator: { id: 1, name: 'Admin User' },
     landing_pages_count: 2,
@@ -192,6 +196,8 @@ const customTemplateNoLogo: LandingPageTemplateConfig = {
     logo_url: null,
     right_column_order: defaultRightOrder,
     left_column_order: ['files', 'contact', 'model_description', 'related_work'],
+    creator_display_limit: 50,
+    contributor_display_limit: 50,
     created_by: 1,
     creator: { id: 1, name: 'Admin User' },
     landing_pages_count: 0,
@@ -288,6 +294,15 @@ describe('LandingPageTemplatesPage', () => {
             expect(screen.getAllByText('Creators / Authors').length).toBeGreaterThanOrEqual(1);
         });
 
+        it('shows creator and contributor display limits on template cards', () => {
+            render(<LandingPageTemplatesPage />);
+
+            expect(screen.getAllByText('Creators shown').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getAllByText('Contributors shown').length).toBeGreaterThanOrEqual(1);
+            expect(screen.getByText('25')).toBeInTheDocument();
+            expect(screen.getByText('75')).toBeInTheDocument();
+        });
+
         it('shows Edit, Upload Logo, and Delete buttons for custom templates', () => {
             render(<LandingPageTemplatesPage />);
             const editButtons = screen.getAllByRole('button', { name: /Edit/i });
@@ -301,6 +316,12 @@ describe('LandingPageTemplatesPage', () => {
             render(<LandingPageTemplatesPage />);
             expect(screen.queryByRole('button', { name: /Edit/i })).not.toBeInTheDocument();
             expect(screen.queryByRole('button', { name: /Delete/i })).not.toBeInTheDocument();
+        });
+
+        it('shows a limits action for default templates', () => {
+            mockTemplates = [defaultTemplate];
+            render(<LandingPageTemplatesPage />);
+            expect(screen.getByRole('button', { name: /Limits/i })).toBeInTheDocument();
         });
 
         it('shows empty state when no templates exist', () => {
@@ -453,6 +474,8 @@ describe('LandingPageTemplatesPage', () => {
             expect(screen.getByText('Edit Template')).toBeInTheDocument();
             const nameInput = screen.getByLabelText('Template Name') as HTMLInputElement;
             expect(nameInput.value).toBe('Geophysics Template');
+            expect((screen.getByLabelText('Creators shown initially') as HTMLInputElement).value).toBe('25');
+            expect((screen.getByLabelText('Contributors shown initially') as HTMLInputElement).value).toBe('75');
         });
 
         it('saves template changes', async () => {
@@ -474,6 +497,56 @@ describe('LandingPageTemplatesPage', () => {
                     `/landing-pages/${customTemplate.id}`,
                     expect.objectContaining({ name: 'Updated Template' }),
                 );
+            });
+        });
+
+        it('saves custom template display limits', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            const editButtons = screen.getAllByRole('button', { name: /Edit/i });
+            await user.click(editButtons[0]);
+
+            await user.clear(screen.getByLabelText('Creators shown initially'));
+            await user.type(screen.getByLabelText('Creators shown initially'), '30');
+            await user.clear(screen.getByLabelText('Contributors shown initially'));
+            await user.type(screen.getByLabelText('Contributors shown initially'), '80');
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith(
+                    `/landing-pages/${customTemplate.id}`,
+                    expect.objectContaining({
+                        creator_display_limit: 30,
+                        contributor_display_limit: 80,
+                    }),
+                );
+            });
+        });
+
+        it('saves only display limits for default templates', async () => {
+            mockedAxiosPut.mockResolvedValue({ data: { message: 'Updated', template: {} } });
+            mockTemplates = [defaultTemplate];
+            const user = userEvent.setup();
+            render(<LandingPageTemplatesPage />);
+
+            await user.click(screen.getByRole('button', { name: /Limits/i }));
+
+            expect(screen.getByText('Edit Display Limits')).toBeInTheDocument();
+            expect(screen.queryByLabelText('Template Name')).not.toBeInTheDocument();
+
+            await user.clear(screen.getByLabelText('Creators shown initially'));
+            await user.type(screen.getByLabelText('Creators shown initially'), '35');
+            await user.clear(screen.getByLabelText('Contributors shown initially'));
+            await user.type(screen.getByLabelText('Contributors shown initially'), '45');
+            await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPut).toHaveBeenCalledWith('/landing-pages/1', {
+                    creator_display_limit: 35,
+                    contributor_display_limit: 45,
+                });
             });
         });
 


### PR DESCRIPTION
This pull request introduces configurable display limits for creators and contributors on landing pages, allowing admins to control how many creators and contributors are shown by default. It adds new fields to the `LandingPageTemplate` model and enforces validation, update restrictions, and cache invalidation logic for these fields. The migration, factory, and API responses are updated accordingly.

**Landing Page Display Limit Feature**

* Added `creator_display_limit` and `contributor_display_limit` integer fields to the `landing_page_templates` table, model, and related ER diagrams, with a default value of 50 and bounds of 1–500. These fields control how many creators and contributors are shown initially on landing pages. [[1]](diffhunk://#diff-dea7bc450cff451e86281391c713d5fdf2707118d0a7aec0188d4e63dbc48492R1-R47) [[2]](diffhunk://#diff-89db60696bf448c0e760b389a3c263334d50c9025088f7bad8dd21dbb26cfb09R64-R69) [[3]](diffhunk://#diff-89db60696bf448c0e760b389a3c263334d50c9025088f7bad8dd21dbb26cfb09R165-R166) [[4]](diffhunk://#diff-89db60696bf448c0e760b389a3c263334d50c9025088f7bad8dd21dbb26cfb09R179-R180) [[5]](diffhunk://#diff-a8d0111421d72b79d6b1e81ad37d41a69ce2f2f1b765ba6e5def7d7311d72814R602-R603) [[6]](diffhunk://#diff-e0196f1170dc7341f74a244f8ee5ad1128d2350be6c80928486fe029eb3867e3R537-R538) [[7]](diffhunk://#diff-4b34f673650eada01f51613399b1596134a56eb3b0985b7642b5953d058788cdR39-R40)
* Updated the landing page rendering logic to select the appropriate display limit from the template and expose these limits in the API response. [[1]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR304-R307) [[2]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR342-R345)

**API and Validation Updates**

* Updated the `LandingPageTemplateController` to support creating and updating the new display limit fields, including validation rules and correct exposure in list and detail endpoints. [[1]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR65-R66) [[2]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR85-R127) [[3]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR271-R272)
* Enhanced `UpdateLandingPageTemplateRequest` validation to restrict which fields are editable for default templates and to enforce min/max limits for display limits. [[1]](diffhunk://#diff-e976cd81325a09aaa0975eac5721055d597f7efb169781c61512f41f5b7a1df2R8-R11) [[2]](diffhunk://#diff-e976cd81325a09aaa0975eac5721055d597f7efb169781c61512f41f5b7a1df2L24-R26) [[3]](diffhunk://#diff-e976cd81325a09aaa0975eac5721055d597f7efb169781c61512f41f5b7a1df2R40-R50)

**Authorization and Policy**

* Adjusted the `LandingPageTemplatePolicy` and controller logic so that only display limit fields can be updated on default templates; all other fields remain immutable. [[1]](diffhunk://#diff-e2a008ff07816412c36ed3e683795d2ded0f59cc1701e919ce3f7f9a6c0adcc6L15-R16) [[2]](diffhunk://#diff-e2a008ff07816412c36ed3e683795d2ded0f59cc1701e919ce3f7f9a6c0adcc6L47-L54) [[3]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR85-R127)

**Caching Improvements**

* Updated `LandingPageRenderDataCacheService` to invalidate cached landing page data when a template's display limits or logo are updated, ensuring changes are reflected promptly. [[1]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR85-R127) [[2]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR206) [[3]](diffhunk://#diff-82208a850b17387f64e8068b48993042dd7739a7e5ef03421cffb1300a14dc2dR241) [[4]](diffhunk://#diff-343b8369747fcac1d8e6249531a884ad21c7a91cdca3be2f03f891b81cb92e4bR9-R13) [[5]](diffhunk://#diff-343b8369747fcac1d8e6249531a884ad21c7a91cdca3be2f03f891b81cb92e4bR41-R77)

**Miscellaneous**

* Updated ER diagrams and factory definitions to include the new fields. [[1]](diffhunk://#diff-a8d0111421d72b79d6b1e81ad37d41a69ce2f2f1b765ba6e5def7d7311d72814R602-R603) [[2]](diffhunk://#diff-e0196f1170dc7341f74a244f8ee5ad1128d2350be6c80928486fe029eb3867e3R537-R538) [[3]](diffhunk://#diff-4b34f673650eada01f51613399b1596134a56eb3b0985b7642b5953d058788cdR39-R40)
* Updated TypeScript types to include the new `LandingPageDisplayLimits` type.