### PR TITLE
Feature: Global Button for Geolocation Entries

### DIFF
--- a/resources/js/components/curation/fields/spatial-temporal-coverage/BoxForm.tsx
+++ b/resources/js/components/curation/fields/spatial-temporal-coverage/BoxForm.tsx
@@ -1,3 +1,7 @@
+import { Globe2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
 import CoordinateInputs from './CoordinateInputs';
 import MapPicker from './MapPicker';
 import type { CoordinateBounds, SpatialTemporalCoverageEntry } from './types';
@@ -10,6 +14,15 @@ interface BoxFormProps {
 }
 
 export default function BoxForm({ entry, apiKey, onChange, onBatchChange }: BoxFormProps) {
+    const handleGlobalCoverageClick = () => {
+        onBatchChange({
+            latMin: '-90.000000',
+            latMax: '90.000000',
+            lonMin: '-180.000000',
+            lonMax: '180.000000',
+        });
+    };
+
     const handleRectangleSelected = (bounds: CoordinateBounds) => {
         const latMinStr = bounds.south.toFixed(6);
         const latMaxStr = bounds.north.toFixed(6);
@@ -53,6 +66,12 @@ export default function BoxForm({ entry, apiKey, onChange, onBatchChange }: BoxF
 
             {/* Right Column: Coordinates */}
             <div className="space-y-4">
+                <div className="flex justify-end">
+                    <Button type="button" variant="outline" size="sm" onClick={handleGlobalCoverageClick}>
+                        <Globe2 className="mr-2 h-4 w-4" />
+                        Global
+                    </Button>
+                </div>
                 <CoordinateInputs
                     latMin={entry.latMin}
                     lonMin={entry.lonMin}

--- a/tests/vitest/components/curation/fields/spatial-temporal-coverage/BoxForm.test.tsx
+++ b/tests/vitest/components/curation/fields/spatial-temporal-coverage/BoxForm.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import BoxForm from '@/components/curation/fields/spatial-temporal-coverage/BoxForm';
@@ -116,6 +117,27 @@ describe('BoxForm', () => {
         render(<BoxForm {...defaultProps} />);
 
         expect(screen.getByTestId('coordinate-order')).toHaveTextContent('lat-lon');
+    });
+
+    it('renders a Global button for world coverage', () => {
+        render(<BoxForm {...defaultProps} />);
+
+        expect(screen.getByRole('button', { name: /global/i })).toBeInTheDocument();
+    });
+
+    it('sets global coverage coordinates when the Global button is clicked', async () => {
+        const user = userEvent.setup();
+        const onBatchChange = vi.fn();
+        render(<BoxForm {...defaultProps} onBatchChange={onBatchChange} />);
+
+        await user.click(screen.getByRole('button', { name: /global/i }));
+
+        expect(onBatchChange).toHaveBeenCalledWith({
+            latMin: '-90.000000',
+            latMax: '90.000000',
+            lonMin: '-180.000000',
+            lonMax: '180.000000',
+        });
     });
 
     it('calls onBatchChange when rectangle is selected on map', async () => {

--- a/tests/vitest/components/curation/fields/spatial-temporal-coverage/CoverageEntryGlobalButton.test.tsx
+++ b/tests/vitest/components/curation/fields/spatial-temporal-coverage/CoverageEntryGlobalButton.test.tsx
@@ -1,0 +1,94 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import CoverageEntry from '@/components/curation/fields/spatial-temporal-coverage/CoverageEntry';
+import type { CoverageType, SpatialTemporalCoverageEntry } from '@/components/curation/fields/spatial-temporal-coverage/types';
+
+vi.mock('@/components/curation/fields/spatial-temporal-coverage/MapPicker', () => ({
+    default: ({
+        onRectangleSelected,
+    }: {
+        onRectangleSelected: (bounds: { south: number; north: number; west: number; east: number }) => void;
+    }) => (
+        <div data-testid="map-picker">
+            <button
+                type="button"
+                onClick={() => onRectangleSelected({ south: 51, north: 53, west: 12, east: 14 })}
+            >
+                Select Rectangle
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock('@/components/curation/fields/spatial-temporal-coverage/PolygonForm', () => ({
+    default: () => <div data-testid="polygon-form">Polygon Form</div>,
+}));
+
+vi.mock('@/components/curation/fields/spatial-temporal-coverage/LineForm', () => ({
+    default: () => <div data-testid="line-form">Line Form</div>,
+}));
+
+describe('CoverageEntry global bounding box shortcut', () => {
+    const createEntry = (type: CoverageType): SpatialTemporalCoverageEntry => ({
+        id: `coverage-${type}`,
+        type,
+        latMin: '',
+        lonMin: '',
+        latMax: '',
+        lonMax: '',
+        startDate: '',
+        endDate: '',
+        startTime: '',
+        endTime: '',
+        timezone: 'UTC',
+        description: '',
+        polygonPoints: type === 'polygon' || type === 'line' ? [] : undefined,
+    });
+
+    const defaultProps = {
+        index: 0,
+        apiKey: 'test-api-key',
+        isFirst: true,
+        onChange: vi.fn(),
+        onBatchChange: vi.fn(),
+        onRemove: vi.fn(),
+        initiallyExpanded: true,
+    };
+
+    it('shows the Global button in the Bounding Box tab', () => {
+        render(<CoverageEntry {...defaultProps} entry={createEntry('box')} />);
+
+        expect(screen.getByRole('tab', { name: /bounding box/i })).toHaveAttribute('data-state', 'active');
+        expect(screen.getByRole('button', { name: /global/i })).toBeInTheDocument();
+    });
+
+    it('passes global coverage coordinates through CoverageEntry when Global is clicked', async () => {
+        const user = userEvent.setup();
+        const onBatchChange = vi.fn();
+        render(<CoverageEntry {...defaultProps} entry={createEntry('box')} onBatchChange={onBatchChange} />);
+
+        await user.click(screen.getByRole('button', { name: /global/i }));
+
+        expect(onBatchChange).toHaveBeenCalledWith({
+            latMin: '-90.000000',
+            latMax: '90.000000',
+            lonMin: '-180.000000',
+            lonMax: '180.000000',
+        });
+    });
+
+    it.each([
+        ['point', /point/i],
+        ['polygon', /polygon/i],
+        ['line', /line/i],
+    ] as const)('does not show the Global button in the %s tab', (type, tabName) => {
+        render(<CoverageEntry {...defaultProps} entry={createEntry(type)} />);
+
+        expect(screen.getByRole('tab', { name: tabName })).toHaveAttribute('data-state', 'active');
+        expect(screen.queryByRole('button', { name: /global/i })).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
This pull request introduces a new "Global" shortcut button to the spatial-temporal coverage bounding box form, allowing users to quickly set the coverage to global coordinates. The change is fully tested with new and updated tests to ensure correct behavior and integration.

**UI Enhancements:**
- Added a "Global" button with a globe icon to the bounding box form in `BoxForm`, enabling users to set global coverage coordinates with a single click. [[1]](diffhunk://#diff-80e53c4796bff30604cc3df76aa75381bc67c9772bbea9dffff323d0c90bcec3R1-R4) [[2]](diffhunk://#diff-80e53c4796bff30604cc3df76aa75381bc67c9772bbea9dffff323d0c90bcec3R17-R25) [[3]](diffhunk://#diff-80e53c4796bff30604cc3df76aa75381bc67c9772bbea9dffff323d0c90bcec3R69-R74)

**Testing Improvements:**
- Added new tests to `BoxForm.test.tsx` to verify the presence and functionality of the "Global" button, including that it sets the correct coordinates when clicked. [[1]](diffhunk://#diff-8dfcc8b5ebbe733c981f8c83afc7ef9868e62c3b31db13b7c3efce1ae09e955bR4) [[2]](diffhunk://#diff-8dfcc8b5ebbe733c981f8c83afc7ef9868e62c3b31db13b7c3efce1ae09e955bR122-R142)
- Introduced a dedicated test suite in `CoverageEntryGlobalButton.test.tsx` to ensure the "Global" button appears only for bounding box entries, correctly updates coordinates, and does not appear for other coverage types.