### PR TITLE
Feature: Expand Thesauri Trees when Keywords are selected

### DIFF
--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -332,10 +332,16 @@ export default function DataCiteForm({
 
     // Check if initial free keywords contain MSL/EPOS triggers (to prevent notification on data load)
     useEffect(() => {
+        const hasInitialControlledMslKeywords = [...(initialGcmdKeywords ?? []), ...(initialGemetKeywords ?? [])].some(
+            (keyword) => typeof keyword.scheme === 'string' && getVocabularyTypeFromScheme(keyword.scheme) === 'msl',
+        );
+
         if (initialFreeKeywords && initialFreeKeywords.length > 0) {
             const triggers = ['epos', 'multi-scale laboratories', 'multi scale laboratories', 'msl'];
             const hasInitialTriggers = initialFreeKeywords.some((keyword) => triggers.some((trigger) => keyword.toLowerCase().includes(trigger)));
-            hasInitialMslTriggers.current = hasInitialTriggers;
+            hasInitialMslTriggers.current = hasInitialTriggers || hasInitialControlledMslKeywords;
+        } else {
+            hasInitialMslTriggers.current = hasInitialControlledMslKeywords;
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []); // Run only once on mount - initialFreeKeywords intentionally excluded
@@ -839,13 +845,17 @@ export default function DataCiteForm({
         void loadVocabularies();
     }, []);
 
-    // Check if MSL section should be shown based on Free Keywords
+    const hasMslControlledKeywords = useMemo(() => {
+        return gcmdKeywords.some((kw) => getVocabularyTypeFromScheme(kw.scheme) === 'msl');
+    }, [gcmdKeywords]);
+
+    // Check if MSL section should be shown based on Free Keywords or selected MSL controlled keywords
     const shouldShowMSLSection = useMemo(() => {
         const keywords = freeKeywords.map((k) => k.value.toLowerCase());
         const triggers = ['epos', 'multi-scale laboratories', 'multi scale laboratories', 'msl'];
 
-        return keywords.some((keyword) => triggers.some((trigger) => keyword.includes(trigger)));
-    }, [freeKeywords]);
+        return hasMslControlledKeywords || keywords.some((keyword) => triggers.some((trigger) => keyword.includes(trigger)));
+    }, [freeKeywords, hasMslControlledKeywords]);
 
     // Load MSL vocabulary when MSL section becomes visible
     useEffect(() => {

--- a/resources/js/components/curation/fields/controlled-vocabularies-field.tsx
+++ b/resources/js/components/curation/fields/controlled-vocabularies-field.tsx
@@ -115,20 +115,45 @@ export default function ControlledVocabulariesField({
     const showAnalyticalMethods = showAnalyticalMethodsTab && enabledThesauri.analytical_methods;
     const showEuroSciVoc = showEuroSciVocTab && enabledThesauri.euroscivoc;
 
-    // Determine default active tab based on what's available
-    const getDefaultTab = (): VocabularyType => {
-        if (showScienceTab) return 'science';
-        if (showPlatformsTab) return 'platforms';
-        if (showInstrumentsTab) return 'instruments';
-        if (showMslTab) return 'msl';
-        if (showChronostrat) return 'chronostratigraphy';
-        if (showGemet) return 'gemet';
-        if (showAnalyticalMethods) return 'analytical_methods';
-        if (showEuroSciVoc) return 'euroscivoc';
-        return 'science'; // Fallback
-    };
+    const visibleVocabularyTypes = useMemo(
+        () =>
+            [
+                ...(showScienceTab ? ['science' as const] : []),
+                ...(showPlatformsTab ? ['platforms' as const] : []),
+                ...(showInstrumentsTab ? ['instruments' as const] : []),
+                ...(showMslTab ? ['msl' as const] : []),
+                ...(showChronostrat ? ['chronostratigraphy' as const] : []),
+                ...(showGemet ? ['gemet' as const] : []),
+                ...(showAnalyticalMethods ? ['analytical_methods' as const] : []),
+                ...(showEuroSciVoc ? ['euroscivoc' as const] : []),
+            ] as VocabularyType[],
+        [showScienceTab, showPlatformsTab, showInstrumentsTab, showMslTab, showChronostrat, showGemet, showAnalyticalMethods, showEuroSciVoc],
+    );
 
-    const [activeTab, setActiveTab] = useState<VocabularyType>(getDefaultTab);
+    // Group selected keywords by vocabulary type (based on scheme)
+    const keywordsByVocabulary = useMemo(() => {
+        const grouped: Record<VocabularyType, SelectedKeyword[]> = {
+            science: [],
+            platforms: [],
+            instruments: [],
+            msl: [],
+            chronostratigraphy: [],
+            gemet: [],
+            analytical_methods: [],
+            euroscivoc: [],
+        };
+
+        for (const keyword of selectedKeywords) {
+            const type = getVocabularyTypeFromScheme(keyword.scheme);
+            grouped[type].push(keyword);
+        }
+
+        return grouped;
+    }, [selectedKeywords]);
+
+    const preferredInitialTab = visibleVocabularyTypes.find((type) => keywordsByVocabulary[type].length > 0) ?? visibleVocabularyTypes[0] ?? 'science';
+
+    const [activeTab, setActiveTab] = useState<VocabularyType>(preferredInitialTab);
     const [searchQuery, setSearchQuery] = useState('');
 
     // Track if auto-switch has already occurred to prevent interference with manual tab changes
@@ -149,27 +174,10 @@ export default function ControlledVocabulariesField({
 
     // Switch to an available tab if the current tab becomes unavailable
     useEffect(() => {
-        const isCurrentTabAvailable =
-            (activeTab === 'science' && showScienceTab) ||
-            (activeTab === 'platforms' && showPlatformsTab) ||
-            (activeTab === 'instruments' && showInstrumentsTab) ||
-            (activeTab === 'msl' && showMslTab) ||
-            (activeTab === 'chronostratigraphy' && showChronostrat) ||
-            (activeTab === 'gemet' && showGemet) ||
-            (activeTab === 'analytical_methods' && showAnalyticalMethods) ||
-            (activeTab === 'euroscivoc' && showEuroSciVoc);
-
-        if (!isCurrentTabAvailable) {
-            if (showScienceTab) setActiveTab('science');
-            else if (showPlatformsTab) setActiveTab('platforms');
-            else if (showInstrumentsTab) setActiveTab('instruments');
-            else if (showMslTab) setActiveTab('msl');
-            else if (showChronostrat) setActiveTab('chronostratigraphy');
-            else if (showGemet) setActiveTab('gemet');
-            else if (showAnalyticalMethods) setActiveTab('analytical_methods');
-            else if (showEuroSciVoc) setActiveTab('euroscivoc');
+        if (!visibleVocabularyTypes.includes(activeTab)) {
+            setActiveTab(preferredInitialTab);
         }
-    }, [activeTab, showScienceTab, showPlatformsTab, showInstrumentsTab, showMslTab, showChronostrat, showGemet, showAnalyticalMethods, showEuroSciVoc]);
+    }, [activeTab, preferredInitialTab, visibleVocabularyTypes]);
 
     // Debounce search query to avoid excessive re-renders
     // Only trigger search after user stops typing for 300ms
@@ -251,27 +259,6 @@ export default function ControlledVocabulariesField({
         [selectedKeywords, onChange],
     );
 
-    // Group selected keywords by vocabulary type (based on scheme)
-    const keywordsByVocabulary = useMemo(() => {
-        const grouped: Record<VocabularyType, SelectedKeyword[]> = {
-            science: [],
-            platforms: [],
-            instruments: [],
-            msl: [],
-            chronostratigraphy: [],
-            gemet: [],
-            analytical_methods: [],
-            euroscivoc: [],
-        };
-
-        for (const keyword of selectedKeywords) {
-            const type = getVocabularyTypeFromScheme(keyword.scheme);
-            grouped[type].push(keyword);
-        }
-
-        return grouped;
-    }, [selectedKeywords]);
-
     // Check if a vocabulary type has selected keywords
     const hasKeywords = useCallback(
         (type: VocabularyType): boolean => {
@@ -281,7 +268,7 @@ export default function ControlledVocabulariesField({
     );
 
     // Check if any thesauri are available
-    const hasAnyThesaurus = showScienceTab || showPlatformsTab || showInstrumentsTab || showMslTab || showChronostrat || showGemet || showAnalyticalMethods || showEuroSciVoc;
+    const hasAnyThesaurus = visibleVocabularyTypes.length > 0;
 
     return (
         <div className="space-y-4">
@@ -295,18 +282,7 @@ export default function ControlledVocabulariesField({
             {/* Selected Keywords Display */}
             {selectedKeywords.length > 0 && (
                 <div className="space-y-3">
-                    {(
-                        [
-                            ...(showScienceTab ? ['science' as const] : []),
-                            ...(showPlatformsTab ? ['platforms' as const] : []),
-                            ...(showInstrumentsTab ? ['instruments' as const] : []),
-                            ...(showMslTab ? ['msl' as const] : []),
-                            ...(showChronostrat ? ['chronostratigraphy' as const] : []),
-                            ...(showGemet ? ['gemet' as const] : []),
-                            ...(showAnalyticalMethods ? ['analytical_methods' as const] : []),
-                            ...(showEuroSciVoc ? ['euroscivoc' as const] : []),
-                        ] as VocabularyType[]
-                    ).map((type) => {
+                    {visibleVocabularyTypes.map((type) => {
                         const keywords = keywordsByVocabulary[type];
                         if (keywords.length === 0) return null;
 
@@ -414,7 +390,7 @@ export default function ControlledVocabulariesField({
                                 'grid w-full',
                                 // Dynamically calculate grid columns based on visible tabs
                                 (() => {
-                                    const visibleCount = [showScienceTab, showPlatformsTab, showInstrumentsTab, showMslTab, showChronostrat, showGemet, showAnalyticalMethods, showEuroSciVoc].filter(Boolean).length;
+                                    const visibleCount = visibleVocabularyTypes.length;
                                     switch (visibleCount) {
                                         case 1:
                                             return 'grid-cols-1';

--- a/resources/js/components/curation/fields/gcmd-tree.tsx
+++ b/resources/js/components/curation/fields/gcmd-tree.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -36,27 +36,34 @@ function highlightText(text: string, query?: string): React.ReactNode {
     );
 }
 
+function hasSelectedDescendant(keyword: VocabularyKeyword, selectedIds: Set<string>): boolean {
+    if (selectedIds.has(keyword.id)) return true;
+    if (!keyword.children || keyword.children.length === 0) return false;
+
+    return keyword.children.some((child) => hasSelectedDescendant(child, selectedIds));
+}
+
 /**
  * Recursive tree node component for GCMD controlled vocabularies
  * Memoized to prevent unnecessary re-renders when parent updates
  */
 const GCMDTreeNodeComponent = ({ node, selectedIds, onToggle, level = 0, pathPrefix = [], searchQuery }: GCMDTreeNodeProps) => {
-    // Check if this node or any of its descendants are selected
-    const hasSelectedDescendant = (keyword: VocabularyKeyword): boolean => {
-        if (selectedIds.has(keyword.id)) return true;
-        if (!keyword.children || keyword.children.length === 0) return false;
-        return keyword.children.some(hasSelectedDescendant);
-    };
-
     // Auto-expand if:
     // 1. Root level (level 0) for initial visibility
     // 2. Node or any descendant is selected (to show selected keywords)
-    const shouldAutoExpand = level === 0 || hasSelectedDescendant(node);
+    const hasSelectedMatch = hasSelectedDescendant(node, selectedIds);
+    const shouldAutoExpand = level === 0 || hasSelectedMatch;
     const [isExpanded, setIsExpanded] = useState(shouldAutoExpand);
 
     const hasChildren = node.children && node.children.length > 0;
     const isSelected = selectedIds.has(node.id);
     const currentPath = [...pathPrefix, node.text];
+
+    useEffect(() => {
+        if (hasSelectedMatch) {
+            setIsExpanded(true);
+        }
+    }, [hasSelectedMatch]);
 
     const handleToggle = () => {
         onToggle(node, currentPath);
@@ -127,7 +134,14 @@ const GCMDTreeNodeComponent = ({ node, selectedIds, onToggle, level = 0, pathPre
 // Memoize the component to prevent re-renders when props haven't changed
 export const GCMDTreeNode = memo(GCMDTreeNodeComponent, (prevProps, nextProps) => {
     // Custom comparison function for better performance
-    return prevProps.node.id === nextProps.node.id && prevProps.selectedIds === nextProps.selectedIds && prevProps.level === nextProps.level;
+    return (
+        prevProps.node === nextProps.node &&
+        prevProps.selectedIds === nextProps.selectedIds &&
+        prevProps.onToggle === nextProps.onToggle &&
+        prevProps.level === nextProps.level &&
+        prevProps.pathPrefix === nextProps.pathPrefix &&
+        prevProps.searchQuery === nextProps.searchQuery
+    );
 });
 
 interface GCMDTreeProps {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4140,6 +4140,46 @@ describe('DataCiteForm', () => {
             });
         });
 
+        it('should show MSL tab when initial controlled MSL keywords exist', async () => {
+            const { toast } = await import('sonner');
+
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    dateTypes={dateTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                    initialGcmdKeywords={[
+                        {
+                            id: 'https://epos-msl.uu.nl/voc/keyword/deformation',
+                            text: 'Deformation',
+                            path: 'Rock and Melt Physics > Deformation',
+                            language: 'en',
+                            scheme: 'EPOS MSL vocabulary',
+                            schemeURI: 'https://epos-msl.uu.nl/voc',
+                        },
+                    ]}
+                />,
+            );
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            await ensureControlledVocabulariesOpen(user);
+
+            await waitFor(() => {
+                expect(screen.getByRole('tab', { name: /MSL Vocabulary/i })).toBeInTheDocument();
+            });
+
+            expect(screen.getByText('Rock and Melt Physics > Deformation')).toBeInTheDocument();
+            expect(screen.getAllByText(/Originating Multi-Scale Laboratories/i).length).toBeGreaterThan(0);
+            expect(toast.info).not.toHaveBeenCalled();
+        });
+
         it('should only notify once when multiple MSL keywords are added', async () => {
             const { toast } = await import('sonner');
             

--- a/tests/vitest/components/curation/fields/__tests__/controlled-vocabularies-field.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/controlled-vocabularies-field.test.tsx
@@ -242,9 +242,93 @@ describe('ControlledVocabulariesField - MSL Tab Auto-Switch', () => {
             />,
         );
 
-        // Check that both keywords are displayed
-        expect(screen.getByText('Rock Physics')).toBeInTheDocument();
+        // Check that both keywords are displayed. Rock Physics also appears in the active tree.
+        expect(screen.getAllByText('Rock Physics').length).toBeGreaterThan(0);
         expect(screen.getByText('Geochemistry')).toBeInTheDocument();
+    });
+});
+
+describe('ControlledVocabulariesField - Initial selected keywords', () => {
+    const mockScienceKeywords: VocabularyKeyword[] = [
+        {
+            id: 'sci-1',
+            text: 'Earth Science',
+            language: 'en',
+            scheme: 'GCMD Science Keywords',
+            schemeURI: 'https://gcmd.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+            description: 'Science keyword',
+            children: [],
+        },
+    ];
+
+    const mockGemetVocabulary: VocabularyKeyword[] = [
+        {
+            id: 'gemet-root',
+            text: 'Environment',
+            language: 'en',
+            scheme: 'GEMET - GEneral Multilingual Environmental Thesaurus',
+            schemeURI: 'http://www.eionet.europa.eu/gemet/concept/',
+            description: 'Root group',
+            children: [
+                {
+                    id: 'gemet-group',
+                    text: 'Natural hazards',
+                    language: 'en',
+                    scheme: 'GEMET - GEneral Multilingual Environmental Thesaurus',
+                    schemeURI: 'http://www.eionet.europa.eu/gemet/concept/',
+                    description: 'Group',
+                    children: [
+                        {
+                            id: 'gemet-earthquake',
+                            text: 'earthquake',
+                            language: 'en',
+                            scheme: 'GEMET - GEneral Multilingual Environmental Thesaurus',
+                            schemeURI: 'http://www.eionet.europa.eu/gemet/concept/',
+                            description: 'Concept',
+                            children: [],
+                        },
+                    ],
+                },
+            ],
+        },
+    ];
+
+    it('activates the first visible tab with selected keywords and expands the selected tree path', () => {
+        const selectedGemetKeywords: SelectedKeyword[] = [
+            {
+                id: 'gemet-earthquake',
+                text: 'earthquake',
+                path: 'Environment > Natural hazards > earthquake',
+                language: 'en',
+                scheme: 'GEMET - GEneral Multilingual Environmental Thesaurus',
+                schemeURI: 'http://www.eionet.europa.eu/gemet/concept/',
+            },
+        ];
+
+        render(
+            <ControlledVocabulariesField
+                scienceKeywords={mockScienceKeywords}
+                platforms={[]}
+                instruments={[]}
+                gemetVocabulary={mockGemetVocabulary}
+                selectedKeywords={selectedGemetKeywords}
+                onChange={vi.fn()}
+                showGemetTab={true}
+                enabledThesauri={{
+                    science_keywords: true,
+                    platforms: true,
+                    instruments: true,
+                    chronostratigraphy: true,
+                    gemet: true,
+                    analytical_methods: true,
+                    euroscivoc: true,
+                }}
+            />,
+        );
+
+        expect(screen.getByRole('tab', { name: /GEMET/i })).toHaveAttribute('aria-selected', 'true');
+        expect(screen.getByText('Natural hazards')).toBeInTheDocument();
+        expect(screen.getByRole('checkbox', { name: 'earthquake' })).toBeChecked();
     });
 });
 

--- a/tests/vitest/components/curation/fields/__tests__/gcmd-tree.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/gcmd-tree.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { GCMDTree, GCMDTreeNode } from '@/components/curation/fields/gcmd-tree';
@@ -141,6 +141,27 @@ describe('gcmd-tree', () => {
 
             // Should auto-expand because grandchild is selected
             expect(screen.getByText('Child')).toBeInTheDocument();
+            expect(screen.getByText('Grandchild')).toBeInTheDocument();
+        });
+
+        it('expands after selectedIds updates to include a descendant', async () => {
+            const childNode = createMockKeyword({ id: 'child-1', text: 'Selected Child' });
+            const node = createMockKeyword({
+                id: 'parent',
+                text: 'Parent',
+                children: [childNode],
+            });
+
+            const { rerender } = render(<GCMDTreeNode node={node} selectedIds={new Set()} onToggle={vi.fn()} level={2} />);
+
+            expect(screen.queryByText('Selected Child')).not.toBeInTheDocument();
+
+            rerender(<GCMDTreeNode node={node} selectedIds={new Set(['child-1'])} onToggle={vi.fn()} level={2} />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Selected Child')).toBeInTheDocument();
+            });
+            expect(screen.getByRole('checkbox', { name: 'Selected Child' })).toBeChecked();
         });
 
         it('collapses when expand button is clicked', () => {
@@ -188,6 +209,20 @@ describe('gcmd-tree', () => {
             // The matching text should be wrapped in a <mark> element
             const mark = screen.getByText('Science');
             expect(mark.tagName).toBe('MARK');
+        });
+
+        it('updates highlighted text when searchQuery changes', () => {
+            const keywords: VocabularyKeyword[] = [createMockKeyword({ id: 'earth-science', text: 'Earth Science Data' })];
+            const selectedIds = new Set<string>();
+            const onToggle = vi.fn();
+
+            const { rerender } = render(<GCMDTree keywords={keywords} selectedIds={selectedIds} onToggle={onToggle} searchQuery="Earth" />);
+
+            expect(screen.getByText('Earth').tagName).toBe('MARK');
+
+            rerender(<GCMDTree keywords={keywords} selectedIds={selectedIds} onToggle={onToggle} searchQuery="Science" />);
+
+            expect(screen.getByText('Science').tagName).toBe('MARK');
         });
 
         it('treats regex metacharacters in the search query literally', () => {


### PR DESCRIPTION
This pull request introduces several improvements to the handling and display of controlled vocabularies—especially for the MSL (Multi-Scale Laboratories) section—in the curation forms. The changes focus on better tab activation logic, improved auto-expansion of selected tree nodes, and more robust UI behavior when initial or updated selections are present. It also adds and updates tests to ensure these behaviors work as intended.

**Controlled Vocabulary Tab and Selection Handling Improvements:**

* The initial active tab in `ControlledVocabulariesField` now automatically selects the first tab with selected keywords (if any), or the first available tab, rather than always defaulting to "science". This ensures that when a user loads a form with pre-selected keywords, the relevant tab is shown and expanded. [[1]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL118-R156) [[2]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL152-R180)
* The logic for grouping selected keywords by vocabulary type is centralized and used for both tab activation and display, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL118-R156) [[2]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL254-L274)
* The check for available thesauri and their display is now based on the computed list of visible vocabulary types, simplifying the code and making it more robust to configuration changes. [[1]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL284-R271) [[2]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL298-R285) [[3]](diffhunk://#diff-b37c4c61d086770faeaf807be3eb8d1945589a19905803b5aed0ccd90d75fecdL417-R393)

**MSL Section and Keyword Triggers:**

* The MSL section is now shown if either relevant free keywords or MSL-controlled keywords are present, ensuring that the section appears appropriately on initial load or when selections change. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R335-R344) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L842-R858)
* A new test verifies that the MSL tab appears when initial controlled MSL keywords are provided, and that notifications are not erroneously triggered in this case.

**GCMD Tree Component Improvements:**

* The GCMD tree nodes now auto-expand when a selected descendant is present, and will dynamically expand if the selection changes to include a descendant after initial render. This provides a more intuitive and user-friendly experience when selecting or loading keywords. [[1]](diffhunk://#diff-7849224e393b87d876521deb1f028069fedcae00d575f19394227415ae274b26R39-R67) [[2]](diffhunk://#diff-7849224e393b87d876521deb1f028069fedcae00d575f19394227415ae274b26L130-R144)
* The memoization logic for `GCMDTreeNode` is improved to prevent unnecessary re-renders while ensuring updates propagate correctly.
* Tests are added to verify that tree nodes expand when a descendant becomes selected after the component is rendered.

**Testing Enhancements:**

* Additional tests are included to verify tab activation and tree expansion with initial selected keywords, and to ensure that UI elements reflect the current selection state as expected. [[1]](diffhunk://#diff-53bbad60125708e38133215c6ad39cf102eb3fa17dd82f966733c893899bb3afL245-R334) [[2]](diffhunk://#diff-c46c0e267b80476c9fe706563e80e1b9fbbfd4affa905c2e0fa9986b088ea777L1-R1)

These changes collectively make the controlled vocabulary selection and display more intuitive, robust, and maintainable, while improving test coverage for key user flows.