### PR TITLE
Feature: Bulk collapse and uncollapse all Form Groups in Data Editor

### DIFF
--- a/app/Http/Controllers/Settings/CurationAccordionController.php
+++ b/app/Http/Controllers/Settings/CurationAccordionController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateCurationAccordionRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+
+class CurationAccordionController extends Controller
+{
+    /**
+     * Update the user's curation form accordion preference.
+     */
+    public function update(UpdateCurationAccordionRequest $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $validated = $request->validated();
+
+        $user->update([
+            'curation_accordion_open_items' => array_values($validated['open_items']),
+        ]);
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -18,6 +18,7 @@ use Inertia\Middleware;
 class HandleInertiaRequests extends Middleware
 {
     use ChecksCacheTagging;
+
     /**
      * The root template that's loaded on the first page visit.
      *
@@ -82,6 +83,7 @@ class HandleInertiaRequests extends Middleware
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'fontSizePreference' => $request->user() ? $request->user()->font_size_preference : 'regular',
+            'curationAccordionOpenItems' => $request->user()?->curation_accordion_open_items,
             'dataResourceCount' => fn (): int => $this->resolveSharedDataResourceCount($request),
             'igsnCount' => fn (): int => $this->resolveSharedIgsnCount($request),
             'appUrl' => $this->getBaseUrl($request),

--- a/app/Http/Requests/Settings/UpdateCurationAccordionRequest.php
+++ b/app/Http/Requests/Settings/UpdateCurationAccordionRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCurationAccordionRequest extends FormRequest
+{
+    public const ALLOWED_OPEN_ITEMS = [
+        'resource-info',
+        'licenses-rights',
+        'authors',
+        'contributors',
+        'descriptions',
+        'controlled-vocabularies',
+        'free-keywords',
+        'msl-laboratories',
+        'spatial-temporal-coverage',
+        'dates',
+        'related-work',
+        'citations',
+        'used-instruments',
+        'funding-references',
+    ];
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('open_items')) {
+            $this->merge(['open_items' => []]);
+        }
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'open_items' => ['present', 'array'],
+            'open_items.*' => ['string', 'distinct', Rule::in(self::ALLOWED_OPEN_ITEMS)],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/UpdateCurationAccordionRequest.php
+++ b/app/Http/Requests/Settings/UpdateCurationAccordionRequest.php
@@ -10,6 +10,10 @@ use Illuminate\Validation\Rule;
 
 class UpdateCurationAccordionRequest extends FormRequest
 {
+    /**
+     * Keep in sync with resources/js/lib/curation-accordion.ts.
+     * CurationAccordionPreferenceTest compares the backend list with the frontend constants.
+     */
     public const ALLOWED_OPEN_ITEMS = [
         'resource-info',
         'licenses-rights',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,36 +6,40 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Enums\UserRole;
+use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
  * @property string $name
  * @property string $email
  * @property string|null $password
- * @property \Illuminate\Support\Carbon|null $password_set_at
+ * @property Carbon|null $password_set_at
  * @property string|null $remember_token
  * @property UserRole $role
  * @property bool $is_active
  * @property string|null $font_size_preference
- * @property \Illuminate\Support\Carbon|null $email_verified_at
- * @property \Illuminate\Support\Carbon|null $deactivated_at
+ * @property array<int, string>|null $curation_accordion_open_items
+ * @property Carbon|null $email_verified_at
+ * @property Carbon|null $deactivated_at
  * @property int|null $deactivated_by
- * @property \Illuminate\Support\Carbon|null $last_seen_at
- * @property \Illuminate\Support\Carbon $created_at
- * @property \Illuminate\Support\Carbon $updated_at
+ * @property Carbon|null $last_seen_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  */
-#[Fillable(['name', 'email', 'password', 'password_set_at', 'font_size_preference', 'role', 'is_active'])]
+#[Fillable(['name', 'email', 'password', 'password_set_at', 'font_size_preference', 'curation_accordion_open_items', 'role', 'is_active'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
 
     /**
@@ -49,6 +53,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'password_set_at' => 'datetime',
+            'curation_accordion_open_items' => 'array',
             'role' => UserRole::class,
             'is_active' => 'boolean',
             'deactivated_at' => 'datetime',
@@ -133,8 +138,8 @@ class User extends Authenticatable
     /**
      * Scope a query to only include active users.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<User>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<User>
+     * @param  Builder<User>  $query
+     * @return Builder<User>
      */
     public function scopeActive($query)
     {
@@ -144,8 +149,8 @@ class User extends Authenticatable
     /**
      * Scope a query to only include inactive users.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<User>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<User>
+     * @param  Builder<User>  $query
+     * @return Builder<User>
      */
     public function scopeInactive($query)
     {
@@ -155,8 +160,8 @@ class User extends Authenticatable
     /**
      * Scope a query to filter by role.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder<User>  $query
-     * @return \Illuminate\Database\Eloquent\Builder<User>
+     * @param  Builder<User>  $query
+     * @return Builder<User>
      */
     public function scopeRole($query, UserRole $role)
     {

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -192,6 +192,7 @@ entity "users" as users {
     password_set_at : TIMESTAMP
     remember_token : VARCHAR
     * font_size_preference : VARCHAR = 'regular'
+    curation_accordion_open_items : JSON <<nullable>>
     * role : VARCHAR = 'curator'
     * is_active : BOOLEAN = true
     deactivated_at : TIMESTAMP

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -166,6 +166,7 @@ erDiagram
         timestamp password_set_at
         varchar remember_token
         varchar font_size_preference "default: regular"
+        json curation_accordion_open_items "nullable"
         varchar role "default: curator"
         boolean is_active "default: true"
         timestamp deactivated_at

--- a/database/migrations/2026_06_05_000001_add_curation_accordion_open_items_to_users_table.php
+++ b/database/migrations/2026_06_05_000001_add_curation_accordion_open_items_to_users_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_06_05_000001_add_curation_accordion_open_items_to_users_table.php
+++ b/database/migrations/2026_06_05_000001_add_curation_accordion_open_items_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->json('curation_accordion_open_items')->nullable()->after('font_size_preference');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('curation_accordion_open_items');
+        });
+    }
+};

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -106,6 +106,10 @@
                 "description": "The Data Editor now turns Save & Validate blocking messages into a grouped clickable summary. When required fields such as title, datacenter, authors, abstract, licenses, or funding references need attention, curators can select the matching entry to reopen the relevant accordion section and jump directly to the affected field instead of scanning the entire form manually."
             },
             {
+                "title": "Data Editor Accordion Bulk Controls",
+                "description": "The Data Editor now shows compact expand-all and collapse-all controls next to every field group header. Curators can close all currently visible field groups to scan the form more quickly, reopen them with one click, and ERNIE stores the preferred accordion state per user so the editor reopens in the same layout on the next visit. Conditional sections such as MSL Laboratories and Used Instruments are included only when visible."
+            },
+            {
                 "title": "Go-Live Hardening for Contact Delivery and Public Operations",
                 "description": "Stage and production stacks no longer expose database and Redis ports on the host, CloudBeaver has been removed from the maintained Docker profiles, and the public /health endpoint now returns only a minimal status payload. Landing-page contact requests are also tracked more accurately across queued, sent, and failed delivery states so successful dispatch is no longer recorded before the queued mail actually leaves the application."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -18,11 +18,11 @@ import { useDoiValidation } from '@/hooks/use-doi-validation';
 import { useFormValidation, type ValidationRule } from '@/hooks/use-form-validation';
 import { validateAllFundingReferences } from '@/hooks/use-funding-reference-validation';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
-import { CURATION_ACCORDION_ITEM_VALUES, type CurationAccordionItemValue,DEFAULT_OPEN_ACCORDION_ITEMS } from '@/lib/curation-accordion';
+import { CURATION_ACCORDION_ITEM_VALUES, DEFAULT_OPEN_ACCORDION_ITEMS } from '@/lib/curation-accordion';
 import { buildDateTime, hasValidDateValue, parseDateTime } from '@/lib/date-utils';
 import { resources } from '@/routes';
 import { store, storeDraft } from '@/routes/editor/resources';
-import type { InstrumentSelection, MSLLaboratory, RelatedIdentifier, SharedData } from '@/types';
+import type { CurationAccordionItemValue, InstrumentSelection, MSLLaboratory, RelatedIdentifier, SharedData } from '@/types';
 import type { SelectedKeyword, VocabularyKeyword } from '@/types/vocabulary';
 import { getVocabularyTypeFromScheme } from '@/types/vocabulary';
 import {
@@ -323,10 +323,7 @@ export default function DataCiteForm({
     });
 
     const [gcmdKeywords, setGcmdKeywords] = useState<SelectedKeyword[]>(() => {
-        const combined = [
-            ...(initialGcmdKeywords ?? []),
-            ...(initialGemetKeywords ?? []),
-        ];
+        const combined = [...(initialGcmdKeywords ?? []), ...(initialGemetKeywords ?? [])];
         if (combined.length > 0) {
             return combined
                 .filter((kw): kw is typeof kw & { scheme: string } => typeof kw.scheme === 'string' && kw.scheme.length > 0)
@@ -337,7 +334,10 @@ export default function DataCiteForm({
                     language: 'language' in kw && typeof kw.language === 'string' ? kw.language : 'en',
                     scheme: kw.scheme,
                     schemeURI: 'schemeURI' in kw && typeof kw.schemeURI === 'string' ? kw.schemeURI : '',
-                    classificationCode: 'classificationCode' in kw && typeof kw.classificationCode === 'string' && kw.classificationCode.trim() !== '' ? kw.classificationCode.trim() : undefined,
+                    classificationCode:
+                        'classificationCode' in kw && typeof kw.classificationCode === 'string' && kw.classificationCode.trim() !== ''
+                            ? kw.classificationCode.trim()
+                            : undefined,
                     isLegacy: 'isLegacy' in kw && (kw.isLegacy === true || kw.isLegacy === 'true' || kw.isLegacy === '1'),
                 }));
         }
@@ -742,7 +742,15 @@ export default function DataCiteForm({
         const loadVocabularies = async () => {
             try {
                 // First, check which thesauri are available
-                let availability = { science_keywords: true, platforms: true, instruments: true, chronostratigraphy: true, gemet: true, analytical_methods: true, euroscivoc: true };
+                let availability = {
+                    science_keywords: true,
+                    platforms: true,
+                    instruments: true,
+                    chronostratigraphy: true,
+                    gemet: true,
+                    analytical_methods: true,
+                    euroscivoc: true,
+                };
                 try {
                     const availabilityRes = await fetch('/api/v1/vocabularies/thesauri-availability');
                     if (availabilityRes.ok) {
@@ -765,7 +773,8 @@ export default function DataCiteForm({
 
                 // Only fetch vocabularies that are enabled
                 const fetchPromises: Promise<Response>[] = [];
-                const fetchOrder: ('science' | 'platforms' | 'instruments' | 'chronostratigraphy' | 'gemet' | 'analytical_methods' | 'euroscivoc')[] = [];
+                const fetchOrder: ('science' | 'platforms' | 'instruments' | 'chronostratigraphy' | 'gemet' | 'analytical_methods' | 'euroscivoc')[] =
+                    [];
 
                 if (availability.science_keywords) {
                     fetchPromises.push(fetch('/vocabularies/gcmd-science-keywords'));
@@ -925,8 +934,7 @@ export default function DataCiteForm({
                 | ((currentItems: CurationAccordionItemValue[]) => readonly CurationAccordionItemValue[]),
             options: { immediate?: boolean; persist?: boolean } = {},
         ) => {
-            const nextItems =
-                typeof nextItemsOrUpdater === 'function' ? nextItemsOrUpdater(openAccordionItemsRef.current) : nextItemsOrUpdater;
+            const nextItems = typeof nextItemsOrUpdater === 'function' ? nextItemsOrUpdater(openAccordionItemsRef.current) : nextItemsOrUpdater;
             const normalizedItems = normalizeAccordionItems(nextItems);
             const persistedVisibleItems = normalizeAccordionItems(normalizedItems, visibleAccordionItemValues);
 
@@ -1615,7 +1623,16 @@ export default function DataCiteForm({
         const availableType = dateTypeOptions.find((dt) => !usedTypes.has(dt.value))?.value ?? 'other';
         setDates((prev) => [
             ...prev,
-            { id: crypto.randomUUID(), startDate: '', endDate: '', dateType: availableType, startTime: null, endTime: null, startTimezone: null, endTimezone: null },
+            {
+                id: crypto.randomUUID(),
+                startDate: '',
+                endDate: '',
+                dateType: availableType,
+                startTime: null,
+                endTime: null,
+                startTimezone: null,
+                endTimezone: null,
+            },
         ]);
     };
 
@@ -1628,7 +1645,6 @@ export default function DataCiteForm({
             errorRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
             errorRef.current.focus();
         }
-
     }, [errorMessage]);
 
     const [resolvedResourceId, setResolvedResourceId] = useState<number | null>(() => {
@@ -1708,17 +1724,15 @@ export default function DataCiteForm({
                     const firstName = contributor.firstName.trim();
                     const lastName = contributor.lastName.trim();
 
-                    const hasContactPersonRole = contributor.roles.some(
-                        (role) => role.value.replace(/\s+/g, '').toLowerCase() === 'contactperson',
-                    );
+                    const hasContactPersonRole = contributor.roles.some((role) => role.value.replace(/\s+/g, '').toLowerCase() === 'contactperson');
 
                     return {
                         type: 'person',
                         orcid: orcid || null,
                         firstName: firstName || null,
                         lastName,
-                        email: hasContactPersonRole ? (contributor.email.trim() || null) : null,
-                        website: hasContactPersonRole ? (contributor.website.trim() || null) : null,
+                        email: hasContactPersonRole ? contributor.email.trim() || null : null,
+                        website: hasContactPersonRole ? contributor.website.trim() || null : null,
                         roles,
                         affiliations,
                         position: index,
@@ -1867,9 +1881,7 @@ export default function DataCiteForm({
             // Pass-through for XML-imported inline citations; the backend
             // persists these on first save, after which the REST-based
             // CitationManagerModal owns the data.
-            ...(initialRelatedItems && initialRelatedItems.length > 0
-                ? { relatedItems: initialRelatedItems }
-                : {}),
+            ...(initialRelatedItems && initialRelatedItems.length > 0 ? { relatedItems: initialRelatedItems } : {}),
             fundingReferences: fundingReferences.map((funding) => ({
                 funderName: funding.funderName,
                 funderIdentifier: funding.funderIdentifier,
@@ -1928,9 +1940,7 @@ export default function DataCiteForm({
             }
 
             // Inject errors into individual field states for inline display
-            const fieldErrors = mapped
-                .filter((e) => e.fieldId)
-                .map((e) => ({ fieldId: e.fieldId!, message: e.message }));
+            const fieldErrors = mapped.filter((e) => e.fieldId).map((e) => ({ fieldId: e.fieldId!, message: e.message }));
             if (fieldErrors.length > 0) {
                 setFieldErrors(fieldErrors);
             }
@@ -2078,9 +2088,7 @@ export default function DataCiteForm({
             if (data?.dataCiteSync?.attempted) {
                 if (data.dataCiteSync.success) {
                     toast.success('DataCite metadata synchronized', {
-                        description: data.dataCiteSync.doi
-                            ? `DOI ${data.dataCiteSync.doi} has been updated.`
-                            : 'Metadata has been updated.',
+                        description: data.dataCiteSync.doi ? `DOI ${data.dataCiteSync.doi} has been updated.` : 'Metadata has been updated.',
                         duration: 4000,
                     });
                 } else {
@@ -2280,7 +2288,8 @@ export default function DataCiteForm({
         (error: MappedError) => {
             // 1. Open the accordion section
             updateOpenAccordionItems(
-                (prev) => (prev.includes(error.sectionId as CurationAccordionItemValue) ? prev : [...prev, error.sectionId as CurationAccordionItemValue]),
+                (prev) =>
+                    prev.includes(error.sectionId as CurationAccordionItemValue) ? prev : [...prev, error.sectionId as CurationAccordionItemValue],
                 { persist: false },
             );
 
@@ -2293,9 +2302,25 @@ export default function DataCiteForm({
     return (
         <form onSubmit={handleSubmit} noValidate className="space-y-6">
             {mappedValidationErrors.length > 0 ? (
-                <ClickableValidationAlert ref={errorRef} errors={mappedValidationErrors} onErrorClick={handleErrorClick} headerMessage={validationAlertHeader} focusable className="p-4" data-testid="global-validation-alert" />
+                <ClickableValidationAlert
+                    ref={errorRef}
+                    errors={mappedValidationErrors}
+                    onErrorClick={handleErrorClick}
+                    headerMessage={validationAlertHeader}
+                    focusable
+                    className="p-4"
+                    data-testid="global-validation-alert"
+                />
             ) : (
-                <ValidationAlert ref={errorRef} severity="error" messages={globalErrorMessages} assertive focusable className="p-4" data-testid="global-validation-alert" />
+                <ValidationAlert
+                    ref={errorRef}
+                    severity="error"
+                    messages={globalErrorMessages}
+                    assertive
+                    focusable
+                    className="p-4"
+                    data-testid="global-validation-alert"
+                />
             )}
             <Accordion type="multiple" value={visibleOpenAccordionItems} onValueChange={handleAccordionValueChange} className="w-full">
                 <AccordionItem value="resource-info">

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -932,17 +932,19 @@ export default function DataCiteForm({
             nextItemsOrUpdater:
                 | readonly CurationAccordionItemValue[]
                 | ((currentItems: CurationAccordionItemValue[]) => readonly CurationAccordionItemValue[]),
-            options: { immediate?: boolean; persist?: boolean } = {},
+            options: { immediate?: boolean; persist?: boolean; persistHiddenItems?: boolean } = {},
         ) => {
             const nextItems = typeof nextItemsOrUpdater === 'function' ? nextItemsOrUpdater(openAccordionItemsRef.current) : nextItemsOrUpdater;
             const normalizedItems = normalizeAccordionItems(nextItems);
-            const persistedVisibleItems = normalizeAccordionItems(normalizedItems, visibleAccordionItemValues);
+            const persistedItems = options.persistHiddenItems
+                ? normalizedItems
+                : normalizeAccordionItems(normalizedItems, visibleAccordionItemValues);
 
             openAccordionItemsRef.current = normalizedItems;
             setOpenAccordionItems(normalizedItems);
 
             if (options.persist ?? true) {
-                persistAccordionPreference(persistedVisibleItems, options.immediate);
+                persistAccordionPreference(persistedItems, options.immediate);
             }
         },
         [persistAccordionPreference, visibleAccordionItemValues],
@@ -950,7 +952,11 @@ export default function DataCiteForm({
 
     const handleAccordionValueChange = useCallback(
         (values: string[]) => {
-            updateOpenAccordionItems(normalizeAccordionItems(values, visibleAccordionItemValues));
+            const visibleItems = normalizeAccordionItems(values, visibleAccordionItemValues);
+            const visibleItemSet = new Set(visibleAccordionItemValues);
+            const hiddenOpenItems = openAccordionItemsRef.current.filter((item) => !visibleItemSet.has(item));
+
+            updateOpenAccordionItems([...visibleItems, ...hiddenOpenItems], { persistHiddenItems: true });
         },
         [updateOpenAccordionItems, visibleAccordionItemValues],
     );

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -18,10 +18,11 @@ import { useDoiValidation } from '@/hooks/use-doi-validation';
 import { useFormValidation, type ValidationRule } from '@/hooks/use-form-validation';
 import { validateAllFundingReferences } from '@/hooks/use-funding-reference-validation';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
+import { CURATION_ACCORDION_ITEM_VALUES, type CurationAccordionItemValue,DEFAULT_OPEN_ACCORDION_ITEMS } from '@/lib/curation-accordion';
 import { buildDateTime, hasValidDateValue, parseDateTime } from '@/lib/date-utils';
 import { resources } from '@/routes';
 import { store, storeDraft } from '@/routes/editor/resources';
-import type { CurationAccordionItemValue, InstrumentSelection, MSLLaboratory, RelatedIdentifier, SharedData } from '@/types';
+import type { InstrumentSelection, MSLLaboratory, RelatedIdentifier, SharedData } from '@/types';
 import type { SelectedKeyword, VocabularyKeyword } from '@/types/vocabulary';
 import { getVocabularyTypeFromScheme } from '@/types/vocabulary';
 import {
@@ -82,37 +83,6 @@ export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
 
 const ABSTRACT_MIN_LENGTH = 50;
 const ABSTRACT_MAX_LENGTH = 17500;
-const CURATION_ACCORDION_ITEM_VALUES = [
-    'resource-info',
-    'licenses-rights',
-    'authors',
-    'contributors',
-    'descriptions',
-    'controlled-vocabularies',
-    'free-keywords',
-    'msl-laboratories',
-    'spatial-temporal-coverage',
-    'dates',
-    'related-work',
-    'citations',
-    'used-instruments',
-    'funding-references',
-] as const satisfies readonly CurationAccordionItemValue[];
-const DEFAULT_OPEN_ACCORDION_ITEMS = [
-    'resource-info',
-    'authors',
-    'licenses-rights',
-    'contributors',
-    'descriptions',
-    'controlled-vocabularies',
-    'free-keywords',
-    'spatial-temporal-coverage',
-    'dates',
-    'related-work',
-    'citations',
-    'funding-references',
-    'used-instruments',
-] as const satisfies readonly CurationAccordionItemValue[];
 const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
 
 function normalizeAccordionItems(
@@ -953,7 +923,7 @@ export default function DataCiteForm({
             nextItemsOrUpdater:
                 | readonly CurationAccordionItemValue[]
                 | ((currentItems: CurationAccordionItemValue[]) => readonly CurationAccordionItemValue[]),
-            options: { immediate?: boolean } = {},
+            options: { immediate?: boolean; persist?: boolean } = {},
         ) => {
             const nextItems =
                 typeof nextItemsOrUpdater === 'function' ? nextItemsOrUpdater(openAccordionItemsRef.current) : nextItemsOrUpdater;
@@ -962,7 +932,10 @@ export default function DataCiteForm({
 
             openAccordionItemsRef.current = normalizedItems;
             setOpenAccordionItems(normalizedItems);
-            persistAccordionPreference(persistedVisibleItems, options.immediate);
+
+            if (options.persist ?? true) {
+                persistAccordionPreference(persistedVisibleItems, options.immediate);
+            }
         },
         [persistAccordionPreference, visibleAccordionItemValues],
     );
@@ -1033,7 +1006,7 @@ export default function DataCiteForm({
         let isMounted = true;
 
         if (shouldShowMSLSection && !openAccordionItems.includes('msl-laboratories')) {
-            updateOpenAccordionItems((prev) => [...prev, 'msl-laboratories']);
+            updateOpenAccordionItems((prev) => [...prev, 'msl-laboratories'], { persist: false });
 
             // Only notify if this is NOT an initial data load and we haven't notified yet
             if (!hasInitialMslTriggers.current && !hasNotifiedMslUnlock.current) {
@@ -1055,7 +1028,7 @@ export default function DataCiteForm({
 
                     if (!openAccordionItems.includes('controlled-vocabularies')) {
                         // Open the controlled vocabularies accordion first
-                        updateOpenAccordionItems((prev) => [...prev, 'controlled-vocabularies']);
+                        updateOpenAccordionItems((prev) => [...prev, 'controlled-vocabularies'], { persist: false });
                     }
 
                     // Scroll to the section
@@ -1074,7 +1047,7 @@ export default function DataCiteForm({
                 }, 300);
             }
         } else if (!shouldShowMSLSection && openAccordionItems.includes('msl-laboratories')) {
-            updateOpenAccordionItems((prev) => prev.filter((item) => item !== 'msl-laboratories'));
+            updateOpenAccordionItems((prev) => prev.filter((item) => item !== 'msl-laboratories'), { persist: false });
             // Reset notification flag when MSL section is hidden
             hasNotifiedMslUnlock.current = false;
         }
@@ -1964,7 +1937,7 @@ export default function DataCiteForm({
 
             // Auto-open accordion sections that have errors
             const sectionsWithErrors = [...new Set(mapped.map((e) => e.sectionId))];
-            updateOpenAccordionItems((prev) => [...new Set([...prev, ...sectionsWithErrors])] as CurationAccordionItemValue[]);
+            updateOpenAccordionItems((prev) => [...new Set([...prev, ...sectionsWithErrors])] as CurationAccordionItemValue[], { persist: false });
 
             // Scroll to first errored field/section after accordion opens
             if (sectionsWithErrors.length > 0) {
@@ -2306,7 +2279,10 @@ export default function DataCiteForm({
     const handleErrorClick = useCallback(
         (error: MappedError) => {
             // 1. Open the accordion section
-            updateOpenAccordionItems((prev) => (prev.includes(error.sectionId as CurationAccordionItemValue) ? prev : [...prev, error.sectionId as CurationAccordionItemValue]));
+            updateOpenAccordionItems(
+                (prev) => (prev.includes(error.sectionId as CurationAccordionItemValue) ? prev : [...prev, error.sectionId as CurationAccordionItemValue]),
+                { persist: false },
+            );
 
             // 2. Scroll to field or section after DOM update (wait for accordion animation)
             scheduleScrollToError(error.fieldSelector, error.sectionId);

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -962,11 +962,17 @@ export default function DataCiteForm({
     );
 
     const collapseAllAccordionItems = useCallback(() => {
-        updateOpenAccordionItems([], { immediate: true });
-    }, [updateOpenAccordionItems]);
+        const visibleItemSet = new Set(visibleAccordionItemValues);
+        const hiddenOpenItems = openAccordionItemsRef.current.filter((item) => !visibleItemSet.has(item));
+
+        updateOpenAccordionItems(hiddenOpenItems, { immediate: true, persistHiddenItems: true });
+    }, [updateOpenAccordionItems, visibleAccordionItemValues]);
 
     const expandAllAccordionItems = useCallback(() => {
-        updateOpenAccordionItems(visibleAccordionItemValues, { immediate: true });
+        const visibleItemSet = new Set(visibleAccordionItemValues);
+        const hiddenOpenItems = openAccordionItemsRef.current.filter((item) => !visibleItemSet.has(item));
+
+        updateOpenAccordionItems([...visibleAccordionItemValues, ...hiddenOpenItems], { immediate: true, persistHiddenItems: true });
     }, [updateOpenAccordionItems, visibleAccordionItemValues]);
 
     useEffect(() => {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -1,6 +1,6 @@
-import { router } from '@inertiajs/react';
+import { router, usePage } from '@inertiajs/react';
 import axios from 'axios';
-import { AlertCircle, Calendar, CheckCircle, Circle, Save } from 'lucide-react';
+import { AlertCircle, Calendar, CheckCircle, ChevronsDown, ChevronsUp, Circle, Save } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -21,7 +21,7 @@ import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
 import { buildDateTime, hasValidDateValue, parseDateTime } from '@/lib/date-utils';
 import { resources } from '@/routes';
 import { store, storeDraft } from '@/routes/editor/resources';
-import type { InstrumentSelection, MSLLaboratory, RelatedIdentifier } from '@/types';
+import type { CurationAccordionItemValue, InstrumentSelection, MSLLaboratory, RelatedIdentifier, SharedData } from '@/types';
 import type { SelectedKeyword, VocabularyKeyword } from '@/types/vocabulary';
 import { getVocabularyTypeFromScheme } from '@/types/vocabulary';
 import {
@@ -82,6 +82,56 @@ export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
 
 const ABSTRACT_MIN_LENGTH = 50;
 const ABSTRACT_MAX_LENGTH = 17500;
+const CURATION_ACCORDION_ITEM_VALUES = [
+    'resource-info',
+    'licenses-rights',
+    'authors',
+    'contributors',
+    'descriptions',
+    'controlled-vocabularies',
+    'free-keywords',
+    'msl-laboratories',
+    'spatial-temporal-coverage',
+    'dates',
+    'related-work',
+    'citations',
+    'used-instruments',
+    'funding-references',
+] as const satisfies readonly CurationAccordionItemValue[];
+const DEFAULT_OPEN_ACCORDION_ITEMS = [
+    'resource-info',
+    'authors',
+    'licenses-rights',
+    'contributors',
+    'descriptions',
+    'controlled-vocabularies',
+    'free-keywords',
+    'spatial-temporal-coverage',
+    'dates',
+    'related-work',
+    'citations',
+    'funding-references',
+    'used-instruments',
+] as const satisfies readonly CurationAccordionItemValue[];
+const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
+
+function normalizeAccordionItems(
+    items: readonly string[],
+    allowedItems: readonly CurationAccordionItemValue[] = CURATION_ACCORDION_ITEM_VALUES,
+): CurationAccordionItemValue[] {
+    const allowed = new Set<CurationAccordionItemValue>(allowedItems);
+    const result: CurationAccordionItemValue[] = [];
+
+    for (const item of items) {
+        if (!allowed.has(item as CurationAccordionItemValue) || result.includes(item as CurationAccordionItemValue)) {
+            continue;
+        }
+
+        result.push(item as CurationAccordionItemValue);
+    }
+
+    return result;
+}
 
 function appendValidationMessage(errors: Record<string, string[]>, backendKey: string, message: string): void {
     const existing = errors[backendKey];
@@ -142,6 +192,7 @@ export default function DataCiteForm({
     activeRelationTypes,
     activeIdentifierTypes,
 }: DataCiteFormProps) {
+    const { curationAccordionOpenItems } = usePage<SharedData>().props;
     const MAX_TITLES = maxTitles;
     const MAX_LICENSES = maxLicenses;
 
@@ -174,6 +225,7 @@ export default function DataCiteForm({
     // Refs to track MSL scroll/animation timeouts for cleanup (separate refs to avoid overwriting)
     const mslScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const mslAnimationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const accordionPreferenceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const [form, setForm] = useState<DataCiteFormData>({
         doi: initialDoi,
@@ -382,21 +434,10 @@ export default function DataCiteForm({
         return [];
     });
     const [datacenterTouched, setDatacenterTouched] = useState(false);
-    const [openAccordionItems, setOpenAccordionItems] = useState<string[]>([
-        'resource-info',
-        'authors',
-        'licenses-rights',
-        'contributors',
-        'descriptions',
-        'controlled-vocabularies',
-        'free-keywords',
-        'spatial-temporal-coverage',
-        'dates',
-        'related-work',
-        'citations',
-        'funding-references',
-        'used-instruments',
-    ]);
+    const [openAccordionItems, setOpenAccordionItems] = useState<CurationAccordionItemValue[]>(() =>
+        normalizeAccordionItems(curationAccordionOpenItems ?? DEFAULT_OPEN_ACCORDION_ITEMS),
+    );
+    const openAccordionItemsRef = useRef(openAccordionItems);
 
     // State to trigger auto-switch to MSL tab when it becomes available
     const [shouldAutoSwitchToMsl, setAutoSwitchToMslState] = useState<boolean>(false);
@@ -857,6 +898,103 @@ export default function DataCiteForm({
         return hasMslControlledKeywords || keywords.some((keyword) => triggers.some((trigger) => keyword.includes(trigger)));
     }, [freeKeywords, hasMslControlledKeywords]);
 
+    const visibleAccordionItemValues = useMemo<CurationAccordionItemValue[]>(() => {
+        return CURATION_ACCORDION_ITEM_VALUES.filter((value) => {
+            if (value === 'msl-laboratories') {
+                return shouldShowMSLSection;
+            }
+
+            if (value === 'used-instruments') {
+                return shouldShowUsedInstrumentsSection;
+            }
+
+            return true;
+        });
+    }, [shouldShowMSLSection, shouldShowUsedInstrumentsSection]);
+
+    const visibleOpenAccordionItems = useMemo(
+        () => normalizeAccordionItems(openAccordionItems, visibleAccordionItemValues),
+        [openAccordionItems, visibleAccordionItemValues],
+    );
+    const allVisibleAccordionItemsOpen =
+        visibleAccordionItemValues.length > 0 && visibleAccordionItemValues.every((value) => visibleOpenAccordionItems.includes(value));
+    const allVisibleAccordionItemsClosed = visibleOpenAccordionItems.length === 0;
+
+    const persistAccordionPreference = useCallback((items: readonly CurationAccordionItemValue[], immediate = false) => {
+        const persist = () => {
+            router.put(
+                CURATION_ACCORDION_PREFERENCE_URL,
+                {
+                    open_items: [...items],
+                },
+                {
+                    preserveScroll: true,
+                    preserveState: true,
+                    only: ['curationAccordionOpenItems'],
+                },
+            );
+        };
+
+        if (accordionPreferenceTimeoutRef.current) {
+            clearTimeout(accordionPreferenceTimeoutRef.current);
+            accordionPreferenceTimeoutRef.current = null;
+        }
+
+        if (immediate) {
+            persist();
+            return;
+        }
+
+        accordionPreferenceTimeoutRef.current = setTimeout(persist, 400);
+    }, []);
+
+    const updateOpenAccordionItems = useCallback(
+        (
+            nextItemsOrUpdater:
+                | readonly CurationAccordionItemValue[]
+                | ((currentItems: CurationAccordionItemValue[]) => readonly CurationAccordionItemValue[]),
+            options: { immediate?: boolean } = {},
+        ) => {
+            const nextItems =
+                typeof nextItemsOrUpdater === 'function' ? nextItemsOrUpdater(openAccordionItemsRef.current) : nextItemsOrUpdater;
+            const normalizedItems = normalizeAccordionItems(nextItems);
+            const persistedVisibleItems = normalizeAccordionItems(normalizedItems, visibleAccordionItemValues);
+
+            openAccordionItemsRef.current = normalizedItems;
+            setOpenAccordionItems(normalizedItems);
+            persistAccordionPreference(persistedVisibleItems, options.immediate);
+        },
+        [persistAccordionPreference, visibleAccordionItemValues],
+    );
+
+    const handleAccordionValueChange = useCallback(
+        (values: string[]) => {
+            updateOpenAccordionItems(normalizeAccordionItems(values, visibleAccordionItemValues));
+        },
+        [updateOpenAccordionItems, visibleAccordionItemValues],
+    );
+
+    const collapseAllAccordionItems = useCallback(() => {
+        updateOpenAccordionItems([], { immediate: true });
+    }, [updateOpenAccordionItems]);
+
+    const expandAllAccordionItems = useCallback(() => {
+        updateOpenAccordionItems(visibleAccordionItemValues, { immediate: true });
+    }, [updateOpenAccordionItems, visibleAccordionItemValues]);
+
+    useEffect(() => {
+        openAccordionItemsRef.current = openAccordionItems;
+    }, [openAccordionItems]);
+
+    useEffect(() => {
+        return () => {
+            if (accordionPreferenceTimeoutRef.current) {
+                clearTimeout(accordionPreferenceTimeoutRef.current);
+                accordionPreferenceTimeoutRef.current = null;
+            }
+        };
+    }, []);
+
     // Load MSL vocabulary when MSL section becomes visible
     useEffect(() => {
         if (shouldShowMSLSection && gcmdVocabularies.msl.length === 0) {
@@ -895,7 +1033,7 @@ export default function DataCiteForm({
         let isMounted = true;
 
         if (shouldShowMSLSection && !openAccordionItems.includes('msl-laboratories')) {
-            setOpenAccordionItems((prev) => [...prev, 'msl-laboratories']);
+            updateOpenAccordionItems((prev) => [...prev, 'msl-laboratories']);
 
             // Only notify if this is NOT an initial data load and we haven't notified yet
             if (!hasInitialMslTriggers.current && !hasNotifiedMslUnlock.current) {
@@ -917,7 +1055,7 @@ export default function DataCiteForm({
 
                     if (!openAccordionItems.includes('controlled-vocabularies')) {
                         // Open the controlled vocabularies accordion first
-                        setOpenAccordionItems((prev) => [...prev, 'controlled-vocabularies']);
+                        updateOpenAccordionItems((prev) => [...prev, 'controlled-vocabularies']);
                     }
 
                     // Scroll to the section
@@ -936,7 +1074,7 @@ export default function DataCiteForm({
                 }, 300);
             }
         } else if (!shouldShowMSLSection && openAccordionItems.includes('msl-laboratories')) {
-            setOpenAccordionItems((prev) => prev.filter((item) => item !== 'msl-laboratories'));
+            updateOpenAccordionItems((prev) => prev.filter((item) => item !== 'msl-laboratories'));
             // Reset notification flag when MSL section is hidden
             hasNotifiedMslUnlock.current = false;
         }
@@ -953,7 +1091,7 @@ export default function DataCiteForm({
                 mslAnimationTimeoutRef.current = null;
             }
         };
-    }, [shouldShowMSLSection, openAccordionItems, setShouldAutoSwitchToMsl]);
+    }, [shouldShowMSLSection, openAccordionItems, setShouldAutoSwitchToMsl, updateOpenAccordionItems]);
 
     // MSL validation info - show recommendation when section is visible but no laboratories selected
     const mslValidationInfo = useMemo(() => {
@@ -1826,7 +1964,7 @@ export default function DataCiteForm({
 
             // Auto-open accordion sections that have errors
             const sectionsWithErrors = [...new Set(mapped.map((e) => e.sectionId))];
-            setOpenAccordionItems((prev) => [...new Set([...prev, ...sectionsWithErrors])]);
+            updateOpenAccordionItems((prev) => [...new Set([...prev, ...sectionsWithErrors])] as CurationAccordionItemValue[]);
 
             // Scroll to first errored field/section after accordion opens
             if (sectionsWithErrors.length > 0) {
@@ -1836,7 +1974,7 @@ export default function DataCiteForm({
 
             setErrorMessage(headerMessage);
         },
-        [setFieldErrors, setOpenAccordionItems],
+        [setFieldErrors, updateOpenAccordionItems],
     );
 
     const datacenterErrorMessage = useMemo(() => {
@@ -2116,6 +2254,45 @@ export default function DataCiteForm({
         return <Circle className="h-4 w-4 text-gray-400" aria-label="Optional section" />;
     };
 
+    const renderAccordionActions = () => (
+        <>
+            {!allVisibleAccordionItemsClosed && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label="Collapse all field groups"
+                            data-testid="collapse-all-field-groups"
+                            onClick={collapseAllAccordionItems}
+                        >
+                            <ChevronsUp className="h-3.5 w-3.5" aria-hidden="true" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Collapse all field groups</TooltipContent>
+                </Tooltip>
+            )}
+            {!allVisibleAccordionItemsOpen && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            aria-label="Expand all field groups"
+                            data-testid="expand-all-field-groups"
+                            onClick={expandAllAccordionItems}
+                        >
+                            <ChevronsDown className="h-3.5 w-3.5" aria-hidden="true" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Expand all field groups</TooltipContent>
+                </Tooltip>
+            )}
+        </>
+    );
+
     // Build global error messages array for ValidationAlert when no mapped navigation errors are present.
     const globalErrorMessages = useMemo(() => {
         if (errorMessage && mappedValidationErrors.length === 0) {
@@ -2129,12 +2306,12 @@ export default function DataCiteForm({
     const handleErrorClick = useCallback(
         (error: MappedError) => {
             // 1. Open the accordion section
-            setOpenAccordionItems((prev) => (prev.includes(error.sectionId) ? prev : [...prev, error.sectionId]));
+            updateOpenAccordionItems((prev) => (prev.includes(error.sectionId as CurationAccordionItemValue) ? prev : [...prev, error.sectionId as CurationAccordionItemValue]));
 
             // 2. Scroll to field or section after DOM update (wait for accordion animation)
             scheduleScrollToError(error.fieldSelector, error.sectionId);
         },
-        [setOpenAccordionItems],
+        [updateOpenAccordionItems],
     );
 
     return (
@@ -2144,9 +2321,9 @@ export default function DataCiteForm({
             ) : (
                 <ValidationAlert ref={errorRef} severity="error" messages={globalErrorMessages} assertive focusable className="p-4" data-testid="global-validation-alert" />
             )}
-            <Accordion type="multiple" value={openAccordionItems} onValueChange={setOpenAccordionItems} className="w-full">
+            <Accordion type="multiple" value={visibleOpenAccordionItems} onValueChange={handleAccordionValueChange} className="w-full">
                 <AccordionItem value="resource-info">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Resource Information</span>
                             {renderStatusBadge(resourceInfoStatus)}
@@ -2288,7 +2465,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="licenses-rights">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Licenses and Rights</span>
                             {renderStatusBadge(licensesStatus)}
@@ -2328,7 +2505,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="authors">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Authors</span>
                             {renderStatusBadge(authorsStatus)}
@@ -2353,7 +2530,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="contributors">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Contributors</span>
                             {renderStatusBadge(contributorsStatus)}
@@ -2376,7 +2553,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="descriptions">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Descriptions</span>
                             {renderStatusBadge(descriptionsStatus)}
@@ -2400,7 +2577,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="controlled-vocabularies" ref={controlledVocabulariesRef}>
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Controlled Vocabularies</span>
                             {renderStatusBadge(controlledVocabulariesStatus)}
@@ -2439,7 +2616,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="free-keywords">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Free Keywords</span>
                             {renderStatusBadge(freeKeywordsStatus)}
@@ -2457,7 +2634,7 @@ export default function DataCiteForm({
                 </AccordionItem>
                 {shouldShowMSLSection && (
                     <AccordionItem value="msl-laboratories">
-                        <AccordionTrigger>
+                        <AccordionTrigger actions={renderAccordionActions()}>
                             <div className="flex items-center gap-2">
                                 <span>🔬 Originating Multi-Scale Laboratories</span>
                                 <span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium">EPOS/MSL</span>
@@ -2477,7 +2654,7 @@ export default function DataCiteForm({
                     </AccordionItem>
                 )}
                 <AccordionItem value="spatial-temporal-coverage">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Spatial and Temporal Coverage</span>
                             {renderStatusBadge(spatialTemporalCoverageStatus)}
@@ -2498,7 +2675,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="dates">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Dates</span>
                             {renderStatusBadge(datesStatus)}
@@ -2561,7 +2738,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="related-work" data-testid="related-work-section">
-                    <AccordionTrigger data-testid="related-work-accordion-trigger">
+                    <AccordionTrigger data-testid="related-work-accordion-trigger" actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Related Work</span>
                             {renderStatusBadge(relatedWorkStatus)}
@@ -2583,7 +2760,7 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="citations" data-testid="citations-section">
-                    <AccordionTrigger data-testid="citations-accordion-trigger">
+                    <AccordionTrigger data-testid="citations-accordion-trigger" actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Citations</span>
                         </div>
@@ -2599,7 +2776,7 @@ export default function DataCiteForm({
                 </AccordionItem>
                 {shouldShowUsedInstrumentsSection && (
                     <AccordionItem value="used-instruments" data-testid="used-instruments-section">
-                        <AccordionTrigger data-testid="used-instruments-accordion-trigger">
+                        <AccordionTrigger data-testid="used-instruments-accordion-trigger" actions={renderAccordionActions()}>
                             <div className="flex items-center gap-2">
                                 <span>Used Instruments</span>
                                 {renderStatusBadge(instrumentsStatus)}
@@ -2617,7 +2794,7 @@ export default function DataCiteForm({
                     </AccordionItem>
                 )}
                 <AccordionItem value="funding-references">
-                    <AccordionTrigger>
+                    <AccordionTrigger actions={renderAccordionActions()}>
                         <div className="flex items-center gap-2">
                             <span>Funding References</span>
                             {renderStatusBadge(fundingReferencesStatus)}

--- a/resources/js/components/ui/accordion.tsx
+++ b/resources/js/components/ui/accordion.tsx
@@ -29,10 +29,13 @@ function AccordionItem({
 function AccordionTrigger({
   className,
   children,
+  actions,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger> & {
+  actions?: React.ReactNode
+}) {
   return (
-    <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Header className={cn("flex items-start", actions && "gap-1")}>
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
@@ -44,6 +47,7 @@ function AccordionTrigger({
         {children}
         <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
+      {actions ? <div data-slot="accordion-actions" className="flex shrink-0 items-center gap-1 py-3">{actions}</div> : null}
     </AccordionPrimitive.Header>
   )
 }

--- a/resources/js/components/ui/accordion.tsx
+++ b/resources/js/components/ui/accordion.tsx
@@ -68,4 +68,4 @@ function AccordionContent({
   )
 }
 
-export { Accordion, AccordionContent,AccordionItem, AccordionTrigger }
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger }

--- a/resources/js/components/ui/accordion.tsx
+++ b/resources/js/components/ui/accordion.tsx
@@ -47,7 +47,7 @@ function AccordionTrigger({
         {children}
         <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
-      {actions ? <div data-slot="accordion-actions" className="flex shrink-0 items-center gap-1 py-3">{actions}</div> : null}
+      {actions ? <div data-slot="accordion-actions" className="flex shrink-0 items-center gap-1 py-4">{actions}</div> : null}
     </AccordionPrimitive.Header>
   )
 }

--- a/resources/js/lib/curation-accordion.ts
+++ b/resources/js/lib/curation-accordion.ts
@@ -1,0 +1,34 @@
+export const CURATION_ACCORDION_ITEM_VALUES = [
+    'resource-info',
+    'licenses-rights',
+    'authors',
+    'contributors',
+    'descriptions',
+    'controlled-vocabularies',
+    'free-keywords',
+    'msl-laboratories',
+    'spatial-temporal-coverage',
+    'dates',
+    'related-work',
+    'citations',
+    'used-instruments',
+    'funding-references',
+] as const;
+
+export type CurationAccordionItemValue = (typeof CURATION_ACCORDION_ITEM_VALUES)[number];
+
+export const DEFAULT_OPEN_ACCORDION_ITEMS = [
+    'resource-info',
+    'authors',
+    'licenses-rights',
+    'contributors',
+    'descriptions',
+    'controlled-vocabularies',
+    'free-keywords',
+    'spatial-temporal-coverage',
+    'dates',
+    'related-work',
+    'citations',
+    'funding-references',
+    'used-instruments',
+] as const satisfies readonly CurationAccordionItemValue[];

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -1,23 +1,11 @@
 import { InertiaLinkProps } from '@inertiajs/react';
 import { LucideIcon } from 'lucide-react';
 
-export type FontSize = 'regular' | 'large';
+import type { CurationAccordionItemValue } from '@/lib/curation-accordion';
 
-export type CurationAccordionItemValue =
-    | 'resource-info'
-    | 'licenses-rights'
-    | 'authors'
-    | 'contributors'
-    | 'descriptions'
-    | 'controlled-vocabularies'
-    | 'free-keywords'
-    | 'msl-laboratories'
-    | 'spatial-temporal-coverage'
-    | 'dates'
-    | 'related-work'
-    | 'citations'
-    | 'used-instruments'
-    | 'funding-references';
+export type { CurationAccordionItemValue } from '@/lib/curation-accordion';
+
+export type FontSize = 'regular' | 'large';
 
 export type SidebarWorkspace = 'curation' | 'administration';
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -3,6 +3,22 @@ import { LucideIcon } from 'lucide-react';
 
 export type FontSize = 'regular' | 'large';
 
+export type CurationAccordionItemValue =
+    | 'resource-info'
+    | 'licenses-rights'
+    | 'authors'
+    | 'contributors'
+    | 'descriptions'
+    | 'controlled-vocabularies'
+    | 'free-keywords'
+    | 'msl-laboratories'
+    | 'spatial-temporal-coverage'
+    | 'dates'
+    | 'related-work'
+    | 'citations'
+    | 'used-instruments'
+    | 'funding-references';
+
 export type SidebarWorkspace = 'curation' | 'administration';
 
 export type UserRole = 'beginner' | 'curator' | 'group_leader' | 'admin';
@@ -54,6 +70,7 @@ export interface SharedData {
     auth: Auth;
     sidebarOpen: boolean;
     fontSizePreference: FontSize;
+    curationAccordionOpenItems: CurationAccordionItemValue[] | null;
     dataResourceCount?: number;
     igsnCount?: number;
     dataInstitutionCount?: number;
@@ -68,6 +85,7 @@ export interface User {
     name: string;
     email: string;
     font_size_preference: FontSize;
+    curation_accordion_open_items?: CurationAccordionItemValue[] | null;
     role?: UserRole;
     role_label?: string;
     is_active?: boolean;

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DatacenterController;
 use App\Http\Controllers\LandingPageDomainController;
+use App\Http\Controllers\Settings\CurationAccordionController;
 use App\Http\Controllers\Settings\EditorSettingsController;
 use App\Http\Controllers\Settings\FontSizeController;
 use App\Http\Controllers\Settings\PasswordController;
@@ -37,6 +38,7 @@ Route::middleware('auth')->group(function () {
         ->name('password.update');
 
     Route::put('settings/font-size', [FontSizeController::class, 'update'])->name('font-size.update');
+    Route::put('settings/curation-accordion', [CurationAccordionController::class, 'update'])->name('curation-accordion.update');
 
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/appearance');

--- a/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
+++ b/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
@@ -2,10 +2,20 @@
 
 declare(strict_types=1);
 
+use App\Http\Requests\Settings\UpdateCurationAccordionRequest;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
+
+test('allowed curation accordion item values stay in sync with frontend constants', function () {
+    $frontendConstants = (string) file_get_contents(resource_path('js/lib/curation-accordion.ts'));
+
+    preg_match('/export const CURATION_ACCORDION_ITEM_VALUES = \[(?<items>.*?)\] as const;/s', $frontendConstants, $matches);
+    preg_match_all("/'([^']+)'/", $matches['items'] ?? '', $itemMatches);
+
+    expect(UpdateCurationAccordionRequest::ALLOWED_OPEN_ITEMS)->toBe($itemMatches[1]);
+});
 
 test('guests are redirected when updating curation accordion preference', function () {
     $this->put(route('curation-accordion.update'), [

--- a/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
+++ b/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
@@ -14,7 +14,7 @@ test('allowed curation accordion item values stay in sync with frontend constant
     preg_match('/export const CURATION_ACCORDION_ITEM_VALUES = \[(?<items>.*?)\] as const;/s', $frontendConstants, $matches);
     preg_match_all("/'([^']+)'/", $matches['items'] ?? '', $itemMatches);
 
-    expect(UpdateCurationAccordionRequest::ALLOWED_OPEN_ITEMS)->toBe($itemMatches[1]);
+    expect(UpdateCurationAccordionRequest::ALLOWED_OPEN_ITEMS)->toEqualCanonicalizing($itemMatches[1]);
 });
 
 test('guests are redirected when updating curation accordion preference', function () {

--- a/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
+++ b/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -66,5 +68,5 @@ test('duplicate curation accordion item values are rejected', function () {
             'open_items' => ['authors', 'authors'],
         ])
         ->assertRedirect('/editor')
-        ->assertSessionHasErrors('open_items.0');
+        ->assertSessionHasErrors('open_items.1');
 });

--- a/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
+++ b/tests/pest/Feature/Settings/CurationAccordionPreferenceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('guests are redirected when updating curation accordion preference', function () {
+    $this->put(route('curation-accordion.update'), [
+        'open_items' => ['resource-info'],
+    ])->assertRedirect(route('login'));
+});
+
+test('authenticated users can persist curation accordion open items', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('curation-accordion.update'), [
+            'open_items' => ['resource-info', 'authors', 'funding-references'],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->curation_accordion_open_items)->toBe([
+        'resource-info',
+        'authors',
+        'funding-references',
+    ]);
+});
+
+test('authenticated users can persist all curation accordions as collapsed', function () {
+    $user = User::factory()->create([
+        'curation_accordion_open_items' => ['resource-info'],
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('curation-accordion.update'), [
+            'open_items' => [],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->curation_accordion_open_items)->toBe([]);
+});
+
+test('unknown curation accordion item values are rejected', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from('/editor')
+        ->put(route('curation-accordion.update'), [
+            'open_items' => ['resource-info', 'unknown-section'],
+        ])
+        ->assertRedirect('/editor')
+        ->assertSessionHasErrors('open_items.1');
+
+    expect($user->refresh()->curation_accordion_open_items)->toBeNull();
+});
+
+test('duplicate curation accordion item values are rejected', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from('/editor')
+        ->put(route('curation-accordion.update'), [
+            'open_items' => ['authors', 'authors'],
+        ])
+        ->assertRedirect('/editor')
+        ->assertSessionHasErrors('open_items.0');
+});

--- a/tests/pest/Unit/Middleware/MiddlewareTest.php
+++ b/tests/pest/Unit/Middleware/MiddlewareTest.php
@@ -225,6 +225,28 @@ describe('HandleInertiaRequests', function () {
         expect($shared['fontSizePreference'])->toBe('large');
     });
 
+    it('shares null curationAccordionOpenItems when no user', function () {
+        $middleware = new HandleInertiaRequests;
+        $request = Request::create('/test');
+
+        $shared = $middleware->share($request);
+
+        expect($shared['curationAccordionOpenItems'])->toBeNull();
+    });
+
+    it('shares curationAccordionOpenItems from authenticated user', function () {
+        $user = User::factory()->create([
+            'curation_accordion_open_items' => ['resource-info', 'authors'],
+        ]);
+        $middleware = new HandleInertiaRequests;
+        $request = Request::create('/test');
+        $request->setUserResolver(fn () => $user);
+
+        $shared = $middleware->share($request);
+
+        expect($shared['curationAccordionOpenItems'])->toBe(['resource-info', 'authors']);
+    });
+
     it('shares appUrl and baseUrl', function () {
         $middleware = new HandleInertiaRequests;
         $request = Request::create('http://localhost/test');

--- a/tests/playwright/helpers/page-objects/DataCiteFormPage.ts
+++ b/tests/playwright/helpers/page-objects/DataCiteFormPage.ts
@@ -66,7 +66,7 @@ export class DataCiteFormPage {
     this.descriptionsAccordion = getAccordionTrigger(page, /Descriptions/i);
     this.controlledVocabulariesAccordion = getAccordionTrigger(page, /Controlled Vocabularies/i);
     this.freeKeywordsAccordion = getAccordionTrigger(page, /Free Keywords/i);
-    this.mslLaboratoriesAccordion = getAccordionTrigger(page, /MSL Laboratories/i);
+    this.mslLaboratoriesAccordion = getAccordionTrigger(page, /Originating Multi-Scale Laboratories/i);
     this.spatialTemporalCoverageAccordion = getAccordionTrigger(page, /Spatial.*Temporal Coverage/i);
     this.datesAccordion = getAccordionTrigger(page, /Dates/i);
     this.relatedWorkAccordion = getAccordionTrigger(page, /Related Work/i);

--- a/tests/playwright/helpers/page-objects/DataCiteFormPage.ts
+++ b/tests/playwright/helpers/page-objects/DataCiteFormPage.ts
@@ -31,7 +31,10 @@ export class DataCiteFormPage {
   readonly spatialTemporalCoverageAccordion: Locator;
   readonly datesAccordion: Locator;
   readonly relatedWorkAccordion: Locator;
+  readonly usedInstrumentsAccordion: Locator;
   readonly fundingAccordion: Locator;
+  readonly collapseAllButtons: Locator;
+  readonly expandAllButtons: Locator;
   
   // Resource Info Fields
   readonly doiInput: Locator;
@@ -67,7 +70,10 @@ export class DataCiteFormPage {
     this.spatialTemporalCoverageAccordion = getAccordionTrigger(page, /Spatial.*Temporal Coverage/i);
     this.datesAccordion = getAccordionTrigger(page, /Dates/i);
     this.relatedWorkAccordion = getAccordionTrigger(page, /Related Work/i);
+    this.usedInstrumentsAccordion = getAccordionTrigger(page, /Used Instruments/i);
     this.fundingAccordion = getAccordionTrigger(page, /Funding/i);
+    this.collapseAllButtons = page.getByRole('button', { name: /Collapse all field groups/i });
+    this.expandAllButtons = page.getByRole('button', { name: /Expand all field groups/i });
     
     // Resource Info Fields
     this.doiInput = page.locator('#doi');

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -36,23 +36,16 @@ test.describe('DataCite Form Validation UX', () => {
   });
 
   test.describe('Accordion Bulk Controls', () => {
-    test('collapses and expands all visible field groups', async () => {
-      await expect(formPage.usedInstrumentsAccordion).toBeVisible();
+    test('collapses and expands always-visible field groups', async () => {
+      await expect(formPage.resourceInfoAccordion).toBeVisible();
 
-      if (await formPage.expandAllButtons.count() > 0) {
-        await formPage.expandAllButtons.first().click();
-        await expect(formPage.expandAllButtons).toHaveCount(0);
+      if (await formPage.collapseAllButtons.count() > 0) {
+        await formPage.collapseAllButtons.first().click();
       }
-
-      await expect(formPage.collapseAllButtons.first()).toBeVisible();
-      await expect(formPage.expandAllButtons).toHaveCount(0);
-
-      await formPage.collapseAllButtons.first().click();
 
       await expect(formPage.resourceInfoAccordion).toHaveAttribute('aria-expanded', 'false');
       await expect(formPage.authorsAccordion).toHaveAttribute('aria-expanded', 'false');
       await expect(formPage.fundingAccordion).toHaveAttribute('aria-expanded', 'false');
-      await expect(formPage.collapseAllButtons).toHaveCount(0);
       await expect(formPage.expandAllButtons.first()).toBeVisible();
 
       await formPage.expandAllButtons.first().click();
@@ -60,7 +53,6 @@ test.describe('DataCite Form Validation UX', () => {
       await expect(formPage.resourceInfoAccordion).toHaveAttribute('aria-expanded', 'true');
       await expect(formPage.authorsAccordion).toHaveAttribute('aria-expanded', 'true');
       await expect(formPage.fundingAccordion).toHaveAttribute('aria-expanded', 'true');
-      await expect(formPage.expandAllButtons).toHaveCount(0);
       await expect(formPage.collapseAllButtons.first()).toBeVisible();
     });
   });

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -34,6 +34,36 @@ test.describe('DataCite Form Validation UX', () => {
     await formPage.goto();
     await formPage.waitForFormLoad();
   });
+
+  test.describe('Accordion Bulk Controls', () => {
+    test('collapses and expands all visible field groups', async () => {
+      await expect(formPage.usedInstrumentsAccordion).toBeVisible();
+
+      if (await formPage.expandAllButtons.count() > 0) {
+        await formPage.expandAllButtons.first().click();
+        await expect(formPage.expandAllButtons).toHaveCount(0);
+      }
+
+      await expect(formPage.collapseAllButtons.first()).toBeVisible();
+      await expect(formPage.expandAllButtons).toHaveCount(0);
+
+      await formPage.collapseAllButtons.first().click();
+
+      await expect(formPage.resourceInfoAccordion).toHaveAttribute('aria-expanded', 'false');
+      await expect(formPage.authorsAccordion).toHaveAttribute('aria-expanded', 'false');
+      await expect(formPage.fundingAccordion).toHaveAttribute('aria-expanded', 'false');
+      await expect(formPage.collapseAllButtons).toHaveCount(0);
+      await expect(formPage.expandAllButtons.first()).toBeVisible();
+
+      await formPage.expandAllButtons.first().click();
+
+      await expect(formPage.resourceInfoAccordion).toHaveAttribute('aria-expanded', 'true');
+      await expect(formPage.authorsAccordion).toHaveAttribute('aria-expanded', 'true');
+      await expect(formPage.fundingAccordion).toHaveAttribute('aria-expanded', 'true');
+      await expect(formPage.expandAllButtons).toHaveCount(0);
+      await expect(formPage.collapseAllButtons.first()).toBeVisible();
+    });
+  });
   
   test.describe('Inline Field Validation', () => {
     test('shows error for invalid year (out of range)', async ({ page }) => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -446,6 +446,39 @@ describe('DataCiteForm', () => {
             );
         });
 
+        it('preserves hidden conditional field groups when collapsing all visible field groups', () => {
+            mockUsePageProps.mockReturnValue({
+                curationAccordionOpenItems: ['resource-info', 'authors', 'funding-references', 'used-instruments'],
+            });
+            global.fetch = vi.fn((input: RequestInfo | URL) => {
+                const url = input.toString();
+
+                if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                    return Promise.resolve(createJsonResponse({ pid4inst: { available: false } }));
+                }
+
+                return createDefaultFetchResponse(url);
+            });
+
+            renderDataCiteForm();
+
+            fireEvent.click(screen.getAllByRole('button', { name: /Collapse all field groups/i })[0]);
+
+            expect(getAccordionTrigger(/Resource Information/i)).toHaveAttribute('aria-expanded', 'false');
+            expect(getAccordionTrigger(/Authors/i)).toHaveAttribute('aria-expanded', 'false');
+            expect(getAccordionTrigger(/Funding References/i)).toHaveAttribute('aria-expanded', 'false');
+            expect(mockRouterPut).toHaveBeenCalledWith(
+                '/settings/curation-accordion',
+                {
+                    open_items: ['used-instruments'],
+                },
+                expect.objectContaining({
+                    preserveScroll: true,
+                    preserveState: true,
+                }),
+            );
+        });
+
         it('expands every visible field group from a saved collapsed preference', async () => {
             mockUsePageProps.mockReturnValue({
                 curationAccordionOpenItems: [],
@@ -471,6 +504,31 @@ describe('DataCiteForm', () => {
                     preserveState: true,
                 }),
             );
+        });
+
+        it('preserves hidden conditional field groups when expanding all visible field groups', () => {
+            mockUsePageProps.mockReturnValue({
+                curationAccordionOpenItems: ['used-instruments'],
+            });
+            global.fetch = vi.fn((input: RequestInfo | URL) => {
+                const url = input.toString();
+
+                if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                    return Promise.resolve(createJsonResponse({ pid4inst: { available: false } }));
+                }
+
+                return createDefaultFetchResponse(url);
+            });
+
+            renderDataCiteForm();
+
+            fireEvent.click(screen.getAllByRole('button', { name: /Expand all field groups/i })[0]);
+
+            expect(getAccordionTrigger(/Resource Information/i)).toHaveAttribute('aria-expanded', 'true');
+            expect(getAccordionTrigger(/Authors/i)).toHaveAttribute('aria-expanded', 'true');
+            expect(getAccordionTrigger(/Funding References/i)).toHaveAttribute('aria-expanded', 'true');
+            const payload = mockRouterPut.mock.calls[0][1] as { open_items: string[] };
+            expect(payload.open_items).toEqual(expect.arrayContaining(['resource-info', 'authors', 'funding-references', 'used-instruments']));
         });
 
         it('does not include hidden conditional field groups when expanding all', async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -3030,6 +3030,7 @@ describe('DataCiteForm', () => {
         await fillRequiredContributor(user);
         await fillRequiredAbstract(user);
 
+        mockRouterPut.mockClear();
         await user.click(saveButton);
 
         expect(axios.post).toHaveBeenCalledWith(
@@ -3073,6 +3074,8 @@ describe('DataCiteForm', () => {
         expect(screen.getByRole('button', { name: /^A main title is required\.$/i })).toBeInTheDocument();
         // Should NOT redirect on validation failure (Issue #624)
         expect(mockRouterVisit).not.toHaveBeenCalled();
+        await new Promise((resolve) => setTimeout(resolve, 450));
+        expect(mockRouterPut).not.toHaveBeenCalled();
         },
     );
 
@@ -3348,6 +3351,10 @@ describe('DataCiteForm', () => {
         const fundingTrigger = getAccordionTrigger(/Funding References/i);
         await user.click(fundingTrigger);
         expect(fundingTrigger).toHaveAttribute('aria-expanded', 'false');
+        await waitFor(() => {
+            expect(mockRouterPut).toHaveBeenCalled();
+        });
+        mockRouterPut.mockClear();
 
         const fundingScrollSpy = vi.spyOn(fundingTrigger, 'scrollIntoView');
 
@@ -3357,6 +3364,8 @@ describe('DataCiteForm', () => {
             expect(fundingTrigger).toHaveAttribute('aria-expanded', 'true');
             expect(fundingScrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
         });
+        await new Promise((resolve) => setTimeout(resolve, 450));
+        expect(mockRouterPut).not.toHaveBeenCalled();
     });
 
     it(

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -43,10 +43,7 @@ vi.mock('sonner', () => ({
     },
 }));
 
-import {
-    getTagifyInstance,
-    type TagifyEnabledInput,
-} from '../../../tagify-helpers';
+import { getTagifyInstance, type TagifyEnabledInput } from '../../../tagify-helpers';
 
 const { createTagifyMock } = await vi.hoisted(() => import('@test-helpers/tagify-mock'));
 vi.mock('@yaireo/tagify', () => createTagifyMock());
@@ -143,7 +140,7 @@ describe('DataCiteForm', () => {
     const ensureAuthorsOpen = async (user: ReturnType<typeof userEvent.setup>) => {
         // Use getAllByRole and filter to avoid matching "Import authors from CSV" button
         const buttons = screen.getAllByRole('button', { name: /Authors/i });
-        const authorsTrigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const authorsTrigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!authorsTrigger) throw new Error('Authors accordion trigger not found');
         if (authorsTrigger.getAttribute('aria-expanded') === 'false') {
             await user.click(authorsTrigger);
@@ -153,7 +150,7 @@ describe('DataCiteForm', () => {
     const ensureContributorsOpen = async (user: ReturnType<typeof userEvent.setup>) => {
         // Use getAllByRole and filter to avoid matching "Import contributors from CSV" button
         const buttons = screen.getAllByRole('button', { name: /Contributors/i });
-        const contributorsTrigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const contributorsTrigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!contributorsTrigger) throw new Error('Contributors accordion trigger not found');
         if (contributorsTrigger.getAttribute('aria-expanded') === 'false') {
             await user.click(contributorsTrigger);
@@ -163,7 +160,7 @@ describe('DataCiteForm', () => {
     const ensureFreeKeywordsOpen = async (user: ReturnType<typeof userEvent.setup>) => {
         // Use getAllByRole and filter to find the accordion trigger (not the help button)
         const buttons = screen.getAllByRole('button', { name: /Free Keywords/i });
-        const freeKeywordsTrigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const freeKeywordsTrigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!freeKeywordsTrigger) throw new Error('Free Keywords accordion trigger not found');
         if (freeKeywordsTrigger.getAttribute('aria-expanded') === 'false') {
             await user.click(freeKeywordsTrigger);
@@ -173,7 +170,7 @@ describe('DataCiteForm', () => {
     const ensureControlledVocabulariesOpen = async (user: ReturnType<typeof userEvent.setup>) => {
         // Use getAllByRole and filter to find the accordion trigger (not the help button)
         const buttons = screen.getAllByRole('button', { name: /Controlled Vocabularies/i });
-        const controlledVocabTrigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const controlledVocabTrigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!controlledVocabTrigger) throw new Error('Controlled Vocabularies accordion trigger not found');
         if (controlledVocabTrigger.getAttribute('aria-expanded') === 'false') {
             await user.click(controlledVocabTrigger);
@@ -183,7 +180,7 @@ describe('DataCiteForm', () => {
     const ensureDatesOpen = async (user: ReturnType<typeof userEvent.setup>) => {
         // Use getAllByRole and filter to find the accordion trigger (not the help button)
         const buttons = screen.getAllByRole('button', { name: /Dates/i });
-        const datesTrigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const datesTrigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!datesTrigger) throw new Error('Dates accordion trigger not found');
         if (datesTrigger.getAttribute('aria-expanded') === 'false') {
             await user.click(datesTrigger);
@@ -194,7 +191,7 @@ describe('DataCiteForm', () => {
     // Helper to get accordion trigger by section name
     const getAccordionTrigger = (sectionName: RegExp | string): HTMLElement => {
         const buttons = screen.getAllByRole('button', { name: sectionName });
-        const trigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const trigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!trigger) throw new Error(`Accordion trigger for "${sectionName}" not found`);
         return trigger;
     };
@@ -207,20 +204,17 @@ describe('DataCiteForm', () => {
 
     const fillRequiredContributor = async (
         user: ReturnType<typeof userEvent.setup>,
-        {
-            lastName = 'Helper',
-            role = contributorPersonRoles[0]?.name ?? 'Researcher',
-        }: { lastName?: string; role?: string } = {},
+        { lastName = 'Helper', role = contributorPersonRoles[0]?.name ?? 'Researcher' }: { lastName?: string; role?: string } = {},
     ) => {
         await ensureContributorsOpen(user);
-        
+
         // Check if we need to add the first contributor
         const addFirstContributorButton = screen.queryByRole('button', { name: /Add [Ff]irst [Cc]ontributor/i });
         if (addFirstContributorButton) {
             await user.click(addFirstContributorButton);
         }
-        
-        const roleInput = await screen.findByTestId('contributor-0-roles-input') as TagifyEnabledInput;
+
+        const roleInput = (await screen.findByTestId('contributor-0-roles-input')) as TagifyEnabledInput;
 
         await waitFor(() => {
             expect(roleInput.tagify).toBeTruthy();
@@ -242,20 +236,17 @@ describe('DataCiteForm', () => {
         await user.type(lastNameInput, lastName);
     };
 
-    const fillRequiredAuthor = async (
-        user: ReturnType<typeof userEvent.setup>,
-        lastName = 'Curator',
-    ) => {
+    const fillRequiredAuthor = async (user: ReturnType<typeof userEvent.setup>, lastName = 'Curator') => {
         await ensureAuthorsOpen(user);
-        
+
         // Check if we need to add the first author
         const addFirstAuthorButton = screen.queryByRole('button', { name: /Add [Ff]irst [Aa]uthor/i });
         if (addFirstAuthorButton) {
             await user.click(addFirstAuthorButton);
         }
-        
+
         // Wait for the author section to be visible
-        const lastNameInput = await screen.findByRole('textbox', { name: /^Last name/ }) as HTMLInputElement;
+        const lastNameInput = (await screen.findByRole('textbox', { name: /^Last name/ })) as HTMLInputElement;
         if (lastNameInput.value) {
             await user.clear(lastNameInput);
         }
@@ -265,7 +256,7 @@ describe('DataCiteForm', () => {
     const ensureDescriptionsOpen = async (user: ReturnType<typeof userEvent.setup>) => {
         // Use getAllByRole and filter to find the accordion trigger (not the help button)
         const buttons = screen.getAllByRole('button', { name: /Descriptions/i });
-        const descriptionsTrigger = buttons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const descriptionsTrigger = buttons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!descriptionsTrigger) throw new Error('Descriptions accordion trigger not found');
         if (descriptionsTrigger.getAttribute('aria-expanded') === 'false') {
             await user.click(descriptionsTrigger);
@@ -280,6 +271,12 @@ describe('DataCiteForm', () => {
         const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
         await user.click(abstractTextarea);
         await user.keyboard(abstract);
+    };
+
+    const advanceAccordionPreferenceDebounce = async () => {
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(450);
+        });
     };
 
     beforeAll(() => {
@@ -309,11 +306,11 @@ describe('DataCiteForm', () => {
             isLoading: false,
             error: null,
         });
-        
+
         // Mock axios.post for form submission - return axios response format
         // Note: Vocabularies are loaded via fetch, not axios
         const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn>; isAxiosError: (error: unknown) => boolean };
-        
+
         // Axios response: { data, status, statusText, headers, config, request }
         mockedAxios.post = vi.fn().mockResolvedValue({
             data: { message: 'Success' },
@@ -322,15 +319,15 @@ describe('DataCiteForm', () => {
             headers: {},
             config: {},
         });
-        
+
         // Mock axios.isAxiosError helper - check for truthy isAxiosError flag
         mockedAxios.isAxiosError = (error: unknown) => {
             return error !== null && typeof error === 'object' && 'isAxiosError' in error && !!(error as { isAxiosError?: boolean }).isAxiosError;
         };
-        
+
         // Keep global.fetch mock for backward compatibility with other parts
         global.fetch = vi.fn((input: RequestInfo | URL) => createDefaultFetchResponse(input.toString()));
-        
+
         document.head.innerHTML = '<meta name="csrf-token" content="test-csrf-token">';
         clearXsrfCookie();
     });
@@ -372,7 +369,7 @@ describe('DataCiteForm', () => {
         { id: 4, name: 'Rights Holder', slug: 'rights-holder' },
     ];
     const authorRoles: Role[] = [{ id: 5, name: 'Author', slug: 'author' }];
-    
+
     const dateTypes: DateType[] = [
         { id: 1, name: 'Accepted', slug: 'accepted', description: 'The date that the publisher accepted the resource.' },
         { id: 2, name: 'Available', slug: 'available', description: 'The date the resource is made publicly available.' },
@@ -501,24 +498,21 @@ describe('DataCiteForm', () => {
         });
     });
 
-    it(
-        'renders fields, title options and supports adding/removing titles',
-        { timeout: 60000 },
-        async () => {
-            render(
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                    licenses={licenses}
-                    languages={languages}
-                    contributorPersonRoles={contributorPersonRoles}
-                    contributorInstitutionRoles={contributorInstitutionRoles}
-                    authorRoles={authorRoles}
+    it('renders fields, title options and supports adding/removing titles', { timeout: 60000 }, async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
-            );
+        );
         expect(useRorAffiliations).toHaveBeenCalled();
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 
@@ -526,15 +520,15 @@ describe('DataCiteForm', () => {
         const resourceTrigger = getAccordionTrigger(/Resource Information/i);
         // Use getAllByRole and filter for Authors/Contributors to avoid matching Import CSV buttons
         const authorsButtons = screen.getAllByRole('button', { name: /Authors/i });
-        const authorsTrigger = authorsButtons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const authorsTrigger = authorsButtons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!authorsTrigger) throw new Error('Authors accordion trigger not found');
-        
+
         const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
-        
+
         const contributorsButtons = screen.getAllByRole('button', { name: /Contributors/i });
-        const contributorsTrigger = contributorsButtons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const contributorsTrigger = contributorsButtons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!contributorsTrigger) throw new Error('Contributors accordion trigger not found');
-        
+
         expect(resourceTrigger).toHaveAttribute('aria-expanded', 'true');
         expect(authorsTrigger).toHaveAttribute('aria-expanded', 'true');
         expect(licensesTrigger).toHaveAttribute('aria-expanded', 'true');
@@ -553,9 +547,7 @@ describe('DataCiteForm', () => {
         // resource type option
         const resourceTypeTrigger = screen.getByLabelText('Resource Type', { exact: false });
         await user.click(resourceTypeTrigger);
-        expect(
-            await screen.findByRole('option', { name: 'Dataset' }),
-        ).toBeInTheDocument();
+        expect(await screen.findByRole('option', { name: 'Dataset' })).toBeInTheDocument();
 
         // language options
         const languageTrigger = screen.getByLabelText('Language of Data', {
@@ -566,9 +558,7 @@ describe('DataCiteForm', () => {
         expect(languageLabel).toHaveTextContent('*');
         await user.click(languageTrigger);
         for (const option of languages) {
-            expect(
-                await screen.findByRole('option', { name: option.name }),
-            ).toBeInTheDocument();
+            expect(await screen.findByRole('option', { name: option.name })).toBeInTheDocument();
         }
         await user.keyboard('{Escape}');
 
@@ -580,9 +570,7 @@ describe('DataCiteForm', () => {
         expect(licenseTrigger).toHaveAttribute('aria-required', 'true');
         const licenseLabel = screen.getAllByText('License', { selector: 'label' })[0];
         expect(licenseLabel).toHaveTextContent('*');
-        expect(
-            screen.queryByRole('button', { name: 'Add license' }),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Add license' })).not.toBeInTheDocument();
         await user.click(licenseTrigger);
         const mitOption = await screen.findByRole('option', {
             name: 'MIT License',
@@ -595,12 +583,8 @@ describe('DataCiteForm', () => {
         });
         expect(licenseTriggers).toHaveLength(2);
         expect(licenseTriggers[1]).not.toHaveAttribute('aria-required', 'true');
-        expect(
-            screen.getByRole('button', { name: 'Remove license' }),
-        ).toBeInTheDocument();
-        expect(
-            screen.queryByRole('button', { name: 'Add license' }),
-        ).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Remove license' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Add license' })).not.toBeInTheDocument();
 
         // title fields
         const titleInput = screen.getByRole('textbox', { name: /Title/ });
@@ -609,13 +593,13 @@ describe('DataCiteForm', () => {
         expect(titleTypeTrigger).toHaveTextContent('Main Title');
 
         await ensureAuthorsOpen(user);
-        
+
         // Add first author
         const addFirstAuthorButton = await screen.findByRole('button', { name: /Add [Ff]irst [Aa]uthor/i });
         await user.click(addFirstAuthorButton);
-        
+
         await ensureContributorsOpen(user);
-        
+
         // Add first contributor
         const addFirstContributorButton = await screen.findByRole('button', { name: /Add [Ff]irst [Cc]ontributor/i });
         await user.click(addFirstContributorButton);
@@ -631,9 +615,7 @@ describe('DataCiteForm', () => {
         expect(await screen.findByText('Contributor type')).toBeInTheDocument();
         expect(screen.getByLabelText(/^Roles/)).toBeInTheDocument();
         // After adding first contributor, button text changes - use more flexible pattern
-        expect(
-            screen.getAllByRole('button', { name: /Add.*contributor/i }).length,
-        ).toBeGreaterThan(0);
+        expect(screen.getAllByRole('button', { name: /Add.*contributor/i }).length).toBeGreaterThan(0);
 
         // add and remove title rows
         const addButton = screen.getByRole('button', { name: 'Add title' });
@@ -649,15 +631,11 @@ describe('DataCiteForm', () => {
         })[1];
         expect(secondTitleTypeTrigger).toHaveTextContent('Subtitle');
         await user.click(secondTitleTypeTrigger);
-        expect(
-            screen.queryByRole('option', { name: 'Main Title' }),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Main Title' })).not.toBeInTheDocument();
         await user.click(secondTitleTypeTrigger);
         const removeButton = screen.getByRole('button', { name: 'Remove title' });
         await user.click(removeButton);
-        expect(
-            screen.getAllByRole('textbox', { name: /Title/ }),
-        ).toHaveLength(1);
+        expect(screen.getAllByRole('textbox', { name: /Title/ })).toHaveLength(1);
     });
 
     it('gives the datacenter field more grid width and keeps long selected datacenter badges wrapped', () => {
@@ -700,7 +678,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -712,7 +690,7 @@ describe('DataCiteForm', () => {
         );
 
         await ensureAuthorsOpen(user);
-        
+
         const message = await screen.findByTestId('author-roles-availability');
         expect(message).toHaveTextContent('The available author role is Author.');
         expect(message).toHaveAttribute('id', 'author-roles-description');
@@ -720,7 +698,7 @@ describe('DataCiteForm', () => {
         // Add first author to make the author-entries-group visible
         const addFirstAuthorButton = await screen.findByRole('button', { name: /Add [Ff]irst [Aa]uthor/i });
         await user.click(addFirstAuthorButton);
-        
+
         const group = await screen.findByTestId('author-entries-group');
         expect(group).toHaveAttribute('role', 'list');
         expect(group).toHaveAttribute('aria-describedby', 'author-roles-description');
@@ -731,7 +709,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -768,32 +746,28 @@ describe('DataCiteForm', () => {
         });
     });
 
-    it(
-        'save button is always enabled regardless of required fields (Issue #538)',
-        { timeout: 60000 },
-        async () => {
-            render(
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                    licenses={licenses}
-                    languages={languages}
-                    contributorPersonRoles={contributorPersonRoles}
-                    contributorInstitutionRoles={contributorInstitutionRoles}
-                    authorRoles={authorRoles}
-                    descriptionTypes={descriptionTypes}
-                    googleMapsApiKey="test-api-key"
-                />,
-            );
+    it('save button is always enabled regardless of required fields (Issue #538)', { timeout: 60000 }, async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
 
-            const saveButton = screen.getByRole('button', { name: 'Save & Validate' });
+        const saveButton = screen.getByRole('button', { name: 'Save & Validate' });
 
-            // Save button should always be enabled, even when required fields are empty
-            expect(saveButton).toBeEnabled();
-            expect(saveButton).toHaveAttribute('aria-disabled', 'false');
-        },
-    );
+        // Save button should always be enabled, even when required fields are empty
+        expect(saveButton).toBeEnabled();
+        expect(saveButton).toHaveAttribute('aria-disabled', 'false');
+    });
 
     it('shows the used instruments section when PID4INST is enabled', async () => {
         render(
@@ -1010,92 +984,84 @@ describe('DataCiteForm', () => {
         expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
-    it(
-        'shows validation error list when saving with missing required fields (Issue #538)',
-        { timeout: 60000 },
-        async () => {
-            const { container } = render(
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                    licenses={licenses}
-                    languages={languages}
-                    contributorPersonRoles={contributorPersonRoles}
-                    contributorInstitutionRoles={contributorInstitutionRoles}
-                    authorRoles={authorRoles}
-                    descriptionTypes={descriptionTypes}
-                    googleMapsApiKey="test-api-key"
-                />,
-            );
+    it('shows validation error list when saving with missing required fields (Issue #538)', { timeout: 60000 }, async () => {
+        const { container } = render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
 
-            // Submit the form without filling any required fields
-            const formElement = container.querySelector('form')!;
-            await act(async () => {
-                fireEvent.submit(formElement);
-            });
+        // Submit the form without filling any required fields
+        const formElement = container.querySelector('form')!;
+        await act(async () => {
+            fireEvent.submit(formElement);
+        });
 
-            // ValidationAlert should show with the error summary
-            await waitFor(() => {
-                expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
-            });
+        // ValidationAlert should show with the error summary
+        await waitFor(() => {
+            expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
+        });
 
-            // Individual missing field messages should be listed
-            expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: /^Resource Type is required\.$/i })).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: /^Primary License is required\.$/i })).toBeInTheDocument();
-        },
-    );
+        // Individual missing field messages should be listed
+        expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Resource Type is required\.$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Primary License is required\.$/i })).toBeInTheDocument();
+    });
 
-    it(
-        'shows validation error list on every save attempt, not just the first (Issue #538)',
-        { timeout: 60000 },
-        async () => {
-            const { container } = render(
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                    licenses={licenses}
-                    languages={languages}
-                    contributorPersonRoles={contributorPersonRoles}
-                    contributorInstitutionRoles={contributorInstitutionRoles}
-                    authorRoles={authorRoles}
-                    descriptionTypes={descriptionTypes}
-                    googleMapsApiKey="test-api-key"
-                />,
-            );
+    it('shows validation error list on every save attempt, not just the first (Issue #538)', { timeout: 60000 }, async () => {
+        const { container } = render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
 
-            const formElement = container.querySelector('form')!;
+        const formElement = container.querySelector('form')!;
 
-            // First save attempt
-            await act(async () => {
-                fireEvent.submit(formElement);
-            });
-            await waitFor(() => {
-                expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
-            });
-            expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
+        // First save attempt
+        await act(async () => {
+            fireEvent.submit(formElement);
+        });
+        await waitFor(() => {
+            expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
+        });
+        expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
 
-            // Second save attempt — error list must still appear
-            await act(async () => {
-                fireEvent.submit(formElement);
-            });
-            await waitFor(() => {
-                expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
-            });
-            expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
-        },
-    );
+        // Second save attempt — error list must still appear
+        await act(async () => {
+            fireEvent.submit(formElement);
+        });
+        await waitFor(() => {
+            expect(screen.getByText('Please complete all required fields before saving.')).toBeInTheDocument();
+        });
+        expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
+    });
 
     it('supports managing person and institution authors with affiliations', { timeout: 60000 }, async () => {
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1130,12 +1096,8 @@ describe('DataCiteForm', () => {
         expect(authorScope.getByRole('textbox', { name: /First name/i })).toBeInTheDocument();
 
         const affiliationField = authorScope.getByTestId('author-0-affiliations-field');
-        expect(
-            screen.queryByRole('button', { name: /Add affiliation/i }),
-        ).not.toBeInTheDocument();
-        expect(
-            screen.queryByText('Separate multiple affiliations with commas.'),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Add affiliation/i })).not.toBeInTheDocument();
+        expect(screen.queryByText('Separate multiple affiliations with commas.')).not.toBeInTheDocument();
 
         const affiliationInput = screen.getByTestId('author-0-affiliations-input') as TagifyEnabledInput;
 
@@ -1146,11 +1108,7 @@ describe('DataCiteForm', () => {
         const affiliationTagify = getTagifyInstance(affiliationInput);
 
         await act(async () => {
-            affiliationTagify.addTags(
-                ['University A', 'University B'],
-                true,
-                false,
-            );
+            affiliationTagify.addTags(['University A', 'University B'], true, false);
         });
 
         await waitFor(() => {
@@ -1163,15 +1121,15 @@ describe('DataCiteForm', () => {
         const addAuthorButtons = await screen.findAllByRole('button', { name: /Add.*author/i });
         await user.click(addAuthorButtons[0]);
         expect(screen.getAllByRole('heading', { name: /Author \d/ })).toHaveLength(2);
-        
+
         // After adding a second author, only the second author should have the Add button visible on desktop
         const updatedAddButtons = await screen.findAllByRole('button', { name: /Add.*author/i });
         expect(updatedAddButtons.length).toBeGreaterThanOrEqual(1);
-        
+
         const removeAuthorButton = screen.getByRole('button', { name: 'Remove author 2' });
         await user.click(removeAuthorButton);
         expect(screen.getAllByRole('heading', { name: /Author \d/ })).toHaveLength(1);
-        
+
         // After removing the second author, the Add button should be visible again
         expect((await screen.findAllByRole('button', { name: /Add.*author/i })).length).toBeGreaterThanOrEqual(1);
     });
@@ -1194,7 +1152,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1245,7 +1203,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1276,9 +1234,7 @@ describe('DataCiteForm', () => {
         });
 
         await waitFor(() => {
-            expect(
-                screen.queryByTestId('author-0-affiliations-ror-ids'),
-            ).not.toBeInTheDocument();
+            expect(screen.queryByTestId('author-0-affiliations-ror-ids')).not.toBeInTheDocument();
         });
     });
 
@@ -1287,7 +1243,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1305,7 +1261,6 @@ describe('DataCiteForm', () => {
                         ],
                     },
                 ]}
-            
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
@@ -1318,61 +1273,58 @@ describe('DataCiteForm', () => {
         expect(badgesContainer).toHaveTextContent('https://ror.org/02mhbdp94');
     });
 
-    it(
-        'supports adding, removing and managing multiple authors independently',
-        { timeout: 60000 },
-        async () => {
-            render(
-                <DataCiteForm
+    it('supports adding, removing and managing multiple authors independently', { timeout: 60000 }, async () => {
+        render(
+            <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
-                    contributorPersonRoles={contributorPersonRoles}
-                    contributorInstitutionRoles={contributorInstitutionRoles}
-                    authorRoles={authorRoles}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
-            );
+        );
 
-            const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
 
-            await ensureAuthorsOpen(user);
+        await ensureAuthorsOpen(user);
 
-            // Add the first author
-            const addFirstAuthorButton = await screen.findByRole('button', { name: /Add [Ff]irst [Aa]uthor/i });
-            await user.click(addFirstAuthorButton);
+        // Add the first author
+        const addFirstAuthorButton = await screen.findByRole('button', { name: /Add [Ff]irst [Aa]uthor/i });
+        await user.click(addFirstAuthorButton);
 
-            // Add more authors - button changes to "Add another author"
-            const getAddButtons = async () => await screen.findAllByRole('button', { name: /Add.*author/i });
-            
-            const authorGroup = screen.getByTestId('author-entries-group');
+        // Add more authors - button changes to "Add another author"
+        const getAddButtons = async () => await screen.findAllByRole('button', { name: /Add.*author/i });
 
-            const firstLastNameInput = within(authorGroup).getByRole('textbox', { name: /Last name/i });
-            await user.clear(firstLastNameInput);
-            await user.type(firstLastNameInput, 'First Author');
-            
-            await user.click((await getAddButtons())[0]);
-            
-            await waitFor(() => {
-                expect(screen.getByRole('heading', { name: 'Author 2' })).toBeInTheDocument();
-            });
-            
-            const secondLastNameInput = within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[1];
-            await user.clear(secondLastNameInput);
-            await user.type(secondLastNameInput, 'Second Author');
-            
-            await user.click((await getAddButtons())[0]);
-            
-            await waitFor(() => {
-                expect(screen.getByRole('heading', { name: 'Author 3' })).toBeInTheDocument();
-            });
-            
-            const thirdLastNameInput = within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[2];
-            await user.clear(thirdLastNameInput);
-            await user.type(thirdLastNameInput, 'Third Author');
+        const authorGroup = screen.getByTestId('author-entries-group');
+
+        const firstLastNameInput = within(authorGroup).getByRole('textbox', { name: /Last name/i });
+        await user.clear(firstLastNameInput);
+        await user.type(firstLastNameInput, 'First Author');
+
+        await user.click((await getAddButtons())[0]);
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { name: 'Author 2' })).toBeInTheDocument();
+        });
+
+        const secondLastNameInput = within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[1];
+        await user.clear(secondLastNameInput);
+        await user.type(secondLastNameInput, 'Second Author');
+
+        await user.click((await getAddButtons())[0]);
+
+        await waitFor(() => {
+            expect(screen.getByRole('heading', { name: 'Author 3' })).toBeInTheDocument();
+        });
+
+        const thirdLastNameInput = within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[2];
+        await user.clear(thirdLastNameInput);
+        await user.type(thirdLastNameInput, 'Third Author');
 
         // Verify all three authors are present
         expect(screen.getByRole('heading', { name: 'Author 1' })).toBeInTheDocument();
@@ -1389,12 +1341,8 @@ describe('DataCiteForm', () => {
 
         // Verify first and third are still persons
         expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })).toHaveLength(2);
-        expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[0]).toHaveValue(
-            'First Author',
-        );
-        expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[1]).toHaveValue(
-            'Third Author',
-        );
+        expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[0]).toHaveValue('First Author');
+        expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[1]).toHaveValue('Third Author');
 
         // Set first author as contact person
         const firstContactCheckbox = screen.getAllByRole('checkbox', { name: /Contact person/i })[0];
@@ -1439,9 +1387,7 @@ describe('DataCiteForm', () => {
         expect(screen.queryByRole('heading', { name: 'Author 3' })).not.toBeInTheDocument();
 
         // Former third author should now be second author
-        expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[1]).toHaveValue(
-            'Third Author',
-        );
+        expect(within(authorGroup).getAllByRole('textbox', { name: /Last name/i })[1]).toHaveValue('Third Author');
 
         // First author contact data should be preserved
         expect(screen.getByRole('textbox', { name: /Email address/i })).toHaveValue('first@example.com');
@@ -1449,8 +1395,8 @@ describe('DataCiteForm', () => {
 
         // Former third author affiliations should be preserved
         const secondAffiliationInput = screen.getAllByTestId(/author-\d+-affiliations-input/)[1] as TagifyEnabledInput;
-        const updatedAffiliationValues = getTagifyInstance(secondAffiliationInput).value
-            .map((tag) => tag.value)
+        const updatedAffiliationValues = getTagifyInstance(secondAffiliationInput)
+            .value.map((tag) => tag.value)
             .filter((value): value is string => Boolean(value));
         expect(updatedAffiliationValues).toContain('Institution X');
         expect(updatedAffiliationValues).toContain('Institution Y');
@@ -1467,26 +1413,23 @@ describe('DataCiteForm', () => {
         expect(screen.queryByRole('heading', { name: 'Author 2' })).not.toBeInTheDocument();
 
         // Remaining author should be the former third author
-        expect(within(authorGroup).getByRole('textbox', { name: /Last name/i })).toHaveValue(
-            'Third Author',
-        );
-        
+        expect(within(authorGroup).getByRole('textbox', { name: /Last name/i })).toHaveValue('Third Author');
+
         // Affiliations should be preserved
         const finalAffiliationInput = screen.getByTestId('author-0-affiliations-input') as TagifyEnabledInput;
-        const finalAffiliationValues = getTagifyInstance(finalAffiliationInput).value
-            .map((tag) => tag.value)
+        const finalAffiliationValues = getTagifyInstance(finalAffiliationInput)
+            .value.map((tag) => tag.value)
             .filter((value): value is string => Boolean(value));
         expect(finalAffiliationValues).toContain('Institution X');
         expect(finalAffiliationValues).toContain('Institution Y');
-    },
-    );
+    });
 
     it('applies responsive layout for author inputs', async () => {
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1520,17 +1463,9 @@ describe('DataCiteForm', () => {
         // Add author button is available after the first author is added
         expect(await screen.findByRole('button', { name: /Add.*author/i })).toBeInTheDocument();
         const authorScopeForLast = await getAuthorScope();
-        expect(
-            authorScopeForLast
-                .getByRole('textbox', { name: /Last name/i })
-                .closest('div'),
-        ).toHaveClass('md:col-span-3');
+        expect(authorScopeForLast.getByRole('textbox', { name: /Last name/i }).closest('div')).toHaveClass('md:col-span-3');
         const authorScopeForFirst = await getAuthorScope();
-        expect(
-            authorScopeForFirst
-                .getByRole('textbox', { name: /First name/i })
-                .closest('div'),
-        ).toHaveClass('md:col-span-3');
+        expect(authorScopeForFirst.getByRole('textbox', { name: /First name/i }).closest('div')).toHaveClass('md:col-span-3');
         const contactField = screen.getByTestId('author-0-contact-field');
         expect(contactField).toHaveClass('md:col-span-1');
         expect(contactField).toHaveClass('flex');
@@ -1543,12 +1478,8 @@ describe('DataCiteForm', () => {
         expect(affiliationGrid).toHaveClass('md:gap-x-3');
         // Affiliations field spans full 12 columns when contact person is not selected
         expect(affiliationContainer).toHaveClass('md:col-span-12');
-        expect(
-            screen.queryByText('Use the 16-digit ORCID identifier when available.')
-        ).not.toBeInTheDocument();
-        expect(
-            screen.queryByText('Provide details for this author and their affiliations.')
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText('Use the 16-digit ORCID identifier when available.')).not.toBeInTheDocument();
+        expect(screen.queryByText('Provide details for this author and their affiliations.')).not.toBeInTheDocument();
     });
 
     it('aligns contact fields alongside affiliations when marked as CP', async () => {
@@ -1556,7 +1487,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1579,9 +1510,7 @@ describe('DataCiteForm', () => {
 
         const affiliationGrid = screen.getByTestId('author-0-affiliations-grid');
         const affiliationContainer = screen.getByTestId('author-0-affiliations-field');
-        const emailContainer = screen
-            .getByRole('textbox', { name: /Email address/i })
-            .closest('div');
+        const emailContainer = screen.getByRole('textbox', { name: /Email address/i }).closest('div');
         const websiteContainer = screen.getByRole('textbox', { name: /Website/i }).closest('div');
 
         expect(affiliationGrid).toHaveClass('md:grid-cols-12');
@@ -1596,7 +1525,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1610,7 +1539,7 @@ describe('DataCiteForm', () => {
         const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
         // Use getAllByRole and filter to avoid matching "Import authors from CSV" button
         const authorsButtons = screen.getAllByRole('button', { name: /Authors/i });
-        const authorsTrigger = authorsButtons.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+        const authorsTrigger = authorsButtons.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
         if (!authorsTrigger) throw new Error('Authors accordion trigger not found');
 
         const position = licensesTrigger.compareDocumentPosition(authorsTrigger);
@@ -1622,7 +1551,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1648,86 +1577,79 @@ describe('DataCiteForm', () => {
 
         const tooltip = await screen.findByRole('tooltip');
         expect(tooltip).toBeVisible();
-        expect(tooltip).toHaveTextContent(
-            'Contact Person: Select if this author should be the primary contact.'
-        );
+        expect(tooltip).toHaveTextContent('Contact Person: Select if this author should be the primary contact.');
 
         const contactCheckbox = screen.getByRole('checkbox', { name: /Contact person/i });
         expect(contactCheckbox).toBeInTheDocument();
     });
 
     // TODO: Test skipped due to flaky timeout issues - needs investigation
-    it.skip(
-        'requires an email address when a person author is marked as contact',
-        { timeout: 60000 },
-        async () => {
-            render(
-                <DataCiteForm
-                    resourceTypes={resourceTypes}
-                    titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                    licenses={licenses}
-                    languages={languages}
-                    contributorPersonRoles={contributorPersonRoles}
-                    contributorInstitutionRoles={contributorInstitutionRoles}
-                    authorRoles={authorRoles}
+    it.skip('requires an email address when a person author is marked as contact', { timeout: 60000 }, async () => {
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
-            );
+        );
 
-            const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
 
-            const saveButton = screen.getByRole('button', { name: 'Save & Validate' });
+        const saveButton = screen.getByRole('button', { name: 'Save & Validate' });
 
-            const titleInput = screen.getByRole('textbox', { name: /Title/ });
-            await user.type(titleInput, 'Contact Title');
-            await user.type(screen.getByLabelText('Year', { exact: false }), '2025');
-            await fillRequiredAuthor(user, 'Meyer');
-            await fillRequiredContributor(user);
+        const titleInput = screen.getByRole('textbox', { name: /Title/ });
+        await user.type(titleInput, 'Contact Title');
+        await user.type(screen.getByLabelText('Year', { exact: false }), '2025');
+        await fillRequiredAuthor(user, 'Meyer');
+        await fillRequiredContributor(user);
 
-            await user.click(screen.getByLabelText('Resource Type', { exact: false }));
-            await user.click(await screen.findByRole('option', { name: 'Dataset' }));
+        await user.click(screen.getByLabelText('Resource Type', { exact: false }));
+        await user.click(await screen.findByRole('option', { name: 'Dataset' }));
 
-            await user.click(screen.getByLabelText('Language of Data', { exact: false }));
-            await user.click(await screen.findByRole('option', { name: 'German' }));
+        await user.click(screen.getByLabelText('Language of Data', { exact: false }));
+        await user.click(await screen.findByRole('option', { name: 'German' }));
 
-            const licenseTrigger = screen.getAllByLabelText(/^License/, {
-                selector: 'button',
-            })[0];
-            await user.click(licenseTrigger);
-            await user.click(await screen.findByRole('option', { name: 'MIT License' }));
+        const licenseTrigger = screen.getAllByLabelText(/^License/, {
+            selector: 'button',
+        })[0];
+        await user.click(licenseTrigger);
+        await user.click(await screen.findByRole('option', { name: 'MIT License' }));
 
-            await ensureAuthorsOpen(user);
+        await ensureAuthorsOpen(user);
 
-            const contactCheckbox = screen.getByRole('checkbox', { name: /Contact person/i });
-            await user.click(contactCheckbox);
+        const contactCheckbox = screen.getByRole('checkbox', { name: /Contact person/i });
+        await user.click(contactCheckbox);
 
-            const emailInput = await screen.findByRole('textbox', { name: /Email address/i });
-            expect(emailInput).toBeRequired();
-            expect(screen.getByRole('textbox', { name: /Website/i })).toBeInTheDocument();
-            expect(screen.queryByRole('textbox', { name: /Website \(optional\)/i })).not.toBeInTheDocument();
-            expect(saveButton).toBeDisabled();
+        const emailInput = await screen.findByRole('textbox', { name: /Email address/i });
+        expect(emailInput).toBeRequired();
+        expect(screen.getByRole('textbox', { name: /Website/i })).toBeInTheDocument();
+        expect(screen.queryByRole('textbox', { name: /Website \(optional\)/i })).not.toBeInTheDocument();
+        expect(saveButton).toBeDisabled();
 
-            await user.type(emailInput, 'contact@example.org');
-            await fillRequiredAbstract(user);
+        await user.type(emailInput, 'contact@example.org');
+        await fillRequiredAbstract(user);
 
-
-            await waitFor(
-                () => {
-                    expect(saveButton).toBeEnabled();
-                },
-                { timeout: 10000 },
-            );
-        },
-    );
+        await waitFor(
+            () => {
+                expect(saveButton).toBeEnabled();
+            },
+            { timeout: 10000 },
+        );
+    });
 
     it('prefills DOI when initialDoi is provided', () => {
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1746,7 +1668,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1765,7 +1687,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1835,7 +1757,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1865,7 +1787,6 @@ describe('DataCiteForm', () => {
                         ],
                     },
                 ]}
-            
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
@@ -1885,13 +1806,9 @@ describe('DataCiteForm', () => {
         }) as HTMLInputElement[];
         expect(lastNameInputs[0]).toHaveValue('Hernandez');
 
-        expect(authorScope.getByLabelText('ORCID')).toHaveValue(
-            '0000-0002-2771-9344',
-        );
+        expect(authorScope.getByLabelText('ORCID')).toHaveValue('0000-0002-2771-9344');
 
-        expect(
-            (authorScope.getByRole('textbox', { name: /Institution name/i })) as HTMLInputElement,
-        ).toHaveValue('Example Organization');
+        expect(authorScope.getByRole('textbox', { name: /Institution name/i }) as HTMLInputElement).toHaveValue('Example Organization');
 
         expect(screen.getAllByText('GFZ Data Services').length).toBeGreaterThan(0);
         expect(screen.getAllByText('Independent Collaboration').length).toBeGreaterThan(0);
@@ -1904,7 +1821,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -1917,17 +1834,13 @@ describe('DataCiteForm', () => {
                         orcid: 'https://orcid.org/0000-0001-5727-2427',
                         firstName: 'Ada',
                         lastName: 'Lovelace',
-                        affiliations: [
-                            { value: 'Example Affiliation', rorId: 'https://ror.org/04wxnsj81' },
-                        ],
+                        affiliations: [{ value: 'Example Affiliation', rorId: 'https://ror.org/04wxnsj81' }],
                     },
                     {
                         type: 'institution',
                         roles: ['Distributor'],
                         institutionName: 'Example Org',
-                        affiliations: [
-                            { value: 'Example Org', rorId: 'https://ror.org/03yrm5c26' },
-                        ],
+                        affiliations: [{ value: 'Example Org', rorId: 'https://ror.org/03yrm5c26' }],
                     },
                 ]}
                 descriptionTypes={descriptionTypes}
@@ -1937,18 +1850,12 @@ describe('DataCiteForm', () => {
 
         await ensureContributorsOpen(user);
 
-        const contributorRoleInput = screen.getByTestId(
-            'contributor-0-roles-input',
-        ) as HTMLInputElement;
+        const contributorRoleInput = screen.getByTestId('contributor-0-roles-input') as HTMLInputElement;
         expect(contributorRoleInput.value).toBe('Contact Person');
 
-        const contributorSection = screen
-            .getByRole('heading', { name: 'Contributor 1' })
-            .closest('section') as HTMLElement;
+        const contributorSection = screen.getByRole('heading', { name: 'Contributor 1' }).closest('section') as HTMLElement;
 
-        const contributorOrcidField = within(
-            screen.getByTestId('contributor-0-orcid-field'),
-        ).getByRole('textbox') as HTMLInputElement;
+        const contributorOrcidField = within(screen.getByTestId('contributor-0-orcid-field')).getByRole('textbox') as HTMLInputElement;
         expect(contributorOrcidField.value).toBe('0000-0001-5727-2427');
 
         const contributorFirstNameField = within(contributorSection).getByLabelText('First name', {
@@ -1961,15 +1868,11 @@ describe('DataCiteForm', () => {
         }) as HTMLInputElement;
         expect(contributorLastNameField.value).toBe('Lovelace');
 
-        const contributorAffiliationsInput = screen.getByTestId(
-            'contributor-0-affiliations-input',
-        ) as HTMLInputElement;
+        const contributorAffiliationsInput = screen.getByTestId('contributor-0-affiliations-input') as HTMLInputElement;
         expect(contributorAffiliationsInput.value).toBe('Example Affiliation');
         expect(screen.getByTestId('contributor-0-affiliations-ror-ids')).toBeInTheDocument();
 
-        const institutionSection = screen
-            .getByRole('heading', { name: 'Contributor 2' })
-            .closest('section') as HTMLElement;
+        const institutionSection = screen.getByRole('heading', { name: 'Contributor 2' }).closest('section') as HTMLElement;
 
         const institutionRolesInput = screen.getByTestId('contributor-1-roles-input') as HTMLInputElement;
         expect(institutionRolesInput.value).toBe('Distributor');
@@ -1979,9 +1882,7 @@ describe('DataCiteForm', () => {
         }) as HTMLInputElement;
         expect(institutionNameInput.value).toBe('Example Org');
 
-        const institutionAffiliationsInput = screen.getByTestId(
-            'contributor-1-affiliations-input',
-        ) as HTMLInputElement;
+        const institutionAffiliationsInput = screen.getByTestId('contributor-1-affiliations-input') as HTMLInputElement;
         expect(institutionAffiliationsInput.value).toBe('Example Org');
         expect(screen.getByTestId('contributor-1-affiliations-ror-ids')).toBeInTheDocument();
     });
@@ -1993,7 +1894,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2014,9 +1915,7 @@ describe('DataCiteForm', () => {
 
         await ensureContributorsOpen(user);
 
-        const contributorRoleInput = screen.getByTestId(
-            'contributor-0-roles-input',
-        ) as HTMLInputElement;
+        const contributorRoleInput = screen.getByTestId('contributor-0-roles-input') as HTMLInputElement;
 
         expect(contributorRoleInput.value).toBe('Contact Person, Data Curator');
     });
@@ -2028,7 +1927,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2054,33 +1953,21 @@ describe('DataCiteForm', () => {
 
         await ensureContributorsOpen(user);
 
-        const contributorSection = screen
-            .getByRole('heading', { name: 'Contributor 1' })
-            .closest('section') as HTMLElement;
+        const contributorSection = screen.getByRole('heading', { name: 'Contributor 1' }).closest('section') as HTMLElement;
 
-        const typeField = within(screen.getByTestId('contributor-0-type-field')).getByRole(
-            'combobox',
-        );
+        const typeField = within(screen.getByTestId('contributor-0-type-field')).getByRole('combobox');
         expect(typeField).toHaveTextContent('Institution');
 
         const rolesInput = screen.getByTestId('contributor-0-roles-input') as HTMLInputElement;
         expect(rolesInput.value).toBe('Research Group');
 
-        const institutionNameInput = within(contributorSection).getByDisplayValue(
-            'ExampleContributorRG',
-        ) as HTMLInputElement;
+        const institutionNameInput = within(contributorSection).getByDisplayValue('ExampleContributorRG') as HTMLInputElement;
         expect(institutionNameInput).toBeInTheDocument();
 
-        expect(
-            within(contributorSection).queryByLabelText('First name', { selector: 'input' }),
-        ).not.toBeInTheDocument();
-        expect(
-            within(contributorSection).queryByLabelText('Last name', { selector: 'input' }),
-        ).not.toBeInTheDocument();
+        expect(within(contributorSection).queryByLabelText('First name', { selector: 'input' })).not.toBeInTheDocument();
+        expect(within(contributorSection).queryByLabelText('Last name', { selector: 'input' })).not.toBeInTheDocument();
 
-        const affiliationsInput = screen.getByTestId(
-            'contributor-0-affiliations-input',
-        ) as HTMLInputElement;
+        const affiliationsInput = screen.getByTestId('contributor-0-affiliations-input') as HTMLInputElement;
         expect(affiliationsInput.value).toBe('ExampleOrganization');
 
         const rorList = screen.getByTestId('contributor-0-affiliations-ror-ids');
@@ -2094,7 +1981,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2118,7 +2005,6 @@ describe('DataCiteForm', () => {
                         ],
                     },
                 ]}
-            
                 descriptionTypes={descriptionTypes}
                 googleMapsApiKey="test-api-key"
             />,
@@ -2128,12 +2014,13 @@ describe('DataCiteForm', () => {
 
         // Verify that multiple tags were created (not just one tag with all affiliations)
         const affiliationField = screen.getByTestId('author-0-affiliations-field');
-        const tags = within(affiliationField).getAllByRole('generic', { hidden: true })
-            .filter(el => el.classList.contains('tagify__tag'));
-        
+        const tags = within(affiliationField)
+            .getAllByRole('generic', { hidden: true })
+            .filter((el) => el.classList.contains('tagify__tag'));
+
         // Should have exactly 2 separate tags
         expect(tags.length).toBe(2);
-        
+
         // Verify the tag contents
         expect(tags[0]).toHaveTextContent('GFZ German Research Centre for Geosciences, Potsdam, Germany');
         expect(tags[1]).toHaveTextContent('Seismological Research Centre of the OGS');
@@ -2151,7 +2038,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2184,12 +2071,13 @@ describe('DataCiteForm', () => {
 
         // Verify that multiple tags were created (not just one tag with all affiliations)
         const affiliationField = screen.getByTestId('contributor-0-affiliations-field');
-        const tags = within(affiliationField).getAllByRole('generic', { hidden: true })
-            .filter(el => el.classList.contains('tagify__tag'));
-        
+        const tags = within(affiliationField)
+            .getAllByRole('generic', { hidden: true })
+            .filter((el) => el.classList.contains('tagify__tag'));
+
         // Should have exactly 2 separate tags
         expect(tags.length).toBe(2);
-        
+
         // Verify the tag contents
         expect(tags[0]).toHaveTextContent('Luxembourg Institute of Science and Technology');
         expect(tags[1]).toHaveTextContent('Catchment and Eco-Hydrology Group');
@@ -2200,14 +2088,7 @@ describe('DataCiteForm', () => {
     });
 
     it('allows adding license when last entry filled and under limit', () => {
-        expect(
-            canAddLicense(
-                [
-                    { id: '1', license: 'MIT' },
-                ],
-                2,
-            ),
-        ).toBe(true);
+        expect(canAddLicense([{ id: '1', license: 'MIT' }], 2)).toBe(true);
     });
 
     it('prevents adding license when last entry is empty', () => {
@@ -2224,18 +2105,8 @@ describe('DataCiteForm', () => {
 
     it('determines whether titles can be added', () => {
         expect(canAddTitle([], 3)).toBe(false);
-        expect(
-            canAddTitle(
-                [{ id: '1', title: '', titleType: 'main-title' }],
-                3,
-            ),
-        ).toBe(false);
-        expect(
-            canAddTitle(
-                [{ id: '1', title: 'First', titleType: 'main-title' }],
-                3,
-            ),
-        ).toBe(true);
+        expect(canAddTitle([{ id: '1', title: '', titleType: 'main-title' }], 3)).toBe(false);
+        expect(canAddTitle([{ id: '1', title: 'First', titleType: 'main-title' }], 3)).toBe(true);
     });
 
     it('prefills Language when initialLanguage code is provided', () => {
@@ -2243,7 +2114,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2254,11 +2125,7 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'German',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('German');
     });
 
     it('defaults Language to English when initialLanguage is missing', () => {
@@ -2266,7 +2133,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2276,11 +2143,7 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'English',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('English');
     });
 
     it('defaults Language to English even when English is not the first option', () => {
@@ -2294,7 +2157,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={shuffledLanguages}
                 descriptionTypes={descriptionTypes}
@@ -2302,11 +2165,7 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'English',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('English');
     });
 
     it('prefills Language when initialLanguage name is provided', () => {
@@ -2314,7 +2173,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2325,11 +2184,7 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'German',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('German');
     });
 
     it('prefills French when initialLanguage indicates French', () => {
@@ -2337,7 +2192,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2348,11 +2203,7 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'French',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('French');
     });
 
     it('falls back to the first language with a code when English is unavailable', () => {
@@ -2365,7 +2216,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={limitedLanguages}
                 descriptionTypes={descriptionTypes}
@@ -2373,11 +2224,7 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'German',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('German');
     });
 
     it('defaults to English when languages include incomplete entries', () => {
@@ -2391,7 +2238,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={incompleteLanguages}
                 descriptionTypes={descriptionTypes}
@@ -2399,11 +2246,7 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(
-            screen.getByLabelText('Language of Data', { exact: false }),
-        ).toHaveTextContent(
-            'English',
-        );
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('English');
     });
 
     it('prefills Resource Type when initialResourceType is provided', () => {
@@ -2411,7 +2254,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2422,9 +2265,7 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(screen.getByLabelText('Resource Type', { exact: false })).toHaveTextContent(
-            'Dataset',
-        );
+        expect(screen.getByLabelText('Resource Type', { exact: false })).toHaveTextContent('Dataset');
     });
 
     it('prefills licenses when initialLicenses are provided', () => {
@@ -2432,7 +2273,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2453,7 +2294,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2483,7 +2324,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2527,7 +2368,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2545,9 +2386,7 @@ describe('DataCiteForm', () => {
         await user.click(addButton);
         let inputs = screen.getAllByRole('textbox', { name: /Title/ });
         expect(inputs[1]).not.toBeRequired();
-        let labels = screen
-            .getAllByText(/Title/, { selector: 'label' })
-            .filter((l) => ['Title', 'Title*'].includes(l.textContent?.trim() ?? ''));
+        let labels = screen.getAllByText(/Title/, { selector: 'label' }).filter((l) => ['Title', 'Title*'].includes(l.textContent?.trim() ?? ''));
         expect(labels[0]).toHaveTextContent('*');
         expect(labels[1]).not.toHaveTextContent('*');
 
@@ -2560,9 +2399,7 @@ describe('DataCiteForm', () => {
         await user.click(mainOption);
 
         inputs = screen.getAllByRole('textbox', { name: /Title/ });
-        labels = screen
-            .getAllByText(/Title/, { selector: 'label' })
-            .filter((l) => ['Title', 'Title*'].includes(l.textContent?.trim() ?? ''));
+        labels = screen.getAllByText(/Title/, { selector: 'label' }).filter((l) => ['Title', 'Title*'].includes(l.textContent?.trim() ?? ''));
         expect(inputs[0]).not.toBeRequired();
         expect(inputs[1]).toBeRequired();
         expect(labels[0]).not.toHaveTextContent('*');
@@ -2574,7 +2411,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2607,7 +2444,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2618,90 +2455,76 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(screen.getByRole('textbox', { name: /Title/ })).toHaveValue(
-            'A mandatory Event',
-        );
-        expect(screen.getByRole('combobox', { name: /Title Type/ })).toHaveTextContent(
-            'Main Title',
-        );
+        expect(screen.getByRole('textbox', { name: /Title/ })).toHaveValue('A mandatory Event');
+        expect(screen.getByRole('combobox', { name: /Title Type/ })).toHaveTextContent('Main Title');
     });
 
-    it(
-        'limits title rows to max titles',
-        async () => {
-            render(
-                <DataCiteForm
+    it('limits title rows to max titles', async () => {
+        render(
+            <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
                 contributorInstitutionRoles={contributorInstitutionRoles}
                 authorRoles={authorRoles}
                 maxTitles={3}
-                    descriptionTypes={descriptionTypes}
-                    googleMapsApiKey="test-api-key"
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
             />,
-            );
-            const user = userEvent.setup();
-            const addButton = screen.getByRole('button', { name: 'Add title' });
+        );
+        const user = userEvent.setup();
+        const addButton = screen.getByRole('button', { name: 'Add title' });
         const firstInput = screen.getByRole('textbox', { name: /Title/ });
-            await user.type(firstInput, 'One');
-            await user.click(addButton);
+        await user.type(firstInput, 'One');
+        await user.click(addButton);
         const secondInput = screen.getAllByRole('textbox', { name: /Title/ })[1];
-            await user.type(secondInput, 'Two');
-            await user.click(addButton);
-            expect(
-                screen.getAllByRole('textbox', { name: /Title/ }),
-            ).toHaveLength(3);
-            expect(addButton).toBeDisabled();
-        },
-        10000,
-    );
+        await user.type(secondInput, 'Two');
+        await user.click(addButton);
+        expect(screen.getAllByRole('textbox', { name: /Title/ })).toHaveLength(3);
+        expect(addButton).toBeDisabled();
+    }, 10000);
 
     /**
      * Helper function to get the save operation axios.post call from the mock.
      * The save operation is a POST request to /editor/resources using axios.
-     * 
+     *
      * Returns data in a format compatible with old fetch-based tests:
      * [url, { body: JSON.stringify(data), headers, method: 'POST', credentials: 'same-origin' }]
-     * 
+     *
      * @returns The save call in fetch-compatible format, or null if no save call was found
      * @throws Error if multiple save calls are found (unexpected test scenario)
      */
     const getSaveAxiosCall = () => {
         const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
         const axiosPostMock = mockedAxios.post;
-        
+
         if (!axiosPostMock || !axiosPostMock.mock) {
             return null;
         }
-        
+
         // Find all POST calls to /editor/resources
-        const saveCalls = axiosPostMock.mock.calls
-            .map((call, index) => ({ call, index }))
-            .filter(
-                ({ call }) => call[0] === '/editor/resources'
-            );
-        
+        const saveCalls = axiosPostMock.mock.calls.map((call, index) => ({ call, index })).filter(({ call }) => call[0] === '/editor/resources');
+
         // Validate: exactly zero or one save call expected in most tests
         if (saveCalls.length === 0) {
             return null;
         }
-        
+
         if (saveCalls.length > 1) {
             throw new Error(
                 `Expected at most one save call, but found ${saveCalls.length}. ` +
-                `This might indicate a test issue or unintended form submissions.`
+                    `This might indicate a test issue or unintended form submissions.`,
             );
         }
-        
+
         // Return in fetch-compatible format: [url, options]
         // axios.post(url, data, config) -> [url, { body, headers, method, credentials }]
         const call = axiosPostMock.mock.calls[saveCalls[0].index];
         const [url, data, config] = call;
-        
+
         return [
             url,
             {
@@ -2724,7 +2547,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2757,7 +2580,7 @@ describe('DataCiteForm', () => {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
                 }),
-            })
+            }),
         );
 
         // Get the save operation axios call
@@ -2766,14 +2589,14 @@ describe('DataCiteForm', () => {
         const fetchArgs = saveCall![1];
         expect(fetchArgs).toBeDefined();
         const headers = (fetchArgs as RequestInit).headers as Record<string, string>;
-        
+
         // Note: In real usage, axios interceptors would add CSRF headers automatically.
         // In tests, we verify that axios.post is called with proper structure.
         expect(headers).toMatchObject({
             'Content-Type': 'application/json',
             Accept: 'application/json',
         });
-        
+
         const body = JSON.parse((fetchArgs as RequestInit).body as string);
         expect(body).toMatchObject({
             year: 2024,
@@ -2802,9 +2625,12 @@ describe('DataCiteForm', () => {
 
         // Should redirect to resources list instead of showing modal (Issue #624)
         await waitFor(() => {
-            expect(mockRouterVisit).toHaveBeenCalledWith('/resources', expect.objectContaining({
-                onError: expect.any(Function),
-            }));
+            expect(mockRouterVisit).toHaveBeenCalledWith(
+                '/resources',
+                expect.objectContaining({
+                    onError: expect.any(Function),
+                }),
+            );
         });
 
         const { toast } = await import('sonner');
@@ -2821,7 +2647,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2871,9 +2697,12 @@ describe('DataCiteForm', () => {
 
         // Should redirect to resources list instead of showing modal (Issue #624)
         await waitFor(() => {
-            expect(mockRouterVisit).toHaveBeenCalledWith('/resources', expect.objectContaining({
-                onError: expect.any(Function),
-            }));
+            expect(mockRouterVisit).toHaveBeenCalledWith(
+                '/resources',
+                expect.objectContaining({
+                    onError: expect.any(Function),
+                }),
+            );
         });
 
         const { toast } = await import('sonner');
@@ -2885,7 +2714,7 @@ describe('DataCiteForm', () => {
 
         const responseData = { message: 'Stored' };
         const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
-        mockedAxios.post.mockResolvedValue({ 
+        mockedAxios.post.mockResolvedValue({
             data: responseData,
             status: 200,
             statusText: 'OK',
@@ -2895,7 +2724,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -2927,7 +2756,6 @@ describe('DataCiteForm', () => {
                         ],
                     },
                 ]}
-            
                 availableDatacenters={availableDatacenters}
                 initialDatacenters={[1]}
                 descriptionTypes={descriptionTypes}
@@ -2979,11 +2807,8 @@ describe('DataCiteForm', () => {
         ]);
     });
 
-    it(
-        'shows validation feedback when saving fails',
-        { timeout: 60000 },
-        async () => {
-            const user = userEvent.setup({ pointerEventsCheck: 0 });
+    it('shows validation feedback when saving fails', { timeout: 60000 }, async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
 
         const validationResponse = {
             message: 'Validation failed',
@@ -2993,7 +2818,7 @@ describe('DataCiteForm', () => {
         };
 
         const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
-        mockedAxios.post.mockRejectedValue({ 
+        mockedAxios.post.mockRejectedValue({
             response: {
                 status: 422,
                 data: validationResponse,
@@ -3005,7 +2830,7 @@ describe('DataCiteForm', () => {
             <DataCiteForm
                 resourceTypes={resourceTypes}
                 titleTypes={titleTypes}
-                    dateTypes={dateTypes}
+                dateTypes={dateTypes}
                 licenses={licenses}
                 languages={languages}
                 contributorPersonRoles={contributorPersonRoles}
@@ -3031,53 +2856,62 @@ describe('DataCiteForm', () => {
         await fillRequiredAbstract(user);
 
         mockRouterPut.mockClear();
-        await user.click(saveButton);
+        vi.useFakeTimers();
 
-        expect(axios.post).toHaveBeenCalledWith(
-            '/editor/resources',
-            expect.any(Object), // data payload
-            expect.any(Object)  // config (headers, etc.)
-        );
-        
-        // Get the save operation axios call
-        const saveCall = getSaveAxiosCall();
-        expect(saveCall).toBeDefined();
-        const fetchArgs = saveCall![1];
-        expect(fetchArgs).toBeDefined();
-        const headers = (fetchArgs as RequestInit).headers as Record<string, string>;
-        
-        // Note: In real usage, axios interceptors add CSRF headers.
-        // In tests with mocked axios, we verify basic request structure.
-        expect(headers).toMatchObject({
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-        });
-        
-        const body = JSON.parse((fetchArgs as RequestInit).body as string);
-        expect(body).toMatchObject({
-            licenses: ['MIT'],
-            titles: [
-                {
-                    title: 'Primary Dataset',
-                    titleType: 'main-title',
-                },
-                {
-                    title: 'Only Subtitle',
-                    titleType: 'subtitle',
-                },
-            ],
-        });
+        try {
+            await act(async () => {
+                fireEvent.click(saveButton);
+                await Promise.resolve();
+                await Promise.resolve();
+            });
 
-        await screen.findByText('Validation failed');
-        const alert = screen.getByTestId('global-validation-alert');
-        expect(alert).not.toBeNull();
-        expect(screen.getByRole('button', { name: /^A main title is required\.$/i })).toBeInTheDocument();
-        // Should NOT redirect on validation failure (Issue #624)
-        expect(mockRouterVisit).not.toHaveBeenCalled();
-        await new Promise((resolve) => setTimeout(resolve, 450));
-        expect(mockRouterPut).not.toHaveBeenCalled();
-        },
-    );
+            expect(axios.post).toHaveBeenCalledWith(
+                '/editor/resources',
+                expect.any(Object), // data payload
+                expect.any(Object), // config (headers, etc.)
+            );
+
+            // Get the save operation axios call
+            const saveCall = getSaveAxiosCall();
+            expect(saveCall).toBeDefined();
+            const fetchArgs = saveCall![1];
+            expect(fetchArgs).toBeDefined();
+            const headers = (fetchArgs as RequestInit).headers as Record<string, string>;
+
+            // Note: In real usage, axios interceptors add CSRF headers.
+            // In tests with mocked axios, we verify basic request structure.
+            expect(headers).toMatchObject({
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            });
+
+            const body = JSON.parse((fetchArgs as RequestInit).body as string);
+            expect(body).toMatchObject({
+                licenses: ['MIT'],
+                titles: [
+                    {
+                        title: 'Primary Dataset',
+                        titleType: 'main-title',
+                    },
+                    {
+                        title: 'Only Subtitle',
+                        titleType: 'subtitle',
+                    },
+                ],
+            });
+
+            expect(screen.getByText('Validation failed')).toBeInTheDocument();
+            const alert = screen.getByTestId('global-validation-alert');
+            expect(alert).not.toBeNull();
+            expect(screen.getByRole('button', { name: /^A main title is required\.$/i })).toBeInTheDocument();
+            // Should NOT redirect on validation failure (Issue #624)
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+            await advanceAccordionPreferenceDebounce();
+            expect(mockRouterPut).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 
     it('marks the datacenter field invalid for backend datacenter element errors', { timeout: 20000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -3344,7 +3178,9 @@ describe('DataCiteForm', () => {
         await user.click(screen.getByRole('button', { name: /save & validate/i }));
 
         await waitFor(() => {
-            expect(screen.getByRole('button', { name: /^Please fix the validation errors in the Funding References section before submitting\.$/i })).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: /^Please fix the validation errors in the Funding References section before submitting\.$/i }),
+            ).toBeInTheDocument();
         });
         expect(axios.post).not.toHaveBeenCalled();
 
@@ -3358,26 +3194,214 @@ describe('DataCiteForm', () => {
 
         const fundingScrollSpy = vi.spyOn(fundingTrigger, 'scrollIntoView');
 
-        await user.click(screen.getByRole('button', { name: /^Please fix the validation errors in the Funding References section before submitting\.$/i }));
+        vi.useFakeTimers();
 
-        await waitFor(() => {
+        try {
+            fireEvent.click(
+                screen.getByRole('button', { name: /^Please fix the validation errors in the Funding References section before submitting\.$/i }),
+            );
             expect(fundingTrigger).toHaveAttribute('aria-expanded', 'true');
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(200);
+            });
+
             expect(fundingScrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
-        });
-        await new Promise((resolve) => setTimeout(resolve, 450));
-        expect(mockRouterPut).not.toHaveBeenCalled();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(250);
+            });
+
+            expect(mockRouterPut).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
-    it(
-        'shows a network error message when saving throws',
-        { timeout: 60000 },
-        async () => {
-            const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    it('shows a network error message when saving throws', { timeout: 60000 }, async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-            // Mock axios.post to throw a network error
-            const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
-            mockedAxios.post.mockRejectedValue(new Error('Network Error'));
+        // Mock axios.post to throw a network error
+        const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+        mockedAxios.post.mockRejectedValue(new Error('Network Error'));
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                initialLicenses={['MIT']}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const saveButton = screen.getByRole('button', { name: /save & validate/i });
+        await fillRequiredAuthor(user);
+        await fillRequiredContributor(user);
+        await fillRequiredAbstract(user);
+
+        await waitFor(() => expect(saveButton).toBeEnabled(), { timeout: 10000 });
+        await user.click(saveButton);
+
+        await waitFor(() => {
+            expect(axios.post).toHaveBeenCalled();
+        });
+
+        // Use findAllByRole and filter to find the network error alert specifically
+        const alerts = await screen.findAllByRole('alert');
+        const networkErrorAlert = alerts.find((alert) => alert.textContent?.includes('A network error prevented saving the resource'));
+        expect(networkErrorAlert).toBeDefined();
+        expect(networkErrorAlert).toHaveTextContent('A network error prevented saving the resource. Please try again.');
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to save resource', expect.any(Error));
+    });
+
+    describe('Descriptions', () => {
+        it('renders the Descriptions accordion section', () => {
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    dateTypes={dateTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
+
+            expect(getAccordionTrigger(/Descriptions/i)).toBeInTheDocument();
+        });
+
+        it('shows Abstract validation error when saving without Abstract (Issue #538)', async () => {
+            const user = userEvent.setup();
+            const { container } = render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    dateTypes={dateTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    initialYear="2024"
+                    initialResourceType="1"
+                    initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                    initialLicenses={['MIT']}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
+
+            await fillRequiredAuthor(user);
+            await fillRequiredContributor(user);
+
+            const saveButton = screen.getByRole('button', { name: /save & validate/i });
+            // Save button should be enabled even without Abstract
+            expect(saveButton).toBeEnabled();
+
+            // Submit the form — should show validation error about missing Abstract
+            const formElement = container.querySelector('form')!;
+            await act(async () => {
+                fireEvent.submit(formElement);
+            });
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /^Abstract is required\.$/i })).toBeInTheDocument();
+            });
+        });
+
+        it('save button remains enabled when Abstract is filled', { timeout: 60000 }, async () => {
+            const user = userEvent.setup();
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    dateTypes={dateTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    initialYear="2024"
+                    initialResourceType="1"
+                    initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                    initialLicenses={['MIT']}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
+
+            await fillRequiredAuthor(user);
+            await fillRequiredContributor(user);
+
+            // Fill Abstract
+            const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
+            await user.type(abstractTextarea, 'This is a sufficiently long abstract for save button coverage.');
+
+            const saveButton = screen.getByRole('button', { name: /save & validate/i });
+            await waitFor(() => expect(saveButton).toBeEnabled());
+        });
+
+        it('blocks Save & Validate when Abstract is shorter than 50 characters', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
+                    dateTypes={dateTypes}
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    initialYear="2024"
+                    initialResourceType="1"
+                    initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                    initialLicenses={['MIT']}
+                    availableDatacenters={availableDatacenters}
+                    initialDatacenters={[1]}
+                    initialAuthors={[
+                        {
+                            type: 'person',
+                            lastName: 'Curator',
+                        },
+                    ]}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
+
+            const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
+            await user.type(abstractTextarea, 'Short abstract');
+
+            await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', { name: /^Abstract must be at least 50 characters \(current: 14\)$/i })).toBeInTheDocument();
+            });
+            expect(axios.post).not.toHaveBeenCalled();
+        });
+
+        it('includes descriptions in the payload when submitting', { timeout: 60000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            const responseData = { message: 'Success', resource: { id: 1 } };
+            (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({ data: responseData, status: 200 });
 
             render(
                 <DataCiteForm
@@ -3400,346 +3424,153 @@ describe('DataCiteForm', () => {
                 />,
             );
 
-            const saveButton = screen.getByRole('button', { name: /save & validate/i });
             await fillRequiredAuthor(user);
             await fillRequiredContributor(user);
-            await fillRequiredAbstract(user);
 
-            await waitFor(() => expect(saveButton).toBeEnabled(), { timeout: 10000 });
+            // Fill Abstract (required)
+            const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
+            await user.type(abstractTextarea, 'This is a sufficiently long abstract for payload submission tests.');
+
+            // Fill Methods (optional)
+            const methodsTab = screen.getByRole('tab', { name: /^Methods$/i });
+            await user.click(methodsTab);
+            const methodsTextarea = screen.getByRole('textbox', { name: /Methods/i });
+            await user.type(methodsTextarea, 'Test methodology');
+
+            const saveButton = screen.getByRole('button', { name: /save & validate/i });
+            await waitFor(() => expect(saveButton).toBeEnabled());
             await user.click(saveButton);
 
             await waitFor(() => {
                 expect(axios.post).toHaveBeenCalled();
             });
 
-            // Use findAllByRole and filter to find the network error alert specifically
-            const alerts = await screen.findAllByRole('alert');
-            const networkErrorAlert = alerts.find(alert => 
-                alert.textContent?.includes('A network error prevented saving the resource')
+            // Get the save operation fetch call
+            const fetchCall = getSaveAxiosCall();
+            expect(fetchCall).toBeDefined();
+            const requestBody = JSON.parse(fetchCall![1].body);
+
+            expect(requestBody.descriptions).toBeDefined();
+            expect(requestBody.descriptions).toHaveLength(2);
+            expect(requestBody.descriptions).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        descriptionType: 'Abstract',
+                        description: 'This is a sufficiently long abstract for payload submission tests.',
+                    }),
+                    expect.objectContaining({
+                        descriptionType: 'Methods',
+                        description: 'Test methodology',
+                    }),
+                ]),
             );
-            expect(networkErrorAlert).toBeDefined();
-            expect(networkErrorAlert).toHaveTextContent(
-                'A network error prevented saving the resource. Please try again.',
-            );
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'Failed to save resource',
-                expect.any(Error),
-            );
-        },
-    );
+        }); // Increased timeout for this long-running test with multiple user interactions
 
-    describe('Descriptions', () => {
-        it('renders the Descriptions accordion section', () => {
-            render(
-                <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
-
-        expect(getAccordionTrigger(/Descriptions/i)).toBeInTheDocument();
-    });
-
-    it('shows Abstract validation error when saving without Abstract (Issue #538)', async () => {
-        const user = userEvent.setup();
-        const { container } = render(
-            <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                initialYear="2024"
-                initialResourceType="1"
-                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
-                initialLicenses={['MIT']}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
-
-        await fillRequiredAuthor(user);
-        await fillRequiredContributor(user);
-
-        const saveButton = screen.getByRole('button', { name: /save & validate/i });
-        // Save button should be enabled even without Abstract
-        expect(saveButton).toBeEnabled();
-
-        // Submit the form — should show validation error about missing Abstract
-        const formElement = container.querySelector('form')!;
-        await act(async () => {
-            fireEvent.submit(formElement);
-        });
-        await waitFor(() => {
-            expect(screen.getByRole('button', { name: /^Abstract is required\.$/i })).toBeInTheDocument();
-        });
-    });
-
-    it('save button remains enabled when Abstract is filled', { timeout: 60000 }, async () => {
-        const user = userEvent.setup();
-        render(
-            <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                initialYear="2024"
-                initialResourceType="1"
-                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
-                initialLicenses={['MIT']}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
-
-        await fillRequiredAuthor(user);
-        await fillRequiredContributor(user);
-
-
-        // Fill Abstract
-        const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'This is a sufficiently long abstract for save button coverage.');
-
-        const saveButton = screen.getByRole('button', { name: /save & validate/i });
-        await waitFor(() => expect(saveButton).toBeEnabled());
-    });
-
-    it('blocks Save & Validate when Abstract is shorter than 50 characters', async () => {
-        const user = userEvent.setup({ pointerEventsCheck: 0 });
-        render(
-            <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
-                dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                initialYear="2024"
-                initialResourceType="1"
-                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
-                initialLicenses={['MIT']}
-                availableDatacenters={availableDatacenters}
-                initialDatacenters={[1]}
-                initialAuthors={[
-                    {
-                        type: 'person',
-                        lastName: 'Curator',
-                    },
-                ]}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
-
-        const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'Short abstract');
-
-        await user.click(screen.getByRole('button', { name: /save & validate/i }));
-
-        await waitFor(() => {
-            expect(screen.getByRole('button', { name: /^Abstract must be at least 50 characters \(current: 14\)$/i })).toBeInTheDocument();
-        });
-        expect(axios.post).not.toHaveBeenCalled();
-    });
-
-    it(
-        'includes descriptions in the payload when submitting',
-        { timeout: 60000 },
-        async () => {
+        it('does not include empty descriptions in the payload', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
 
-        const responseData = { message: 'Success', resource: { id: 1 } };
-        (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({ data: responseData, status: 200 });
+            const responseData = { message: 'Success', resource: { id: 1 } };
+            (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({ data: responseData, status: 200 });
 
-        render(
-            <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
                     dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                initialYear="2024"
-                initialResourceType="1"
-                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
-                initialLicenses={['MIT']}
-                availableDatacenters={availableDatacenters}
-                initialDatacenters={[1]}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    initialYear="2024"
+                    initialResourceType="1"
+                    initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                    initialLicenses={['MIT']}
+                    availableDatacenters={availableDatacenters}
+                    initialDatacenters={[1]}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
 
-        await fillRequiredAuthor(user);
-        await fillRequiredContributor(user);
+            await fillRequiredAuthor(user);
+            await fillRequiredContributor(user);
 
+            // Fill only Abstract
+            const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
+            await user.type(abstractTextarea, 'This is a sufficiently long abstract for payload submission tests.');
 
-        // Fill Abstract (required)
-        const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'This is a sufficiently long abstract for payload submission tests.');
+            const saveButton = screen.getByRole('button', { name: /save & validate/i });
+            await waitFor(() => expect(saveButton).toBeEnabled());
+            await user.click(saveButton);
 
-        // Fill Methods (optional)
-        const methodsTab = screen.getByRole('tab', { name: /^Methods$/i });
-        await user.click(methodsTab);
-        const methodsTextarea = screen.getByRole('textbox', { name: /Methods/i });
-        await user.type(methodsTextarea, 'Test methodology');
+            await waitFor(() => {
+                expect(axios.post).toHaveBeenCalled();
+            });
 
-        const saveButton = screen.getByRole('button', { name: /save & validate/i });
-        await waitFor(() => expect(saveButton).toBeEnabled());
-        await user.click(saveButton);
+            // Get the save operation fetch call
+            const fetchCall = getSaveAxiosCall();
+            expect(fetchCall).toBeDefined();
+            const requestBody = JSON.parse(fetchCall![1].body);
 
-        await waitFor(() => {
-            expect(axios.post).toHaveBeenCalled();
+            expect(requestBody.descriptions).toBeDefined();
+            expect(requestBody.descriptions).toHaveLength(1);
+            expect(requestBody.descriptions[0]).toEqual({
+                descriptionType: 'Abstract',
+                description: 'This is a sufficiently long abstract for payload submission tests.',
+                language: null,
+            });
         });
 
-        // Get the save operation fetch call
-        const fetchCall = getSaveAxiosCall();
-        expect(fetchCall).toBeDefined();
-        const requestBody = JSON.parse(fetchCall![1].body);
+        it('trims whitespace from description values', { timeout: 60000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
 
-        expect(requestBody.descriptions).toBeDefined();
-        expect(requestBody.descriptions).toHaveLength(2);
-        expect(requestBody.descriptions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    descriptionType: 'Abstract',
-                    description: 'This is a sufficiently long abstract for payload submission tests.',
-                }),
-                expect.objectContaining({
-                    descriptionType: 'Methods',
-                    description: 'Test methodology',
-                }),
-            ]),
-        );
-        },
-    ); // Increased timeout for this long-running test with multiple user interactions
+            const responseData = { message: 'Success', resource: { id: 1 } };
+            (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({ data: responseData, status: 200 });
 
-    it('does not include empty descriptions in the payload', { timeout: 30000 }, async () => {
-        const user = userEvent.setup({ pointerEventsCheck: 0 });
-
-        const responseData = { message: 'Success', resource: { id: 1 } };
-        (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({ data: responseData, status: 200 });
-
-        render(
-            <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
+            render(
+                <DataCiteForm
+                    resourceTypes={resourceTypes}
+                    titleTypes={titleTypes}
                     dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                initialYear="2024"
-                initialResourceType="1"
-                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
-                initialLicenses={['MIT']}
-                availableDatacenters={availableDatacenters}
-                initialDatacenters={[1]}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
+                    licenses={licenses}
+                    languages={languages}
+                    contributorPersonRoles={contributorPersonRoles}
+                    contributorInstitutionRoles={contributorInstitutionRoles}
+                    authorRoles={authorRoles}
+                    initialYear="2024"
+                    initialResourceType="1"
+                    initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
+                    initialLicenses={['MIT']}
+                    availableDatacenters={availableDatacenters}
+                    initialDatacenters={[1]}
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
+            );
 
-        await fillRequiredAuthor(user);
-        await fillRequiredContributor(user);
+            await fillRequiredAuthor(user);
+            await fillRequiredContributor(user);
 
+            // Fill Abstract with whitespace
+            const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
+            await user.type(abstractTextarea, '   This is a sufficiently long abstract with spaces for trimming tests.   ');
 
-        // Fill only Abstract
-        const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, 'This is a sufficiently long abstract for payload submission tests.');
+            const saveButton = screen.getByRole('button', { name: /save & validate/i });
+            await waitFor(() => expect(saveButton).toBeEnabled());
+            await user.click(saveButton);
 
-        const saveButton = screen.getByRole('button', { name: /save & validate/i });
-        await waitFor(() => expect(saveButton).toBeEnabled());
-        await user.click(saveButton);
+            await waitFor(() => {
+                expect(axios.post).toHaveBeenCalled();
+            });
 
-        await waitFor(() => {
-            expect(axios.post).toHaveBeenCalled();
+            // Get the save operation fetch call
+            const fetchCall = getSaveAxiosCall();
+            expect(fetchCall).toBeDefined();
+            const requestBody = JSON.parse(fetchCall![1].body);
+
+            expect(requestBody.descriptions[0].description).toBe('This is a sufficiently long abstract with spaces for trimming tests.');
         });
-
-        // Get the save operation fetch call
-        const fetchCall = getSaveAxiosCall();
-        expect(fetchCall).toBeDefined();
-        const requestBody = JSON.parse(fetchCall![1].body);
-
-        expect(requestBody.descriptions).toBeDefined();
-        expect(requestBody.descriptions).toHaveLength(1);
-        expect(requestBody.descriptions[0]).toEqual({
-            descriptionType: 'Abstract',
-            description: 'This is a sufficiently long abstract for payload submission tests.',
-            language: null,
-        });
-    });
-
-    it('trims whitespace from description values', { timeout: 60000 }, async () => {
-        const user = userEvent.setup({ pointerEventsCheck: 0 });
-
-        const responseData = { message: 'Success', resource: { id: 1 } };
-        (axios as unknown as { post: ReturnType<typeof vi.fn> }).post.mockResolvedValue({ data: responseData, status: 200 });
-
-        render(
-            <DataCiteForm
-                resourceTypes={resourceTypes}
-                titleTypes={titleTypes}
-                    dateTypes={dateTypes}
-                licenses={licenses}
-                languages={languages}
-                contributorPersonRoles={contributorPersonRoles}
-                contributorInstitutionRoles={contributorInstitutionRoles}
-                authorRoles={authorRoles}
-                initialYear="2024"
-                initialResourceType="1"
-                initialTitles={[{ title: 'Primary Title', titleType: 'main-title' }]}
-                initialLicenses={['MIT']}
-                availableDatacenters={availableDatacenters}
-                initialDatacenters={[1]}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
-        );
-
-        await fillRequiredAuthor(user);
-        await fillRequiredContributor(user);
-
-
-        // Fill Abstract with whitespace
-        const abstractTextarea = screen.getByRole('textbox', { name: /Abstract/i });
-        await user.type(abstractTextarea, '   This is a sufficiently long abstract with spaces for trimming tests.   ');
-
-        const saveButton = screen.getByRole('button', { name: /save & validate/i });
-        await waitFor(() => expect(saveButton).toBeEnabled());
-        await user.click(saveButton);
-
-        await waitFor(() => {
-            expect(axios.post).toHaveBeenCalled();
-        });
-
-        // Get the save operation fetch call
-        const fetchCall = getSaveAxiosCall();
-        expect(fetchCall).toBeDefined();
-        const requestBody = JSON.parse(fetchCall![1].body);
-
-        expect(requestBody.descriptions[0].description).toBe('This is a sufficiently long abstract with spaces for trimming tests.');
-    });
     });
 
     describe('Dates Form Group', () => {
@@ -3754,9 +3585,9 @@ describe('DataCiteForm', () => {
                     contributorPersonRoles={contributorPersonRoles}
                     contributorInstitutionRoles={contributorInstitutionRoles}
                     authorRoles={authorRoles}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
             );
 
             const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -3776,9 +3607,9 @@ describe('DataCiteForm', () => {
                     contributorPersonRoles={contributorPersonRoles}
                     contributorInstitutionRoles={contributorInstitutionRoles}
                     authorRoles={authorRoles}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
             );
 
             // No date fields should be present by default since Created/Updated are auto-managed
@@ -3797,9 +3628,9 @@ describe('DataCiteForm', () => {
                     contributorPersonRoles={contributorPersonRoles}
                     contributorInstitutionRoles={contributorInstitutionRoles}
                     authorRoles={authorRoles}
-                descriptionTypes={descriptionTypes}
-                googleMapsApiKey="test-api-key"
-            />,
+                    descriptionTypes={descriptionTypes}
+                    googleMapsApiKey="test-api-key"
+                />,
             );
             const user = userEvent.setup({ pointerEventsCheck: 0 });
 
@@ -3810,17 +3641,15 @@ describe('DataCiteForm', () => {
             // Find all comboboxes - one is the date picker, one is the date type select
             const allComboboxes = screen.getAllByRole('combobox');
             // DatePicker comboboxes contain "Select date" text
-            const datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            const datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes.length).toBeGreaterThanOrEqual(1);
-            
+
             // Verify 'Created' and 'Updated' are not available in dropdown
-            const dateTypeTriggers = allComboboxes.filter(el => 
-                el.getAttribute('id')?.includes('dateType')
-            );
+            const dateTypeTriggers = allComboboxes.filter((el) => el.getAttribute('id')?.includes('dateType'));
             await user.click(dateTypeTriggers[0]);
-            
+
             const createdOption = screen.queryByRole('option', { name: 'Created' });
             const updatedOption = screen.queryByRole('option', { name: 'Updated' });
             expect(createdOption).not.toBeInTheDocument();
@@ -3850,8 +3679,8 @@ describe('DataCiteForm', () => {
 
             // Should have 2 date picker comboboxes from initialDates
             let allComboboxes = screen.getAllByRole('combobox');
-            let datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            let datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes).toHaveLength(2);
 
@@ -3860,8 +3689,8 @@ describe('DataCiteForm', () => {
             await user.click(removeButton);
 
             allComboboxes = screen.getAllByRole('combobox');
-            datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes).toHaveLength(1);
         });
@@ -3887,15 +3716,13 @@ describe('DataCiteForm', () => {
             const addButton = screen.getByRole('button', { name: 'Add date' });
             await user.click(addButton);
 
-            const dateTypeTriggers = screen.getAllByRole('combobox').filter(el => 
-                el.getAttribute('id')?.includes('dateType')
-            );
+            const dateTypeTriggers = screen.getAllByRole('combobox').filter((el) => el.getAttribute('id')?.includes('dateType'));
             await user.click(dateTypeTriggers[1]);
 
             // 'Accepted' should not be available since it's already used
             const acceptedOption = screen.queryByRole('option', { name: 'Accepted' });
             expect(acceptedOption).not.toBeInTheDocument();
-            
+
             // 'Created' and 'Updated' should also not be available (auto-managed)
             const createdOption = screen.queryByRole('option', { name: 'Created' });
             const updatedOption = screen.queryByRole('option', { name: 'Updated' });
@@ -3944,8 +3771,8 @@ describe('DataCiteForm', () => {
             // "valid" date type should have both start and end date fields (date range)
             // DatePicker uses combobox role
             const allComboboxes = screen.getAllByRole('combobox');
-            const datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            const datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes).toHaveLength(2);
         });
@@ -3970,17 +3797,15 @@ describe('DataCiteForm', () => {
 
             // Initially, "valid" type should have both date pickers with values displayed
             let allComboboxes = screen.getAllByRole('combobox');
-            let datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            let datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes).toHaveLength(2);
             expect(datePickerComboboxes[0]).toHaveTextContent('2024-01-01');
             expect(datePickerComboboxes[1]).toHaveTextContent('2024-12-31');
 
             // Open the date type selector and change to "accepted" (since Created is auto-managed)
-            const dateTypeTrigger = allComboboxes.find(el => 
-                el.getAttribute('id')?.includes('dateType')
-            );
+            const dateTypeTrigger = allComboboxes.find((el) => el.getAttribute('id')?.includes('dateType'));
             expect(dateTypeTrigger).toBeDefined();
             if (dateTypeTrigger) {
                 await user.click(dateTypeTrigger);
@@ -3990,8 +3815,8 @@ describe('DataCiteForm', () => {
 
             // After changing to "accepted", should only have 1 date picker
             allComboboxes = screen.getAllByRole('combobox');
-            datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes).toHaveLength(1);
             // startDate should be preserved
@@ -4022,8 +3847,8 @@ describe('DataCiteForm', () => {
             // Only 'accepted' should be shown, 'created' and 'updated' are auto-managed
             // DatePicker uses combobox role
             const allComboboxes = screen.getAllByRole('combobox');
-            const datePickerComboboxes = allComboboxes.filter(el => 
-                el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || '')
+            const datePickerComboboxes = allComboboxes.filter(
+                (el) => el.textContent?.includes('Select date') || /\d{4}-\d{2}-\d{2}/.test(el.textContent || ''),
             );
             expect(datePickerComboboxes).toHaveLength(1);
             expect(datePickerComboboxes[0]).toHaveTextContent('2024-01-10');
@@ -4038,7 +3863,7 @@ describe('DataCiteForm', () => {
 
         it('should show toast notification when MSL trigger keyword is added', async () => {
             const { toast } = await import('sonner');
-            
+
             render(
                 <DataCiteForm
                     resourceTypes={resourceTypes}
@@ -4059,8 +3884,8 @@ describe('DataCiteForm', () => {
             await ensureFreeKeywordsOpen(user);
 
             // Find the free keywords input
-            const freeKeywordsInput = await screen.findByTestId('free-keywords-input') as TagifyEnabledInput;
-            
+            const freeKeywordsInput = (await screen.findByTestId('free-keywords-input')) as TagifyEnabledInput;
+
             await waitFor(() => {
                 expect(freeKeywordsInput.tagify).toBeTruthy();
             });
@@ -4085,7 +3910,7 @@ describe('DataCiteForm', () => {
 
         it('should show toast notification when MSL keyword is added', async () => {
             const { toast } = await import('sonner');
-            
+
             render(
                 <DataCiteForm
                     resourceTypes={resourceTypes}
@@ -4105,8 +3930,8 @@ describe('DataCiteForm', () => {
             // Open Free Keywords section
             await ensureFreeKeywordsOpen(user);
 
-            const freeKeywordsInput = await screen.findByTestId('free-keywords-input') as TagifyEnabledInput;
-            
+            const freeKeywordsInput = (await screen.findByTestId('free-keywords-input')) as TagifyEnabledInput;
+
             await waitFor(() => {
                 expect(freeKeywordsInput.tagify).toBeTruthy();
             });
@@ -4126,7 +3951,7 @@ describe('DataCiteForm', () => {
 
         it('should NOT show toast notification when initial data contains MSL keywords', async () => {
             const { toast } = await import('sonner');
-            
+
             render(
                 <DataCiteForm
                     resourceTypes={resourceTypes}
@@ -4144,14 +3969,17 @@ describe('DataCiteForm', () => {
             );
 
             // Wait a bit to ensure any potential toast would have been called
-            await waitFor(() => {
-                expect(toast.info).not.toHaveBeenCalled();
-            }, { timeout: 1000 });
+            await waitFor(
+                () => {
+                    expect(toast.info).not.toHaveBeenCalled();
+                },
+                { timeout: 1000 },
+            );
         });
 
         it('should NOT show toast notification when MSL keyword from old dataset', async () => {
             const { toast } = await import('sonner');
-            
+
             render(
                 <DataCiteForm
                     resourceTypes={resourceTypes}
@@ -4169,9 +3997,12 @@ describe('DataCiteForm', () => {
             );
 
             // Wait a bit to ensure any potential toast would have been called
-            await waitFor(() => {
-                expect(toast.info).not.toHaveBeenCalled();
-            }, { timeout: 1000 });
+            await waitFor(
+                () => {
+                    expect(toast.info).not.toHaveBeenCalled();
+                },
+                { timeout: 1000 },
+            );
         });
 
         it('should show MSL Laboratories section when EPOS keyword is added', async () => {
@@ -4196,13 +4027,13 @@ describe('DataCiteForm', () => {
 
             // Open Free Keywords section - use getAllByRole and filter for accordion trigger
             const freeKeywordsTriggers = screen.getAllByRole('button', { name: /Free Keywords/i });
-            const freeKeywordsTrigger = freeKeywordsTriggers.find(btn => btn.getAttribute('data-slot') === 'accordion-trigger');
+            const freeKeywordsTrigger = freeKeywordsTriggers.find((btn) => btn.getAttribute('data-slot') === 'accordion-trigger');
             if (freeKeywordsTrigger && freeKeywordsTrigger.getAttribute('aria-expanded') === 'false') {
                 await user.click(freeKeywordsTrigger);
             }
 
-            const freeKeywordsInput = await screen.findByTestId('free-keywords-input') as TagifyEnabledInput;
-            
+            const freeKeywordsInput = (await screen.findByTestId('free-keywords-input')) as TagifyEnabledInput;
+
             await waitFor(() => {
                 expect(freeKeywordsInput.tagify).toBeTruthy();
             });
@@ -4249,8 +4080,8 @@ describe('DataCiteForm', () => {
             // Open Free Keywords section and add EPOS keyword
             await ensureFreeKeywordsOpen(user);
 
-            const freeKeywordsInput = await screen.findByTestId('free-keywords-input') as TagifyEnabledInput;
-            
+            const freeKeywordsInput = (await screen.findByTestId('free-keywords-input')) as TagifyEnabledInput;
+
             await waitFor(() => {
                 expect(freeKeywordsInput.tagify).toBeTruthy();
             });
@@ -4309,7 +4140,7 @@ describe('DataCiteForm', () => {
 
         it('should only notify once when multiple MSL keywords are added', async () => {
             const { toast } = await import('sonner');
-            
+
             render(
                 <DataCiteForm
                     resourceTypes={resourceTypes}
@@ -4329,8 +4160,8 @@ describe('DataCiteForm', () => {
             // Open Free Keywords section
             await ensureFreeKeywordsOpen(user);
 
-            const freeKeywordsInput = await screen.findByTestId('free-keywords-input') as TagifyEnabledInput;
-            
+            const freeKeywordsInput = (await screen.findByTestId('free-keywords-input')) as TagifyEnabledInput;
+
             await waitFor(() => {
                 expect(freeKeywordsInput.tagify).toBeTruthy();
             });
@@ -4377,8 +4208,8 @@ describe('DataCiteForm', () => {
             // Open Free Keywords section
             await ensureFreeKeywordsOpen(user);
 
-            const freeKeywordsInput = await screen.findByTestId('free-keywords-input') as TagifyEnabledInput;
-            
+            const freeKeywordsInput = (await screen.findByTestId('free-keywords-input')) as TagifyEnabledInput;
+
             await waitFor(() => {
                 expect(freeKeywordsInput.tagify).toBeTruthy();
             });
@@ -4524,9 +4355,7 @@ describe('DataCiteForm', () => {
 
             const [url, data] = mockedAxios.post.mock.calls[0];
             expect(url).toBe('/editor/resources/draft');
-            expect(data.titles).toEqual([
-                { title: 'Draft Dataset', titleType: 'main-title', language: null },
-            ]);
+            expect(data.titles).toEqual([{ title: 'Draft Dataset', titleType: 'main-title', language: null }]);
         });
 
         it('redirects to resources after draft save (Issue #624)', { timeout: 60000 }, async () => {
@@ -4570,9 +4399,12 @@ describe('DataCiteForm', () => {
 
             // Should redirect to resources list (Issue #624)
             await waitFor(() => {
-                expect(mockRouterVisit).toHaveBeenCalledWith('/resources', expect.objectContaining({
-                    onError: expect.any(Function),
-                }));
+                expect(mockRouterVisit).toHaveBeenCalledWith(
+                    '/resources',
+                    expect.objectContaining({
+                        onError: expect.any(Function),
+                    }),
+                );
             });
 
             const { toast } = await import('sonner');
@@ -4636,9 +4468,12 @@ describe('DataCiteForm', () => {
 
             const { toast } = await import('sonner');
             expect(toast.success).toHaveBeenCalledWith('Resource saved!');
-            expect(toast.success).toHaveBeenCalledWith('DataCite metadata synchronized', expect.objectContaining({
-                description: 'DOI 10.5880/test.2024.001 has been updated.',
-            }));
+            expect(toast.success).toHaveBeenCalledWith(
+                'DataCite metadata synchronized',
+                expect.objectContaining({
+                    description: 'DOI 10.5880/test.2024.001 has been updated.',
+                }),
+            );
         });
 
         it('shows DataCite sync warning toast on redirect', { timeout: 60000 }, async () => {
@@ -4673,9 +4508,12 @@ describe('DataCiteForm', () => {
 
             const { toast } = await import('sonner');
             expect(toast.success).toHaveBeenCalledWith('Resource saved!');
-            expect(toast.warning).toHaveBeenCalledWith('DataCite update failed', expect.objectContaining({
-                description: 'API timeout',
-            }));
+            expect(toast.warning).toHaveBeenCalledWith(
+                'DataCite update failed',
+                expect.objectContaining({
+                    description: 'API timeout',
+                }),
+            );
         });
 
         it('handles null DOI in DataCite sync toast gracefully', { timeout: 60000 }, async () => {
@@ -4710,9 +4548,12 @@ describe('DataCiteForm', () => {
 
             const { toast } = await import('sonner');
             // Should use fallback description when DOI is null
-            expect(toast.success).toHaveBeenCalledWith('DataCite metadata synchronized', expect.objectContaining({
-                description: 'Metadata has been updated.',
-            }));
+            expect(toast.success).toHaveBeenCalledWith(
+                'DataCite metadata synchronized',
+                expect.objectContaining({
+                    description: 'Metadata has been updated.',
+                }),
+            );
         });
 
         it('shows warning toast when navigation fails after successful save', { timeout: 60000 }, async () => {
@@ -5047,8 +4888,8 @@ describe('DataCiteForm', () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
             await ensureAuthorsOpen(user);
 
-            const addButton = screen.queryByRole('button', { name: /Add [Ff]irst [Aa]uthor/i })
-                ?? screen.getByRole('button', { name: /Add [Aa]uthor/i });
+            const addButton =
+                screen.queryByRole('button', { name: /Add [Ff]irst [Aa]uthor/i }) ?? screen.getByRole('button', { name: /Add [Aa]uthor/i });
             await user.click(addButton);
 
             expect(screen.queryByText('Last name is required', { exact: false })).not.toBeInTheDocument();
@@ -5105,9 +4946,12 @@ describe('DataCiteForm', () => {
 
             // Should redirect to resources list (Issue #624)
             await waitFor(() => {
-                expect(mockRouterVisit).toHaveBeenCalledWith('/resources', expect.objectContaining({
-                    onError: expect.any(Function),
-                }));
+                expect(mockRouterVisit).toHaveBeenCalledWith(
+                    '/resources',
+                    expect.objectContaining({
+                        onError: expect.any(Function),
+                    }),
+                );
             });
 
             // Should NOT show success modal
@@ -5147,9 +4991,12 @@ describe('DataCiteForm', () => {
 
             // Should redirect to resources after draft save (Issue #624)
             await waitFor(() => {
-                expect(mockRouterVisit).toHaveBeenCalledWith('/resources', expect.objectContaining({
-                    onError: expect.any(Function),
-                }));
+                expect(mockRouterVisit).toHaveBeenCalledWith(
+                    '/resources',
+                    expect.objectContaining({
+                        onError: expect.any(Function),
+                    }),
+                );
             });
         });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -3195,6 +3195,10 @@ describe('DataCiteForm', () => {
         const fundingScrollSpy = vi.spyOn(fundingTrigger, 'scrollIntoView');
 
         vi.useFakeTimers();
+        const animationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            cb(performance.now());
+            return 1;
+        });
 
         try {
             fireEvent.click(
@@ -3214,6 +3218,7 @@ describe('DataCiteForm', () => {
 
             expect(mockRouterPut).not.toHaveBeenCalled();
         } finally {
+            animationFrameSpy.mockRestore();
             vi.useRealTimers();
         }
     });

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -496,6 +496,36 @@ describe('DataCiteForm', () => {
             expect(payload.open_items).not.toContain('msl-laboratories');
             expect(payload.open_items).not.toContain('used-instruments');
         });
+
+        it('preserves hidden conditional field groups when toggling a visible field group', async () => {
+            mockUsePageProps.mockReturnValue({
+                curationAccordionOpenItems: ['resource-info', 'used-instruments'],
+            });
+            global.fetch = vi.fn((input: RequestInfo | URL) => {
+                const url = input.toString();
+
+                if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                    return Promise.resolve(createJsonResponse({ pid4inst: { available: false } }));
+                }
+
+                return createDefaultFetchResponse(url);
+            });
+
+            renderDataCiteForm();
+            vi.useFakeTimers();
+
+            try {
+                fireEvent.click(getAccordionTrigger(/Resource Information/i));
+                await advanceAccordionPreferenceDebounce();
+            } finally {
+                vi.useRealTimers();
+            }
+
+            expect(getAccordionTrigger(/Resource Information/i)).toHaveAttribute('aria-expanded', 'false');
+            const payload = mockRouterPut.mock.calls[0][1] as { open_items: string[] };
+            expect(payload.open_items).toContain('used-instruments');
+            expect(payload.open_items).not.toContain('resource-info');
+        });
     });
 
     it('renders fields, title options and supports adding/removing titles', { timeout: 60000 }, async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -5,14 +5,18 @@ import { act, fireEvent, render, screen, waitFor, within } from '@tests/vitest/u
 import axios from 'axios';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
-import DataCiteForm, { canAddLicense, canAddTitle } from '@/components/curation/datacite-form';
+import DataCiteForm, { canAddLicense, canAddTitle, type DataCiteFormProps } from '@/components/curation/datacite-form';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
 import type { DateType, DescriptionType, Language, License, ResourceType, Role, TitleType } from '@/types';
 
-const { mockRouterVisit } = vi.hoisted(() => ({
+const { mockRouterPut, mockRouterVisit, mockUsePageProps } = vi.hoisted(() => ({
+    mockRouterPut: vi.fn(),
     mockRouterVisit: vi.fn().mockImplementation((_url: string, options?: { onSuccess?: () => void }) => {
         options?.onSuccess?.();
     }),
+    mockUsePageProps: vi.fn(() => ({
+        curationAccordionOpenItems: null as string[] | null,
+    })),
 }));
 
 vi.mock('@inertiajs/react', () => ({
@@ -20,8 +24,12 @@ vi.mock('@inertiajs/react', () => ({
         visit: mockRouterVisit,
         get: vi.fn(),
         post: vi.fn(),
+        put: mockRouterPut,
         reload: vi.fn(),
     },
+    usePage: () => ({
+        props: mockUsePageProps(),
+    }),
 }));
 
 vi.mock('axios');
@@ -286,9 +294,14 @@ describe('DataCiteForm', () => {
         vi.restoreAllMocks();
 
         // Reset router mock for each test
+        mockRouterPut.mockClear();
         mockRouterVisit.mockClear();
         mockRouterVisit.mockImplementation((_url: string, options?: { onSuccess?: () => void }) => {
             options?.onSuccess?.();
+        });
+        mockUsePageProps.mockReset();
+        mockUsePageProps.mockReturnValue({
+            curationAccordionOpenItems: null,
         });
 
         (useRorAffiliations as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -382,6 +395,111 @@ describe('DataCiteForm', () => {
     ];
 
     const availableDatacenters = [{ id: 1, name: 'Test Datacenter' }];
+
+    const renderDataCiteForm = (props: Partial<DataCiteFormProps> = {}) =>
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+                {...props}
+            />,
+        );
+
+    describe('Accordion bulk controls', () => {
+        it('renders collapse-all actions next to visible field group triggers and hides expand-all while all are open', async () => {
+            renderDataCiteForm();
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('collapse-all-field-groups').length).toBeGreaterThanOrEqual(12);
+            });
+
+            expect(screen.queryAllByTestId('expand-all-field-groups')).toHaveLength(0);
+
+            const firstCollapseAllButton = screen.getAllByRole('button', { name: /Collapse all field groups/i })[0];
+            expect(firstCollapseAllButton).not.toHaveAttribute('data-slot', 'accordion-trigger');
+            expect(firstCollapseAllButton.closest('[data-slot="accordion-trigger"]')).toBeNull();
+        });
+
+        it('collapses every visible field group and persists an empty open item list', async () => {
+            renderDataCiteForm();
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            await user.click(screen.getAllByRole('button', { name: /Collapse all field groups/i })[0]);
+
+            expect(getAccordionTrigger(/Resource Information/i)).toHaveAttribute('aria-expanded', 'false');
+            expect(getAccordionTrigger(/Authors/i)).toHaveAttribute('aria-expanded', 'false');
+            expect(getAccordionTrigger(/Funding References/i)).toHaveAttribute('aria-expanded', 'false');
+            expect(screen.queryAllByTestId('collapse-all-field-groups')).toHaveLength(0);
+            expect(screen.getAllByTestId('expand-all-field-groups').length).toBeGreaterThanOrEqual(12);
+            expect(mockRouterPut).toHaveBeenCalledWith(
+                '/settings/curation-accordion',
+                { open_items: [] },
+                expect.objectContaining({
+                    preserveScroll: true,
+                    preserveState: true,
+                }),
+            );
+        });
+
+        it('expands every visible field group from a saved collapsed preference', async () => {
+            mockUsePageProps.mockReturnValue({
+                curationAccordionOpenItems: [],
+            });
+            renderDataCiteForm();
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            expect(getAccordionTrigger(/Resource Information/i)).toHaveAttribute('aria-expanded', 'false');
+
+            await user.click(screen.getAllByRole('button', { name: /Expand all field groups/i })[0]);
+
+            expect(getAccordionTrigger(/Resource Information/i)).toHaveAttribute('aria-expanded', 'true');
+            expect(getAccordionTrigger(/Authors/i)).toHaveAttribute('aria-expanded', 'true');
+            expect(getAccordionTrigger(/Funding References/i)).toHaveAttribute('aria-expanded', 'true');
+            expect(screen.queryAllByTestId('expand-all-field-groups')).toHaveLength(0);
+            expect(mockRouterPut).toHaveBeenCalledWith(
+                '/settings/curation-accordion',
+                expect.objectContaining({
+                    open_items: expect.arrayContaining(['resource-info', 'authors', 'funding-references']),
+                }),
+                expect.objectContaining({
+                    preserveScroll: true,
+                    preserveState: true,
+                }),
+            );
+        });
+
+        it('does not include hidden conditional field groups when expanding all', async () => {
+            mockUsePageProps.mockReturnValue({
+                curationAccordionOpenItems: [],
+            });
+            global.fetch = vi.fn((input: RequestInfo | URL) => {
+                const url = input.toString();
+
+                if (url.includes('/api/v1/vocabularies/pid-availability')) {
+                    return Promise.resolve(createJsonResponse({ pid4inst: { available: false } }));
+                }
+
+                return createDefaultFetchResponse(url);
+            });
+
+            renderDataCiteForm();
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            await user.click(screen.getAllByRole('button', { name: /Expand all field groups/i })[0]);
+
+            const payload = mockRouterPut.mock.calls[0][1] as { open_items: string[] };
+            expect(payload.open_items).not.toContain('msl-laboratories');
+            expect(payload.open_items).not.toContain('used-instruments');
+        });
+    });
 
     it(
         'renders fields, title options and supports adding/removing titles',


### PR DESCRIPTION
This pull request introduces user-specific accordion state persistence for the Data Editor, allowing each curator's preferred accordion section layout to be saved and restored across sessions. It adds backend support for storing the open accordion items in the `users` table, updates the user model and API to handle this preference, and implements the corresponding frontend logic to initialize and update the accordion state. The change is documented in the changelog and database diagrams.

**Backend support for curation accordion preferences:**
- Added a new nullable JSON column `curation_accordion_open_items` to the `users` table via migration, and updated the ER diagrams to reflect this schema change. [[1]](diffhunk://#diff-30bd61606f69055df70c514b9a69beda93e714c51902df52e84d88c83588d648R1-R30) [[2]](diffhunk://#diff-a8d0111421d72b79d6b1e81ad37d41a69ce2f2f1b765ba6e5def7d7311d72814R195) [[3]](diffhunk://#diff-e0196f1170dc7341f74a244f8ee5ad1128d2350be6c80928486fe029eb3867e3R169)
- Updated the `User` model to cast `curation_accordion_open_items` as an array and included it in fillable attributes and property annotations. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR9-R42) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR56)
- Created `CurationAccordionController` and `UpdateCurationAccordionRequest` to validate and update the user's open accordion items, ensuring only allowed values are saved. [[1]](diffhunk://#diff-d3ad42702f5263b5809e940c0518bc3d74a8d3aedb64c734e3838c3b3e8313ffR1-R30) [[2]](diffhunk://#diff-af90e6c8e2f57ac552356d2c1aa65c4bbf2bad9431cb9435daa69c15f650cb40R1-R64)
- Exposed the user's saved accordion state to the frontend via the `HandleInertiaRequests` middleware.

**Frontend integration:**
- Updated the Data Editor form (`datacite-form.tsx`) to initialize the open accordion state from the backend, normalize it, and provide expand/collapse-all controls. The accordion state is now persisted per user. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R21-R25) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L385-R410) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R165)
- Added new imports and utility functions for handling accordion state and allowed values. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R21-R25) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R86-R104)

**Documentation and changelog:**
- Added a changelog entry describing the new accordion bulk controls and persistent preferences.