### PR TITLE
Add SizeFormatSuggestion folder and markdown file for documentation

### DIFF
--- a/modules/assistants/SizeFormatSuggestion/First_Sub-Issue-809_Task1
+++ b/modules/assistants/SizeFormatSuggestion/First_Sub-Issue-809_Task1
@@ -1,0 +1,255 @@
+# Zulässige ressourcenbezogene URL-Quellen
+
+## Zweck
+
+Dieses Dokument definiert, welche ressourcenbezogenen URLs vom Assistant untersucht werden dürfen, um technische Metadaten wie Dateiformat und Dateigröße zu ermitteln. Die Informationen können dabei aus Metadatenseiten, Dateilisten, Verzeichnisstrukturen oder verlinkten Dateien stammen. Die Untersuchung ist ausschließlich auf die Metadatenanreicherung beschränkt und darf nicht zu allgemeinem Web-Crawling ausgeweitet werden.
+
+---
+
+## Zulässige URL-Quellen
+
+Der Assistant darf die folgenden URL-Quellen untersuchen.
+
+### 1. Ressourcenbezogene Links auf Datensatz-Landingpages
+
+Links, die auf einer Datensatz-Landingpage im Abschnitt **"Files"** explizit angeboten werden und zu Dateilisten, Metadatenseiten oder herunterladbaren Ressourcen führen.
+
+Beispiele:
+
+- Download data
+- Download data and description
+- Download code
+- Download model
+- Download static version
+- Download data and README
+- Download video and description
+- Download static versions of Assetmaster and Modelprop and their description
+- Download static version of DEUS (20210621) and description
+- Download static version of Quakeledger and description
+- Download static version of DOuGLAS
+- Download static code version
+
+Beobachtete Datenzentren:
+
+- DIGIS Geochemical Data for GEOROC 2.0
+- EnMAP
+- FID GEO
+- GFZ German Research Centre for Geosciences
+- INTERMAGNET
+- SDDB Scientific Drilling Database
+- SPP 2238: Dynamics of Ore Metals Enrichment (DOME)
+- TERENO
+- WDS World Stress Map
+
+**Begründung:** Diese Links sind direkt einem Datensatz zugeordnet und führen zu Ressourcen, aus denen technische Metadaten ermittelt werden können.
+
+---
+
+### 2. Repository-interne Dateilisten und Verzeichnisstrukturen
+
+Links, die auf vom Repositorium verwaltete Dateilisten, Verzeichnisstrukturen oder Sammlungen von Dateien verweisen.
+
+Mögliche Dateitypen:
+
+- ZIP-Archive
+- PDF-Dateien
+- CSV-Dateien
+- XLS/XLSX-Dateien
+- TXT-Dateien
+- MD-Dateien
+- Bilddateien
+- Weitere Dateien innerhalb von Unterordnern
+
+Beobachtete Datenzentren:
+
+- DIGIS Geochemical Data for GEOROC 2.0
+- FID GEO
+- GFZ German Research Centre for Geosciences
+- SDDB Scientific Drilling Database
+- TERENO
+
+**Begründung:** Diese Seiten enthalten Informationen über die zugehörigen Dateien, beispielsweise Dateinamen, Dateiformate oder Dateigrößen. Dateiformate sind aus den Namen teils abzuleiten, z.B. 2025-014_Traun-et-al_BulkSample_Analyses.xlsx
+
+---
+
+### 3. Metadatenseiten mit technischen Dateiinformationen
+
+Seiten, auf denen technische Informationen zu Dateien direkt als Metadaten dargestellt werden.
+
+Beispiele:
+
+- File Size
+- Data Size
+- Mime Type
+- Data Format
+- File Details
+
+Beobachtete Datenzentren:
+
+- CRC1211DB CRC 1211 Database
+- GEOFON Seismic Networks
+- GEOFON Seismic Events (Ausgabeformate FDSNWS, QuakeML und Text (CSV) direkt auswählbar; keine Größenangabe vorhanden)
+- TR32DB CRC/Transregio 32 Database
+- TRR228DB CRC/Transregio 228 Database
+- ISG International Service for the Geoid
+
+**Begründung:** Die benötigten technischen Metadaten sind direkt auf der Seite verfügbar und müssen nicht aus einer Datei extrahiert werden.
+
+---
+
+### 4. Vom Repositorium verlinkte externe Ressourcen
+
+Externe Ressourcen, die explizit auf einer Datensatz-Landingpage verlinkt sind und Informationen zu den zugehörigen Dateien bereitstellen.
+
+Beispiele:
+
+- Download data via ICGEM
+- Download model via GFZ Data Services
+- Download data via KIT
+
+Beobachtete Datenzentren:
+
+- ICGEM International Centre for Global Earth Models
+
+**Begründung:** Diese Ressourcen sind datensatzbezogen und werden bewusst vom Repositorium bereitgestellt.
+
+---
+
+### 5. Statische Datensatz- oder Software-Releases
+
+Statische Datensatz- oder Softwarepakete, die auf einer Datensatz-Landingpage angeboten werden.
+
+Beispiele:
+
+- Download static version of Quakeledger
+- Download static version of DEUS
+- Download static code version
+- Download static versions of Assetmaster and Modelprop
+
+Beobachtete Datenzentren:
+
+- Riesgos
+- WDS World Stress Map
+
+**Begründung:** Diese Ressourcen verweisen auf die tatsächlich bereitgestellten Dateien eines Datensatzes oder Projekts und liefern technische Informationen wie Dateiformat und Dateigröß
+
+---
+
+## Ausgeschlossene URL-Quellen
+
+Die folgenden URL-Quellen dürfen vom Assistant nicht untersucht werden.
+
+### 1. Formularbasierte Ressourcen
+
+Ressourcen, bei denen vor dem Zugriff auf Dateien oder Dateiinformationen Benutzereingaben erforderlich sind.
+
+Typische Pflichtfelder:
+
+- Full Name
+- Affiliation
+- E-Mail
+- Purpose of Use
+
+Beobachtete Datenzentren:
+
+- ArboDat 2016 (Zugriff auf Ressourcen nur nach Ausfüllen eines Formulars)
+- DEKORP – German Continental Seismic Reflection Program (Zugriff auf Ressourcen nur nach Ausfüllen eines Formulars)
+- GIPP Geophysical Instrument Pool Potsdam (Zugriff auf Ressourcen nur nach Ausfüllen eines Formulars)
+- ISDC Information System and Data Center (teilweise formularbasierte Zugriffe; bei einigen Datensätzen wird auf neuere Versionen verwiesen, deren Ressourcen ohne Formular erreichbar sind)
+- SDDB Scientific Drilling Database (teilweise formularbasierte Zugriffe, insbesondere bei nicht öffentlich verfügbaren Datensätzen)
+
+**Begründung:** Der Assistant darf keine Formulare ausfüllen, personenbezogene Daten übermitteln oder Zugriffsanfragen im Namen von Nutzenden stellen. Ressourcen, deren Zugriff eine Eingabe von Benutzerdaten voraussetzt, sind daher von der Untersuchung ausgeschlossen. 
+
+---
+
+### 2. Authentifizierungs- oder registrierungspflichtige Ressourcen
+
+Ressourcen, die eine Anmeldung, Registrierung oder Benutzerkennung voraussetzen.
+
+Beobachtete Datenzentren:
+
+- IGETS International Geodynamics and Earth Tide Service (SFTP-Zugang)
+
+**Begründung:** Der Assistant darf sich nicht bei externen Diensten authentifizieren.
+
+---
+
+### 3. CAPTCHA- oder Anti-Bot-geschützte Ressourcen
+
+Ressourcen, die eine menschliche Verifikation verlangen.
+
+Beobachtete Datenzentren:
+
+- FID GEO
+
+**Begründung:** Der Assistant darf keine CAPTCHA- oder Anti-Bot-Mechanismen umgehen.
+
+---
+
+### 4. Interaktive Dienste
+
+Interaktive Anwendungen, die keine stabilen technischen Metadaten zu Dateien bereitstellen.
+
+Beispiele:
+
+- ICGEM Calculation Service
+- ICGEM Visualisation Service
+- PIK Interactive WebApp
+- Access WebApp
+
+**Begründung:** Diese Dienste dienen der Interaktion oder Berechnung und stellen keine verlässliche Quelle für technische Dateimetadaten dar.
+
+---
+
+### 5. Projektseiten ohne Datensatzbezug
+
+Beispiele:
+
+- GitHub-Projektseiten ohne direkten Ressourcenbezug
+- Dokumentationsseiten
+- Allgemeine Projektwebseiten
+
+**Begründung:** Es sollen ausschließlich datensatzbezogene Ressourcen untersucht werden.
+
+---
+
+### 6. Nicht erreichbare oder fehlerhafte Ressourcen
+
+Beispiele:
+
+- HTTP 404 Not Found
+- Forbidden
+- Ungültige URLs
+- Page not found
+
+Beobachtete Datenzentren:
+
+- EnMAP
+- TERENO
+- SFB806 and CRC806-Database
+- WDS World Stress Map
+
+**Begründung:** Aus nicht erreichbaren Ressourcen können keine verlässlichen Metadaten gewonnen werden.
+
+---
+## Hauptquellen
+
+- Uni Köln
+- Geofon
+- Data services
+
+## Einschränkung des Geltungsbereichs
+
+Der Assistant darf ausschließlich ressourcenbezogene URLs zur Metadatenanreicherung untersuchen.
+
+Der Assistant darf nicht:
+
+- allgemeines Web-Crawling durchführen,
+- beliebigen Links rekursiv folgen,
+- nicht verknüpfte Ressourcen entdecken,
+- Linkstrukturen aufbauen,
+- auf geschützte Inhalte zugreifen,
+- CAPTCHA- oder Anti-Bot-Mechanismen umgehen,
+- Formulare im Namen von Nutzenden ausfüllen.
+
+Damit wird sichergestellt, dass die Metadatenanreicherung nicht in ein unkontrolliertes Web-Crawling übergeht.


### PR DESCRIPTION
Created the SizeFormatSuggestion folder and added a markdown file for documenting approved download URL sources.

The document will contain allowed resource-linked URLs, landing-page download URLs, and explicit exclusions as defined in Sub-Issue 809.