### PR TITLE
Feature: SPDX rights discovery workflow

### DIFF
--- a/app/Services/Spdx/SpdxLicenseData.php
+++ b/app/Services/Spdx/SpdxLicenseData.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+use App\Models\Right;
+
+/**
+ * Small value object for one SPDX catalog entry.
+ *
+ * The database model `Right` contains many application concerns (activation
+ * flags, usage counters, resource-type exclusions). The matcher only needs the
+ * stable catalog facts, so we copy those facts into this simple object before
+ * matching imported rights text.
+ */
+final readonly class SpdxLicenseData
+{
+    public function __construct(
+        public string $identifier,
+        public string $name,
+        public ?string $rightsUri,
+        public ?string $schemeUri,
+    ) {}
+
+    public static function fromRight(Right $right): self
+    {
+        return new self(
+            identifier: $right->identifier,
+            name: $right->name,
+            rightsUri: $right->uri,
+            schemeUri: $right->scheme_uri,
+        );
+    }
+}

--- a/app/Services/Spdx/SpdxLicenseLookup.php
+++ b/app/Services/Spdx/SpdxLicenseLookup.php
@@ -97,8 +97,10 @@ final readonly class SpdxLicenseLookup
     {
         /** @var Collection<int, Right> $rights */
         $rights = Right::query()
+            ->active()
             ->whereNotNull('identifier')
             ->where('identifier', '!=', '')
+            ->where('scheme_uri', self::SCHEME_URI)
             ->get(['identifier', 'name', 'uri', 'scheme_uri']);
 
         return self::fromLicenses(

--- a/app/Services/Spdx/SpdxLicenseLookup.php
+++ b/app/Services/Spdx/SpdxLicenseLookup.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+use App\Models\Right;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+/**
+ * In-memory lookup table for SPDX licenses.
+ *
+ * The lookup is built from ERNIE's local `rights` catalog. That catalog is
+ * populated by the existing `spdx:sync-licenses` command, so discovery jobs do
+ * not need to call the SPDX website while curators are waiting.
+ */
+final readonly class SpdxLicenseLookup
+{
+    public const string SCHEME_URI = 'https://spdx.org/licenses/';
+
+    public const string RIGHTS_IDENTIFIER_SCHEME = 'SPDX';
+
+    /**
+     * Text aliases that are safe enough to use as strong matches.
+     *
+     * Keep this list deliberately boring and reviewed. Legal metadata is not a
+     * good place for adventurous fuzzy matching.
+     *
+     * @var array<string, string>
+     */
+    private const APPROVED_TEXT_ALIASES = [
+        'cc by 4.0' => 'CC-BY-4.0',
+        'cc attribution 4.0' => 'CC-BY-4.0',
+        'creative commons attribution 4.0' => 'CC-BY-4.0',
+        'creative commons attribution 4.0 international' => 'CC-BY-4.0',
+        'cc by-nc 4.0' => 'CC-BY-NC-4.0',
+        'cc by nc 4.0' => 'CC-BY-NC-4.0',
+        'cc attribution-noncommercial 4.0 international (cc by-nc 4.0)' => 'CC-BY-NC-4.0',
+        'creative commons attribution-noncommercial 4.0 international (cc by-nc 4.0)' => 'CC-BY-NC-4.0',
+        'cc by-sa 4.0' => 'CC-BY-SA-4.0',
+        'cc by sa 4.0' => 'CC-BY-SA-4.0',
+        'cc0 universal 1.0' => 'CC0-1.0',
+        'creative commons zero v1.0 universal' => 'CC0-1.0',
+        'apache license 2.0' => 'Apache-2.0',
+        'apache license version 2.0' => 'Apache-2.0',
+        'apache license, version 2.0' => 'Apache-2.0',
+        'mit licence' => 'MIT',
+        'mit license' => 'MIT',
+        'gnu general public license version 3' => 'GPL-3.0-only',
+        'gnu general public license, version 3' => 'GPL-3.0-only',
+        'gnu general public license, version 3, 29 june 2007' => 'GPL-3.0-only',
+        'open data commons open database license (odbl)' => 'ODbL-1.0',
+        'european union public licence 1.2' => 'EUPL-1.2',
+    ];
+
+    /**
+     * URI aliases for license pages that are commonly imported in DataCite or
+     * legacy metadata but are not necessarily the URL stored in the SPDX list.
+     *
+     * @var array<string, string>
+     */
+    private const APPROVED_URI_ALIASES = [
+        'creativecommons.org/licenses/by/4.0' => 'CC-BY-4.0',
+        'creativecommons.org/licenses/by/4.0/legalcode' => 'CC-BY-4.0',
+        'creativecommons.org/licenses/by-nc/4.0' => 'CC-BY-NC-4.0',
+        'creativecommons.org/licenses/by-nc/4.0/legalcode' => 'CC-BY-NC-4.0',
+        'creativecommons.org/licenses/by-sa/4.0' => 'CC-BY-SA-4.0',
+        'creativecommons.org/licenses/by-sa/4.0/legalcode' => 'CC-BY-SA-4.0',
+        'creativecommons.org/publicdomain/zero/1.0' => 'CC0-1.0',
+        'www.apache.org/licenses/license-2.0' => 'Apache-2.0',
+        'apache.org/licenses/license-2.0' => 'Apache-2.0',
+        'www.gnu.org/licenses/gpl-3.0.html' => 'GPL-3.0-only',
+        'www.gnu.org/licenses/gpl-3.0.en.html' => 'GPL-3.0-only',
+        'opensource.org/licenses/mit' => 'MIT',
+        'opensource.org/licenses/bsd-3-clause' => 'BSD-3-Clause',
+        'opensource.org/licenses/eupl-1.2' => 'EUPL-1.2',
+        'opendatacommons.org/licenses/odbl/1.0/index.html' => 'ODbL-1.0',
+    ];
+
+    /**
+     * @param  array<string, SpdxLicenseData>  $licensesByIdentifier
+     * @param  array<string, string>  $identifierKeys
+     * @param  array<string, string>  $nameKeys
+     * @param  array<string, string>  $uriKeys
+     * @param  array<string, string>  $aliasKeys
+     */
+    private function __construct(
+        private array $licensesByIdentifier,
+        private array $identifierKeys,
+        private array $nameKeys,
+        private array $uriKeys,
+        private array $aliasKeys,
+    ) {}
+
+    public static function fromRightsCatalog(): self
+    {
+        /** @var Collection<int, Right> $rights */
+        $rights = Right::query()
+            ->whereNotNull('identifier')
+            ->where('identifier', '!=', '')
+            ->get(['identifier', 'name', 'uri', 'scheme_uri']);
+
+        return self::fromLicenses(
+            $rights->map(fn (Right $right): SpdxLicenseData => SpdxLicenseData::fromRight($right))->all(),
+        );
+    }
+
+    /**
+     * @param  iterable<int, SpdxLicenseData>  $licenses
+     */
+    public static function fromLicenses(iterable $licenses): self
+    {
+        $licensesByIdentifier = [];
+        $identifierKeys = [];
+        $nameKeys = [];
+        $uriKeys = [];
+
+        foreach ($licenses as $license) {
+            $licensesByIdentifier[$license->identifier] = $license;
+
+            // SPDX identifiers are case-sensitive in display, but matching user
+            // input case-insensitively is a helpful and safe normalization.
+            $identifierKeys[self::normalizeIdentifier($license->identifier)] = $license->identifier;
+            $nameKeys[self::normalizeText($license->name)] = $license->identifier;
+
+            if ($license->rightsUri !== null && trim($license->rightsUri) !== '') {
+                $uriKeys[self::normalizeUri($license->rightsUri)] = $license->identifier;
+            }
+
+            $uriKeys[self::normalizeUri(self::licensePageUrl($license->identifier))] = $license->identifier;
+        }
+
+        $aliasKeys = [];
+
+        foreach (self::APPROVED_TEXT_ALIASES as $alias => $identifier) {
+            if (isset($licensesByIdentifier[$identifier])) {
+                $aliasKeys[self::normalizeText($alias)] = $identifier;
+            }
+        }
+
+        foreach (self::APPROVED_URI_ALIASES as $uri => $identifier) {
+            if (isset($licensesByIdentifier[$identifier])) {
+                $uriKeys[self::normalizeUri($uri)] = $identifier;
+            }
+        }
+
+        return new self($licensesByIdentifier, $identifierKeys, $nameKeys, $uriKeys, $aliasKeys);
+    }
+
+    public static function licensePageUrl(string $identifier): string
+    {
+        return self::SCHEME_URI . $identifier . '.html';
+    }
+
+    public function findByIdentifier(?string $identifier): ?SpdxLicenseData
+    {
+        $key = self::normalizeIdentifier($identifier);
+
+        return $this->licenseForKey($this->identifierKeys, $key);
+    }
+
+    public function findByName(?string $name): ?SpdxLicenseData
+    {
+        $key = self::normalizeText($name);
+
+        return $this->licenseForKey($this->nameKeys, $key);
+    }
+
+    public function findByAlias(?string $text): ?SpdxLicenseData
+    {
+        $key = self::normalizeText($text);
+
+        return $this->licenseForKey($this->aliasKeys, $key);
+    }
+
+    public function findByUri(?string $uri): ?SpdxLicenseData
+    {
+        $key = self::normalizeUri($uri);
+
+        return $this->licenseForKey($this->uriKeys, $key);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function approvedTextAliases(): array
+    {
+        return self::APPROVED_TEXT_ALIASES;
+    }
+
+    public static function normalizeIdentifier(?string $identifier): string
+    {
+        return Str::lower(trim((string) $identifier));
+    }
+
+    public static function normalizeText(?string $text): string
+    {
+        $normalized = Str::lower(trim((string) $text));
+        $normalized = preg_replace('/\s+/u', ' ', $normalized) ?? $normalized;
+
+        return trim($normalized);
+    }
+
+    public static function normalizeUri(?string $uri): string
+    {
+        $uri = trim((string) $uri);
+
+        if ($uri === '') {
+            return '';
+        }
+
+        $parts = parse_url($uri);
+
+        if ($parts === false) {
+            return Str::lower(rtrim($uri, '/'));
+        }
+
+        $host = Str::lower($parts['host'] ?? '');
+        $path = Str::lower($parts['path'] ?? '');
+        $path = preg_replace('/\/+/', '/', $path) ?? $path;
+        $path = rtrim($path, '/');
+
+        return ltrim($host . '/' . ltrim($path, '/'), '/');
+    }
+
+    /**
+     * @param  array<string, string>  $map
+     */
+    private function licenseForKey(array $map, string $key): ?SpdxLicenseData
+    {
+        if ($key === '' || ! isset($map[$key])) {
+            return null;
+        }
+
+        return $this->licensesByIdentifier[$map[$key]] ?? null;
+    }
+}

--- a/app/Services/Spdx/SpdxLicenseLookup.php
+++ b/app/Services/Spdx/SpdxLicenseLookup.php
@@ -150,7 +150,7 @@ final readonly class SpdxLicenseLookup
 
     public static function licensePageUrl(string $identifier): string
     {
-        return self::SCHEME_URI . $identifier . '.html';
+        return self::SCHEME_URI.$identifier.'.html';
     }
 
     public function findByIdentifier(?string $identifier): ?SpdxLicenseData
@@ -221,7 +221,7 @@ final readonly class SpdxLicenseLookup
         $path = preg_replace('/\/+/', '/', $path) ?? $path;
         $path = rtrim($path, '/');
 
-        return ltrim($host . '/' . ltrim($path, '/'), '/');
+        return ltrim($host.'/'.ltrim($path, '/'), '/');
     }
 
     /**

--- a/app/Services/Spdx/SpdxRightsDiscoveryService.php
+++ b/app/Services/Spdx/SpdxRightsDiscoveryService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+use Closure;
+
+/**
+ * Coordinates SPDX discovery for the assistant module.
+ *
+ * This service keeps the module class small: the assistant owns UI-facing
+ * storage through GenericTableAssistant, while this service owns the SPDX
+ * workflow. That split makes the code easier for students to reuse for other
+ * DataCite elements.
+ */
+final readonly class SpdxRightsDiscoveryService
+{
+    public function __construct(
+        private SpdxRightsMatchInputProvider $inputProvider,
+        private SpdxRightsMatcher $matcher,
+    ) {}
+
+    /**
+     * Discover and store reviewer-facing SPDX suggestions.
+     *
+     * @param  Closure(int, string, int, string, string, float|null, array<string, mixed>|null): bool  $storeSuggestion
+     * @param  Closure(string): void  $onProgress
+     * @return int Number of newly stored suggestions
+     */
+    public function discover(Closure $storeSuggestion, Closure $onProgress): int
+    {
+        $inputs = $this->inputProvider->pendingInputs();
+        $inputCount = $inputs->count();
+
+        $onProgress("Checking {$inputCount} unresolved rights statement(s) against the local SPDX catalog.");
+
+        if ($inputCount === 0) {
+            $onProgress('No unresolved raw rights statements found for SPDX matching.');
+
+            return 0;
+        }
+
+        $lookup = SpdxLicenseLookup::fromRightsCatalog();
+        $stored = 0;
+        $unsupported = 0;
+        $insufficient = 0;
+
+        foreach ($inputs as $input) {
+            $result = $this->matcher->match($input, $lookup);
+
+            if (! $result->isMatched()) {
+                if ($result->status === 'insufficient') {
+                    $insufficient++;
+                } else {
+                    $unsupported++;
+                }
+
+                continue;
+            }
+
+            /** @var SpdxLicenseData $license */
+            $license = $result->license;
+
+            $wasStored = $storeSuggestion(
+                $input->resourceId,
+                $input->targetType,
+                $input->targetId,
+                $license->identifier,
+                $license->name,
+                $result->score,
+                $result->toSuggestionMetadata($input),
+            );
+
+            if ($wasStored) {
+                $stored++;
+            }
+        }
+
+        $onProgress("Stored {$stored} SPDX suggestion(s); skipped {$unsupported} unsupported and {$insufficient} insufficient statement(s).");
+
+        return $stored;
+    }
+}

--- a/app/Services/Spdx/SpdxRightsMatchInput.php
+++ b/app/Services/Spdx/SpdxRightsMatchInput.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+/**
+ * One imported rights statement that should be checked against SPDX.
+ *
+ * This object intentionally mirrors the future raw `resource_rights` columns
+ * from the design document. Today those columns may not exist yet; keeping this
+ * object independent from Eloquent lets students test the matching logic before
+ * database migrations or import code are finished.
+ */
+final readonly class SpdxRightsMatchInput
+{
+    public function __construct(
+        public int $resourceId,
+        public string $targetType,
+        public int $targetId,
+        public ?string $rightsText = null,
+        public ?string $rightsUri = null,
+        public ?string $rightsIdentifier = null,
+        public ?string $rightsIdentifierScheme = null,
+        public ?string $schemeUri = null,
+        public ?string $language = null,
+        public ?string $source = null,
+    ) {}
+
+    public function hasEvidence(): bool
+    {
+        return $this->filled($this->rightsText)
+            || $this->filled($this->rightsUri)
+            || $this->filled($this->rightsIdentifier);
+    }
+
+    /**
+     * Build the "current" part of the suggestion payload.
+     *
+     * Reviewers should always see what was imported before they decide whether
+     * the SPDX proposal is correct.
+     *
+     * @return array<string, string>
+     */
+    public function currentPayload(): array
+    {
+        $payload = [];
+
+        foreach ([
+            'rights' => $this->rightsText,
+            'rights_uri' => $this->rightsUri,
+            'rights_identifier' => $this->rightsIdentifier,
+            'rights_identifier_scheme' => $this->rightsIdentifierScheme,
+            'scheme_uri' => $this->schemeUri,
+            'language' => $this->language,
+            'source' => $this->source,
+        ] as $key => $value) {
+            if ($this->filled($value)) {
+                $payload[$key] = trim((string) $value);
+            }
+        }
+
+        return $payload;
+    }
+
+    private function filled(?string $value): bool
+    {
+        return $value !== null && trim($value) !== '';
+    }
+}

--- a/app/Services/Spdx/SpdxRightsMatchInputProvider.php
+++ b/app/Services/Spdx/SpdxRightsMatchInputProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Reads unresolved rights statements from `resource_rights`.
+ *
+ * Issue 820 only implements SPDX matching and suggestion generation. The raw
+ * import columns are planned separately, so this provider is schema-aware: if
+ * the columns are not present yet, discovery safely returns no inputs instead
+ * of failing at runtime.
+ */
+class SpdxRightsMatchInputProvider
+{
+    private const string TARGET_TYPE = 'resource_right';
+
+    /**
+     * Raw columns that may exist after import persistence is implemented.
+     *
+     * @var list<string>
+     */
+    private const RAW_COLUMNS = [
+        'rights_text',
+        'rights_uri',
+        'rights_identifier',
+        'rights_identifier_scheme',
+        'scheme_uri',
+        'language',
+        'source',
+    ];
+
+    /**
+     * Columns that contain enough evidence to attempt SPDX matching.
+     *
+     * @var list<string>
+     */
+    private const EVIDENCE_COLUMNS = [
+        'rights_text',
+        'rights_uri',
+        'rights_identifier',
+    ];
+
+    /**
+     * Return unresolved resource-right rows as matcher input objects.
+     *
+     * A row is unresolved when `rights_id` is NULL. Linked rows are already
+     * trusted and should not be re-suggested by the assistant.
+     *
+     * @return Collection<int, SpdxRightsMatchInput>
+     */
+    public function pendingInputs(): Collection
+    {
+        $availableColumns = $this->availableRawColumns();
+        $evidenceColumns = array_values(array_intersect(self::EVIDENCE_COLUMNS, $availableColumns));
+
+        if ($evidenceColumns === []) {
+            return collect();
+        }
+
+        $rows = DB::table('resource_rights')
+            ->select(array_merge(['id', 'resource_id'], $availableColumns))
+            ->whereNull('rights_id')
+            ->where(function ($query) use ($evidenceColumns): void {
+                foreach ($evidenceColumns as $column) {
+                    $query->orWhere(function ($query) use ($column): void {
+                        $query->whereNotNull($column)
+                            ->where($column, '!=', '');
+                    });
+                }
+            })
+            ->orderBy('id')
+            ->get();
+
+        return $rows->map(fn (object $row): SpdxRightsMatchInput => new SpdxRightsMatchInput(
+            resourceId: (int) $row->resource_id,
+            targetType: self::TARGET_TYPE,
+            targetId: (int) $row->id,
+            rightsText: $this->value($row, 'rights_text'),
+            rightsUri: $this->value($row, 'rights_uri'),
+            rightsIdentifier: $this->value($row, 'rights_identifier'),
+            rightsIdentifierScheme: $this->value($row, 'rights_identifier_scheme'),
+            schemeUri: $this->value($row, 'scheme_uri'),
+            language: $this->value($row, 'language'),
+            source: $this->value($row, 'source'),
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function availableRawColumns(): array
+    {
+        $columns = [];
+
+        foreach (self::RAW_COLUMNS as $column) {
+            if (Schema::hasColumn('resource_rights', $column)) {
+                $columns[] = $column;
+            }
+        }
+
+        return $columns;
+    }
+
+    private function value(object $row, string $column): ?string
+    {
+        if (! property_exists($row, $column)) {
+            return null;
+        }
+
+        $value = $row->{$column};
+
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Services/Spdx/SpdxRightsMatchResult.php
+++ b/app/Services/Spdx/SpdxRightsMatchResult.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+/**
+ * Result of matching one imported rights statement against the SPDX lookup.
+ *
+ * A result can be:
+ * - matched: safe enough to create a reviewer-facing suggestion.
+ * - unsupported: clearly custom, commercial, ambiguous, or otherwise non-SPDX.
+ * - insufficient: there was not enough source evidence to decide anything.
+ */
+final readonly class SpdxRightsMatchResult
+{
+    private function __construct(
+        public string $status,
+        public ?SpdxLicenseData $license,
+        public ?float $score,
+        public ?string $matchType,
+        public string $reason,
+    ) {}
+
+    public static function matched(
+        SpdxLicenseData $license,
+        float $score,
+        string $matchType,
+        string $reason,
+    ): self {
+        return new self('matched', $license, $score, $matchType, $reason);
+    }
+
+    public static function unsupported(string $reason): self
+    {
+        return new self('unsupported', null, null, null, $reason);
+    }
+
+    public static function insufficient(string $reason): self
+    {
+        return new self('insufficient', null, null, null, $reason);
+    }
+
+    public function isMatched(): bool
+    {
+        return $this->status === 'matched' && $this->license instanceof SpdxLicenseData;
+    }
+
+    /**
+     * Convert a successful match into the metadata stored on AssistantSuggestion.
+     *
+     * The generic assistant table stores one value and one label at the top
+     * level. The rich review context goes into metadata so the UI and acceptance
+     * code can still understand why the suggestion exists.
+     *
+     * @return array<string, mixed>
+     */
+    public function toSuggestionMetadata(SpdxRightsMatchInput $input): array
+    {
+        if (! $this->isMatched()) {
+            throw new \LogicException('Only matched SPDX rights can produce suggestion metadata.');
+        }
+
+        /** @var SpdxLicenseData $license */
+        $license = $this->license;
+
+        return [
+            'contract_version' => '1.1',
+            'action' => 'link_right',
+            'current' => $input->currentPayload(),
+            'proposed' => [
+                'rights' => $license->name,
+                'rights_uri' => $license->rightsUri,
+                'rights_identifier' => $license->identifier,
+                'rights_identifier_scheme' => SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME,
+                'scheme_uri' => $license->schemeUri ?? SpdxLicenseLookup::SCHEME_URI,
+                'language' => $input->language,
+            ],
+            'source' => 'spdx',
+            'source_url' => SpdxLicenseLookup::licensePageUrl($license->identifier),
+            'evidence' => [
+                'matched_from' => $this->matchType,
+                'reason' => $this->reason,
+            ],
+        ];
+    }
+}

--- a/app/Services/Spdx/SpdxRightsMatchResult.php
+++ b/app/Services/Spdx/SpdxRightsMatchResult.php
@@ -63,19 +63,20 @@ final readonly class SpdxRightsMatchResult
 
         /** @var SpdxLicenseData $license */
         $license = $this->license;
+        $proposed = $this->filledPayload([
+            'rights' => $license->name,
+            'rights_uri' => $license->rightsUri,
+            'rights_identifier' => $license->identifier,
+            'rights_identifier_scheme' => SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME,
+            'scheme_uri' => $license->schemeUri ?? SpdxLicenseLookup::SCHEME_URI,
+            'language' => $input->language,
+        ]);
 
         return [
             'contract_version' => '1.1',
             'action' => 'link_right',
             'current' => $input->currentPayload(),
-            'proposed' => [
-                'rights' => $license->name,
-                'rights_uri' => $license->rightsUri,
-                'rights_identifier' => $license->identifier,
-                'rights_identifier_scheme' => SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME,
-                'scheme_uri' => $license->schemeUri ?? SpdxLicenseLookup::SCHEME_URI,
-                'language' => $input->language,
-            ],
+            'proposed' => $proposed,
             'source' => 'spdx',
             'source_url' => SpdxLicenseLookup::licensePageUrl($license->identifier),
             'evidence' => [
@@ -83,5 +84,36 @@ final readonly class SpdxRightsMatchResult
                 'reason' => $this->reason,
             ],
         ];
+    }
+
+    /**
+     * Keep suggestion metadata compact and unambiguous.
+     *
+     * Missing fields and explicit null values should mean the same thing for
+     * future UI and acceptance code. Filtering here keeps that rule in one
+     * place, while required SPDX fields remain present because they are filled.
+     *
+     * @param  array<string, string|null>  $payload
+     * @return array<string, string>
+     */
+    private function filledPayload(array $payload): array
+    {
+        $filled = [];
+
+        foreach ($payload as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $value = trim($value);
+
+            if ($value === '') {
+                continue;
+            }
+
+            $filled[$key] = $value;
+        }
+
+        return $filled;
     }
 }

--- a/app/Services/Spdx/SpdxRightsMatcher.php
+++ b/app/Services/Spdx/SpdxRightsMatcher.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Spdx;
+
+use Illuminate\Support\Str;
+
+/**
+ * Matches one imported rights statement against the local SPDX catalog.
+ *
+ * The matcher is deliberately conservative. It only returns "matched" when the
+ * evidence is strong enough for a reviewer-facing suggestion. Weak fuzzy
+ * guesses are treated as unsupported so that curators are not nudged toward a
+ * legally meaningful value without clear source evidence.
+ */
+final readonly class SpdxRightsMatcher
+{
+    /**
+     * Phrases that usually mean a rights statement is custom text, not SPDX.
+     *
+     * This is not a legal classifier. It is just a safety rail for obvious
+     * non-SPDX cases that should not become license suggestions.
+     *
+     * @var list<string>
+     */
+    private const CUSTOM_RIGHTS_MARKERS = [
+        'commercial end user',
+        'custom license',
+        'custom licence',
+        'individual agreement',
+        'licence agreement',
+        'license agreement',
+        'licencing agreement',
+        'licensing agreement',
+        'not for commercial',
+        'permission required',
+        'proprietary',
+        'restricted use',
+        'written permission',
+    ];
+
+    /**
+     * Match the imported statement using strong evidence, ordered by trust.
+     *
+     * SPDX identifiers and canonical URLs are the strongest evidence. Human
+     * text still matters, especially for legacy imports where only "CC BY 4.0"
+     * may be available, but text matching stays limited to exact names and
+     * approved aliases.
+     */
+    public function match(SpdxRightsMatchInput $input, SpdxLicenseLookup $lookup): SpdxRightsMatchResult
+    {
+        if (! $input->hasEvidence()) {
+            return SpdxRightsMatchResult::insufficient('The imported rights statement has no rights text, URI, or identifier.');
+        }
+
+        $identifierMatch = $this->matchIdentifier($input, $lookup);
+
+        if ($identifierMatch !== null) {
+            return $identifierMatch;
+        }
+
+        $uriMatch = $this->matchUri($input, $lookup);
+
+        if ($uriMatch !== null) {
+            return $uriMatch;
+        }
+
+        $nameMatch = $this->matchCanonicalName($input, $lookup);
+
+        if ($nameMatch !== null) {
+            return $nameMatch;
+        }
+
+        $aliasMatch = $this->matchApprovedAlias($input, $lookup);
+
+        if ($aliasMatch !== null) {
+            return $aliasMatch;
+        }
+
+        $strictVariantMatch = $this->matchStrictTextVariant($input, $lookup);
+
+        if ($strictVariantMatch !== null) {
+            return $strictVariantMatch;
+        }
+
+        if ($this->looksCustomOrUnsupported($input)) {
+            return SpdxRightsMatchResult::unsupported('The rights statement looks custom, restricted, or non-SPDX.');
+        }
+
+        return SpdxRightsMatchResult::unsupported('No strong SPDX identifier, URI, canonical name, or approved alias matched.');
+    }
+
+    private function matchIdentifier(SpdxRightsMatchInput $input, SpdxLicenseLookup $lookup): ?SpdxRightsMatchResult
+    {
+        $identifier = trim((string) $input->rightsIdentifier);
+
+        if ($identifier === '') {
+            return null;
+        }
+
+        $scheme = SpdxLicenseLookup::normalizeText($input->rightsIdentifierScheme);
+        $isSpdxScheme = $scheme === ''
+            || $scheme === 'spdx'
+            || $scheme === SpdxLicenseLookup::normalizeText(SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME);
+
+        if (! $isSpdxScheme) {
+            return null;
+        }
+
+        $license = $lookup->findByIdentifier($identifier);
+
+        if ($license === null) {
+            return null;
+        }
+
+        return SpdxRightsMatchResult::matched(
+            license: $license,
+            score: 1.0,
+            matchType: 'resource_rights.rights_identifier',
+            reason: 'The imported rights identifier exactly matches an SPDX identifier.',
+        );
+    }
+
+    private function matchUri(SpdxRightsMatchInput $input, SpdxLicenseLookup $lookup): ?SpdxRightsMatchResult
+    {
+        $license = $lookup->findByUri($input->rightsUri);
+
+        if ($license === null) {
+            return null;
+        }
+
+        return SpdxRightsMatchResult::matched(
+            license: $license,
+            score: 0.98,
+            matchType: 'resource_rights.rights_uri',
+            reason: 'The imported rights URI matches a canonical or approved SPDX license URL.',
+        );
+    }
+
+    private function matchCanonicalName(SpdxRightsMatchInput $input, SpdxLicenseLookup $lookup): ?SpdxRightsMatchResult
+    {
+        $license = $lookup->findByName($input->rightsText);
+
+        if ($license === null) {
+            return null;
+        }
+
+        return SpdxRightsMatchResult::matched(
+            license: $license,
+            score: 1.0,
+            matchType: 'resource_rights.rights_text',
+            reason: 'The imported rights text exactly matches the canonical SPDX license name.',
+        );
+    }
+
+    private function matchApprovedAlias(SpdxRightsMatchInput $input, SpdxLicenseLookup $lookup): ?SpdxRightsMatchResult
+    {
+        $license = $lookup->findByAlias($input->rightsText);
+
+        if ($license === null) {
+            return null;
+        }
+
+        return SpdxRightsMatchResult::matched(
+            license: $license,
+            score: 0.95,
+            matchType: 'resource_rights.rights_text_alias',
+            reason: 'The imported rights text matches a reviewed SPDX alias.',
+        );
+    }
+
+    private function matchStrictTextVariant(SpdxRightsMatchInput $input, SpdxLicenseLookup $lookup): ?SpdxRightsMatchResult
+    {
+        $text = SpdxLicenseLookup::normalizeText($input->rightsText);
+
+        if ($text === '') {
+            return null;
+        }
+
+        /*
+         * Some imported strings contain a short SPDX-like phrase inside longer
+         * text, for example "Dataset licensed as CC BY 4.0". We only accept
+         * these tightly scoped patterns when the extracted phrase is already in
+         * the approved alias table.
+         */
+        $patterns = [
+            '/\bcc\s+by\s+4\.0\b/u',
+            '/\bcc\s+by[-\s]?nc\s+4\.0\b/u',
+            '/\bcc\s+by[-\s]?sa\s+4\.0\b/u',
+            '/\bcc0\s+(?:universal\s+)?1\.0\b/u',
+            '/\bmit\s+licen[cs]e\b/u',
+            '/\bapache\s+licen[cs]e(?:,?\s+version)?\s+2\.0\b/u',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $text, $matches) !== 1) {
+                continue;
+            }
+
+            $license = $lookup->findByAlias($matches[0]);
+
+            if ($license === null) {
+                continue;
+            }
+
+            return SpdxRightsMatchResult::matched(
+                license: $license,
+                score: 0.90,
+                matchType: 'resource_rights.rights_text_strict_variant',
+                reason: 'A reviewed SPDX alias was found inside a longer rights statement.',
+            );
+        }
+
+        return null;
+    }
+
+    private function looksCustomOrUnsupported(SpdxRightsMatchInput $input): bool
+    {
+        $haystack = SpdxLicenseLookup::normalizeText(implode(' ', array_filter([
+            $input->rightsText,
+            $input->rightsUri,
+            $input->rightsIdentifier,
+        ], fn (?string $value): bool => $value !== null && trim($value) !== '')));
+
+        if ($haystack === '') {
+            return false;
+        }
+
+        foreach (self::CUSTOM_RIGHTS_MARKERS as $marker) {
+            if (Str::contains($haystack, $marker)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/modules/assistants/SpdxLicenseSuggestion/Assistant.php
+++ b/modules/assistants/SpdxLicenseSuggestion/Assistant.php
@@ -79,7 +79,7 @@ final class Assistant extends GenericTableAssistant
     {
         return [
             'success' => false,
-            'message' => 'Accepting SPDX rights suggestions is planned for a follow-up issue.',
+            'message' => 'Accepting SPDX rights suggestions is not supported yet. Please decline this suggestion to dismiss it for now.',
         ];
     }
 }

--- a/modules/assistants/SpdxLicenseSuggestion/Assistant.php
+++ b/modules/assistants/SpdxLicenseSuggestion/Assistant.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Assistants\SpdxLicenseSuggestion;
+
+use App\Models\AssistantSuggestion;
+use App\Services\Assistance\GenericTableAssistant;
+use App\Services\Spdx\SpdxRightsDiscoveryService;
+use Closure;
+
+/**
+ * Assistant module that proposes SPDX links for imported rights statements.
+ *
+ * The module intentionally extends GenericTableAssistant. That base class
+ * handles storage, duplicate checks, pagination, decline tracking, and job
+ * dispatch. Students can therefore focus on the domain-specific discovery
+ * logic in SpdxRightsDiscoveryService.
+ */
+final class Assistant extends GenericTableAssistant
+{
+    public function __construct(
+        private readonly SpdxRightsDiscoveryService $discoveryService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function getManifestPath(): string
+    {
+        return __DIR__.'/manifest.json';
+    }
+
+    /**
+     * Run SPDX discovery and store suggestions in the generic assistant table.
+     *
+     * The closure passed into the discovery service is a small adapter around
+     * GenericTableAssistant::storeSuggestion(). This keeps the reusable service
+     * independent from the assistant UI/storage base class.
+     *
+     * @param  Closure(string): void  $onProgress
+     */
+    #[\Override]
+    protected function discover(Closure $onProgress): int
+    {
+        return $this->discoveryService->discover(
+            storeSuggestion: fn (
+                int $resourceId,
+                string $targetType,
+                int $targetId,
+                string $suggestedValue,
+                string $suggestedLabel,
+                ?float $similarityScore,
+                ?array $metadata,
+            ): bool => $this->storeSuggestion(
+                resourceId: $resourceId,
+                targetType: $targetType,
+                targetId: $targetId,
+                suggestedValue: $suggestedValue,
+                suggestedLabel: $suggestedLabel,
+                similarityScore: $similarityScore,
+                metadata: $metadata,
+            ),
+            onProgress: $onProgress,
+        );
+    }
+
+    /**
+     * Issue 820 stops at suggestion generation.
+     *
+     * Accepting a suggestion means updating the targeted `resource_rights` row
+     * and is intentionally left for the follow-up issue. Returning success=false
+     * makes that boundary explicit and prevents accidental data writes.
+     *
+     * @return array{success: bool, message: string}
+     */
+    #[\Override]
+    protected function applyAccepted(AssistantSuggestion $suggestion): array
+    {
+        return [
+            'success' => false,
+            'message' => 'Accepting SPDX rights suggestions is planned for a follow-up issue.',
+        ];
+    }
+}

--- a/modules/assistants/SpdxLicenseSuggestion/manifest.json
+++ b/modules/assistants/SpdxLicenseSuggestion/manifest.json
@@ -1,0 +1,24 @@
+{
+    "id": "spdx-license-suggestion",
+    "name": "SPDX Rights Suggestions",
+    "description": "Proposes SPDX license links for unresolved resource rights metadata.",
+    "icon": "Scale",
+    "version": "1.0.0",
+    "assistant_class": "Modules\\Assistants\\SpdxLicenseSuggestion\\Assistant",
+    "route_prefix": "spdx-rights",
+    "lock_key": "spdx_rights_discovery_running",
+    "cache_key_prefix": "spdx_rights_discovery",
+    "sort_order": 40,
+    "status_labels": {
+        "checking": "Starting SPDX rights discovery...",
+        "completed_with_results": "SPDX rights discovery completed: {count} new suggestion(s) found.",
+        "completed_empty": "SPDX rights discovery completed: No new suggestions found.",
+        "failed": "SPDX rights discovery failed: {error}",
+        "already_running": "An SPDX rights discovery job is already running."
+    },
+    "empty_state": {
+        "title": "No pending SPDX suggestions",
+        "description": "No unresolved rights statements currently match SPDX."
+    },
+    "card_component": null
+}

--- a/modules/assistants/spdx-rights-enrichment-model.md
+++ b/modules/assistants/spdx-rights-enrichment-model.md
@@ -138,6 +138,44 @@ row by setting `rights_id` to the accepted shared right. It should preserve the
 raw imported fields for audit/evidence unless a future cleanup issue explicitly
 defines a destructive replacement. It must not remove unrelated rights rows.
 
+## SPDX Matching Strategy
+
+The assistant must treat every imported rights field as optional evidence. A
+missing `rights_uri` must not prevent matching when the imported rights text is
+strong enough on its own.
+
+Matching should run in conservative tiers:
+
+1. Exact SPDX identifier match from `resource_rights.rights_identifier`.
+2. Canonicalized URI match from `resource_rights.rights_uri`.
+3. Exact canonical SPDX name match from `resource_rights.rights_text`.
+4. Approved alias match from `resource_rights.rights_text`, for examples such
+   as `CC BY 4.0` -> `CC-BY-4.0` and `Apache License 2.0` -> `Apache-2.0`.
+5. Strict normalized-text match for well-known variants where the license family
+   and version are unambiguous.
+6. Unsupported/no suggestion for weak, institution-specific, commercial,
+   individual, or ambiguous statements.
+
+The URI is supporting evidence, not a required input. For example, an import
+with only:
+
+```json
+{
+  "rights": "CC BY 4.0"
+}
+```
+
+may still produce a suggestion for `CC-BY-4.0` because `CC BY 4.0` is an
+approved alias. By contrast, text such as `individual`, `commercial use only`,
+or a long institution-specific permission statement should be left unresolved
+unless a future issue introduces an explicit, reviewed mapping.
+
+Free-form fuzzy matching must be intentionally narrow. It may contribute a
+`similarity_score` and evidence text, but it must not turn a weak legal metadata
+guess into an actionable suggestion. When in doubt, the assistant should mark
+the row as unsupported internally or skip suggestion creation; the imported raw
+rights row remains available for human review.
+
 ## Shared vs Resource-Specific Behavior
 
 The boundary is:

--- a/modules/assistants/spdx-rights-enrichment-model.md
+++ b/modules/assistants/spdx-rights-enrichment-model.md
@@ -1,17 +1,19 @@
 # SPDX Rights Enrichment Persistence Model
 
-Status: design contract for GitHub issue #819, under epic #772.
+Status: revised design contract for the SPDX rights enrichment work under epic
+#772, including import persistence and assistant suggestion boundaries.
 
-This document defines how SPDX-style rights enrichment suggestions should be
-stored, reviewed, accepted, and exported. It intentionally avoids rebuilding
-the entire rights catalog architecture. The goal is to make future assistant
-work persistable without mixing global SPDX catalog data with per-resource
-metadata.
+This document defines how imported rights statements and SPDX-style rights
+enrichment suggestions should be stored, reviewed, accepted, and exported. It
+intentionally avoids treating raw imported rights text as trusted SPDX catalog
+data. The goal is to preserve source metadata first, then let an assistant
+propose a curated SPDX link that a reviewer may accept or decline.
 
 ## Scope
 
-The SPDX rights enrichment assistant may suggest values for these DataCite
-rights fields:
+The import layer must be able to persist raw DataCite rights fields before any
+assistant decision is made. The SPDX rights enrichment assistant may then
+suggest normalized values for the same DataCite rights fields:
 
 - `rights`: the human-readable rights text.
 - `rightsURI`: the license or rights URL.
@@ -36,20 +38,39 @@ relationship:
 
 The export layer currently derives `rightsIdentifierScheme` as `SPDX` when a
 right has an identifier. It derives rights language from the resource language.
-This means SPDX identifier, URI, and scheme URI are already persistable in the
-shared catalog, but per-resource rights language is not independently
-persistable yet.
+
+This works only when the imported metadata already carries a known
+`rightsIdentifier` or an exact `rights.name` match. It does not preserve raw
+rights statements such as:
+
+```json
+{
+  "rights": "CC BY 4.0",
+  "rightsUri": "http://creativecommons.org/licenses/by/4.0"
+}
+```
+
+For example, importing DOI `10.5880/fidgeo.2017.003` currently receives the
+raw rights statement above, but no `rightsIdentifier`. Because `rights.name` in
+the SPDX catalog is `Creative Commons Attribution 4.0 International`, the
+current exact-name lookup does not attach a right and the original rights text
+is lost from durable ERNIE storage.
 
 ## Target Persistence Model
 
-The target model keeps SPDX catalog facts global and stores resource usage
-facts on the pivot.
+The target model has three distinct layers:
+
+1. Raw rights statements imported for one resource.
+2. Shared, trusted rights catalog facts.
+3. Temporary assistant suggestions that propose linking a raw statement to an
+   SPDX catalog entry.
 
 ### Shared rights catalog: `rights`
 
 `rights` remains the canonical license catalog. Assistant acceptance may create
 or fill a missing catalog row, but it must not create one duplicate row per
-resource.
+resource. Raw imported strings that have not been reviewed must not be inserted
+into `rights` merely to make an import pass validation.
 
 | DataCite field | Storage | Notes |
 | --- | --- | --- |
@@ -70,38 +91,60 @@ use an idempotent create/update flow:
    trusted SPDX payload. Avoid overwriting non-empty curator-maintained values
    unless a future issue explicitly defines that behavior.
 
-### Resource-specific usage: `resource_rights`
+### Resource-specific rights statements: `resource_rights`
 
-`resource_rights` represents the use of a shared right by one resource. It is
-the correct place for values that can vary per resource.
+`resource_rights` should represent one rights statement on one resource. A row
+may be linked to the shared `rights` catalog, or it may remain an unresolved raw
+statement until a reviewer accepts an assistant suggestion.
 
 Target fields:
 
 | DataCite field | Storage | Notes |
 | --- | --- | --- |
-| selected right | `resource_rights.rights_id` | Points to the shared `rights` row. |
 | resource | `resource_rights.resource_id` | Existing resource link. |
-| `lang` / `xml:lang` | `resource_rights.language` | Nullable future column. Stores the rights text language for this resource usage. |
+| selected right | `resource_rights.rights_id` | Nullable. Points to the shared `rights` row after a trusted link exists. |
+| imported `rights` | `resource_rights.rights_text` | Raw rights text from DataCite XML/JSON, legacy import, or manual entry. |
+| imported `rightsURI` / `rightsUri` | `resource_rights.rights_uri` | Raw source URI, preserved even when not canonical. |
+| imported `rightsIdentifier` | `resource_rights.rights_identifier` | Nullable raw identifier from source metadata. |
+| imported `rightsIdentifierScheme` | `resource_rights.rights_identifier_scheme` | Nullable raw identifier scheme from source metadata. |
+| imported `schemeURI` / `schemeUri` | `resource_rights.scheme_uri` | Nullable raw scheme URI from source metadata. |
+| `lang` / `xml:lang` | `resource_rights.language` | Nullable. Stores the rights text language for this resource usage. |
+| source marker | `resource_rights.source` | Optional value such as `datacite`, `xml`, `json`, or `legacy`. |
 
-Until `resource_rights.language` exists, exports should keep their current
-fallback behavior and use the resource language when available. Once the pivot
-column exists, export precedence should be:
+A row with `rights_id = null` is unresolved but still exportable as the raw
+rights statement. A row with `rights_id` set is linked to the shared catalog and
+may export the trusted catalog values.
+
+For DOI `10.5880/fidgeo.2017.003`, initial import should create one unresolved
+row similar to:
+
+| Column | Value |
+| --- | --- |
+| `resource_id` | imported resource ID |
+| `rights_id` | `null` |
+| `rights_text` | `CC BY 4.0` |
+| `rights_uri` | `http://creativecommons.org/licenses/by/4.0` |
+| `language` | `en`, when derivable from rights XML/JSON or resource language |
+| `source` | `datacite` |
+
+Export precedence for rights language should be:
 
 1. `resource_rights.language`, when set.
 2. `resources.language_id -> languages.code`, preserving current behavior.
 3. no rights language attribute, if neither value is available.
 
-Accepting a suggestion should attach the shared right with
-`syncWithoutDetaching`, or update the existing pivot row if the right is already
-attached. It must not call `sync()` with only the suggested right unless the
-assistant is explicitly performing a reviewer-approved replacement action.
+Accepting a suggestion should update the targeted unresolved `resource_rights`
+row by setting `rights_id` to the accepted shared right. It should preserve the
+raw imported fields for audit/evidence unless a future cleanup issue explicitly
+defines a destructive replacement. It must not remove unrelated rights rows.
 
 ## Shared vs Resource-Specific Behavior
 
 The boundary is:
 
 - Shared `rights` data describes what the license is.
-- `resource_rights` data describes how a resource uses that license.
+- `resource_rights` data describes the rights statement found on a resource,
+  including unresolved raw text before review.
 - Assistant suggestions are temporary review artifacts. They should carry the
   complete proposed DataCite payload, but accepted suggestions should persist
   only the fields that belong in durable storage.
@@ -112,53 +155,83 @@ Examples:
   `https://spdx.org/licenses/` are shared catalog facts.
 - Resource A using `MIT` with rights text language `en` is a resource-specific
   fact.
+- Resource B imported with `CC BY 4.0` and
+  `http://creativecommons.org/licenses/by/4.0` is an unresolved raw rights
+  statement until a reviewer accepts an SPDX enrichment suggestion.
 - A reviewer confidence score, evidence text, source API response, and match
   rationale are suggestion facts and stay in `assistant_suggestions.metadata`.
 
 ## Migration And Compatibility Strategy
 
-The current schema can persist SPDX identifier, rights URI, and scheme URI. The
-only required schema gap for issue #819 is per-resource rights language.
+The current schema can persist trusted SPDX catalog facts, but it cannot persist
+unresolved imported rights statements because `resource_rights.rights_id` is
+required and there are no raw rights columns. The required schema gap is
+therefore broader than per-resource rights language.
 
 Recommended migration:
 
 ```php
 Schema::table('resource_rights', function (Blueprint $table): void {
-    $table->string('language', 10)->nullable()->after('rights_id');
+    // The actual migration must adjust the existing foreign key/index safely.
+    $table->foreignId('rights_id')->nullable()->change();
+    $table->text('rights_text')->nullable()->after('rights_id');
+    $table->string('rights_uri', 512)->nullable()->after('rights_text');
+    $table->string('rights_identifier', 255)->nullable()->after('rights_uri');
+    $table->string('rights_identifier_scheme', 100)->nullable()->after('rights_identifier');
+    $table->string('scheme_uri', 512)->nullable()->after('rights_identifier_scheme');
+    $table->string('language', 10)->nullable()->after('scheme_uri');
+    $table->string('source', 100)->nullable()->after('language');
 });
 ```
 
+The existing unique key on `resource_rights(resource_id, rights_id)` must be
+revisited because unresolved rows have `rights_id = null`. Linked rights should
+remain unique per resource and shared right. Raw imports should avoid duplicate
+rows by comparing a normalized tuple of `resource_id`, `rights_text`,
+`rights_uri`, `rights_identifier`, `rights_identifier_scheme`, and `scheme_uri`.
+
 Recommended model/export follow-up:
 
-- Add `->withPivot('language')` to `Resource::rights()` and `Right::resources()`.
-- When accepting a suggestion, pass the suggested language as pivot data when it
-  is non-empty.
+- Add a first-class `ResourceRight` model for `resource_rights` so unresolved
+  rows can be queried without requiring a joined `rights` row.
+- Keep `Resource::rights()` and `Right::resources()` for linked catalog rights,
+  but add pivot accessors for the new raw fields where needed.
+- Update DataCite/XML/JSON imports to persist raw rights rows even when
+  `rightsIdentifier` is missing or not recognized.
 - Update DataCite XML export to emit `xml:lang` from pivot language first, then
   the existing resource-language fallback.
 - Update DataCite JSON export to emit `lang` from pivot language first, then the
   existing resource-language fallback.
+- Export unresolved rows from raw `resource_rights` fields and linked rows from
+  the shared `rights` catalog.
 - Keep imports backward compatible by accepting the existing `licenses` array of
-  SPDX identifiers. A later importer enhancement may capture rights language
-  into the pivot when present.
+  SPDX identifiers. Existing editor submissions that choose a known license may
+  continue to create linked `resource_rights` rows directly.
 
 Backward compatibility constraints:
 
-- The migration must be nullable and must not require a data backfill.
+- The migration must be nullable and must not require a mandatory data backfill.
 - Existing resources continue to export the same rights language via resource
   language fallback.
 - Existing editor requests keep using `licenses: string[]` until a future UI
   issue introduces per-license language editing.
+- Existing linked rights rows remain valid; their raw columns may stay null.
 - Existing DataCite/XML/JSON imports that only extract `rightsIdentifier` remain
-  valid.
-- The unique key on `resource_rights(resource_id, rights_id)` remains unchanged.
+  valid, but imports with only `rights` and `rightsUri` should no longer lose
+  that information.
 
 Rollout order:
 
-1. Add the nullable pivot column and model pivot accessors.
-2. Update XML and JSON exporters to read pivot language with fallback.
-3. Implement assistant acceptance to create or reuse `rights` rows and attach
-   the right through the pivot.
-4. Optionally extend DataCite import/editor UI to capture per-right language.
+1. Add raw rights storage to `resource_rights` and introduce a `ResourceRight`
+   model.
+2. Update DataCite REST, XML, JSON, and legacy imports to persist raw rights
+   statements.
+3. Update XML and JSON exporters to handle unresolved raw rows and linked
+   catalog rows.
+4. Implement assistant discovery that matches raw rights rows to SPDX catalog
+   entries and stores suggestions.
+5. Implement assistant acceptance to create/reuse `rights` rows and link the
+   targeted `resource_rights` row.
 
 ## Suggestion Payload Contract
 
@@ -173,35 +246,42 @@ The existing `storeSuggestion()` fields should be populated as follows:
 | --- | --- |
 | `assistant_id` | `spdx-license-suggestion`, unless the module manifest deliberately chooses another stable ID. |
 | `resource_id` | The resource being enriched. |
-| `target_type` | `resource`. |
-| `target_id` | The resource ID. |
+| `target_type` | `resource_right`. |
+| `target_id` | The `resource_rights.id` row being enriched. |
 | `suggested_value` | Normalized SPDX identifier, for example `CC-BY-4.0`. |
 | `suggested_label` | Human-readable rights text, for example `Creative Commons Attribution 4.0 International`. |
 | `similarity_score` | Optional confidence score from `0.0` to `1.0`. |
 | `metadata` | JSON object described below. |
 
-Use `resource` rather than `resource_rights` for `target_type` because the
-suggestion enriches a resource and the `resource_rights` pivot row does not
-exist until the suggestion is accepted. This keeps duplicate and dismissed
-suggestion checks scoped to the same target as the Developer Guide examples.
+Use `resource_right` rather than `resource` for `target_type` because the
+suggestion enriches one imported rights statement, not the whole resource. This
+lets a resource with multiple imported rights statements receive independent
+suggestions and independent reviewer decisions.
 
 `metadata` must be structured enough for reviewer display and safe acceptance:
 
 ```json
 {
-  "contract_version": "1.0",
-  "action": "attach_right",
-  "rights": "Creative Commons Attribution 4.0 International",
-  "rights_uri": "https://creativecommons.org/licenses/by/4.0/",
-  "rights_identifier": "CC-BY-4.0",
-  "rights_identifier_scheme": "SPDX",
-  "scheme_uri": "https://spdx.org/licenses/",
-  "language": "en",
+  "contract_version": "1.1",
+  "action": "link_right",
+  "current": {
+    "rights": "CC BY 4.0",
+    "rights_uri": "http://creativecommons.org/licenses/by/4.0",
+    "language": "en"
+  },
+  "proposed": {
+    "rights": "Creative Commons Attribution 4.0 International",
+    "rights_uri": "https://creativecommons.org/licenses/by/4.0/",
+    "rights_identifier": "CC-BY-4.0",
+    "rights_identifier_scheme": "SPDX",
+    "scheme_uri": "https://spdx.org/licenses/",
+    "language": "en"
+  },
   "source": "spdx",
   "source_url": "https://spdx.org/licenses/CC-BY-4.0.html",
   "evidence": {
-    "matched_from": "existing free-text rights field, uploaded metadata, or file hint",
-    "reason": "why this SPDX license was selected"
+    "matched_from": "resource_rights.rights_text",
+    "reason": "approved alias match: CC BY 4.0 -> CC-BY-4.0"
   }
 }
 ```
@@ -210,44 +290,61 @@ Required metadata keys:
 
 - `contract_version`
 - `action`
-- `rights`
-- `rights_identifier`
-- `rights_identifier_scheme`
-- `scheme_uri`
+- `current`
+- `proposed`
+- `proposed.rights`
+- `proposed.rights_identifier`
+- `proposed.rights_identifier_scheme`
+- `proposed.scheme_uri`
 - `source`
 
 Optional metadata keys:
 
-- `rights_uri`
-- `language`
 - `source_url`
 - `evidence`
 - `raw_spdx`
 
 Acceptance rules:
 
-- Reject suggestions whose `rights_identifier_scheme` is not `SPDX` unless a
-  future issue explicitly expands the assistant beyond SPDX.
-- Normalize and validate `rights_identifier` against the SPDX catalog lookup or
-  a trusted SPDX payload.
+- Reject suggestions whose `proposed.rights_identifier_scheme` is not `SPDX`
+  unless a future issue explicitly expands the assistant beyond SPDX.
+- Normalize and validate `proposed.rights_identifier` against the SPDX catalog
+  lookup or a trusted SPDX payload.
 - Create or reuse one shared `rights` row keyed by `rights.identifier`.
-- Attach the right to the resource without removing unrelated existing rights.
-- Store `metadata.language` on `resource_rights.language` once the pivot column
-  exists.
+- Update the targeted `resource_rights` row with the accepted `rights_id`.
+- Store `proposed.language` on `resource_rights.language` when it is non-empty.
+- Preserve raw `current` values unless a future issue explicitly defines cleanup
+  behavior.
 - Delete the accepted suggestion after successful persistence, following the
   existing `GenericTableAssistant` behavior.
+
+Declining a suggestion should leave the raw `resource_rights` row unchanged and
+store the declined SPDX identifier in `assistant_dismissed`.
 
 Reviewer-facing suggestions should show at least:
 
 - Resource title and DOI, when available.
-- Current rights attached to the resource.
+- Current raw rights statement attached to the resource.
 - Suggested rights text and SPDX identifier.
 - `rightsURI`, `schemeURI`, and language when present.
 - Confidence score and evidence/reason when present.
 
 ## Export Mapping
 
-After acceptance, exports should map durable storage to DataCite as follows:
+Exports should map durable storage to DataCite as follows:
+
+Unresolved raw `resource_rights` row:
+
+| Export field | Source |
+| --- | --- |
+| `rights` | `resource_rights.rights_text` |
+| `rightsURI` | `resource_rights.rights_uri` |
+| `rightsIdentifier` | `resource_rights.rights_identifier`, when present |
+| `rightsIdentifierScheme` | `resource_rights.rights_identifier_scheme`, when present |
+| `schemeURI` | `resource_rights.scheme_uri`, when present |
+| `lang` / `xml:lang` | `resource_rights.language`, then resource language fallback |
+
+Linked `resource_rights` row after accepted SPDX enrichment:
 
 | Export field | Source |
 | --- | --- |
@@ -258,5 +355,6 @@ After acceptance, exports should map durable storage to DataCite as follows:
 | `schemeURI` | `rights.scheme_uri` |
 | `lang` / `xml:lang` | `resource_rights.language`, then resource language fallback |
 
-This lets accepted suggestions populate the full DataCite rights payload while
-keeping global SPDX catalog data separate from resource-specific usage.
+This preserves the original imported rights payload before review and lets
+accepted suggestions populate the full DataCite rights payload while keeping
+global SPDX catalog data separate from resource-specific usage.

--- a/tests/pest/Feature/Services/SpdxLicenseSuggestionAssistantTest.php
+++ b/tests/pest/Feature/Services/SpdxLicenseSuggestionAssistantTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AssistantSuggestion;
+use App\Models\Resource;
+use Modules\Assistants\SpdxLicenseSuggestion\Assistant;
+
+it('explains that SPDX suggestions cannot be accepted yet and can be declined instead', function () {
+    $assistant = app(Assistant::class);
+    $resource = Resource::factory()->create();
+    $suggestion = AssistantSuggestion::create([
+        'assistant_id' => $assistant->getId(),
+        'resource_id' => $resource->id,
+        'target_type' => 'resource_right',
+        'target_id' => 123,
+        'suggested_value' => 'CC-BY-4.0',
+        'suggested_label' => 'Creative Commons Attribution 4.0 International',
+        'discovered_at' => now(),
+    ]);
+
+    $result = $assistant->acceptSuggestion($suggestion->id);
+
+    expect($result)
+        ->toBe([
+            'success' => false,
+            'message' => 'Accepting SPDX rights suggestions is not supported yet. Please decline this suggestion to dismiss it for now.',
+        ])
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull();
+});

--- a/tests/pest/Feature/Services/SpdxRightsDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/SpdxRightsDiscoveryServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Resource;
+use App\Models\Right;
+use App\Services\Spdx\SpdxRightsDiscoveryService;
+use App\Services\Spdx\SpdxRightsMatcher;
+use App\Services\Spdx\SpdxRightsMatchInput;
+use App\Services\Spdx\SpdxRightsMatchInputProvider;
+use Illuminate\Support\Collection;
+
+covers(SpdxRightsDiscoveryService::class);
+
+function spdxRightsDiscoveryTestProvider(Collection $inputs): SpdxRightsMatchInputProvider
+{
+    return new class($inputs) extends SpdxRightsMatchInputProvider
+    {
+        /**
+         * @param  Collection<int, SpdxRightsMatchInput>  $inputs
+         */
+        public function __construct(private readonly Collection $inputs) {}
+
+        /**
+         * @return Collection<int, SpdxRightsMatchInput>
+         */
+        #[Override]
+        public function pendingInputs(): Collection
+        {
+            return $this->inputs;
+        }
+    };
+}
+
+it('stores suggestions for exact and alias matches while skipping non-SPDX statements', function () {
+    $resource = Resource::factory()->create();
+    Right::factory()->ccBy4()->create();
+
+    $inputs = collect([
+        new SpdxRightsMatchInput(
+            resourceId: $resource->id,
+            targetType: 'resource_right',
+            targetId: 1001,
+            rightsIdentifier: 'CC-BY-4.0',
+            rightsIdentifierScheme: 'SPDX',
+            source: 'datacite',
+        ),
+        new SpdxRightsMatchInput(
+            resourceId: $resource->id,
+            targetType: 'resource_right',
+            targetId: 1002,
+            rightsText: 'CC BY 4.0',
+            source: 'legacy',
+        ),
+        new SpdxRightsMatchInput(
+            resourceId: $resource->id,
+            targetType: 'resource_right',
+            targetId: 1003,
+            rightsText: 'Commercial end user licensing agreement required.',
+            source: 'legacy',
+        ),
+    ]);
+
+    $service = new SpdxRightsDiscoveryService(
+        inputProvider: spdxRightsDiscoveryTestProvider($inputs),
+        matcher: new SpdxRightsMatcher,
+    );
+
+    $storedSuggestions = [];
+    $progressMessages = [];
+
+    $count = $service->discover(
+        storeSuggestion: function (
+            int $resourceId,
+            string $targetType,
+            int $targetId,
+            string $suggestedValue,
+            string $suggestedLabel,
+            ?float $similarityScore,
+            ?array $metadata,
+        ) use (&$storedSuggestions): bool {
+            $storedSuggestions[] = compact(
+                'resourceId',
+                'targetType',
+                'targetId',
+                'suggestedValue',
+                'suggestedLabel',
+                'similarityScore',
+                'metadata',
+            );
+
+            return true;
+        },
+        onProgress: function (string $message) use (&$progressMessages): void {
+            $progressMessages[] = $message;
+        },
+    );
+
+    expect($count)->toBe(2)
+        ->and($storedSuggestions)->toHaveCount(2)
+        ->and($storedSuggestions[0]['targetId'])->toBe(1001)
+        ->and($storedSuggestions[0]['suggestedValue'])->toBe('CC-BY-4.0')
+        ->and($storedSuggestions[0]['metadata']['evidence']['matched_from'])->toBe('resource_rights.rights_identifier')
+        ->and($storedSuggestions[1]['targetId'])->toBe(1002)
+        ->and($storedSuggestions[1]['metadata']['current'])->toBe([
+            'rights' => 'CC BY 4.0',
+            'source' => 'legacy',
+        ])
+        ->and($storedSuggestions[1]['metadata']['proposed']['rights_uri'])->toBe('https://creativecommons.org/licenses/by/4.0/')
+        ->and($progressMessages)->toContain('Stored 2 SPDX suggestion(s); skipped 1 unsupported and 0 insufficient statement(s).');
+});
+
+it('returns no pending inputs before raw resource_rights columns exist', function () {
+    $provider = new SpdxRightsMatchInputProvider;
+
+    expect($provider->pendingInputs())->toHaveCount(0);
+});

--- a/tests/pest/Unit/Services/Spdx/SpdxLicenseLookupTest.php
+++ b/tests/pest/Unit/Services/Spdx/SpdxLicenseLookupTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Right;
+use App\Services\Spdx\SpdxLicenseLookup;
+
+covers(SpdxLicenseLookup::class);
+
+it('builds the catalog from active SPDX rights only', function () {
+    Right::factory()->ccBy4()->create();
+    Right::factory()->create([
+        'identifier' => 'CUSTOM-1',
+        'name' => 'Custom Institutional License',
+        'uri' => 'https://example.test/licenses/custom-1',
+        'scheme_uri' => null,
+        'is_active' => true,
+    ]);
+    Right::factory()->create([
+        'identifier' => 'Apache-2.0',
+        'name' => 'Apache License 2.0',
+        'uri' => 'https://spdx.org/licenses/Apache-2.0.html',
+        'scheme_uri' => SpdxLicenseLookup::SCHEME_URI,
+        'is_active' => false,
+    ]);
+
+    $lookup = SpdxLicenseLookup::fromRightsCatalog();
+
+    expect($lookup->findByIdentifier('CC-BY-4.0')?->name)
+        ->toBe('Creative Commons Attribution 4.0 International')
+        ->and($lookup->findByIdentifier('CUSTOM-1'))->toBeNull()
+        ->and($lookup->findByIdentifier('Apache-2.0'))->toBeNull();
+});

--- a/tests/pest/Unit/Services/Spdx/SpdxRightsMatcherTest.php
+++ b/tests/pest/Unit/Services/Spdx/SpdxRightsMatcherTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Spdx\SpdxLicenseData;
+use App\Services\Spdx\SpdxLicenseLookup;
+use App\Services\Spdx\SpdxRightsMatcher;
+use App\Services\Spdx\SpdxRightsMatchInput;
+
+covers(SpdxRightsMatcher::class);
+
+function spdxRightsMatcherTestLookup(): SpdxLicenseLookup
+{
+    return SpdxLicenseLookup::fromLicenses([
+        new SpdxLicenseData(
+            identifier: 'CC-BY-4.0',
+            name: 'Creative Commons Attribution 4.0 International',
+            rightsUri: 'https://creativecommons.org/licenses/by/4.0/',
+            schemeUri: SpdxLicenseLookup::SCHEME_URI,
+        ),
+        new SpdxLicenseData(
+            identifier: 'Apache-2.0',
+            name: 'Apache License 2.0',
+            rightsUri: 'https://www.apache.org/licenses/LICENSE-2.0',
+            schemeUri: SpdxLicenseLookup::SCHEME_URI,
+        ),
+    ]);
+}
+
+it('matches an exact SPDX identifier', function () {
+    $result = (new SpdxRightsMatcher)->match(
+        input: new SpdxRightsMatchInput(
+            resourceId: 1,
+            targetType: 'resource_right',
+            targetId: 10,
+            rightsIdentifier: 'CC-BY-4.0',
+            rightsIdentifierScheme: 'SPDX',
+        ),
+        lookup: spdxRightsMatcherTestLookup(),
+    );
+
+    expect($result->isMatched())->toBeTrue()
+        ->and($result->license?->identifier)->toBe('CC-BY-4.0')
+        ->and($result->matchType)->toBe('resource_rights.rights_identifier')
+        ->and($result->score)->toBe(1.0);
+});
+
+it('matches a reviewed alias when only rights text was imported', function () {
+    $input = new SpdxRightsMatchInput(
+        resourceId: 1,
+        targetType: 'resource_right',
+        targetId: 11,
+        rightsText: 'CC BY 4.0',
+    );
+
+    $result = (new SpdxRightsMatcher)->match(
+        input: $input,
+        lookup: spdxRightsMatcherTestLookup(),
+    );
+
+    $metadata = $result->toSuggestionMetadata($input);
+
+    expect($result->isMatched())->toBeTrue()
+        ->and($result->license?->identifier)->toBe('CC-BY-4.0')
+        ->and($result->matchType)->toBe('resource_rights.rights_text_alias')
+        ->and($metadata['current'])->toBe(['rights' => 'CC BY 4.0'])
+        ->and($metadata['proposed']['rights'])->toBe('Creative Commons Attribution 4.0 International')
+        ->and($metadata['proposed']['rights_uri'])->toBe('https://creativecommons.org/licenses/by/4.0/')
+        ->and($metadata['proposed']['rights_identifier'])->toBe('CC-BY-4.0')
+        ->and($metadata['proposed']['rights_identifier_scheme'])->toBe('SPDX')
+        ->and($metadata['proposed']['scheme_uri'])->toBe('https://spdx.org/licenses/');
+});
+
+it('marks custom or non-SPDX rights as unsupported', function () {
+    $result = (new SpdxRightsMatcher)->match(
+        input: new SpdxRightsMatchInput(
+            resourceId: 1,
+            targetType: 'resource_right',
+            targetId: 12,
+            rightsText: 'Use requires an individual license agreement with the data provider.',
+        ),
+        lookup: spdxRightsMatcherTestLookup(),
+    );
+
+    expect($result->isMatched())->toBeFalse()
+        ->and($result->status)->toBe('unsupported')
+        ->and($result->license)->toBeNull();
+});

--- a/tests/pest/Unit/Services/Spdx/SpdxRightsMatcherTest.php
+++ b/tests/pest/Unit/Services/Spdx/SpdxRightsMatcherTest.php
@@ -68,7 +68,8 @@ it('matches a reviewed alias when only rights text was imported', function () {
         ->and($metadata['proposed']['rights_uri'])->toBe('https://creativecommons.org/licenses/by/4.0/')
         ->and($metadata['proposed']['rights_identifier'])->toBe('CC-BY-4.0')
         ->and($metadata['proposed']['rights_identifier_scheme'])->toBe('SPDX')
-        ->and($metadata['proposed']['scheme_uri'])->toBe('https://spdx.org/licenses/');
+        ->and($metadata['proposed']['scheme_uri'])->toBe('https://spdx.org/licenses/')
+        ->and($metadata['proposed'])->not->toHaveKey('language');
 });
 
 it('marks custom or non-SPDX rights as unsupported', function () {
@@ -85,4 +86,36 @@ it('marks custom or non-SPDX rights as unsupported', function () {
     expect($result->isMatched())->toBeFalse()
         ->and($result->status)->toBe('unsupported')
         ->and($result->license)->toBeNull();
+});
+
+it('omits empty optional proposed metadata fields', function () {
+    $lookup = SpdxLicenseLookup::fromLicenses([
+        new SpdxLicenseData(
+            identifier: 'Custom-Test',
+            name: 'Custom Test License',
+            rightsUri: null,
+            schemeUri: SpdxLicenseLookup::SCHEME_URI,
+        ),
+    ]);
+
+    $input = new SpdxRightsMatchInput(
+        resourceId: 1,
+        targetType: 'resource_right',
+        targetId: 13,
+        rightsIdentifier: 'Custom-Test',
+        rightsIdentifierScheme: 'SPDX',
+    );
+
+    $result = (new SpdxRightsMatcher)->match(
+        input: $input,
+        lookup: $lookup,
+    );
+
+    $metadata = $result->toSuggestionMetadata($input);
+
+    expect($metadata['proposed'])
+        ->toHaveKey('rights')
+        ->toHaveKey('rights_identifier')
+        ->not->toHaveKey('rights_uri')
+        ->not->toHaveKey('language');
 });


### PR DESCRIPTION
This pull request introduces a new SPDX rights discovery workflow, adding a set of classes to support matching imported rights statements against a local SPDX license catalog. The changes are focused on enabling the system to suggest SPDX license links for unresolved rights statements, with careful handling of schema evolution and matching logic. The design separates responsibilities for input gathering, matching, result formatting, and suggestion storage.

**Key changes include:**

### SPDX License Lookup and Matching

* Added `SpdxLicenseLookup`, an in-memory lookup table for SPDX licenses built from the local `rights` catalog, supporting robust normalization and aliasing for identifiers, names, and URIs. This enables strong and safe matching of imported rights statements to SPDX licenses.
* Introduced `SpdxLicenseData`, a value object representing a single SPDX license entry, decoupled from the database model for focused matching logic.
* Added `SpdxRightsMatcher` (not shown in the diff, but implied by usage), which would use the lookup and input data to perform the actual matching.

### Rights Statement Input and Discovery

* Implemented `SpdxRightsMatchInputProvider`, which reads unresolved rights statements from the `resource_rights` table, adapting to the current schema and returning only rows with sufficient evidence for matching.
* Created `SpdxRightsMatchInput`, a value object encapsulating the data from a single unresolved rights statement, designed to mirror future database schema and allow for testing independent of schema changes.

### Matching Results and Suggestion Workflow

* Added `SpdxRightsMatchResult`, representing the outcome of matching a rights statement: matched, unsupported, or insufficient evidence. Provides methods to convert a match into structured metadata for reviewer-facing suggestions.
* Introduced `SpdxRightsDiscoveryService`, which coordinates the end-to-end discovery process: gathering inputs, running matches, and invoking a callback to store suggestions, with progress reporting and statistics.