### PR TITLE
Fix: Improve Name Type Resolution for Creators and Contributors

### DIFF
--- a/app/Models/GeoLocation.php
+++ b/app/Models/GeoLocation.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * GeoLocation Model (DataCite #18)
@@ -29,8 +31,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property float|null $in_polygon_point_latitude
  * @property float|null $elevation
  * @property string|null $elevation_unit
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read Resource $resource
  *
  * @see https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/geolocation/
@@ -38,7 +40,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 #[Fillable(['resource_id', 'geo_type', 'place', 'point_longitude', 'point_latitude', 'elevation', 'elevation_unit', 'west_bound_longitude', 'east_bound_longitude', 'south_bound_latitude', 'north_bound_latitude', 'polygon_points', 'in_polygon_point_longitude', 'in_polygon_point_latitude'])]
 class GeoLocation extends Model
 {
-    /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     public const GLOBAL_COVERAGE_TOLERANCE = 0.000001;
@@ -55,6 +57,51 @@ class GeoLocation extends Model
         'in_polygon_point_longitude' => 'decimal:8',
         'in_polygon_point_latitude' => 'decimal:8',
     ];
+
+    public function setPointLongitudeAttribute(mixed $value): void
+    {
+        $this->attributes['point_longitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setPointLatitudeAttribute(mixed $value): void
+    {
+        $this->attributes['point_latitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setElevationAttribute(mixed $value): void
+    {
+        $this->attributes['elevation'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setWestBoundLongitudeAttribute(mixed $value): void
+    {
+        $this->attributes['west_bound_longitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setEastBoundLongitudeAttribute(mixed $value): void
+    {
+        $this->attributes['east_bound_longitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setSouthBoundLatitudeAttribute(mixed $value): void
+    {
+        $this->attributes['south_bound_latitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setNorthBoundLatitudeAttribute(mixed $value): void
+    {
+        $this->attributes['north_bound_latitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setInPolygonPointLongitudeAttribute(mixed $value): void
+    {
+        $this->attributes['in_polygon_point_longitude'] = $this->normaliseNullableDecimal($value);
+    }
+
+    public function setInPolygonPointLatitudeAttribute(mixed $value): void
+    {
+        $this->attributes['in_polygon_point_latitude'] = $this->normaliseNullableDecimal($value);
+    }
 
     /** @return BelongsTo<Resource, static> */
     public function resource(): BelongsTo
@@ -152,5 +199,18 @@ class GeoLocation extends Model
             : self::GLOBAL_COVERAGE_TOLERANCE;
 
         return abs($actual - $expected) <= $tolerance;
+    }
+
+    private function normaliseNullableDecimal(mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $value = trim($value);
+        }
+
+        return is_numeric($value) ? $value : null;
     }
 }

--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\Enums\CacheKey;
 use App\Support\Traits\ChecksCacheTagging;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -22,6 +23,8 @@ class DataCiteApiService
     use ChecksCacheTagging;
 
     private const DEFAULT_TIMEOUT_SECONDS = 10.0;
+
+    private const RESPONSE_BODY_LOG_EXCERPT_LENGTH = 1000;
 
     /** Sentinel value stored in cache to represent a confirmed 404. */
     private const CACHE_NULL_SENTINEL = '__NULL__';
@@ -125,8 +128,7 @@ class DataCiteApiService
                 }
 
                 Log::warning("DOI resolution returned non-JSON metadata for {$originalDoi}", [
-                    'status' => $response->status(),
-                    'body' => $response->body(),
+                    ...$this->responseLogContext($response),
                 ]);
 
                 return self::CACHE_TRANSIENT_FAILURE;
@@ -139,8 +141,7 @@ class DataCiteApiService
             }
 
             Log::warning("DOI resolution error for {$originalDoi}", [
-                'status' => $response->status(),
-                'body' => $response->body(),
+                ...$this->responseLogContext($response),
             ]);
 
             return self::CACHE_TRANSIENT_FAILURE;
@@ -199,8 +200,16 @@ class DataCiteApiService
         $cleanDoi = $doi !== '' ? $this->normalizeDoi($doi) : null;
         $doiUrl = $cleanDoi !== null ? "https://doi.org/{$cleanDoi}" : '';
 
-        // Build citation: [Authors] ([Year]): [Title]. [Publisher]. [DOI URL]
-        return trim("{$authorsString} ({$year}): {$title}. {$publisher}. {$doiUrl}");
+        $segments = [
+            "{$authorsString} ({$year}): {$title}",
+            $publisher,
+        ];
+
+        if ($doiUrl !== '') {
+            $segments[] = $doiUrl;
+        }
+
+        return implode('. ', $segments);
     }
 
     /**
@@ -322,8 +331,7 @@ class DataCiteApiService
             }
 
             Log::warning("DataCite REST API error for {$originalDoi}", [
-                'status' => $response->status(),
-                'body' => $response->body(),
+                ...$this->responseLogContext($response),
             ]);
 
             return self::CACHE_TRANSIENT_FAILURE;
@@ -334,6 +342,21 @@ class DataCiteApiService
 
             return self::CACHE_TRANSIENT_FAILURE;
         }
+    }
+
+    /**
+     * @return array{status: int, content_type: string|null, body_excerpt: string, body_truncated: bool}
+     */
+    private function responseLogContext(Response $response): array
+    {
+        $body = $response->body();
+
+        return [
+            'status' => $response->status(),
+            'content_type' => $response->header('Content-Type'),
+            'body_excerpt' => substr($body, 0, self::RESPONSE_BODY_LOG_EXCERPT_LENGTH),
+            'body_truncated' => strlen($body) > self::RESPONSE_BODY_LOG_EXCERPT_LENGTH,
+        ];
     }
 
     /**

--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -11,11 +11,11 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 /**
- * Service für den Abruf von DOI-Metadaten über die doi.org Content Negotiation API.
+ * Service for fetching DOI metadata through the doi.org Content Negotiation API.
  *
- * Funktioniert registrarunabhängig mit allen DOI-Registraren (DataCite, Crossref, mEDRA, etc.)
+ * Works independently of the DOI registrar (DataCite, Crossref, mEDRA, etc.).
  *
- * API-Dokumentation: https://citation.crosscite.org/docs.html
+ * API documentation: https://citation.crosscite.org/docs.html
  */
 class DataCiteApiService
 {
@@ -55,12 +55,12 @@ class DataCiteApiService
     }
 
     /**
-     * Ruft Metadaten für eine DOI über Content Negotiation ab.
+     * Fetch metadata for a DOI through Content Negotiation.
      *
      * Results are cached for 24 hours to reduce load on doi.org.
      *
-     * @param  string  $doi  Die DOI, für die Metadaten abgerufen werden sollen
-     * @return array<string, mixed>|null Die Metadaten als Array oder null bei Fehler
+     * @param  string  $doi  The DOI to fetch metadata for
+     * @return array<string, mixed>|null The metadata array, or null on failure
      */
     public function getMetadata(string $doi, ?float $timeoutSeconds = null, bool $cacheTransientFailure = true): ?array
     {
@@ -154,16 +154,16 @@ class DataCiteApiService
     }
 
     /**
-     * Erstellt einen Zitationsstring aus CSL JSON Metadaten.
+     * Build a citation string from CSL JSON metadata.
      *
-     * CSL JSON ist das Standardformat der doi.org Content Negotiation API.
+     * CSL JSON is the standard format returned by the doi.org Content Negotiation API.
      *
-     * @param  array<string, mixed>  $metadata  Die Metadaten von doi.org
-     * @return string Die formatierte Zitation
+     * @param  array<string, mixed>  $metadata  The metadata from doi.org
+     * @return string The formatted citation
      */
     public function buildCitationFromMetadata(array $metadata): string
     {
-        // Autoren aus CSL JSON Format extrahieren
+        // Extract authors from CSL JSON.
         $authors = is_array($metadata['author'] ?? null) ? $metadata['author'] : [];
         $authorStrings = [];
         foreach ($authors as $author) {
@@ -185,21 +185,21 @@ class DataCiteApiService
         }
         $authorsString = ! empty($authorStrings) ? implode('; ', $authorStrings) : 'Unknown Author';
 
-        // Jahr extrahieren - verschiedene mögliche Felder prüfen
+        // Extract the year from several possible CSL date fields.
         $year = $this->metadataYear($metadata);
 
-        // Titel extrahieren
+        // Extract the title.
         $title = $this->metadataString($metadata['title'] ?? null, 'Untitled');
 
-        // Verlag extrahieren
+        // Extract the publisher.
         $publisher = $this->metadataString($metadata['publisher'] ?? null, 'Unknown Publisher');
 
-        // DOI extrahieren
+        // Extract the DOI.
         $doi = $this->metadataString($metadata['DOI'] ?? null);
         $cleanDoi = $doi !== '' ? $this->normalizeDoi($doi) : null;
         $doiUrl = $cleanDoi !== null ? "https://doi.org/{$cleanDoi}" : '';
 
-        // Zitation aufbauen: [Autoren] ([Jahr]): [Titel]. [Verlag]. [DOI URL]
+        // Build citation: [Authors] ([Year]): [Title]. [Publisher]. [DOI URL]
         return trim("{$authorsString} ({$year}): {$title}. {$publisher}. {$doiUrl}");
     }
 
@@ -209,7 +209,13 @@ class DataCiteApiService
     private function metadataYear(array $metadata): string
     {
         foreach (['issued', 'published', 'created'] as $field) {
-            $year = $this->metadataString($metadata[$field]['date-parts'] ?? null);
+            $date = $metadata[$field] ?? null;
+
+            if (! is_array($date)) {
+                continue;
+            }
+
+            $year = $this->metadataString($date['date-parts'] ?? null);
 
             if ($year !== '') {
                 return $year;

--- a/app/Services/DataCiteApiService.php
+++ b/app/Services/DataCiteApiService.php
@@ -118,7 +118,18 @@ class DataCiteApiService
                 ->get($url);
 
             if ($response->successful()) {
-                return $response->json();
+                $metadata = $response->json();
+
+                if (is_array($metadata)) {
+                    return $metadata;
+                }
+
+                Log::warning("DOI resolution returned non-JSON metadata for {$originalDoi}", [
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
+
+                return self::CACHE_TRANSIENT_FAILURE;
             }
 
             if ($response->status() === 404) {
@@ -153,41 +164,84 @@ class DataCiteApiService
     public function buildCitationFromMetadata(array $metadata): string
     {
         // Autoren aus CSL JSON Format extrahieren
-        $authors = $metadata['author'] ?? [];
+        $authors = is_array($metadata['author'] ?? null) ? $metadata['author'] : [];
         $authorStrings = [];
         foreach ($authors as $author) {
-            $family = isset($author['family']) && is_string($author['family']) ? $author['family'] : null;
-            $given = isset($author['given']) && is_string($author['given']) ? $author['given'] : null;
-            $literal = isset($author['literal']) && is_string($author['literal']) ? $author['literal'] : null;
+            if (! is_array($author)) {
+                continue;
+            }
 
-            if ($family !== null && $given !== null) {
+            $family = $this->metadataString($author['family'] ?? null);
+            $given = $this->metadataString($author['given'] ?? null);
+            $literal = $this->metadataString($author['literal'] ?? null);
+
+            if ($family !== '' && $given !== '') {
                 $authorStrings[] = $family.', '.$this->abbreviateGivenName($given);
-            } elseif ($literal !== null) {
+            } elseif ($literal !== '') {
                 $authorStrings[] = $literal;
-            } elseif ($family !== null) {
+            } elseif ($family !== '') {
                 $authorStrings[] = $family;
             }
         }
         $authorsString = ! empty($authorStrings) ? implode('; ', $authorStrings) : 'Unknown Author';
 
         // Jahr extrahieren - verschiedene mögliche Felder prüfen
-        $year = $metadata['issued']['date-parts'][0][0] ??
-                $metadata['published']['date-parts'][0][0] ??
-                $metadata['created']['date-parts'][0][0] ??
-                'n.d.';
+        $year = $this->metadataYear($metadata);
 
         // Titel extrahieren
-        $title = $metadata['title'] ?? 'Untitled';
+        $title = $this->metadataString($metadata['title'] ?? null, 'Untitled');
 
         // Verlag extrahieren
-        $publisher = $metadata['publisher'] ?? 'Unknown Publisher';
+        $publisher = $this->metadataString($metadata['publisher'] ?? null, 'Unknown Publisher');
 
         // DOI extrahieren
-        $doi = $metadata['DOI'] ?? '';
-        $doiUrl = $doi ? "https://doi.org/{$doi}" : '';
+        $doi = $this->metadataString($metadata['DOI'] ?? null);
+        $cleanDoi = $doi !== '' ? $this->normalizeDoi($doi) : null;
+        $doiUrl = $cleanDoi !== null ? "https://doi.org/{$cleanDoi}" : '';
 
         // Zitation aufbauen: [Autoren] ([Jahr]): [Titel]. [Verlag]. [DOI URL]
         return trim("{$authorsString} ({$year}): {$title}. {$publisher}. {$doiUrl}");
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    private function metadataYear(array $metadata): string
+    {
+        foreach (['issued', 'published', 'created'] as $field) {
+            $year = $this->metadataString($metadata[$field]['date-parts'] ?? null);
+
+            if ($year !== '') {
+                return $year;
+            }
+        }
+
+        return 'n.d.';
+    }
+
+    private function metadataString(mixed $value, string $fallback = ''): string
+    {
+        if (is_string($value)) {
+            $value = trim($value);
+
+            return $value !== '' ? $value : $fallback;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                $string = $this->metadataString($item);
+
+                if ($string !== '') {
+                    return $string;
+                }
+            }
+        }
+
+        return $fallback;
     }
 
     /**

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -37,6 +37,7 @@ use App\Models\Subject;
 use App\Models\Title;
 use App\Models\TitleType;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Support\OrcidNormalizer;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -615,7 +616,10 @@ class DataCiteToResourceTransformer
 
         if (is_array($nameIdentifiers)) {
             foreach ($nameIdentifiers as $nameId) {
-                if (! is_array($nameId) || ($nameId['nameIdentifierScheme'] ?? '') !== 'ORCID') {
+                if (
+                    ! is_array($nameId)
+                    || strtolower(trim((string) ($nameId['nameIdentifierScheme'] ?? ''))) !== 'orcid'
+                ) {
                     continue;
                 }
 
@@ -623,13 +627,13 @@ class DataCiteToResourceTransformer
                     ? trim((string) $nameId['nameIdentifier'])
                     : '';
 
-                if ($identifier === '') {
+                if ($identifier === '' || ! OrcidNormalizer::isValid($identifier)) {
                     continue;
                 }
 
-                $orcid = $identifier;
+                $orcid = OrcidNormalizer::toUrl($identifier);
                 $scheme = 'ORCID';
-                $schemeUri = $nameId['schemeUri'] ?? 'https://orcid.org';
+                $schemeUri = 'https://orcid.org';
                 break;
             }
         }
@@ -791,11 +795,15 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
-            if ($scheme === strtolower($expectedScheme)) {
-                return true;
+            if ($expectedScheme === 'ORCID') {
+                if ($scheme === 'orcid' || str_contains($identifier, 'orcid.org/')) {
+                    return OrcidNormalizer::isValid($identifier);
+                }
+
+                continue;
             }
 
-            if ($expectedScheme === 'ORCID' && str_contains($identifier, 'orcid.org/')) {
+            if ($scheme === strtolower($expectedScheme)) {
                 return true;
             }
 

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -341,11 +341,6 @@ class DataCiteToResourceTransformer
                 if ($titleTypeId === null) {
                     $titleTypeId = $this->resolveTitleTypeId('Other', 'Other');
                 }
-
-                // If still null, use MainTitle as last resort
-                if ($titleTypeId === null) {
-                    $titleTypeId = $mainTitleId;
-                }
             }
 
             Title::create([

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -611,9 +611,23 @@ class DataCiteToResourceTransformer
         $scheme = null;
         $schemeUri = null;
 
-        foreach ($data['nameIdentifiers'] ?? [] as $nameId) {
-            if (($nameId['nameIdentifierScheme'] ?? '') === 'ORCID') {
-                $orcid = $nameId['nameIdentifier'] ?? null;
+        $nameIdentifiers = $data['nameIdentifiers'] ?? [];
+
+        if (is_array($nameIdentifiers)) {
+            foreach ($nameIdentifiers as $nameId) {
+                if (! is_array($nameId) || ($nameId['nameIdentifierScheme'] ?? '') !== 'ORCID') {
+                    continue;
+                }
+
+                $identifier = isset($nameId['nameIdentifier'])
+                    ? trim((string) $nameId['nameIdentifier'])
+                    : '';
+
+                if ($identifier === '') {
+                    continue;
+                }
+
+                $orcid = $identifier;
                 $scheme = 'ORCID';
                 $schemeUri = $nameId['schemeUri'] ?? 'https://orcid.org';
                 break;
@@ -755,7 +769,13 @@ class DataCiteToResourceTransformer
      */
     private function hasNameIdentifierScheme(array $data, string $expectedScheme): bool
     {
-        foreach ($data['nameIdentifiers'] ?? [] as $nameIdentifier) {
+        $nameIdentifiers = $data['nameIdentifiers'] ?? [];
+
+        if (! is_array($nameIdentifiers)) {
+            return false;
+        }
+
+        foreach ($nameIdentifiers as $nameIdentifier) {
             if (! is_array($nameIdentifier)) {
                 continue;
             }
@@ -766,6 +786,10 @@ class DataCiteToResourceTransformer
             $identifier = isset($nameIdentifier['nameIdentifier'])
                 ? strtolower(trim((string) $nameIdentifier['nameIdentifier']))
                 : '';
+
+            if ($identifier === '') {
+                continue;
+            }
 
             if ($scheme === strtolower($expectedScheme)) {
                 return true;
@@ -905,9 +929,23 @@ class DataCiteToResourceTransformer
         $scheme = null;
         $schemeUri = null;
 
-        foreach ($data['nameIdentifiers'] ?? [] as $nameId) {
-            if (($nameId['nameIdentifierScheme'] ?? '') === 'ROR') {
-                $ror = $nameId['nameIdentifier'] ?? null;
+        $nameIdentifiers = $data['nameIdentifiers'] ?? [];
+
+        if (is_array($nameIdentifiers)) {
+            foreach ($nameIdentifiers as $nameId) {
+                if (! is_array($nameId) || ($nameId['nameIdentifierScheme'] ?? '') !== 'ROR') {
+                    continue;
+                }
+
+                $identifier = isset($nameId['nameIdentifier'])
+                    ? trim((string) $nameId['nameIdentifier'])
+                    : '';
+
+                if ($identifier === '') {
+                    continue;
+                }
+
+                $ror = $identifier;
                 $scheme = 'ROR';
                 $schemeUri = $nameId['schemeUri'] ?? 'https://ror.org';
                 break;

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -856,11 +856,14 @@ class DataCiteToResourceTransformer
             return;
         }
 
+        $persistedPosition = $position + 1;
+
         Log::debug('Corrected DataCite party nameType during import', [
             'resource_id' => $resource->id,
             'doi' => $resource->doi,
             'role' => $partyRole,
-            'position' => $position,
+            'position' => $persistedPosition,
+            'source_index' => $position,
             'name' => $data['name'] ?? null,
             'declared_name_type' => $declaredNameType,
             'resolved_name_type' => $resolvedNameType,

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -893,7 +893,7 @@ class DataCiteToResourceTransformer
 
     private function wordCount(string $name): int
     {
-        if (preg_match_all('/[\pL\pN]+/u', $name, $matches) === false) {
+        if (preg_match_all('/[\p{L}\p{N}]+/u', $name, $matches) === false) {
             return 0;
         }
 

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -315,18 +315,11 @@ class DataCiteToResourceTransformer
      * In the database, all titles must reference a TitleType record, including MainTitle.
      *
      * @param  array<int, array<string, mixed>>  $titles
-     *
-     * @throws \RuntimeException If required TitleType records are missing from the database
      */
     private function transformTitles(array $titles, Resource $resource): void
     {
         // Pre-fetch MainTitle ID for titles without titleType attribute
-        $mainTitleId = $this->getLookupId(TitleType::class, 'slug', 'MainTitle');
-        if ($mainTitleId === null) {
-            throw new \RuntimeException(
-                'TitleType "MainTitle" not found in database. Please run: php artisan db:seed --class=TitleTypeSeeder'
-            );
-        }
+        $mainTitleId = $this->resolveTitleTypeId('MainTitle', 'Main Title');
 
         foreach ($titles as $titleData) {
             $titleValue = $titleData['title'] ?? null;
@@ -346,7 +339,7 @@ class DataCiteToResourceTransformer
 
                 // Fall back to Other if specific type not found
                 if ($titleTypeId === null) {
-                    $titleTypeId = $this->getLookupId(TitleType::class, 'slug', 'Other');
+                    $titleTypeId = $this->resolveTitleTypeId('Other', 'Other');
                 }
 
                 // If still null, use MainTitle as last resort
@@ -362,6 +355,28 @@ class DataCiteToResourceTransformer
                 'language' => $titleData['lang'] ?? null,
             ]);
         }
+    }
+
+    private function resolveTitleTypeId(string $slug, string $name): int
+    {
+        $titleTypeId = $this->getLookupId(TitleType::class, 'slug', $slug);
+
+        if ($titleTypeId !== null) {
+            return $titleTypeId;
+        }
+
+        $titleType = TitleType::query()->firstOrCreate(
+            ['slug' => $slug],
+            [
+                'name' => $name,
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ],
+        );
+
+        unset($this->lookupCache[TitleType::class.':slug']);
+
+        return (int) $titleType->id;
     }
 
     /**

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -55,6 +55,7 @@ class DataCiteToResourceTransformer
 
     public function __construct(
         private ?RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService = null,
+        private ?RorLookupService $rorLookupService = null,
     ) {}
 
     /**
@@ -803,16 +804,41 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
-            if ($scheme === strtolower($expectedScheme)) {
-                return true;
+            if ($expectedScheme === 'ROR') {
+                if ($this->canonicalRorIdentifier($identifier, $scheme) !== null) {
+                    return true;
+                }
+
+                continue;
             }
 
-            if ($expectedScheme === 'ROR' && str_contains($identifier, 'ror.org/')) {
+            if ($scheme === strtolower($expectedScheme)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function canonicalRorIdentifier(string $identifier, string $scheme): ?string
+    {
+        $identifier = trim($identifier);
+        $scheme = strtolower(trim($scheme));
+
+        if ($identifier === '') {
+            return null;
+        }
+
+        if ($scheme !== 'ror' && ! str_contains(strtolower($identifier), 'ror.org/')) {
+            return null;
+        }
+
+        return $this->rorLookupService()->canonicalise($identifier);
+    }
+
+    private function rorLookupService(): RorLookupService
+    {
+        return $this->rorLookupService ??= app(RorLookupService::class);
     }
 
     /**
@@ -941,21 +967,26 @@ class DataCiteToResourceTransformer
 
         if (is_array($nameIdentifiers)) {
             foreach ($nameIdentifiers as $nameId) {
-                if (! is_array($nameId) || ($nameId['nameIdentifierScheme'] ?? '') !== 'ROR') {
+                if (! is_array($nameId)) {
                     continue;
                 }
 
                 $identifier = isset($nameId['nameIdentifier'])
                     ? trim((string) $nameId['nameIdentifier'])
                     : '';
+                $nameIdentifierScheme = isset($nameId['nameIdentifierScheme'])
+                    ? trim((string) $nameId['nameIdentifierScheme'])
+                    : '';
 
-                if ($identifier === '') {
+                $canonicalRor = $this->canonicalRorIdentifier($identifier, $nameIdentifierScheme);
+
+                if ($canonicalRor === null) {
                     continue;
                 }
 
-                $ror = $identifier;
+                $ror = $canonicalRor;
                 $scheme = 'ROR';
-                $schemeUri = $nameId['schemeUri'] ?? 'https://ror.org';
+                $schemeUri = 'https://ror.org';
                 break;
             }
         }

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -676,8 +676,8 @@ class DataCiteToResourceTransformer
     /**
      * Resolve the local party type from DataCite data.
      *
-     * Legacy DataCite records can mark institutions as Personal. Strong evidence
-     * from structured names and identifiers wins over the raw nameType value.
+     * Legacy DataCite records can mark institutions as Personal. Identifier
+     * schemes and organization-looking full names win over the raw nameType value.
      *
      * @param  array<string, mixed>  $data
      */
@@ -685,25 +685,29 @@ class DataCiteToResourceTransformer
     {
         $declaredNameType = $this->normaliseNameType($data['nameType'] ?? null);
 
-        if ($this->hasStructuredPersonName($data) || $this->hasNameIdentifierScheme($data, 'ORCID')) {
-            return 'Personal';
-        }
-
         if ($this->hasNameIdentifierScheme($data, 'ROR')) {
             return 'Organizational';
+        }
+
+        if ($this->hasNameIdentifierScheme($data, 'ORCID')) {
+            return 'Personal';
         }
 
         $name = isset($data['name']) ? trim((string) $data['name']) : '';
 
         if ($name === '') {
-            return $declaredNameType ?? 'Personal';
+            return $this->hasStructuredPersonName($data) ? 'Personal' : ($declaredNameType ?? 'Personal');
         }
 
-        if ($declaredNameType === 'Organizational') {
+        if ($this->looksLikeOrganization($name, false)) {
             return 'Organizational';
         }
 
-        if ($this->looksLikeOrganization($name)) {
+        if ($this->hasStructuredPersonName($data)) {
+            return 'Personal';
+        }
+
+        if ($declaredNameType === 'Organizational') {
             return 'Organizational';
         }
 
@@ -800,7 +804,7 @@ class DataCiteToResourceTransformer
      * Uses word-boundary matching to avoid substring false positives
      * (e.g. "inc" must not match inside "Vincenzo").
      */
-    private function looksLikeOrganization(string $name): bool
+    private function looksLikeOrganization(string $name, bool $includeWeakShapeSignals = true): bool
     {
         $orgKeywords = [
             'institute', 'institution', 'university', 'universität',
@@ -812,8 +816,10 @@ class DataCiteToResourceTransformer
             'library', 'service', 'survey', 'observatory',
             'government', 'administration', 'directorate',
             'geoscience', 'geophysical', 'geological', 'geomagnetic',
+            'geoforschungszentrum', 'forschungszentrum',
             'meteorological', 'seismology', 'earthquake', 'space',
             'research', 'resources', 'branch', 'national', 'royal',
+            'intermagnet', 'secretariat',
             'observatorio', 'institut', 'instituto', 'ecole', 'universidad',
             'gmbh', 'ltd', 'inc', 'e\.v\.', 'helmholtz',
         ];
@@ -830,6 +836,10 @@ class DataCiteToResourceTransformer
 
         if (! str_contains($name, ',') && preg_match('/\([A-Za-z][A-Za-z .&-]{2,}\)\s*$/', $name) === 1) {
             return true;
+        }
+
+        if (! $includeWeakShapeSignals) {
+            return false;
         }
 
         return $this->wordCount($name) >= 4

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -1131,20 +1131,21 @@ class DataCiteToResourceTransformer
                 // Filter out points with missing coordinates instead of coercing to 0
                 $validPoints = array_filter(
                     $polygon['polygonPoints'],
-                    fn (array $p): bool => isset($p['pointLongitude'], $p['pointLatitude']),
+                    fn (array $p): bool => $this->normaliseCoordinate($p['pointLongitude'] ?? null) !== null
+                        && $this->normaliseCoordinate($p['pointLatitude'] ?? null) !== null,
                 );
 
                 // Only store polygon if at least 3 valid points remain
                 if (count($validPoints) >= 3) {
                     $polygonPoints = array_values(array_map(fn (array $p): array => [
-                        'longitude' => (float) $p['pointLongitude'],
-                        'latitude' => (float) $p['pointLatitude'],
+                        'longitude' => $this->normaliseCoordinate($p['pointLongitude']),
+                        'latitude' => $this->normaliseCoordinate($p['pointLatitude']),
                     ], $validPoints));
                 }
 
                 if (isset($polygon['inPolygonPoint'])) {
-                    $inPolygonPointLon = $polygon['inPolygonPoint']['pointLongitude'] ?? null;
-                    $inPolygonPointLat = $polygon['inPolygonPoint']['pointLatitude'] ?? null;
+                    $inPolygonPointLon = $this->normaliseCoordinate($polygon['inPolygonPoint']['pointLongitude'] ?? null);
+                    $inPolygonPointLat = $this->normaliseCoordinate($polygon['inPolygonPoint']['pointLatitude'] ?? null);
                 }
             }
 
@@ -1162,17 +1163,34 @@ class DataCiteToResourceTransformer
                 'resource_id' => $resource->id,
                 'geo_type' => $geoType,
                 'place' => $geoData['geoLocationPlace'] ?? null,
-                'point_longitude' => $point['pointLongitude'] ?? null,
-                'point_latitude' => $point['pointLatitude'] ?? null,
-                'west_bound_longitude' => $box['westBoundLongitude'] ?? null,
-                'east_bound_longitude' => $box['eastBoundLongitude'] ?? null,
-                'south_bound_latitude' => $box['southBoundLatitude'] ?? null,
-                'north_bound_latitude' => $box['northBoundLatitude'] ?? null,
+                'point_longitude' => $this->normaliseCoordinate($point['pointLongitude'] ?? null),
+                'point_latitude' => $this->normaliseCoordinate($point['pointLatitude'] ?? null),
+                'west_bound_longitude' => $this->normaliseCoordinate($box['westBoundLongitude'] ?? null),
+                'east_bound_longitude' => $this->normaliseCoordinate($box['eastBoundLongitude'] ?? null),
+                'south_bound_latitude' => $this->normaliseCoordinate($box['southBoundLatitude'] ?? null),
+                'north_bound_latitude' => $this->normaliseCoordinate($box['northBoundLatitude'] ?? null),
                 'polygon_points' => $polygonPoints,
                 'in_polygon_point_longitude' => $inPolygonPointLon,
                 'in_polygon_point_latitude' => $inPolygonPointLat,
             ]);
         }
+    }
+
+    private function normaliseCoordinate(mixed $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $value = trim($value);
+
+            if ($value === '') {
+                return null;
+            }
+        }
+
+        return is_numeric($value) ? (float) $value : null;
     }
 
     /**

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -385,7 +385,9 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
-            $nameType = $creatorData['nameType'] ?? $this->inferNameType($creatorData);
+            $declaredNameType = $this->normaliseNameType($creatorData['nameType'] ?? null);
+            $nameType = $this->resolveNameType($creatorData);
+            $this->logNameTypeOverride('creator', $resource, $position, $creatorData, $declaredNameType, $nameType);
 
             try {
                 if ($nameType === 'Organizational') {
@@ -442,7 +444,9 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
-            $nameType = $contributorData['nameType'] ?? $this->inferNameType($contributorData);
+            $declaredNameType = $this->normaliseNameType($contributorData['nameType'] ?? null);
+            $nameType = $this->resolveNameType($contributorData);
+            $this->logNameTypeOverride('contributor', $resource, $position, $contributorData, $declaredNameType, $nameType);
 
             try {
                 if ($nameType === 'Organizational') {
@@ -670,54 +674,125 @@ class DataCiteToResourceTransformer
     }
 
     /**
-     * Infer nameType when DataCite doesn't provide it.
+     * Resolve the local party type from DataCite data.
      *
-     * A creator/contributor without familyName AND without givenName
-     * but WITH a 'name' field is likely an organization.
+     * Legacy DataCite records can mark institutions as Personal. Strong evidence
+     * from structured names and identifiers wins over the raw nameType value.
      *
      * @param  array<string, mixed>  $data
      */
-    private function inferNameType(array $data): string
+    private function resolveNameType(array $data): string
     {
-        $hasFamilyName = isset($data['familyName']) && trim((string) $data['familyName']) !== '';
-        $hasGivenName = isset($data['givenName']) && trim((string) $data['givenName']) !== '';
+        $declaredNameType = $this->normaliseNameType($data['nameType'] ?? null);
 
-        if ($hasFamilyName || $hasGivenName) {
+        if ($this->hasStructuredPersonName($data) || $this->hasNameIdentifierScheme($data, 'ORCID')) {
             return 'Personal';
+        }
+
+        if ($this->hasNameIdentifierScheme($data, 'ROR')) {
+            return 'Organizational';
         }
 
         $name = isset($data['name']) ? trim((string) $data['name']) : '';
 
         if ($name === '') {
-            return 'Personal';
+            return $declaredNameType ?? 'Personal';
         }
 
-        // Organization names often contain institutional keywords.
-        // Check for these BEFORE parsePersonName, which would split
-        // "Alfred Wegener Institute" into given="Alfred Wegener", family="Institute".
+        if ($declaredNameType === 'Organizational') {
+            return 'Organizational';
+        }
+
         if ($this->looksLikeOrganization($name)) {
             return 'Organizational';
         }
 
-        // Try to parse the name — if parsing yields both a family AND a given
-        // name, this is likely a Personal creator (e.g. "Doe, John" or "John Doe").
-        // Names that only yield a family part (single word like "GEOMAR") default
-        // to Organizational. Comma+suffix names like "Smith, Jr." are treated as
-        // Personal via the comma-detection fallback below.
-        $parts = $this->parsePersonName($name);
-
-        if ($parts['given'] !== null && trim($parts['given']) !== '') {
+        if ($this->looksLikePersonName($name)) {
             return 'Personal';
         }
 
-        // If parsePersonName returned a family name but no given name,
-        // check if the original name contains a comma — this indicates
-        // a structured person name (e.g. "Smith, Jr.") rather than an org.
-        if ($parts['family'] !== null && str_contains($name, ',')) {
-            return 'Personal';
+        return $declaredNameType ?? 'Organizational';
+    }
+
+    private function normaliseNameType(mixed $nameType): ?string
+    {
+        if (! is_string($nameType)) {
+            return null;
         }
 
-        return 'Organizational';
+        return match (strtolower(trim($nameType))) {
+            'personal' => 'Personal',
+            'organizational' => 'Organizational',
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function hasStructuredPersonName(array $data): bool
+    {
+        return (isset($data['familyName']) && trim((string) $data['familyName']) !== '')
+            || (isset($data['givenName']) && trim((string) $data['givenName']) !== '');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function hasNameIdentifierScheme(array $data, string $expectedScheme): bool
+    {
+        foreach ($data['nameIdentifiers'] ?? [] as $nameIdentifier) {
+            if (! is_array($nameIdentifier)) {
+                continue;
+            }
+
+            $scheme = isset($nameIdentifier['nameIdentifierScheme'])
+                ? strtolower(trim((string) $nameIdentifier['nameIdentifierScheme']))
+                : '';
+            $identifier = isset($nameIdentifier['nameIdentifier'])
+                ? strtolower(trim((string) $nameIdentifier['nameIdentifier']))
+                : '';
+
+            if ($scheme === strtolower($expectedScheme)) {
+                return true;
+            }
+
+            if ($expectedScheme === 'ORCID' && str_contains($identifier, 'orcid.org/')) {
+                return true;
+            }
+
+            if ($expectedScheme === 'ROR' && str_contains($identifier, 'ror.org/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function logNameTypeOverride(
+        string $partyRole,
+        Resource $resource,
+        int $position,
+        array $data,
+        ?string $declaredNameType,
+        string $resolvedNameType,
+    ): void {
+        if ($declaredNameType === null || $declaredNameType === $resolvedNameType) {
+            return;
+        }
+
+        Log::debug('Corrected DataCite party nameType during import', [
+            'resource_id' => $resource->id,
+            'doi' => $resource->doi,
+            'role' => $partyRole,
+            'position' => $position,
+            'name' => $data['name'] ?? null,
+            'declared_name_type' => $declaredNameType,
+            'resolved_name_type' => $resolvedNameType,
+        ]);
     }
 
     /**
@@ -735,12 +810,50 @@ class DataCiteToResourceTransformer
             'department', 'ministry', 'bureau', 'authority',
             'association', 'society', 'academy', 'museum',
             'library', 'service', 'survey', 'observatory',
+            'government', 'administration', 'directorate',
+            'geoscience', 'geophysical', 'geological', 'geomagnetic',
+            'meteorological', 'seismology', 'earthquake', 'space',
+            'research', 'resources', 'branch', 'national', 'royal',
+            'observatorio', 'institut', 'instituto', 'ecole', 'universidad',
             'gmbh', 'ltd', 'inc', 'e\.v\.', 'helmholtz',
         ];
 
         $pattern = '/\b('.implode('|', $orgKeywords).')\b/iu';
 
-        return (bool) preg_match($pattern, $name);
+        if ((bool) preg_match($pattern, $name)) {
+            return true;
+        }
+
+        if (preg_match('/^[A-Z0-9&.\- ]{3,}$/', $name) === 1) {
+            return true;
+        }
+
+        if (! str_contains($name, ',') && preg_match('/\([A-Za-z][A-Za-z .&-]{2,}\)\s*$/', $name) === 1) {
+            return true;
+        }
+
+        return $this->wordCount($name) >= 4
+            && preg_match('/(?:[\/&]|\b(?:of|for|and|de|del|du|des|der|la|le|fuer|et)\b)/iu', $name) === 1;
+    }
+
+    private function looksLikePersonName(string $name): bool
+    {
+        $parts = $this->parsePersonName($name);
+
+        if ($parts['given'] !== null && trim($parts['given']) !== '') {
+            return true;
+        }
+
+        return $parts['family'] !== null && str_contains($name, ',');
+    }
+
+    private function wordCount(string $name): int
+    {
+        if (preg_match_all('/[\pL\pN]+/u', $name, $matches) === false) {
+            return 0;
+        }
+
+        return count($matches[0]);
     }
 
     /**

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -214,37 +214,13 @@ class ResourceStorageService
     private function storeTitles(Resource $resource, array $data, bool $isUpdate): void
     {
         /**
-         * Collect all titleType values for lookup.
-         * prepareForValidation() maps incoming values to DB slugs where possible.
-         * All titles (including MainTitle) are stored with their TitleType ID.
-         *
-         * Note: In DataCite XML, MainTitle has no titleType attribute, but in the
-         * database we always store the reference to the TitleType record.
-         *
-         * @var array<int, string> $titleTypeInputValues
-         */
-        $titleTypeInputValues = [];
-
-        foreach ($data['titles'] as $titleData) {
-            $normalized = Str::kebab($titleData['titleType'] ?? '');
-
-            // Empty or 'main-title' defaults to MainTitle slug
-            if ($normalized === '' || $normalized === 'main-title') {
-                $titleTypeInputValues[] = 'MainTitle';
-            } else {
-                $titleTypeInputValues[] = (string) ($titleData['titleType'] ?? '');
-            }
-        }
-
-        $titleTypeInputValues = array_values(array_unique($titleTypeInputValues));
-
-        /**
          * Map normalized (kebab-case) slugs to DB title type IDs.
+         * Editor and legacy import payloads can provide values like "alternative-title",
+         * while the database stores DataCite slugs like "AlternativeTitle".
          *
          * @var array<string, int> $titleTypeMap
          */
         $titleTypeMap = TitleType::query()
-            ->whereIn('slug', $titleTypeInputValues)
             ->get(['id', 'slug'])
             ->mapWithKeys(fn (TitleType $type): array => [Str::kebab($type->slug) => $type->id])
             ->all();

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -251,13 +251,8 @@ class ResourceStorageService
 
         // Also add mapping for empty string and 'main-title' to MainTitle ID
         // Note: 'MainTitle' in kebab-case becomes 'main-title'
-        $mainTitleId = $titleTypeMap['main-title'] ?? null;
-        if ($mainTitleId === null) {
-            // MainTitle TitleType is required - throw specific error
-            throw new \RuntimeException(
-                'TitleType "MainTitle" not found in database. Please run: php artisan db:seed --class=TitleTypeSeeder'
-            );
-        }
+        $mainTitleId = $titleTypeMap['main-title'] ?? $this->ensureTitleType('MainTitle', 'Main Title');
+        $titleTypeMap['main-title'] = $mainTitleId;
         $titleTypeMap[''] = $mainTitleId;
 
         $resourceTitles = [];
@@ -285,6 +280,18 @@ class ResourceStorageService
         }
 
         $resource->titles()->createMany($resourceTitles);
+    }
+
+    private function ensureTitleType(string $slug, string $name): int
+    {
+        return (int) TitleType::query()->firstOrCreate(
+            ['slug' => $slug],
+            [
+                'name' => $name,
+                'is_active' => true,
+                'is_elmo_active' => true,
+            ],
+        )->id;
     }
 
     /**

--- a/app/Services/RorLookupService.php
+++ b/app/Services/RorLookupService.php
@@ -89,6 +89,7 @@ class RorLookupService
      * - Full URL: https://ror.org/04z8jg394
      * - Bare ID: 04z8jg394
      * - HTTP URL: http://ror.org/04z8jg394
+     * - Protocol-less URL: ror.org/04z8jg394
      *
      * @return string|null Canonical ROR URL (e.g., "https://ror.org/04z8jg394") or null
      */
@@ -100,12 +101,12 @@ class RorLookupService
             return null;
         }
 
-        // If already a full URL with ror.org host, extract and normalize
-        if (preg_match('#^https?://ror\.org/(.+)$#i', $trimmed, $matches)) {
+        // If already a URL with ror.org host, extract and normalize
+        if (preg_match('#^(?:https?://)?(?:www\.)?ror\.org/(.+)$#i', $trimmed, $matches)) {
             $rorId = Str::lower(trim($matches[1], '/'));
 
             // Only accept a single alphanumeric segment (valid ROR ID format)
-            return preg_match('/^[a-z0-9]+$/', $rorId) ? 'https://ror.org/' . $rorId : null;
+            return preg_match('/^[a-z0-9]+$/', $rorId) ? 'https://ror.org/'.$rorId : null;
         }
 
         // If it looks like a URL with a non-ROR host, don't process it
@@ -117,7 +118,7 @@ class RorLookupService
         $path = Str::lower(trim($trimmed, '/'));
 
         // Only accept a single alphanumeric segment (valid ROR ID format)
-        return preg_match('/^[a-z0-9]+$/', $path) ? 'https://ror.org/' . $path : null;
+        return preg_match('/^[a-z0-9]+$/', $path) ? 'https://ror.org/'.$path : null;
     }
 
     /**
@@ -127,7 +128,7 @@ class RorLookupService
      */
     public function isRorUrl(string $value): bool
     {
-        return (bool) preg_match('#^https?://ror\.org/[a-z0-9]+/?$#i', trim($value));
+        return (bool) preg_match('#^(?:https?://)?(?:www\.)?ror\.org/[a-z0-9]+/?$#i', trim($value));
     }
 
     /**

--- a/app/Services/SumarioPmdContactEnrichmentService.php
+++ b/app/Services/SumarioPmdContactEnrichmentService.php
@@ -233,7 +233,7 @@ class SumarioPmdContactEnrichmentService
 
         $normalised = mb_strtolower(trim($name), 'UTF-8');
         $normalised = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalised) ?: $normalised;
-        $normalised = preg_replace('/[^\pL\pN]+/u', ' ', $normalised) ?? '';
+        $normalised = preg_replace('/[^\p{L}\p{N}]+/u', ' ', $normalised) ?? '';
         $normalised = preg_replace('/\s+/', ' ', $normalised) ?? '';
 
         return trim($normalised);

--- a/app/Support/OrcidNormalizer.php
+++ b/app/Support/OrcidNormalizer.php
@@ -22,6 +22,8 @@ final class OrcidNormalizer
         'http://orcid.org/',
         'https://www.orcid.org/',
         'http://www.orcid.org/',
+        'orcid.org/',
+        'www.orcid.org/',
     ];
 
     /**
@@ -35,6 +37,7 @@ final class OrcidNormalizer
      * Examples:
      *  - "https://orcid.org/0000-0002-1825-0097"  → "0000-0002-1825-0097"
      *  - "https://www.orcid.org/0000-0002-1825-0097" → "0000-0002-1825-0097"
+     *  - "orcid.org/0000-0002-1825-0097" → "0000-0002-1825-0097"
      *  - "0000-0002-1825-0097" → "0000-0002-1825-0097"
      */
     public static function extractBareId(string $orcid): string

--- a/scripts/audit_datacite_party_types.php
+++ b/scripts/audit_datacite_party_types.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Institution;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Database\Eloquent\Model;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require __DIR__.'/../bootstrap/app.php';
+$app->make(Kernel::class)->bootstrap();
+
+$sampleLimit = 25;
+$summary = [
+    'resources' => Resource::query()->count(),
+    'creators' => emptyPartySummary(),
+    'contributors' => emptyPartySummary(),
+    'intermagnet_10_5880_intermagnet_1991_2020' => intermagnetSummary($sampleLimit),
+];
+
+auditParties(ResourceCreator::class, 'creatorable', 'creators', $summary, $sampleLimit);
+auditParties(ResourceContributor::class, 'contributorable', 'contributors', $summary, $sampleLimit);
+
+echo json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL;
+
+/**
+ * @return array<string, mixed>
+ */
+function emptyPartySummary(): array
+{
+    return [
+        'audited' => 0,
+        'persons' => 0,
+        'institutions' => 0,
+        'missing_party' => 0,
+        'person_that_looks_organizational' => 0,
+        'institution_that_looks_personal' => 0,
+        'person_that_looks_organizational_samples' => [],
+        'institution_that_looks_personal_samples' => [],
+    ];
+}
+
+/**
+ * @param  class-string<ResourceCreator|ResourceContributor>  $modelClass
+ * @param  array<string, mixed>  $summary
+ */
+function auditParties(string $modelClass, string $relation, string $summaryKey, array &$summary, int $sampleLimit): void
+{
+    $modelClass::query()
+        ->with(['resource:id,doi', $relation])
+        ->orderBy('id')
+        ->chunkById(1000, function ($rows) use ($relation, $summaryKey, &$summary, $sampleLimit): void {
+            foreach ($rows as $row) {
+                $summary[$summaryKey]['audited']++;
+
+                $party = $row->{$relation};
+                if (! $party instanceof Model) {
+                    $summary[$summaryKey]['missing_party']++;
+
+                    continue;
+                }
+
+                if ($party instanceof Person) {
+                    $summary[$summaryKey]['persons']++;
+
+                    if (! hasScheme($party, 'ORCID') && personLooksOrganizational($party)) {
+                        recordFlag($summary[$summaryKey], 'person_that_looks_organizational', $row, personNames($party)[0] ?? '', $sampleLimit);
+                    }
+
+                    continue;
+                }
+
+                if ($party instanceof Institution) {
+                    $summary[$summaryKey]['institutions']++;
+
+                    if (! hasScheme($party, 'ROR') && looksLikePersonName($party->name ?? '')) {
+                        recordFlag($summary[$summaryKey], 'institution_that_looks_personal', $row, $party->name ?? '', $sampleLimit);
+                    }
+                }
+            }
+        });
+}
+
+/**
+ * @param  array<string, mixed>  $partySummary
+ */
+function recordFlag(array &$partySummary, string $counter, mixed $row, string $name, int $sampleLimit): void
+{
+    $partySummary[$counter]++;
+
+    $samplesKey = "{$counter}_samples";
+    if (count($partySummary[$samplesKey]) >= $sampleLimit) {
+        return;
+    }
+
+    $partySummary[$samplesKey][] = [
+        'row_id' => $row->id,
+        'resource_id' => $row->resource_id,
+        'doi' => $row->resource?->doi,
+        'position' => $row->position,
+        'name' => $name,
+    ];
+}
+
+function hasScheme(Person|Institution $party, string $scheme): bool
+{
+    return strtoupper((string) $party->name_identifier_scheme) === $scheme && filled($party->name_identifier);
+}
+
+function personLooksOrganizational(Person $person): bool
+{
+    foreach (personNames($person) as $name) {
+        if (looksLikeOrganization($name, false)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @return list<string>
+ */
+function personNames(Person $person): array
+{
+    $given = trim((string) $person->given_name);
+    $family = trim((string) $person->family_name);
+
+    return array_values(array_unique(array_filter([
+        trim("{$given} {$family}"),
+        trim("{$family} {$given}"),
+        $given !== '' && $family !== '' ? "{$family}, {$given}" : '',
+        $family,
+        $given,
+    ], fn (string $name): bool => $name !== '')));
+}
+
+function looksLikeOrganization(string $name, bool $includeWeakShapeSignals = true): bool
+{
+    $name = trim($name);
+    if ($name === '') {
+        return false;
+    }
+
+    $keywords = [
+        'academy',
+        'administration',
+        'agency',
+        'association',
+        'authority',
+        'branch',
+        'bureau',
+        'center',
+        'centre',
+        'college',
+        'commission',
+        'committee',
+        'consortium',
+        'corporation',
+        'council',
+        'department',
+        'directorate',
+        'earthquake',
+        'ecole',
+        'facility',
+        'federal',
+        'foundation',
+        'geological',
+        'geology',
+        'geomagnetic',
+        'geoforschungszentrum',
+        'geophysical',
+        'geoscience',
+        'gmbh',
+        'government',
+        'group',
+        'institute',
+        'institution',
+        'institut',
+        'instituto',
+        'intermagnet',
+        'laboratory',
+        'lab',
+        'meteorological',
+        'ministry',
+        'national',
+        'observatory',
+        'observatorio',
+        'office',
+        'organisation',
+        'organization',
+        'project',
+        'research',
+        'resources',
+        'royal',
+        'school',
+        'secretariat',
+        'seismology',
+        'service',
+        'society',
+        'space',
+        'survey',
+        'university',
+        'universidad',
+        'universit',
+        'universitat',
+        'universitaet',
+    ];
+
+    if (preg_match('/\b('.implode('|', array_map('preg_quote', $keywords)).')\b/i', $name) === 1) {
+        return true;
+    }
+
+    if (preg_match('/^[A-Z0-9&.\- ]{3,}$/', $name) === 1 && preg_match('/[A-Z]/', $name) === 1) {
+        return true;
+    }
+
+    if (! str_contains($name, ',') && preg_match('/\([A-Za-z][A-Za-z .&-]{2,}\)\s*$/', $name) === 1) {
+        return true;
+    }
+
+    if (! $includeWeakShapeSignals) {
+        return false;
+    }
+
+    return wordCount($name) >= 4
+        && preg_match('/(?:\/|&|\b(?:of|for|and|de|del|du|des|der|la|le|fuer|et)\b)/i', $name) === 1;
+}
+
+function looksLikePersonName(string $name): bool
+{
+    $name = trim($name);
+    if ($name === '' || looksLikeOrganization($name)) {
+        return false;
+    }
+
+    $word = "\\p{Lu}\\p{Ll}[\\p{L}'-]*";
+    $givenPart = "(?:{$word}|\\p{Lu}\\.)(?:\\s+(?:{$word}|\\p{Lu}\\.))*";
+
+    return preg_match("/^{$word},\\s*{$givenPart}$/u", $name) === 1
+        || preg_match("/^{$word}\\s+{$word}$/u", $name) === 1;
+}
+
+function wordCount(string $name): int
+{
+    return preg_match_all('/[\p{L}\p{N}]+/u', $name);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function intermagnetSummary(int $sampleLimit): array
+{
+    $resource = Resource::query()
+        ->where('doi', '10.5880/intermagnet.1991.2020')
+        ->with(['creators.creatorable', 'contributors.contributorable'])
+        ->first();
+
+    if ($resource === null) {
+        return ['found' => false];
+    }
+
+    return [
+        'found' => true,
+        'resource_id' => $resource->id,
+        'creator_type_counts' => typeCounts($resource->creators, 'creatorable'),
+        'contributor_type_counts' => typeCounts($resource->contributors, 'contributorable'),
+        'creator_samples' => partySamples($resource->creators, 'creatorable', $sampleLimit),
+        'contributor_samples' => partySamples($resource->contributors, 'contributorable', $sampleLimit),
+    ];
+}
+
+function typeLabel(mixed $party): string
+{
+    return match (true) {
+        $party instanceof Person => 'Person',
+        $party instanceof Institution => 'Institution',
+        default => 'Missing',
+    };
+}
+
+function partyName(mixed $party): string
+{
+    if ($party instanceof Person) {
+        return $party->full_name;
+    }
+
+    if ($party instanceof Institution) {
+        return $party->name;
+    }
+
+    return '';
+}
+
+/**
+ * @return array<string, int>
+ */
+function typeCounts($rows, string $relation): array
+{
+    $counts = ['Person' => 0, 'Institution' => 0, 'Missing' => 0];
+
+    foreach ($rows as $row) {
+        $counts[typeLabel($row->{$relation})]++;
+    }
+
+    return $counts;
+}
+
+/**
+ * @return list<array<string, mixed>>
+ */
+function partySamples($rows, string $relation, int $sampleLimit): array
+{
+    $samples = [];
+
+    foreach ($rows as $row) {
+        if (count($samples) >= $sampleLimit) {
+            break;
+        }
+
+        $samples[] = [
+            'position' => $row->position,
+            'type' => typeLabel($row->{$relation}),
+            'name' => partyName($row->{$relation}),
+        ];
+    }
+
+    return $samples;
+}

--- a/scripts/audit_datacite_party_types.php
+++ b/scripts/audit_datacite_party_types.php
@@ -248,7 +248,11 @@ function looksLikePersonName(string $name): bool
 
 function wordCount(string $name): int
 {
-    return preg_match_all('/[\p{L}\p{N}]+/u', $name);
+    if (preg_match_all('/[\p{L}\p{N}]+/u', $name, $matches) === false) {
+        return 0;
+    }
+
+    return count($matches[0]);
 }
 
 /**

--- a/tests/pest/Feature/Models/GeoLocationTest.php
+++ b/tests/pest/Feature/Models/GeoLocationTest.php
@@ -81,6 +81,34 @@ describe('Box locations', function () {
             ->and($geoLocation->hasPoint())->toBeFalse();
     });
 
+    it('normalizes blank nullable coordinate values before persisting', function () {
+        $geoLocation = GeoLocation::create([
+            'resource_id' => $this->resource->id,
+            'geo_type' => 'box',
+            'west_bound_longitude' => '37.704000',
+            'east_bound_longitude' => '',
+            'south_bound_latitude' => '-3.316760',
+            'north_bound_latitude' => '   ',
+            'point_longitude' => 'not-a-coordinate',
+            'point_latitude' => null,
+            'elevation' => '',
+            'in_polygon_point_longitude' => '',
+            'in_polygon_point_latitude' => 'not-a-coordinate',
+        ]);
+
+        $freshGeoLocation = GeoLocation::find($geoLocation->id);
+
+        expect((string) $freshGeoLocation->west_bound_longitude)->toBe('37.70400000')
+            ->and($freshGeoLocation->east_bound_longitude)->toBeNull()
+            ->and((string) $freshGeoLocation->south_bound_latitude)->toBe('-3.31676000')
+            ->and($freshGeoLocation->north_bound_latitude)->toBeNull()
+            ->and($freshGeoLocation->point_longitude)->toBeNull()
+            ->and($freshGeoLocation->point_latitude)->toBeNull()
+            ->and($freshGeoLocation->elevation)->toBeNull()
+            ->and($freshGeoLocation->in_polygon_point_longitude)->toBeNull()
+            ->and($freshGeoLocation->in_polygon_point_latitude)->toBeNull();
+    });
+
     it('creates a valid box via factory', function () {
         $geoLocation = GeoLocation::factory()->withBox()->create([
             'resource_id' => $this->resource->id,

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -1641,6 +1641,56 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
             ->and($institution->name_identifier_scheme)->toBe('ROR');
     });
 
+    it('persists ROR identifiers detected from lowercase or missing schemes', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/ror-signal-persistence.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'ROR Signal Persistence Test']],
+                'creators' => [
+                    [
+                        'name' => 'Royal Meteorological Institute (Belgium)',
+                        'nameType' => 'Personal',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => 'http://ror.org/05Q1P6X47',
+                                'nameIdentifierScheme' => 'ror',
+                                'schemeUri' => 'http://ror.org',
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => 'GFZ German Research Centre for Geosciences',
+                        'nameType' => 'Personal',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => 'ror.org/04Z8JG394',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creators = $resource->creators()->orderBy('position')->get();
+        $firstInstitution = Institution::findOrFail($creators[0]->creatorable_id);
+        $secondInstitution = Institution::findOrFail($creators[1]->creatorable_id);
+
+        expect($creators)->toHaveCount(2)
+            ->and($creators[0]->creatorable_type)->toBe(Institution::class)
+            ->and($firstInstitution->name_identifier)->toBe('https://ror.org/05q1p6x47')
+            ->and($firstInstitution->name_identifier_scheme)->toBe('ROR')
+            ->and($firstInstitution->scheme_uri)->toBe('https://ror.org')
+            ->and($creators[1]->creatorable_type)->toBe(Institution::class)
+            ->and($secondInstitution->name_identifier)->toBe('https://ror.org/04z8jg394')
+            ->and($secondInstitution->name_identifier_scheme)->toBe('ROR')
+            ->and($secondInstitution->scheme_uri)->toBe('https://ror.org');
+    });
+
     it('ignores blank name identifiers when resolving creator types', function (): void {
         $user = User::factory()->create();
         $transformer = new DataCiteToResourceTransformer;

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -1531,6 +1531,48 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
             ->and($institution->name_identifier_scheme)->toBe('ROR');
     });
 
+    it('ignores blank name identifiers when resolving creator types', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/blank-name-identifier-signals.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Blank Name Identifier Signals Test']],
+                'creators' => [
+                    [
+                        'name' => 'Doe, Jane',
+                        'nameType' => 'Personal',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => '   ',
+                                'nameIdentifierScheme' => 'ROR',
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => 'Royal Meteorological Institute (Belgium)',
+                        'nameType' => 'Personal',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => '',
+                                'nameIdentifierScheme' => 'ORCID',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creators = $resource->creators()->orderBy('position')->get();
+
+        expect($creators)->toHaveCount(2)
+            ->and($creators[0]->creatorable_type)->toBe(Person::class)
+            ->and($creators[1]->creatorable_type)->toBe(Institution::class);
+    });
+
     it('applies the same institutional correction to contributors', function (): void {
         $user = User::factory()->create();
         $transformer = new DataCiteToResourceTransformer;

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -308,6 +308,84 @@ describe('DataCiteToResourceTransformer', function (): void {
                 ->and($person->name_identifier_scheme)->toBe('ORCID');
         });
 
+        it('normalizes valid ORCID identifiers to canonical URLs', function (): void {
+            $user = User::factory()->create();
+            $transformer = new DataCiteToResourceTransformer;
+
+            $doiData = [
+                'attributes' => [
+                    'doi' => '10.5880/orcid-normalized.2024.001',
+                    'titles' => [['title' => 'ORCID Normalization Test']],
+                    'creators' => [
+                        [
+                            'familyName' => 'Curie',
+                            'givenName' => 'Marie',
+                            'nameType' => 'Personal',
+                            'nameIdentifiers' => [
+                                [
+                                    'nameIdentifier' => '0000-0002-1825-0097',
+                                    'nameIdentifierScheme' => 'ORCID',
+                                    'schemeUri' => 'http://orcid.org',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            $transformer->transform($doiData, $user->id);
+            $person = Person::where('family_name', 'Curie')->firstOrFail();
+
+            expect($person->name_identifier)->toBe('https://orcid.org/0000-0002-1825-0097')
+                ->and($person->name_identifier_scheme)->toBe('ORCID')
+                ->and($person->scheme_uri)->toBe('https://orcid.org');
+        });
+
+        it('ignores invalid ORCID identifiers during import', function (): void {
+            $user = User::factory()->create();
+            $transformer = new DataCiteToResourceTransformer;
+
+            $doiData = [
+                'attributes' => [
+                    'doi' => '10.5880/orcid-invalid.2024.001',
+                    'publicationYear' => 2024,
+                    'titles' => [['title' => 'Invalid ORCID Test']],
+                    'creators' => [
+                        [
+                            'name' => 'Doe, Jane',
+                            'nameType' => 'Personal',
+                            'nameIdentifiers' => [
+                                [
+                                    'nameIdentifier' => '0000-0002-1825-0000',
+                                    'nameIdentifierScheme' => 'ORCID',
+                                ],
+                            ],
+                        ],
+                        [
+                            'name' => 'Royal Meteorological Institute (Belgium)',
+                            'nameType' => 'Personal',
+                            'nameIdentifiers' => [
+                                [
+                                    'nameIdentifier' => 'not-an-orcid',
+                                    'nameIdentifierScheme' => 'ORCID',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            $resource = $transformer->transform($doiData, $user->id);
+            $creators = $resource->creators()->orderBy('position')->get();
+            $person = Person::findOrFail($creators[0]->creatorable_id);
+
+            expect($creators)->toHaveCount(2)
+                ->and($creators[0]->creatorable_type)->toBe(Person::class)
+                ->and($person->name_identifier)->toBeNull()
+                ->and($person->name_identifier_scheme)->toBeNull()
+                ->and($creators[1]->creatorable_type)->toBe(Institution::class);
+        });
+
         it('creates organizational creators (institutions)', function (): void {
             $user = User::factory()->create();
             $transformer = new DataCiteToResourceTransformer;

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\ContributorType;
+use App\Models\Institution;
 use App\Models\Language;
 use App\Models\Person;
 use App\Models\Publisher;
@@ -1324,6 +1325,175 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
 
         // "John Smith" → Personal (2 tokens, no org keyword)
         expect($creators[2]->creatorable_type)->toBe(Person::class);
+    });
+
+    it('corrects legacy institutional creators that DataCite marks as Personal', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/intermagnet-personal-orgs.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Intermagnet Personal Institution Test']],
+                'creators' => [
+                    [
+                        'name' => 'Bureau Central de Magnetisme Terrestre, BCMT (France)',
+                        'nameType' => 'Personal',
+                    ],
+                    [
+                        'name' => 'Institute of Geology and Geophysics, Chinese Academy of Sciences (China)',
+                        'nameType' => 'Personal',
+                    ],
+                    [
+                        'name' => 'John Smith',
+                        'nameType' => 'Personal',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creators = $resource->creators()->orderBy('position')->get();
+
+        expect($creators)->toHaveCount(3)
+            ->and($creators[0]->creatorable_type)->toBe(Institution::class)
+            ->and($creators[1]->creatorable_type)->toBe(Institution::class)
+            ->and($creators[2]->creatorable_type)->toBe(Person::class);
+    });
+
+    it('infers Intermagnet-style institutional creators when DataCite omits nameType', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/intermagnet-missing-nametype.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Intermagnet Missing NameType Test']],
+                'creators' => [
+                    [
+                        'name' => 'INTERMAGNET',
+                    ],
+                    [
+                        'name' => 'Geoscience Australia (Australia)',
+                    ],
+                    [
+                        'name' => 'Jane Doe',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creators = $resource->creators()->orderBy('position')->get();
+
+        expect($creators)->toHaveCount(3)
+            ->and($creators[0]->creatorable_type)->toBe(Institution::class)
+            ->and($creators[1]->creatorable_type)->toBe(Institution::class)
+            ->and($creators[2]->creatorable_type)->toBe(Person::class);
+    });
+
+    it('lets structured person names override an incorrect Organizational nameType', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/structured-person-overrides-org.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Structured Person Override Test']],
+                'creators' => [
+                    [
+                        'name' => 'Doe, Jane',
+                        'familyName' => 'Doe',
+                        'givenName' => 'Jane',
+                        'nameType' => 'Organizational',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creator = $resource->creators()->firstOrFail();
+        $person = Person::findOrFail($creator->creatorable_id);
+
+        expect($creator->creatorable_type)->toBe(Person::class)
+            ->and($person->family_name)->toBe('Doe')
+            ->and($person->given_name)->toBe('Jane');
+    });
+
+    it('uses name identifier schemes as strong person and institution signals', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/name-identifier-signals.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Name Identifier Signals Test']],
+                'creators' => [
+                    [
+                        'name' => 'Doe, Jane',
+                        'nameType' => 'Organizational',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => 'https://orcid.org/0000-0002-1825-0097',
+                                'nameIdentifierScheme' => 'ORCID',
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => 'Royal Meteorological Institute (Belgium)',
+                        'nameType' => 'Personal',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => 'https://ror.org/05q1p6x47',
+                                'nameIdentifierScheme' => 'ROR',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creators = $resource->creators()->orderBy('position')->get();
+        $institution = Institution::findOrFail($creators[1]->creatorable_id);
+
+        expect($creators)->toHaveCount(2)
+            ->and($creators[0]->creatorable_type)->toBe(Person::class)
+            ->and($creators[1]->creatorable_type)->toBe(Institution::class)
+            ->and($institution->name_identifier)->toBe('https://ror.org/05q1p6x47')
+            ->and($institution->name_identifier_scheme)->toBe('ROR');
+    });
+
+    it('applies the same institutional correction to contributors', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/contributor-personal-org-correction.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Contributor Institution Correction Test']],
+                'creators' => [
+                    ['familyName' => 'Creator', 'givenName' => 'Casey', 'nameType' => 'Personal'],
+                ],
+                'contributors' => [
+                    [
+                        'name' => 'Royal Meteorological Institute (Belgium)',
+                        'nameType' => 'Personal',
+                        'contributorType' => 'HostingInstitution',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $contributor = $resource->contributors()->firstOrFail();
+
+        expect($contributor->contributorable_type)->toBe(Institution::class);
     });
 
 });

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -222,6 +222,31 @@ describe('DataCiteToResourceTransformer', function (): void {
                 ->and($firstTitle->title_type_id)->toBe($mainTitleType->id);
         });
 
+        it('recreates the required MainTitle type when the lookup table is missing it', function (): void {
+            TitleType::query()->delete();
+
+            $user = User::factory()->create();
+            $transformer = new DataCiteToResourceTransformer;
+
+            $doiData = [
+                'attributes' => [
+                    'doi' => '10.5880/missing-main-title-type.2024.001',
+                    'titles' => [
+                        ['title' => 'Main Title From Missing Lookup'],
+                    ],
+                    'creators' => [
+                        ['familyName' => 'Test', 'givenName' => 'User', 'nameType' => 'Personal'],
+                    ],
+                ],
+            ];
+
+            $resource = $transformer->transform($doiData, $user->id);
+            $mainTitleType = TitleType::where('slug', 'MainTitle')->firstOrFail();
+
+            expect($mainTitleType->name)->toBe('Main Title')
+                ->and($resource->titles()->sole()->title_type_id)->toBe($mainTitleType->id);
+        });
+
         it('creates multiple titles with different types', function (): void {
             $user = User::factory()->create();
             $transformer = new DataCiteToResourceTransformer;

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -22,6 +22,7 @@ use Database\Seeders\PublisherSeeder;
 use Database\Seeders\RelationTypeSeeder;
 use Database\Seeders\ResourceTypeSeeder;
 use Database\Seeders\TitleTypeSeeder;
+use Illuminate\Support\Facades\Log;
 
 beforeEach(function (): void {
     // Ensure all required lookup tables are seeded
@@ -1533,6 +1534,48 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
             ->and($creators[0]->creatorable_type)->toBe(Institution::class)
             ->and($creators[1]->creatorable_type)->toBe(Institution::class)
             ->and($creators[2]->creatorable_type)->toBe(Person::class);
+    });
+
+    it('logs corrected nameType with persisted position and source index', function (): void {
+        Log::spy();
+
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/name-type-log-position.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'NameType Log Position Test']],
+                'creators' => [
+                    [
+                        'familyName' => 'Curator',
+                        'givenName' => 'Casey',
+                        'nameType' => 'Personal',
+                    ],
+                    [
+                        'name' => 'Royal Meteorological Institute (Belgium)',
+                        'nameType' => 'Personal',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+
+        expect($resource->creators()->orderBy('position')->pluck('position')->all())->toBe([1, 2]);
+
+        Log::shouldHaveReceived('debug')
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Corrected DataCite party nameType during import'
+                && $context['resource_id'] === $resource->id
+                && $context['doi'] === '10.5880/name-type-log-position.2024.001'
+                && $context['role'] === 'creator'
+                && $context['position'] === 2
+                && $context['source_index'] === 1
+                && $context['name'] === 'Royal Meteorological Institute (Belgium)'
+                && $context['declared_name_type'] === 'Personal'
+                && $context['resolved_name_type'] === 'Organizational')
+            ->once();
     });
 
     it('infers Intermagnet-style institutional creators when DataCite omits nameType', function (): void {

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -35,6 +35,43 @@ beforeEach(function (): void {
     test()->seed(RelationTypeSeeder::class);
 });
 
+describe('DataCiteToResourceTransformer - geo location normalization', function (): void {
+    it('normalizes empty geo box coordinates to null instead of writing empty strings', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/empty-geo-box.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Empty Geo Box Test']],
+                'creators' => [
+                    ['familyName' => 'Creator', 'givenName' => 'Casey', 'nameType' => 'Personal'],
+                ],
+                'geoLocations' => [
+                    [
+                        'geoLocationPlace' => 'Challa Lake, Kenya',
+                        'geoLocationBox' => [
+                            'westBoundLongitude' => '37.704000',
+                            'eastBoundLongitude' => '',
+                            'southBoundLatitude' => '-3.316760',
+                            'northBoundLatitude' => '   ',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $geoLocation = $resource->geoLocations()->firstOrFail();
+
+        expect((string) $geoLocation->west_bound_longitude)->toBe('37.70400000')
+            ->and($geoLocation->east_bound_longitude)->toBeNull()
+            ->and((string) $geoLocation->south_bound_latitude)->toBe('-3.31676000')
+            ->and($geoLocation->north_bound_latitude)->toBeNull();
+    });
+});
+
 afterEach(function (): void {
     Mockery::close();
 });

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -14,6 +14,7 @@ use App\Models\User;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\DataCiteToResourceTransformer;
 use Database\Seeders\ContributorTypeSeeder;
+use Database\Seeders\DateTypeSeeder;
 use Database\Seeders\DescriptionTypeSeeder;
 use Database\Seeders\IdentifierTypeSeeder;
 use Database\Seeders\LanguageSeeder;
@@ -739,9 +740,9 @@ describe('DataCiteToResourceTransformer', function (): void {
 describe('DataCiteToResourceTransformer - Issue #371: Date Created Handling', function (): void {
 
     beforeEach(function (): void {
-        test()->seed(\Database\Seeders\ResourceTypeSeeder::class);
-        test()->seed(\Database\Seeders\TitleTypeSeeder::class);
-        test()->seed(\Database\Seeders\DateTypeSeeder::class);
+        test()->seed(ResourceTypeSeeder::class);
+        test()->seed(TitleTypeSeeder::class);
+        test()->seed(DateTypeSeeder::class);
     });
 
     it('preserves imported Created date from DataCite response', function (): void {
@@ -894,7 +895,7 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
 
         $creator = $resource->creators()->first();
         expect($creator)->not->toBeNull()
-            ->and($creator->creatorable_type)->toBe(\App\Models\Institution::class);
+            ->and($creator->creatorable_type)->toBe(Institution::class);
     });
 
     it('infers Personal nameType for comma-separated name without nameType', function (): void {
@@ -1075,7 +1076,7 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
 
         $contributor = $resource->contributors()->first();
         expect($contributor)->not->toBeNull()
-            ->and($contributor->contributorable_type)->toBe(\App\Models\Institution::class);
+            ->and($contributor->contributorable_type)->toBe(Institution::class);
     });
 
     it('infers Personal for contributor with parseable name and no nameType', function (): void {
@@ -1154,7 +1155,7 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
         expect($creators[0]->creatorable_type)->toBe(Person::class);
 
         // Creator 2: Organizational (explicit)
-        expect($creators[1]->creatorable_type)->toBe(\App\Models\Institution::class);
+        expect($creators[1]->creatorable_type)->toBe(Institution::class);
 
         // Creator 3: Personal (inferred via parsePersonName from "Schmidt, Maria")
         expect($creators[2]->creatorable_type)->toBe(Person::class);
@@ -1318,10 +1319,10 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
         $creators = $resource->creators()->orderBy('position')->get();
 
         // "Alfred Wegener Institute" → Organizational (keyword "institute")
-        expect($creators[0]->creatorable_type)->toBe(\App\Models\Institution::class);
+        expect($creators[0]->creatorable_type)->toBe(Institution::class);
 
         // "Helmholtz Centre Potsdam GFZ" → Organizational (keyword "helmholtz"/"centre" + 4 tokens)
-        expect($creators[1]->creatorable_type)->toBe(\App\Models\Institution::class);
+        expect($creators[1]->creatorable_type)->toBe(Institution::class);
 
         // "John Smith" → Personal (2 tokens, no org keyword)
         expect($creators[2]->creatorable_type)->toBe(Person::class);
@@ -1494,6 +1495,71 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
         $contributor = $resource->contributors()->firstOrFail();
 
         expect($contributor->contributorable_type)->toBe(Institution::class);
+    });
+
+    it('treats structured contributor names as institutions when the full name is organizational', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/structured-contributor-org-correction.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Structured Contributor Organization Correction Test']],
+                'creators' => [
+                    ['familyName' => 'Creator', 'givenName' => 'Casey', 'nameType' => 'Personal'],
+                ],
+                'contributors' => [
+                    [
+                        'name' => 'secretariat, INTERMAGNET',
+                        'familyName' => 'secretariat',
+                        'givenName' => 'INTERMAGNET',
+                        'nameType' => 'Personal',
+                        'contributorType' => 'ContactPerson',
+                    ],
+                    [
+                        'name' => 'Deutsches GeoForschungsZentrum GFZ',
+                        'familyName' => 'GeoForschungsZentrum GFZ',
+                        'givenName' => 'Deutsches',
+                        'nameType' => 'Personal',
+                        'contributorType' => 'HostingInstitution',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $contributors = $resource->contributors()->orderBy('position')->get();
+
+        expect($contributors)->toHaveCount(2)
+            ->and($contributors[0]->contributorable_type)->toBe(Institution::class)
+            ->and($contributors[1]->contributorable_type)->toBe(Institution::class);
+    });
+
+    it('keeps structured person names with name particles as persons', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/structured-person-particles.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Structured Person Particles Test']],
+                'creators' => [
+                    [
+                        'name' => 'Rodrigo J. Abarca Del Rio',
+                        'familyName' => 'Abarca Del Rio',
+                        'givenName' => 'Rodrigo J.',
+                        'nameType' => 'Personal',
+                    ],
+                ],
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $creator = $resource->creators()->firstOrFail();
+
+        expect($creator->creatorable_type)->toBe(Person::class);
     });
 
 });

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -341,6 +341,38 @@ describe('DataCiteToResourceTransformer', function (): void {
                 ->and($person->scheme_uri)->toBe('https://orcid.org');
         });
 
+        it('normalizes protocol-less ORCID identifiers during import', function (): void {
+            $user = User::factory()->create();
+            $transformer = new DataCiteToResourceTransformer;
+
+            $doiData = [
+                'attributes' => [
+                    'doi' => '10.5880/orcid-protocol-less.2024.001',
+                    'titles' => [['title' => 'Protocol-less ORCID Test']],
+                    'creators' => [
+                        [
+                            'name' => 'Lovelace, Ada',
+                            'nameType' => 'Organizational',
+                            'nameIdentifiers' => [
+                                [
+                                    'nameIdentifier' => 'www.orcid.org/0000-0002-1825-0097',
+                                    'nameIdentifierScheme' => 'ORCID',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            $resource = $transformer->transform($doiData, $user->id);
+            $creator = $resource->creators()->firstOrFail();
+            $person = Person::findOrFail($creator->creatorable_id);
+
+            expect($creator->creatorable_type)->toBe(Person::class)
+                ->and($person->name_identifier)->toBe('https://orcid.org/0000-0002-1825-0097')
+                ->and($person->name_identifier_scheme)->toBe('ORCID');
+        });
+
         it('ignores invalid ORCID identifiers during import', function (): void {
             $user = User::factory()->create();
             $transformer = new DataCiteToResourceTransformer;

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -128,6 +128,36 @@ describe('ResourceStorageService', function () {
             ->and($resource->titles()->sole()->title_type_id)->toBe($mainTitleType->id);
     });
 
+    it('stores editor title type slugs using the matching DataCite title type', function () {
+        $resourceType = ResourceType::first();
+        $alternativeTitleType = TitleType::where('slug', 'AlternativeTitle')->firstOrFail();
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Recovered Alternative Title Resource',
+                    'titleType' => 'alternative-title',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'Jane',
+                    'lastName' => 'Recovery',
+                    'position' => 0,
+                ],
+            ],
+        ];
+
+        [$resource, $isUpdate] = $this->service->store($data, $this->user->id);
+
+        expect($isUpdate)->toBeFalse()
+            ->and($resource->titles()->sole()->title_type_id)->toBe($alternativeTitleType->id);
+    });
+
     it('updates an existing resource', function () {
         $resourceType = ResourceType::first();
 

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Models\FunderIdentifierType;
 use App\Models\IdentifierType;
 use App\Models\LandingPage;
 use App\Models\RelationType;
 use App\Models\Resource;
+use App\Models\ResourceInstrument;
 use App\Models\ResourceType;
+use App\Models\Right;
 use App\Models\TitleType;
 use App\Models\User;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
@@ -91,6 +94,38 @@ describe('ResourceStorageService', function () {
         expect($resource->descriptions()->count())->toBe(1);
         $description = $resource->descriptions->first();
         expect($description->value)->toBe('Test abstract description.');
+    });
+
+    it('recreates MainTitle title type when storing a resource and the lookup row is missing', function () {
+        TitleType::query()->delete();
+        $resourceType = ResourceType::first();
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Recovered Main Title Resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'Jane',
+                    'lastName' => 'Recovery',
+                    'position' => 0,
+                ],
+            ],
+        ];
+
+        [$resource, $isUpdate] = $this->service->store($data, $this->user->id);
+        $mainTitleType = TitleType::where('slug', 'MainTitle')->firstOrFail();
+
+        expect($isUpdate)->toBeFalse()
+            ->and($mainTitleType->name)->toBe('Main Title')
+            ->and($resource->titles()->sole()->title_type_id)->toBe($mainTitleType->id);
     });
 
     it('updates an existing resource', function () {
@@ -183,7 +218,7 @@ describe('ResourceStorageService', function () {
         $resourceType = ResourceType::first();
 
         // Create a test license
-        $license = \App\Models\Right::factory()->create([
+        $license = Right::factory()->create([
             'identifier' => 'test-license',
             'name' => 'Test License',
         ]);
@@ -368,10 +403,10 @@ describe('ResourceStorageService', function () {
     it('stores related identifiers with resolved citation labels and trimmed relation details', function () {
         $resourceType = ResourceType::first();
 
-        $mock = \Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
         $mock->shouldReceive('resolveBestEffort')
             ->once()
-            ->with('10.5880/test.related', 'DOI', \Mockery::type('float'))
+            ->with('10.5880/test.related', 'DOI', Mockery::type('float'))
             ->andReturn('Doe, J. (2026): Auto-resolved citation.');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 
@@ -435,7 +470,7 @@ describe('ResourceStorageService', function () {
     it('preserves manual related identifier citation labels without calling the resolver', function () {
         $resourceType = ResourceType::first();
 
-        $mock = \Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
         $mock->shouldNotReceive('resolveBestEffort');
         $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
 
@@ -833,7 +868,7 @@ describe('ResourceStorageService - Issue #371: Date Created Handling', function 
                 ->and($instruments[1]->instrument_pid)->toBe('http://hdl.handle.net/21.12132/NEW002');
 
             // Old instrument should be gone
-            expect(\App\Models\ResourceInstrument::where('instrument_pid', 'http://hdl.handle.net/21.12132/OLD001')->exists())->toBeFalse();
+            expect(ResourceInstrument::where('instrument_pid', 'http://hdl.handle.net/21.12132/OLD001')->exists())->toBeFalse();
         });
 
         it('skips instruments with empty pid or name', function () {
@@ -934,7 +969,7 @@ describe('ResourceStorageService - Issue #371: Date Created Handling', function 
 
         it('stores funder_identifier_type_id correctly for ROR funders', function () {
             $resourceType = ResourceType::first();
-            $rorType = \App\Models\FunderIdentifierType::where('name', 'ROR')->first();
+            $rorType = FunderIdentifierType::where('name', 'ROR')->first();
 
             $data = [
                 'resourceId' => null,
@@ -969,7 +1004,7 @@ describe('ResourceStorageService - Issue #371: Date Created Handling', function 
 
         it('stores funder_identifier_type_id correctly for Crossref Funder ID', function () {
             $resourceType = ResourceType::first();
-            $crossrefType = \App\Models\FunderIdentifierType::where('name', 'Crossref Funder ID')->first();
+            $crossrefType = FunderIdentifierType::where('name', 'Crossref Funder ID')->first();
 
             $data = [
                 'resourceId' => null,

--- a/tests/pest/Feature/Services/RorLookupServiceTest.php
+++ b/tests/pest/Feature/Services/RorLookupServiceTest.php
@@ -16,6 +16,18 @@ describe('RorLookupService', function () {
         expect($service->canonicalise('http://ror.org/04z8jg394'))->toBe('https://ror.org/04z8jg394');
     });
 
+    test('canonicalises protocol-less ROR URL', function () {
+        $service = new RorLookupService;
+
+        expect($service->canonicalise('ror.org/04z8jg394'))->toBe('https://ror.org/04z8jg394');
+    });
+
+    test('canonicalises protocol-less www ROR URL', function () {
+        $service = new RorLookupService;
+
+        expect($service->canonicalise('www.ror.org/04z8jg394'))->toBe('https://ror.org/04z8jg394');
+    });
+
     test('canonicalises bare ROR ID', function () {
         $service = new RorLookupService;
 
@@ -45,6 +57,8 @@ describe('RorLookupService', function () {
 
         expect($service->isRorUrl('https://ror.org/04z8jg394'))->toBeTrue()
             ->and($service->isRorUrl('http://ror.org/04z8jg394'))->toBeTrue()
+            ->and($service->isRorUrl('ror.org/04z8jg394'))->toBeTrue()
+            ->and($service->isRorUrl('www.ror.org/04z8jg394'))->toBeTrue()
             ->and($service->isRorUrl('https://example.com'))->toBeFalse()
             ->and($service->isRorUrl('GFZ Potsdam'))->toBeFalse()
             ->and($service->isRorUrl(''))->toBeFalse();

--- a/tests/pest/Unit/Services/DataCiteApiServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteApiServiceTest.php
@@ -296,6 +296,21 @@ describe('buildCitationFromMetadata', function (): void {
         expect($result)->toContain('(2023)');
     });
 
+    it('falls back when an earlier CSL date field is malformed', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Doe', 'given' => 'John']],
+            'issued' => '2024',
+            'published' => ['date-parts' => [[2023]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => '10.5880/test.2024.001',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toContain('(2023)');
+    });
+
     it('falls back to created date-parts when issued and published are missing', function (): void {
         $metadata = [
             'author' => [['family' => 'Doe', 'given' => 'John']],

--- a/tests/pest/Unit/Services/DataCiteApiServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteApiServiceTest.php
@@ -200,10 +200,20 @@ describe('getMetadata', function (): void {
 
     it('returns null on HTTP exception', function (): void {
         Http::fake([
-            'doi.org/*' => fn () => throw new \Exception('Connection timeout'),
+            'doi.org/*' => fn () => throw new Exception('Connection timeout'),
         ]);
 
         $result = $this->service->getMetadata('10.5880/test.2024.001');
+
+        expect($result)->toBeNull();
+    });
+
+    it('returns null when doi.org responds successfully without JSON metadata', function (): void {
+        Http::fake([
+            'doi.org/*' => Http::response('', 200, ['Content-Type' => 'text/html']),
+        ]);
+
+        $result = $this->service->getMetadata('10.5880/non-json-response');
 
         expect($result)->toBeNull();
     });
@@ -449,6 +459,23 @@ describe('buildCitationFromMetadata', function (): void {
 
         expect($result)->toStartWith('Dupont, J.-P. (2024)');
     });
+
+    it('normalizes array-valued CSL fields before building citations', function (): void {
+        $metadata = [
+            'author' => [
+                ['literal' => ['INTERMAGNET']],
+                ['family' => ['Doe'], 'given' => ['Jane Marie']],
+            ],
+            'issued' => ['date-parts' => [[[2024]]]],
+            'title' => ['Geomagnetic Dataset', 'Alternative Title'],
+            'publisher' => ['GFZ'],
+            'DOI' => ['10.5880/array.2024.001'],
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toBe('INTERMAGNET; Doe, J. M. (2024): Geomagnetic Dataset. GFZ. https://doi.org/10.5880/array.2024.001');
+    });
 });
 
 // =========================================================================
@@ -596,7 +623,7 @@ describe('getDataCiteMetadata', function (): void {
 
     it('returns null on HTTP exception', function (): void {
         Http::fake([
-            'api.datacite.org/*' => fn () => throw new \Exception('Connection timeout'),
+            'api.datacite.org/*' => fn () => throw new Exception('Connection timeout'),
         ]);
 
         $result = $this->service->getDataCiteMetadata('10.5880/test.2024.001');

--- a/tests/pest/Unit/Services/DataCiteApiServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteApiServiceTest.php
@@ -7,6 +7,7 @@ use App\Services\DataCiteApiService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 covers(DataCiteApiService::class);
 
@@ -217,6 +218,29 @@ describe('getMetadata', function (): void {
 
         expect($result)->toBeNull();
     });
+
+    it('logs an excerpt and content type for non-JSON DOI responses', function (): void {
+        Log::spy();
+
+        $body = str_repeat('x', 1100);
+
+        Http::fake([
+            'doi.org/*' => Http::response($body, 200, ['Content-Type' => 'text/html; charset=UTF-8']),
+        ]);
+
+        $result = $this->service->getMetadata('10.5880/non-json-response-with-large-body');
+
+        expect($result)->toBeNull();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $message, array $context): bool => str_contains($message, 'non-JSON metadata')
+                && $context['status'] === 200
+                && $context['content_type'] === 'text/html; charset=UTF-8'
+                && $context['body_excerpt'] === substr($body, 0, 1000)
+                && $context['body_truncated'] === true
+                && ! array_key_exists('body', $context))
+            ->once();
+    });
 });
 
 // =========================================================================
@@ -364,7 +388,7 @@ describe('buildCitationFromMetadata', function (): void {
         expect($result)->toContain('Unknown Publisher');
     });
 
-    it('omits DOI URL when DOI is missing', function (): void {
+    it('omits DOI segment when DOI is missing', function (): void {
         $metadata = [
             'author' => [['family' => 'Doe', 'given' => 'John']],
             'issued' => ['date-parts' => [[2024]]],
@@ -374,7 +398,21 @@ describe('buildCitationFromMetadata', function (): void {
 
         $result = $this->service->buildCitationFromMetadata($metadata);
 
-        expect($result)->not->toContain('https://doi.org/');
+        expect($result)->toBe('Doe, J. (2024): Test. GFZ');
+    });
+
+    it('omits DOI segment when DOI normalization fails', function (): void {
+        $metadata = [
+            'author' => [['family' => 'Doe', 'given' => 'John']],
+            'issued' => ['date-parts' => [[2024]]],
+            'title' => 'Test',
+            'publisher' => 'GFZ',
+            'DOI' => 'https://doi.org/',
+        ];
+
+        $result = $this->service->buildCitationFromMetadata($metadata);
+
+        expect($result)->toBe('Doe, J. (2024): Test. GFZ');
     });
 
     it('abbreviates multiple space-separated given names', function (): void {

--- a/tests/pest/Unit/Support/OrcidNormalizerTest.php
+++ b/tests/pest/Unit/Support/OrcidNormalizerTest.php
@@ -27,6 +27,14 @@ describe('extractBareId', function (): void {
         expect(OrcidNormalizer::extractBareId('http://www.orcid.org/0000-0002-1825-0097'))->toBe('0000-0002-1825-0097');
     });
 
+    it('strips protocol-less orcid.org prefix', function (): void {
+        expect(OrcidNormalizer::extractBareId('orcid.org/0000-0002-1825-0097'))->toBe('0000-0002-1825-0097');
+    });
+
+    it('strips protocol-less www.orcid.org prefix', function (): void {
+        expect(OrcidNormalizer::extractBareId('www.orcid.org/0000-0002-1825-0097'))->toBe('0000-0002-1825-0097');
+    });
+
     it('handles case-insensitive prefixes', function (): void {
         expect(OrcidNormalizer::extractBareId('HTTPS://ORCID.ORG/0000-0002-1825-0097'))->toBe('0000-0002-1825-0097');
     });
@@ -47,6 +55,11 @@ describe('toUrl', function (): void {
 
     it('normalizes http variant to canonical https URL', function (): void {
         expect(OrcidNormalizer::toUrl('http://orcid.org/0000-0002-1825-0097'))->toBe('https://orcid.org/0000-0002-1825-0097');
+    });
+
+    it('normalizes protocol-less variants to canonical URL', function (): void {
+        expect(OrcidNormalizer::toUrl('orcid.org/0000-0002-1825-0097'))->toBe('https://orcid.org/0000-0002-1825-0097');
+        expect(OrcidNormalizer::toUrl('www.orcid.org/0000-0002-1825-0097'))->toBe('https://orcid.org/0000-0002-1825-0097');
     });
 });
 
@@ -71,6 +84,11 @@ describe('isValidFormat', function (): void {
         expect(OrcidNormalizer::isValidFormat('https://www.orcid.org/0000-0002-1825-0097'))->toBeTrue();
     });
 
+    it('accepts protocol-less ORCID URLs', function (): void {
+        expect(OrcidNormalizer::isValidFormat('orcid.org/0000-0002-1825-0097'))->toBeTrue();
+        expect(OrcidNormalizer::isValidFormat('www.orcid.org/0000-0002-1825-0097'))->toBeTrue();
+    });
+
     it('rejects malformed strings', function (): void {
         expect(OrcidNormalizer::isValidFormat('not-an-orcid'))->toBeFalse();
         expect(OrcidNormalizer::isValidFormat('1234'))->toBeFalse();
@@ -91,6 +109,11 @@ describe('isValidChecksum', function (): void {
         expect(OrcidNormalizer::isValidChecksum('https://www.orcid.org/0000-0002-1825-0097'))->toBeTrue();
     });
 
+    it('validates checksum from protocol-less URL format', function (): void {
+        expect(OrcidNormalizer::isValidChecksum('orcid.org/0000-0002-1825-0097'))->toBeTrue();
+        expect(OrcidNormalizer::isValidChecksum('www.orcid.org/0000-0002-1825-0097'))->toBeTrue();
+    });
+
     it('rejects non-ORCID strings', function (): void {
         expect(OrcidNormalizer::isValidChecksum('not-valid'))->toBeFalse();
     });
@@ -107,6 +130,11 @@ describe('isValid', function (): void {
 
     it('accepts valid www ORCID URL', function (): void {
         expect(OrcidNormalizer::isValid('https://www.orcid.org/0000-0002-1825-0097'))->toBeTrue();
+    });
+
+    it('accepts valid protocol-less ORCID URLs', function (): void {
+        expect(OrcidNormalizer::isValid('orcid.org/0000-0002-1825-0097'))->toBeTrue();
+        expect(OrcidNormalizer::isValid('www.orcid.org/0000-0002-1825-0097'))->toBeTrue();
     });
 
     it('rejects valid format with bad checksum', function (): void {

--- a/tests/playwright/helpers/page-objects/LoginPage.ts
+++ b/tests/playwright/helpers/page-objects/LoginPage.ts
@@ -56,7 +56,7 @@ export class LoginPage {
    */
   async loginAndWaitForDashboard(email: string, password: string) {
     await this.login(email, password);
-    await this.page.waitForURL(/\/dashboard/, { timeout: 15000 });
+    await expect(this.page).toHaveURL(/\/dashboard/, { timeout: 30000 });
   }
 
   /**


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the geolocation model, DOI metadata handling, and DataCite resource transformation. The main highlights include more robust decimal normalization for geolocation fields, enhanced error handling and citation formatting in the DOI metadata service, and improved handling of title types and person identifiers during DataCite resource transformation.

**GeoLocation Model Improvements:**

* Added setter methods in `GeoLocation` to normalize decimal fields, ensuring all relevant attributes are consistently processed as nullable decimals. [[1]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1R61-R105) [[2]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1R203-R215)
* Updated type hints and imports for clarity and correctness, such as using `Carbon` and refining the factory usage. [[1]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1R8-R12) [[2]](diffhunk://#diff-9ea793c904beb8f88eaa1b9ba0f8df09fc07608abd3e62ee93b3042c1a0ce8d1L32-R43)

**DOI Metadata Service Enhancements:**

* Improved error handling in `DataCiteApiService` by adding detailed logging context for API responses and handling non-JSON responses gracefully. [[1]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L121-R134) [[2]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L131-R144) [[3]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9L265-R334) [[4]](diffhunk://#diff-4217e88dd2f148a34b98535fa20d73d0d5ab2889c836684025b236c099e950a9R347-R361)
* Refactored citation building to better parse and format CSL JSON metadata, including robust extraction of authors, year, title, publisher, and DOI, and introduced helper methods for string normalization.

**DataCite Resource Transformation Improvements:**

* Improved handling of `TitleType` in `DataCiteToResourceTransformer` by adding a method to resolve or create missing title types, ensuring all titles are assigned a valid type. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L318-R324) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L349-R344) [[3]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R357-R378)
* Enhanced name type determination and logging for creators and contributors, providing better diagnostics and normalization. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L388-R402) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L445-R461)
* Improved ORCID identifier extraction and normalization for persons, ensuring only valid ORCIDs are processed and stored as URLs.

These changes collectively improve data integrity, error visibility, and compatibility with external metadata sources.