### PR TITLE
Documentation: Use NPM for artisan commands of Laravel 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,51 @@ This README documents the Docker-based development workflow only. For deeper set
 - On macOS, Docker Desktop runs on both Apple Silicon and Intel Macs. On Apple Silicon, enable **Use Rosetta for x86_64/amd64 emulation** under Docker Desktop → Settings → General so images without a native `arm64` build still run reliably.
 - On macOS, the default shell (`zsh`) and the bundled `openssl` (LibreSSL) work out of the box. If Node.js is not installed yet, the easiest route is [Homebrew](https://brew.sh) (`brew install node`) or a version manager such as `nvm`.
 
+### Optional Host-Side PHP And Composer
+
+The Docker-first workflow runs Composer and Laravel Artisan commands inside the `app` container, so PHP extensions such as `bcmath` are already available there:
+
+```bash
+npm run composer:app -- install
+npm run artisan -- make:controller TestController
+```
+
+If you prefer to run `composer install` directly on the host, install PHP 8.5 with the required extensions, including `bcmath`, and verify that the PHP CLI used by Composer sees it.
+
+Linux:
+
+```bash
+# Fedora
+sudo dnf install php-bcmath
+
+# Debian, Ubuntu, or WSL2 with Ubuntu
+sudo apt install php-bcmath
+
+php -m | grep -i '^bcmath$'
+composer install
+```
+
+macOS with Homebrew PHP:
+
+```bash
+brew install php
+php -m | grep -i '^bcmath$'
+composer install
+```
+
+If `bcmath` is still missing on macOS, check `php --ini` and make sure your shell is using the Homebrew PHP binary rather than another PHP installation.
+
+Windows:
+
+- With WSL2, run the Debian/Ubuntu commands above inside your WSL shell.
+- With native Windows PHP, enable `extension=bcmath` in the loaded `php.ini`, then verify it from PowerShell:
+
+```powershell
+php --ini
+php -m | findstr /I bcmath
+composer install
+```
+
 ### Step-By-Step Setup
 
 1. Clone the repository:
@@ -96,7 +141,7 @@ This README documents the Docker-based development workflow only. For deeper set
 6. Generate the application key:
 
 ```
-   docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan key:generate
+   npm run artisan -- key:generate
 ```
 
    The development container normally writes `APP_KEY` to `.env` automatically on first boot. If the application reports `No application encryption key has been specified` (or `APP_KEY=` in `.env` is still empty), run this once while the stack is running, then reload the page.
@@ -115,7 +160,7 @@ This README documents the Docker-based development workflow only. For deeper set
 8. Create the first administrator account:
 
 ```
-   docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan add-user "Admin Name" admin@example.com SecurePassword
+   npm run artisan -- add-user "Admin Name" admin@example.com SecurePassword
 ```
 
    The first user created in a fresh environment becomes an administrator automatically.
@@ -123,10 +168,16 @@ This README documents the Docker-based development workflow only. For deeper set
 9. Initialize SPDX license data:
 
 ```
-   docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan spdx:sync-licenses
+   npm run artisan -- spdx:sync-licenses
 ```
 
 The Docker entrypoints install missing Composer dependencies and container-local npm dependencies, run migrations, and seed baseline data when the database is empty. Host-side frontend commands still require the local `npm install` step above.
+
+For day-to-day Laravel commands, use the running app container instead of installing Composer dependencies on the host. For example:
+
+```bash
+npm run artisan -- make:controller TestController
+```
 
 ### Common Permission Errors
 
@@ -206,14 +257,16 @@ Host-side frontend commands in this repository require local `node_modules` in y
 | `npm run docker:dev:reset`      | Stop the stack and remove Docker volumes                                                   |
 | `npm run docker:dev:assessment` | Start the stack with the assessment profile, which adds the F-UJI container                |
 | `npm run docker:dev:parity`     | Start the stack with the parity profile, which currently adds the F-UJI container          |
+| `npm run artisan -- <command>`  | Run a Laravel Artisan command inside the app container                                     |
+| `npm run composer:app -- <cmd>` | Run Composer inside the app container                                                      |
 | `npm run check:backend`         | Run Pest and PHPStan against the Docker-backed backend workflow                            |
 | `npm run check:frontend`        | Run ESLint, OpenAPI linting, TypeScript checks, and one-shot Vitest on the host            |
 | `npm run check:parity`          | Run the parity validation flow, including the MySQL-sensitive backend slice and Playwright |
 
-For ad-hoc Laravel commands, use the app container directly:
+For example, create a controller with:
 
 ```bash
-docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan <command>
+npm run artisan -- make:controller TestController
 ```
 
 ## Testing And Quality Checks

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -94,10 +94,16 @@ If the repository stays under `D:\` or another NTFS path:
 7. Create the first administrator account.
 
    ```bash
-   docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan add-user "Admin Name" admin@example.com SecurePassword
+   npm run artisan -- add-user "Admin Name" admin@example.com SecurePassword
    ```
 
 The Docker entrypoints install missing Composer dependencies and container-local npm dependencies, run migrations, and seed baseline data when the database is empty. Host-side frontend commands still require the local `npm install` step above.
+
+For day-to-day Laravel commands, use the npm wrappers. They run inside the app container, and generated files are written into the bind-mounted repository, so they still appear in your host checkout:
+
+```bash
+npm run artisan -- make:controller TestController
+```
 
 ## Profiles And Services
 
@@ -133,8 +139,9 @@ npm run docker:dev:parity
 | Start the backend services needed for PHP checks | Host shell | `npm run docker:dev:backend:d` |
 | Stop the stack | Host shell | `npm run docker:dev:down` |
 | Reset Docker volumes | Host shell | `npm run docker:dev:reset` |
-| Laravel Artisan | app container | `docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan <command>` |
-| Composer | app container | `docker compose --env-file .env.docker -f docker-compose.dev.yml exec app composer <command>` |
+| Laravel Artisan | npm wrapper into app container | `npm run artisan -- <command>` |
+| Example controller generator | npm wrapper into app container | `npm run artisan -- make:controller TestController` |
+| Composer | npm wrapper into app container | `npm run composer:app -- <command>` |
 | Pest | Host shell via npm wrapper | `npm run test:php` |
 | MySQL-sensitive Pest slice | Host shell via npm wrapper | `npm run test:php:mysql-sensitive` |
 | PHPStan | Host shell via npm wrapper | `npm run phpstan:check` |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "docker:dev:backend:d": "docker compose --env-file .env.docker -f docker-compose.dev.yml up -d --wait db redis app",
     "docker:dev:down": "docker compose --env-file .env.docker -f docker-compose.dev.yml down",
     "docker:dev:reset": "docker compose --env-file .env.docker -f docker-compose.dev.yml down -v",
+    "artisan": "docker compose --env-file .env.docker -f docker-compose.dev.yml exec app php artisan",
+    "composer:app": "docker compose --env-file .env.docker -f docker-compose.dev.yml exec app composer",
     "db:dev:test:prepare": "npm run docker:dev:backend:d && docker compose --env-file .env.docker -f docker-compose.dev.yml exec -T db mysql -uroot -prootsecret -e \"CREATE DATABASE IF NOT EXISTS ernie_test; GRANT ALL PRIVILEGES ON ernie_test.* TO 'ernie'@'%'; FLUSH PRIVILEGES;\"",
     "db:dev:test:reset": "docker compose --env-file .env.docker -f docker-compose.dev.yml exec -T db mysql -uroot -prootsecret -e \"DROP DATABASE IF EXISTS ernie_test; CREATE DATABASE ernie_test; GRANT ALL PRIVILEGES ON ernie_test.* TO 'ernie'@'%'; FLUSH PRIVILEGES;\"",
     "format": "prettier --write resources/",


### PR DESCRIPTION
This pull request improves the developer experience by introducing npm-based wrappers for running Laravel Artisan and Composer commands inside the Docker app container, and updates documentation to reflect this simpler workflow. These changes make it easier to run backend commands without needing to remember lengthy Docker commands or install PHP and Composer on the host machine. Documentation is updated throughout to guide developers on the new recommended approach and provide troubleshooting tips for optional host-side PHP usage.

**Developer workflow improvements:**

* Added npm scripts `artisan` and `composer:app` to `package.json` for running Laravel Artisan and Composer commands within the app container, simplifying backend command execution.
* Updated documentation (`README.md` and `docs/local-development.md`) to recommend using `npm run artisan -- <command>` and `npm run composer:app -- <command>` instead of direct Docker commands for common backend tasks such as creating users, running migrations, and generating controllers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R144) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R181) [[3]](diffhunk://#diff-53e532051b05508d4e9b669b7dbb53f2d317faf2d91cb965e0bf98cc1a2133deL97-R107) [[4]](diffhunk://#diff-53e532051b05508d4e9b669b7dbb53f2d317faf2d91cb965e0bf98cc1a2133deL136-R144) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R260-R269)

**Optional host-side PHP/Composer guidance:**

* Added a new section in `README.md` explaining how to set up and verify required PHP extensions (like `bcmath`) for users who prefer running Composer directly on the host, with platform-specific instructions for Linux, macOS, and Windows.

These changes streamline backend development workflows and clarify setup steps for all supported platforms.