### PR TITLE
Fix: Merge ContactPerson into author editor row

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM php:8.5.6-fpm-trixie@sha256:e88c4218493214d7d2611dea9707359dc3b0c63814c0a5e
 
 WORKDIR /var/www/html
 
+ARG PHP_REDIS_VERSION=6.3.0
+
 # Install system dependencies needed for the PHP runtime and extension builds.
 RUN apt-get update && apt-get install -y \
     libnghttp2-14 \
@@ -37,8 +39,13 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip sodium xsl intl sockets
 
-# Install Redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install Redis extension from the official phpredis source tag.
+RUN set -eux; \
+    curl -fsSL "https://github.com/phpredis/phpredis/archive/refs/tags/${PHP_REDIS_VERSION}.tar.gz" -o /tmp/phpredis.tar.gz; \
+    mkdir -p /usr/src/php/ext/redis; \
+    tar -xzf /tmp/phpredis.tar.gz -C /usr/src/php/ext/redis --strip-components=1; \
+    docker-php-ext-install redis; \
+    rm -rf /tmp/phpredis.tar.gz /usr/src/php/ext/redis
 
 COPY --from=composer:2.9.8@sha256:b09bccd91a78fe8a9ab4b33d707b862e8fe54fec17782e32683ad2a69c46867d /usr/bin/composer /usr/bin/composer
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,8 @@ FROM php:8.5.6-fpm-trixie@sha256:e88c4218493214d7d2611dea9707359dc3b0c63814c0a5e
 
 WORKDIR /var/www/html
 
+ARG PHP_REDIS_VERSION=6.3.0
+
 # Copy .node-version so the following RUN step can derive the NodeSource major
 # from the repository's single source of truth.
 COPY .node-version /tmp/.node-version
@@ -156,8 +158,13 @@ RUN apt-get update && apt-get install -y \
 # Install PHP extensions
 RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip sodium xsl intl sockets
 
-# Install Redis extension
-RUN pecl install redis && docker-php-ext-enable redis
+# Install Redis extension from the official phpredis source tag.
+RUN set -eux; \
+    curl -fsSL "https://github.com/phpredis/phpredis/archive/refs/tags/${PHP_REDIS_VERSION}.tar.gz" -o /tmp/phpredis.tar.gz; \
+    mkdir -p /usr/src/php/ext/redis; \
+    tar -xzf /tmp/phpredis.tar.gz -C /usr/src/php/ext/redis --strip-components=1; \
+    docker-php-ext-install redis; \
+    rm -rf /tmp/phpredis.tar.gz /usr/src/php/ext/redis
 
 # Install Xdebug for debugging (optional, disabled by default)
 RUN pecl install xdebug && docker-php-ext-enable xdebug

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -7,11 +7,15 @@ namespace App\Services\Editor;
 use App\Models\Affiliation;
 use App\Models\ContributorType;
 use App\Models\Datacenter;
+use App\Models\FundingReference;
 use App\Models\IdentifierType;
 use App\Models\Institution;
 use App\Models\Person;
+use App\Models\RelatedIdentifier;
 use App\Models\RelationType;
 use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
 use App\Models\ResourceDate;
 use App\Models\Setting;
 use App\Support\GemetVocabularyParser;
@@ -153,13 +157,29 @@ class EditorDataTransformer
             });
 
         $authors = [];
+        /** @var array<string, int> $authorIndexesByIdentity */
+        $authorIndexesByIdentity = [];
         $contributors = [];
 
         foreach ($creatorableGroups as $group) {
             // In DataCite 4.6, all ResourceCreator entries are creators (no role distinction)
-            /** @var \App\Models\ResourceCreator $firstEntry */
+            /** @var ResourceCreator $firstEntry */
             $firstEntry = $group->first();
             $creatorable = $firstEntry->creatorable;
+
+            $isContact = false;
+            $email = null;
+            $website = null;
+
+            foreach ($group as $creatorEntry) {
+                if (! (bool) $creatorEntry->is_contact) {
+                    continue;
+                }
+
+                $isContact = true;
+                $email ??= $creatorEntry->email;
+                $website ??= $creatorEntry->website;
+            }
 
             // Collect all unique affiliations from all entries of this creator
             $allAffiliations = $group->flatMap(function ($creator) {
@@ -172,8 +192,16 @@ class EditorDataTransformer
             // All ResourceCreator entries are creators in DataCite 4.6
             $data = [
                 'position' => $firstEntry->position,
-                'isContact' => false, // Contact tracking will be handled differently
+                'isContact' => $isContact,
             ];
+
+            if ($isContact && $email !== null) {
+                $data['email'] = $email;
+            }
+
+            if ($isContact && $website !== null) {
+                $data['website'] = $website;
+            }
 
             if ($firstEntry->creatorable_type === Person::class) {
                 /** @var Person $creatorable */
@@ -203,14 +231,41 @@ class EditorDataTransformer
             ])->values()->toArray();
 
             $authors[] = $data;
+
+            if ($creatorable instanceof Person) {
+                $authorIndex = array_key_last($authors);
+
+                foreach ($this->personIdentityKeys($creatorable) as $identityKey) {
+                    $authorIndexesByIdentity[$identityKey] ??= $authorIndex;
+                }
+            }
         }
 
         // Transform ResourceContributor entries to contributors format
         foreach ($resource->contributors as $contributor) {
-            /** @var \App\Models\ResourceContributor $contributor */
+            /** @var ResourceContributor $contributor */
+            $contributorTypes = $contributor->contributorTypes;
+            $hasContactPersonRole = $contributorTypes
+                ->contains(fn (ContributorType $ct): bool => $ct->slug === 'ContactPerson');
+            $matchingAuthorIndex = $hasContactPersonRole
+                ? $this->matchingAuthorIndexForContributor($contributor, $authorIndexesByIdentity)
+                : null;
+
+            if ($matchingAuthorIndex !== null) {
+                $this->mergeContributorContactIntoAuthor($authors[$matchingAuthorIndex], $contributor);
+
+                $contributorTypes = $contributorTypes
+                    ->reject(fn (ContributorType $ct): bool => $ct->slug === 'ContactPerson')
+                    ->values();
+
+                if ($contributorTypes->isEmpty()) {
+                    continue;
+                }
+            }
+
             $data = [
                 'position' => $contributor->position,
-                'roles' => $contributor->contributorTypes->pluck('name')->values()->toArray(),
+                'roles' => $contributorTypes->pluck('name')->values()->toArray(),
             ];
 
             if ($contributor->contributorable_type === Person::class) {
@@ -228,10 +283,10 @@ class EditorDataTransformer
                     $person->name_identifier_scheme,
                 );
 
-                $hasContactPersonRole = $contributor->contributorTypes
+                $hasVisibleContactPersonRole = $contributorTypes
                     ->contains(fn (ContributorType $ct): bool => $ct->slug === 'ContactPerson');
-                $data['email'] = $hasContactPersonRole ? ($contributor->email ?? '') : '';
-                $data['website'] = $hasContactPersonRole ? ($contributor->website ?? '') : '';
+                $data['email'] = $hasVisibleContactPersonRole ? ($contributor->email ?? '') : '';
+                $data['website'] = $hasVisibleContactPersonRole ? ($contributor->website ?? '') : '';
             } elseif ($contributor->contributorable_type === Institution::class) {
                 /** @var Institution $institution */
                 $institution = $contributor->contributorable;
@@ -257,6 +312,87 @@ class EditorDataTransformer
             'authors' => $authors,
             'contributors' => $contributors,
         ];
+    }
+
+    /**
+     * @param  array<string, int>  $authorIndexesByIdentity
+     */
+    private function matchingAuthorIndexForContributor(ResourceContributor $contributor, array $authorIndexesByIdentity): ?int
+    {
+        if ($contributor->contributorable_type !== Person::class) {
+            return null;
+        }
+
+        $person = $contributor->contributorable;
+
+        if (! $person instanceof Person) {
+            return null;
+        }
+
+        foreach ($this->personIdentityKeys($person) as $identityKey) {
+            if (array_key_exists($identityKey, $authorIndexesByIdentity)) {
+                return $authorIndexesByIdentity[$identityKey];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function personIdentityKeys(Person $person): array
+    {
+        $keys = ["person-id:{$person->id}"];
+
+        if ($person->name_identifier !== null && $person->name_identifier !== '') {
+            $scheme = $person->name_identifier_scheme ?? 'ORCID';
+
+            if (strtoupper($scheme) === 'ORCID') {
+                $keys[] = 'orcid:'.strtolower(OrcidNormalizer::extractBareId($person->name_identifier));
+            }
+        }
+
+        $normalisedName = $this->normalisePersonIdentityName($person);
+
+        if ($normalisedName !== null) {
+            $keys[] = 'name:'.$normalisedName;
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    private function normalisePersonIdentityName(Person $person): ?string
+    {
+        $givenName = trim((string) ($person->given_name ?? ''));
+        $familyName = trim((string) ($person->family_name ?? ''));
+
+        if ($givenName === '' || $familyName === '') {
+            return null;
+        }
+
+        $normalised = mb_strtolower($familyName.'|'.$givenName, 'UTF-8');
+        $normalised = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalised) ?: $normalised;
+        $normalised = preg_replace('/[^\p{L}\p{N}|]+/u', ' ', $normalised) ?? '';
+        $normalised = preg_replace('/\s+/', ' ', $normalised) ?? '';
+
+        return trim($normalised);
+    }
+
+    /**
+     * @param  array<string, mixed>  $author
+     */
+    private function mergeContributorContactIntoAuthor(array &$author, ResourceContributor $contributor): void
+    {
+        $author['isContact'] = true;
+
+        if (($author['email'] ?? '') === '' && $contributor->email !== null) {
+            $author['email'] = $contributor->email;
+        }
+
+        if (($author['website'] ?? '') === '' && $contributor->website !== null) {
+            $author['website'] = $contributor->website;
+        }
     }
 
     /**
@@ -488,7 +624,7 @@ class EditorDataTransformer
     {
         return $resource->relatedIdentifiers
             ->sortBy('position')
-            ->map(fn (\App\Models\RelatedIdentifier $relatedId): array => [
+            ->map(fn (RelatedIdentifier $relatedId): array => [
                 'identifier' => $relatedId->identifier,
                 'identifier_type' => $relatedId->identifierType->slug,
                 'relation_type' => $relatedId->relationType->slug,
@@ -509,7 +645,7 @@ class EditorDataTransformer
         return $resource->fundingReferences
             ->sortBy('position')
             ->map(function ($funding): array {
-                /** @var \App\Models\FundingReference $funding */
+                /** @var FundingReference $funding */
                 $identifierType = $funding->funderIdentifierType;
 
                 return [

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -345,11 +345,15 @@ class EditorDataTransformer
     {
         $keys = ["person-id:{$person->id}"];
 
-        if ($person->name_identifier !== null && $person->name_identifier !== '') {
+        if ($person->name_identifier !== null && trim($person->name_identifier) !== '') {
             $scheme = $person->name_identifier_scheme ?? 'ORCID';
 
             if (strtoupper($scheme) === 'ORCID') {
-                $keys[] = 'orcid:'.strtolower(OrcidNormalizer::extractBareId($person->name_identifier));
+                $bareOrcid = OrcidNormalizer::extractBareId($person->name_identifier);
+
+                if ($bareOrcid !== '' && OrcidNormalizer::isValidFormat($bareOrcid)) {
+                    $keys[] = 'orcid:'.strtolower($bareOrcid);
+                }
             }
         }
 

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -345,16 +345,12 @@ class EditorDataTransformer
     {
         $keys = ["person-id:{$person->id}"];
 
-        if ($person->name_identifier !== null && trim($person->name_identifier) !== '') {
-            $scheme = $person->name_identifier_scheme ?? 'ORCID';
+        $orcidIdentityKey = $this->personOrcidIdentityKey($person);
 
-            if (strtoupper($scheme) === 'ORCID') {
-                $bareOrcid = OrcidNormalizer::extractBareId($person->name_identifier);
+        if ($orcidIdentityKey !== null) {
+            $keys[] = $orcidIdentityKey;
 
-                if ($bareOrcid !== '' && OrcidNormalizer::isValidFormat($bareOrcid)) {
-                    $keys[] = 'orcid:'.strtolower($bareOrcid);
-                }
-            }
+            return array_values(array_unique($keys));
         }
 
         $normalisedName = $this->normalisePersonIdentityName($person);
@@ -364,6 +360,23 @@ class EditorDataTransformer
         }
 
         return array_values(array_unique($keys));
+    }
+
+    private function personOrcidIdentityKey(Person $person): ?string
+    {
+        if ($person->name_identifier !== null && trim($person->name_identifier) !== '') {
+            $scheme = $person->name_identifier_scheme ?? 'ORCID';
+
+            if (strtoupper($scheme) === 'ORCID') {
+                $bareOrcid = OrcidNormalizer::extractBareId($person->name_identifier);
+
+                if ($bareOrcid !== '' && OrcidNormalizer::isValidFormat($bareOrcid)) {
+                    return 'orcid:'.strtolower($bareOrcid);
+                }
+            }
+        }
+
+        return null;
     }
 
     private function normalisePersonIdentityName(Person $person): ?string

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -289,17 +289,13 @@ class ResourceStorageService
      */
     private function personDataIdentityKeys(array $personData): array
     {
-        $keys = [];
-        $orcid = $this->filledContactString($personData['orcid'] ?? null);
+        $orcidIdentityKey = $this->personDataOrcidIdentityKey($personData);
 
-        if ($orcid !== null) {
-            $bareOrcid = OrcidNormalizer::extractBareId($orcid);
-
-            if ($bareOrcid !== '' && OrcidNormalizer::isValidFormat($bareOrcid)) {
-                $keys[] = 'orcid:'.strtolower($bareOrcid);
-            }
+        if ($orcidIdentityKey !== null) {
+            return [$orcidIdentityKey];
         }
 
+        $keys = [];
         $firstName = $this->normalisePersonIdentityPart($personData['firstName'] ?? null);
         $lastName = $this->normalisePersonIdentityPart($personData['lastName'] ?? null);
 
@@ -308,6 +304,26 @@ class ResourceStorageService
         }
 
         return array_values(array_unique($keys));
+    }
+
+    /**
+     * @param  array<string, mixed>  $personData
+     */
+    private function personDataOrcidIdentityKey(array $personData): ?string
+    {
+        $orcid = $this->filledContactString($personData['orcid'] ?? null);
+
+        if ($orcid === null) {
+            return null;
+        }
+
+        $bareOrcid = OrcidNormalizer::extractBareId($orcid);
+
+        if ($bareOrcid === '' || ! OrcidNormalizer::isValidFormat($bareOrcid)) {
+            return null;
+        }
+
+        return 'orcid:'.strtolower($bareOrcid);
     }
 
     private function normalisePersonIdentityPart(mixed $value): ?string

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -289,7 +289,11 @@ class ResourceStorageService
         $orcid = $this->filledContactString($personData['orcid'] ?? null);
 
         if ($orcid !== null) {
-            $keys[] = 'orcid:'.strtolower(OrcidNormalizer::extractBareId($orcid));
+            $bareOrcid = OrcidNormalizer::extractBareId($orcid);
+
+            if ($bareOrcid !== '' && OrcidNormalizer::isValidFormat($bareOrcid)) {
+                $keys[] = 'orcid:'.strtolower($bareOrcid);
+            }
         }
 
         $firstName = $this->normalisePersonIdentityPart($personData['firstName'] ?? null);

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -24,6 +24,7 @@ use App\Services\Citations\RelatedItemStorageService;
 use App\Services\Entities\AffiliationService;
 use App\Services\Entities\InstitutionService;
 use App\Services\Entities\PersonService;
+use App\Support\OrcidNormalizer;
 use App\Support\SubjectBreadcrumbPath;
 use App\Support\UriHelper;
 use Carbon\Carbon;
@@ -155,57 +156,208 @@ class ResourceStorageService
     {
         $relatedIdentifiers = $data['relatedIdentifiers'] ?? null;
 
-        if (! is_array($relatedIdentifiers)) {
+        if (is_array($relatedIdentifiers)) {
+            $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
+
+            foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
+                if (! is_array($relatedIdentifier)) {
+                    continue;
+                }
+
+                $identifier = isset($relatedIdentifier['identifier'])
+                    ? trim((string) $relatedIdentifier['identifier'])
+                    : '';
+
+                if ($identifier === '') {
+                    unset($relatedIdentifiers[$index]['citationLabel']);
+
+                    continue;
+                }
+
+                $relatedIdentifiers[$index]['identifier'] = $identifier;
+
+                $citationLabel = isset($relatedIdentifier['citationLabel'])
+                    ? trim((string) $relatedIdentifier['citationLabel'])
+                    : '';
+
+                if ($citationLabel !== '') {
+                    $relatedIdentifiers[$index]['citationLabel'] = $citationLabel;
+
+                    continue;
+                }
+
+                $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolveBestEffort(
+                    $identifier,
+                    (string) ($relatedIdentifier['identifierType'] ?? ''),
+                    $citationResolutionDeadline,
+                );
+
+                if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
+                    $relatedIdentifiers[$index]['citationLabel'] = trim($resolvedCitationLabel);
+
+                    continue;
+                }
+
+                unset($relatedIdentifiers[$index]['citationLabel']);
+            }
+
+            $data['relatedIdentifiers'] = $relatedIdentifiers;
+        }
+
+        return $this->ensureAuthorContactPersonContributors($data);
+    }
+
+    /**
+     * Expand the editor's author-level CP flag back into the DataCite-compatible
+     * contributor representation required for storage and export.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function ensureAuthorContactPersonContributors(array $data): array
+    {
+        $authors = $data['authors'] ?? [];
+
+        if (! is_array($authors)) {
             return $data;
         }
 
-        $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
+        $contributors = $data['contributors'] ?? [];
 
-        foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
-            if (! is_array($relatedIdentifier)) {
-                continue;
-            }
-
-            $identifier = isset($relatedIdentifier['identifier'])
-                ? trim((string) $relatedIdentifier['identifier'])
-                : '';
-
-            if ($identifier === '') {
-                unset($relatedIdentifiers[$index]['citationLabel']);
-
-                continue;
-            }
-
-            $relatedIdentifiers[$index]['identifier'] = $identifier;
-
-            $citationLabel = isset($relatedIdentifier['citationLabel'])
-                ? trim((string) $relatedIdentifier['citationLabel'])
-                : '';
-
-            if ($citationLabel !== '') {
-                $relatedIdentifiers[$index]['citationLabel'] = $citationLabel;
-
-                continue;
-            }
-
-            $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolveBestEffort(
-                $identifier,
-                (string) ($relatedIdentifier['identifierType'] ?? ''),
-                $citationResolutionDeadline,
-            );
-
-            if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
-                $relatedIdentifiers[$index]['citationLabel'] = trim($resolvedCitationLabel);
-
-                continue;
-            }
-
-            unset($relatedIdentifiers[$index]['citationLabel']);
+        if (! is_array($contributors)) {
+            $contributors = [];
         }
 
-        $data['relatedIdentifiers'] = $relatedIdentifiers;
+        foreach ($authors as $author) {
+            if (! is_array($author) || ($author['type'] ?? 'person') !== 'person' || ! (bool) ($author['isContact'] ?? false)) {
+                continue;
+            }
+
+            $matchingContributorIndex = $this->matchingPersonContributorIndex($contributors, $author);
+
+            if ($matchingContributorIndex !== null) {
+                /** @var array<string, mixed> $contributor */
+                $contributor = $contributors[$matchingContributorIndex];
+                $contributor['roles'] = $this->rolesWithContactPerson($contributor['roles'] ?? []);
+                $contributor['email'] = $author['email'] ?? null;
+                $contributor['website'] = $author['website'] ?? null;
+                $contributors[$matchingContributorIndex] = $contributor;
+
+                continue;
+            }
+
+            $contributors[] = $this->authorContactContributorData($author, count($contributors));
+        }
+
+        $data['contributors'] = array_values($contributors);
 
         return $data;
+    }
+
+    /**
+     * @param  array<int, mixed>  $contributors
+     * @param  array<string, mixed>  $author
+     */
+    private function matchingPersonContributorIndex(array $contributors, array $author): ?int
+    {
+        $authorKeys = $this->personDataIdentityKeys($author);
+
+        if ($authorKeys === []) {
+            return null;
+        }
+
+        foreach ($contributors as $index => $contributor) {
+            if (! is_array($contributor) || ($contributor['type'] ?? 'person') !== 'person') {
+                continue;
+            }
+
+            if (array_intersect($authorKeys, $this->personDataIdentityKeys($contributor)) !== []) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $personData
+     * @return list<string>
+     */
+    private function personDataIdentityKeys(array $personData): array
+    {
+        $keys = [];
+        $orcid = $this->filledContactString($personData['orcid'] ?? null);
+
+        if ($orcid !== null) {
+            $keys[] = 'orcid:'.strtolower(OrcidNormalizer::extractBareId($orcid));
+        }
+
+        $firstName = $this->normalisePersonIdentityPart($personData['firstName'] ?? null);
+        $lastName = $this->normalisePersonIdentityPart($personData['lastName'] ?? null);
+
+        if ($firstName !== null && $lastName !== null) {
+            $keys[] = 'name:'.$lastName.'|'.$firstName;
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    private function normalisePersonIdentityPart(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        $normalised = mb_strtolower($value, 'UTF-8');
+        $normalised = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalised) ?: $normalised;
+        $normalised = preg_replace('/[^\p{L}\p{N}]+/u', ' ', $normalised) ?? '';
+        $normalised = preg_replace('/\s+/', ' ', $normalised) ?? '';
+
+        return trim($normalised);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rolesWithContactPerson(mixed $roles): array
+    {
+        $roles = is_array($roles)
+            ? array_values(array_filter(
+                $roles,
+                fn (mixed $role): bool => is_string($role) && trim($role) !== '',
+            ))
+            : [];
+
+        if (! $this->hasContactPersonRole(['roles' => $roles])) {
+            $roles[] = 'ContactPerson';
+        }
+
+        return array_values(array_unique($roles));
+    }
+
+    /**
+     * @param  array<string, mixed>  $author
+     * @return array<string, mixed>
+     */
+    private function authorContactContributorData(array $author, int $position): array
+    {
+        return [
+            'type' => 'person',
+            'firstName' => $author['firstName'] ?? null,
+            'lastName' => $author['lastName'] ?? null,
+            'orcid' => $author['orcid'] ?? null,
+            'roles' => ['ContactPerson'],
+            'email' => $author['email'] ?? null,
+            'website' => $author['website'] ?? null,
+            'affiliations' => $author['affiliations'] ?? [],
+            'position' => $position,
+        ];
     }
 
     /**

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -156,53 +156,57 @@ class ResourceStorageService
     {
         $relatedIdentifiers = $data['relatedIdentifiers'] ?? null;
 
-        if (is_array($relatedIdentifiers)) {
-            $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
+        if (! is_array($relatedIdentifiers)) {
+            $data['relatedIdentifiers'] = [];
 
-            foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
-                if (! is_array($relatedIdentifier)) {
-                    continue;
-                }
+            return $this->ensureAuthorContactPersonContributors($data);
+        }
 
-                $identifier = isset($relatedIdentifier['identifier'])
-                    ? trim((string) $relatedIdentifier['identifier'])
-                    : '';
+        $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
 
-                if ($identifier === '') {
-                    unset($relatedIdentifiers[$index]['citationLabel']);
-
-                    continue;
-                }
-
-                $relatedIdentifiers[$index]['identifier'] = $identifier;
-
-                $citationLabel = isset($relatedIdentifier['citationLabel'])
-                    ? trim((string) $relatedIdentifier['citationLabel'])
-                    : '';
-
-                if ($citationLabel !== '') {
-                    $relatedIdentifiers[$index]['citationLabel'] = $citationLabel;
-
-                    continue;
-                }
-
-                $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolveBestEffort(
-                    $identifier,
-                    (string) ($relatedIdentifier['identifierType'] ?? ''),
-                    $citationResolutionDeadline,
-                );
-
-                if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
-                    $relatedIdentifiers[$index]['citationLabel'] = trim($resolvedCitationLabel);
-
-                    continue;
-                }
-
-                unset($relatedIdentifiers[$index]['citationLabel']);
+        foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
+            if (! is_array($relatedIdentifier)) {
+                continue;
             }
 
-            $data['relatedIdentifiers'] = $relatedIdentifiers;
+            $identifier = isset($relatedIdentifier['identifier'])
+                ? trim((string) $relatedIdentifier['identifier'])
+                : '';
+
+            if ($identifier === '') {
+                unset($relatedIdentifiers[$index]['citationLabel']);
+
+                continue;
+            }
+
+            $relatedIdentifiers[$index]['identifier'] = $identifier;
+
+            $citationLabel = isset($relatedIdentifier['citationLabel'])
+                ? trim((string) $relatedIdentifier['citationLabel'])
+                : '';
+
+            if ($citationLabel !== '') {
+                $relatedIdentifiers[$index]['citationLabel'] = $citationLabel;
+
+                continue;
+            }
+
+            $resolvedCitationLabel = $this->relatedIdentifierCitationLabelService->resolveBestEffort(
+                $identifier,
+                (string) ($relatedIdentifier['identifierType'] ?? ''),
+                $citationResolutionDeadline,
+            );
+
+            if (is_string($resolvedCitationLabel) && trim($resolvedCitationLabel) !== '') {
+                $relatedIdentifiers[$index]['citationLabel'] = trim($resolvedCitationLabel);
+
+                continue;
+            }
+
+            unset($relatedIdentifiers[$index]['citationLabel']);
         }
+
+        $data['relatedIdentifiers'] = $relatedIdentifiers;
 
         return $this->ensureAuthorContactPersonContributors($data);
     }

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-06-03",
+        "date": "2026-06-12",
         "features": [
             {
                 "title": "Landing Page and Portal Statistics Dashboard",

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -260,6 +260,10 @@
         ],
         "fixes": [
             {
+                "title": "Merged Contact-Person Authors in the Data Editor",
+                "description": "Legacy DataCite imports now load creators who are also Contact Person contributors as a single author row with the CP checkbox, email, and website fields in /editor. ERNIE still persists and exports the required separate DataCite creator and ContactPerson contributor records, while standalone ContactPerson contributors continue to appear normally in the Contributors section."
+            },
+            {
                 "title": "Readable Sidebar Count Badges",
                 "description": "Primary sidebar count badges such as Resources and IGSNs now keep their white foreground color when their navigation item is active or hovered. This preserves readable contrast on the GFZ-blue badge background in light mode while leaving default and warning badges unchanged."
             },

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1064,6 +1064,13 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <h4>Drag & Drop Reordering</h4>
                         <p>Reorder authors and contributors by dragging them to the desired position.</p>
+
+                        <h4>Contact Persons</h4>
+                        <p>
+                            Authors can be marked as contact persons with the CP checkbox. When imported metadata contains the same person as both
+                            an author and a Contact Person contributor, the editor shows one author entry for editing while ERNIE keeps the
+                            separate creator and Contact Person contributor records required for DataCite export.
+                        </p>
                     </>
                 ),
             },

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -699,6 +699,48 @@ describe('transformCreators', function (): void {
             ->and($result['contributors'][0]['website'])->toBe('https://chris.example.org');
     });
 
+    it('does not merge ContactPerson contributors through an empty ORCID identity key', function (): void {
+        $contactType = ContributorType::firstOrCreate(
+            ['slug' => 'ContactPerson'],
+            ['name' => 'Contact Person', 'category' => 'person'],
+        );
+        $author = Person::factory()->create([
+            'given_name' => 'Avery',
+            'family_name' => 'Author',
+            'name_identifier' => 'orcid.org/',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+        $contact = Person::factory()->create([
+            'given_name' => 'Bailey',
+            'family_name' => 'Contact',
+            'name_identifier' => 'https://orcid.org/',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+
+        ResourceCreator::factory()->forPerson($author)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+        ]);
+        $contributor = ResourceContributor::factory()->forPerson($contact)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+            'email' => 'bailey.contact@example.org',
+        ]);
+        $contributor->contributorTypes()->sync([$contactType->id]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'])->toHaveCount(1)
+            ->and($result['authors'][0]['firstName'])->toBe('Avery')
+            ->and($result['authors'][0]['isContact'])->toBeFalse()
+            ->and($result['contributors'])->toHaveCount(1)
+            ->and($result['contributors'][0]['firstName'])->toBe('Bailey')
+            ->and($result['contributors'][0]['roles'])->toBe(['Contact Person'])
+            ->and($result['contributors'][0]['email'])->toBe('bailey.contact@example.org');
+    });
+
     it('merges only the ContactPerson role when a matching contributor has additional roles', function (): void {
         $contactType = ContributorType::firstOrCreate(
             ['slug' => 'ContactPerson'],

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -741,6 +741,48 @@ describe('transformCreators', function (): void {
             ->and($result['contributors'][0]['email'])->toBe('bailey.contact@example.org');
     });
 
+    it('does not merge same-name ContactPerson contributors when valid ORCIDs differ', function (): void {
+        $contactType = ContributorType::firstOrCreate(
+            ['slug' => 'ContactPerson'],
+            ['name' => 'Contact Person', 'category' => 'person'],
+        );
+        $author = Person::factory()->create([
+            'given_name' => 'Morgan',
+            'family_name' => 'Shared',
+            'name_identifier' => 'https://orcid.org/0000-0002-1825-0097',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+        $contact = Person::factory()->create([
+            'given_name' => 'Morgan',
+            'family_name' => 'Shared',
+            'name_identifier' => 'https://orcid.org/0000-0002-1694-233X',
+            'name_identifier_scheme' => 'ORCID',
+        ]);
+
+        ResourceCreator::factory()->forPerson($author)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+        ]);
+        $contributor = ResourceContributor::factory()->forPerson($contact)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+            'email' => 'morgan.contact@example.org',
+        ]);
+        $contributor->contributorTypes()->sync([$contactType->id]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'])->toHaveCount(1)
+            ->and($result['authors'][0]['firstName'])->toBe('Morgan')
+            ->and($result['authors'][0]['isContact'])->toBeFalse()
+            ->and($result['contributors'])->toHaveCount(1)
+            ->and($result['contributors'][0]['firstName'])->toBe('Morgan')
+            ->and($result['contributors'][0]['roles'])->toBe(['Contact Person'])
+            ->and($result['contributors'][0]['email'])->toBe('morgan.contact@example.org');
+    });
+
     it('merges only the ContactPerson role when a matching contributor has additional roles', function (): void {
         $contactType = ContributorType::firstOrCreate(
             ['slug' => 'ContactPerson'],

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\Affiliation;
+use App\Models\ContributorType;
 use App\Models\DateType;
 use App\Models\Description;
 use App\Models\DescriptionType;
@@ -598,6 +599,167 @@ describe('transformCreators', function (): void {
 
         expect($result['contributors'][0]['affiliations'])->toHaveCount(1)
             ->and($result['contributors'][0]['affiliations'][0]['value'])->toBe('MIT');
+    });
+
+    it('loads creator contact fields onto the author row', function (): void {
+        $person = Person::factory()->create([
+            'given_name' => 'Jane',
+            'family_name' => 'Contact',
+        ]);
+
+        ResourceCreator::factory()->forPerson($person)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+            'is_contact' => true,
+            'email' => 'jane.contact@example.org',
+            'website' => 'https://jane.example.org',
+        ]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'])->toHaveCount(1)
+            ->and($result['authors'][0]['isContact'])->toBeTrue()
+            ->and($result['authors'][0]['email'])->toBe('jane.contact@example.org')
+            ->and($result['authors'][0]['website'])->toBe('https://jane.example.org')
+            ->and($result['contributors'])->toBeEmpty();
+    });
+
+    it('merges a matching ContactPerson contributor into the author row for editor loading', function (): void {
+        $contactType = ContributorType::firstOrCreate(
+            ['slug' => 'ContactPerson'],
+            ['name' => 'Contact Person', 'category' => 'person'],
+        );
+        $person = Person::factory()->create([
+            'given_name' => 'Mira',
+            'family_name' => 'Merge',
+        ]);
+
+        ResourceCreator::factory()->forPerson($person)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+            'is_contact' => false,
+        ]);
+        $contributor = ResourceContributor::factory()->forPerson($person)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 2,
+            'email' => 'mira.merge@example.org',
+            'website' => 'https://mira.example.org',
+        ]);
+        $contributor->contributorTypes()->sync([$contactType->id]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'])->toHaveCount(1)
+            ->and($result['authors'][0]['isContact'])->toBeTrue()
+            ->and($result['authors'][0]['email'])->toBe('mira.merge@example.org')
+            ->and($result['authors'][0]['website'])->toBe('https://mira.example.org')
+            ->and($result['contributors'])->toBeEmpty();
+    });
+
+    it('keeps standalone ContactPerson contributors visible in the contributors section', function (): void {
+        $contactType = ContributorType::firstOrCreate(
+            ['slug' => 'ContactPerson'],
+            ['name' => 'Contact Person', 'category' => 'person'],
+        );
+        $author = Person::factory()->create([
+            'given_name' => 'Anna',
+            'family_name' => 'Author',
+        ]);
+        $contact = Person::factory()->create([
+            'given_name' => 'Chris',
+            'family_name' => 'Contact',
+        ]);
+
+        ResourceCreator::factory()->forPerson($author)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+        ]);
+        $contributor = ResourceContributor::factory()->forPerson($contact)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+            'email' => 'chris.contact@example.org',
+            'website' => 'https://chris.example.org',
+        ]);
+        $contributor->contributorTypes()->sync([$contactType->id]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'][0]['isContact'])->toBeFalse()
+            ->and($result['contributors'])->toHaveCount(1)
+            ->and($result['contributors'][0]['type'])->toBe('person')
+            ->and($result['contributors'][0]['firstName'])->toBe('Chris')
+            ->and($result['contributors'][0]['roles'])->toBe(['Contact Person'])
+            ->and($result['contributors'][0]['email'])->toBe('chris.contact@example.org')
+            ->and($result['contributors'][0]['website'])->toBe('https://chris.example.org');
+    });
+
+    it('merges only the ContactPerson role when a matching contributor has additional roles', function (): void {
+        $contactType = ContributorType::firstOrCreate(
+            ['slug' => 'ContactPerson'],
+            ['name' => 'Contact Person', 'category' => 'person'],
+        );
+        $collectorType = ContributorType::firstOrCreate(
+            ['slug' => 'DataCollector'],
+            ['name' => 'Data Collector', 'category' => 'person'],
+        );
+        $person = Person::factory()->create([
+            'given_name' => 'Dana',
+            'family_name' => 'Dual',
+        ]);
+
+        ResourceCreator::factory()->forPerson($person)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+        ]);
+        $contributor = ResourceContributor::factory()->forPerson($person)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+            'email' => 'dana.dual@example.org',
+        ]);
+        $contributor->contributorTypes()->sync([$contactType->id, $collectorType->id]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'][0]['isContact'])->toBeTrue()
+            ->and($result['authors'][0]['email'])->toBe('dana.dual@example.org')
+            ->and($result['contributors'])->toHaveCount(1)
+            ->and($result['contributors'][0]['firstName'])->toBe('Dana')
+            ->and($result['contributors'][0]['roles'])->toBe(['Data Collector'])
+            ->and($result['contributors'][0]['email'])->toBe('');
+    });
+
+    it('keeps institution ContactPerson contributors visible', function (): void {
+        $contactType = ContributorType::firstOrCreate(
+            ['slug' => 'ContactPerson'],
+            ['name' => 'Contact Person', 'category' => 'person'],
+        );
+        $institution = Institution::factory()->create([
+            'name' => 'Contact Institute',
+        ]);
+
+        $contributor = ResourceContributor::factory()->forInstitution($institution)->create([
+            'resource_id' => $this->resource->id,
+            'position' => 1,
+        ]);
+        $contributor->contributorTypes()->sync([$contactType->id]);
+
+        $this->resource->load(['creators.creatorable', 'creators.affiliations', 'contributors.contributorable', 'contributors.affiliations', 'contributors.contributorTypes']);
+
+        $result = $this->transformer->transformCreators($this->resource);
+
+        expect($result['authors'])->toBeEmpty()
+            ->and($result['contributors'])->toHaveCount(1)
+            ->and($result['contributors'][0]['type'])->toBe('institution')
+            ->and($result['contributors'][0]['institutionName'])->toBe('Contact Institute')
+            ->and($result['contributors'][0]['roles'])->toBe(['Contact Person']);
     });
 });
 

--- a/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
@@ -183,6 +183,40 @@ describe('ResourceStorageService – Contributor Contact Person email/website', 
             ->and($contributorsByGivenName->get('Avery')?->email)->toBe('avery.author@example.org');
     });
 
+    it('does not reuse a same-name contributor when valid ORCIDs differ', function () {
+        ContributorType::firstOrCreate(
+            ['slug' => 'DataCollector'],
+            ['name' => 'Data Collector', 'category' => 'person'],
+        );
+
+        $data = contributorResourceData([
+            'firstName' => 'Morgan',
+            'lastName' => 'Shared',
+            'orcid' => 'https://orcid.org/0000-0002-1694-233X',
+            'roles' => ['DataCollector'],
+            'email' => null,
+            'website' => null,
+        ]);
+        $data['authors'][0]['firstName'] = 'Morgan';
+        $data['authors'][0]['lastName'] = 'Shared';
+        $data['authors'][0]['orcid'] = 'https://orcid.org/0000-0002-1825-0097';
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'morgan.author@example.org';
+        $data['authors'][0]['website'] = 'https://morgan-author.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        $resource->load(['contributors.contributorable', 'contributors.contributorTypes']);
+
+        $contributorsByOrcid = $resource->contributors
+            ->keyBy(fn ($contributor): string => $contributor->contributorable->name_identifier);
+
+        expect($resource->contributors)->toHaveCount(2)
+            ->and($contributorsByOrcid->get('https://orcid.org/0000-0002-1694-233X')?->contributorTypes->pluck('slug')->all())->toBe(['DataCollector'])
+            ->and($contributorsByOrcid->get('https://orcid.org/0000-0002-1694-233X')?->email)->toBeNull()
+            ->and($contributorsByOrcid->get('https://orcid.org/0000-0002-1825-0097')?->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson'])
+            ->and($contributorsByOrcid->get('https://orcid.org/0000-0002-1825-0097')?->email)->toBe('morgan.author@example.org');
+    });
+
     it('does not duplicate an explicitly submitted matching ContactPerson contributor', function () {
         $data = contributorResourceData([
             'firstName' => 'Jane',

--- a/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
@@ -6,6 +6,9 @@ use App\Models\ContributorType;
 use App\Models\ResourceType;
 use App\Models\TitleType;
 use App\Models\User;
+use App\Services\DataCiteJsonExporter;
+use App\Services\DataCiteXmlExporter;
+use App\Services\Editor\EditorDataTransformer;
 use App\Services\ResourceStorageService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -91,6 +94,132 @@ describe('ResourceStorageService – Contributor Contact Person email/website', 
         expect($creator->is_contact)->toBeTrue()
             ->and($creator->email)->toBe('author.contact@example.org')
             ->and($creator->website)->toBe('https://author.example.org');
+    });
+
+    it('stores a matching ContactPerson contributor for a creator marked as contact person', function () {
+        $data = contributorResourceData();
+        $data['contributors'] = [];
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'author.contact@example.org';
+        $data['authors'][0]['website'] = 'https://author.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        $resource->load(['creators.creatorable', 'contributors.contributorable', 'contributors.contributorTypes']);
+
+        $creator = $resource->creators->sole();
+        $contributor = $resource->contributors->sole();
+
+        expect($creator->is_contact)->toBeTrue()
+            ->and($contributor->email)->toBe('author.contact@example.org')
+            ->and($contributor->website)->toBe('https://author.example.org')
+            ->and($contributor->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson']);
+
+        $json = app(DataCiteJsonExporter::class)->export($resource->fresh());
+        $xml = app(DataCiteXmlExporter::class)->export($resource->fresh());
+
+        expect($json['data']['attributes']['creators'])->toHaveCount(1)
+            ->and($json['data']['attributes']['contributors'])->toHaveCount(1)
+            ->and($json['data']['attributes']['contributors'][0]['contributorType'])->toBe('ContactPerson')
+            ->and($xml)->toContain('<contributor contributorType="ContactPerson">');
+    });
+
+    it('adds ContactPerson role to a matching contributor instead of creating a duplicate row', function () {
+        ContributorType::firstOrCreate(
+            ['slug' => 'DataCollector'],
+            ['name' => 'Data Collector', 'category' => 'person'],
+        );
+
+        $data = contributorResourceData([
+            'firstName' => 'Jane',
+            'lastName' => 'Doe',
+            'roles' => ['DataCollector'],
+            'email' => null,
+            'website' => null,
+        ]);
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'jane.doe@example.org';
+        $data['authors'][0]['website'] = 'https://jane.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        $contributor = $resource->contributors()->with('contributorTypes')->sole();
+
+        expect($resource->contributors()->count())->toBe(1)
+            ->and($contributor->email)->toBe('jane.doe@example.org')
+            ->and($contributor->website)->toBe('https://jane.example.org')
+            ->and($contributor->contributorTypes->pluck('slug')->sort()->values()->all())->toBe(['ContactPerson', 'DataCollector']);
+    });
+
+    it('does not duplicate an explicitly submitted matching ContactPerson contributor', function () {
+        $data = contributorResourceData([
+            'firstName' => 'Jane',
+            'lastName' => 'Doe',
+            'roles' => ['ContactPerson'],
+            'email' => 'stale-contact@example.org',
+            'website' => 'https://stale.example.org',
+        ]);
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'jane.author@example.org';
+        $data['authors'][0]['website'] = 'https://jane-author.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        $contributor = $resource->contributors()->with('contributorTypes')->sole();
+
+        expect($resource->contributors()->count())->toBe(1)
+            ->and($contributor->email)->toBe('jane.author@example.org')
+            ->and($contributor->website)->toBe('https://jane-author.example.org')
+            ->and($contributor->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson']);
+    });
+
+    it('keeps ContactPerson contributor after an editor load-save cycle with merged authors', function () {
+        $data = contributorResourceData();
+        $data['contributors'] = [];
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'cycle.contact@example.org';
+        $data['authors'][0]['website'] = 'https://cycle.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        $editorData = app(EditorDataTransformer::class)->transformResource($resource->fresh([
+            'resourceType',
+            'language',
+            'titles.titleType',
+            'rights',
+            'creators.creatorable',
+            'creators.affiliations',
+            'contributors.contributorable',
+            'contributors.affiliations',
+            'contributors.contributorTypes',
+            'descriptions',
+            'dates',
+            'subjects',
+            'geoLocations',
+            'relatedIdentifiers.identifierType',
+            'relatedIdentifiers.relationType',
+            'fundingReferences.funderIdentifierType',
+            'instruments',
+            'datacenters',
+        ]));
+
+        expect($editorData['authors'])->toHaveCount(1)
+            ->and($editorData['authors'][0]['isContact'])->toBeTrue()
+            ->and($editorData['contributors'])->toBeEmpty();
+
+        $updateData = $data;
+        $updateData['resourceId'] = $resource->id;
+        $updateData['authors'] = $editorData['authors'];
+        $updateData['contributors'] = $editorData['contributors'];
+
+        [$updatedResource] = $this->service->store($updateData, $this->user->id);
+        $updatedResource->load(['creators', 'contributors.contributorTypes']);
+
+        expect($updatedResource->creators)->toHaveCount(1)
+            ->and($updatedResource->contributors)->toHaveCount(1)
+            ->and($updatedResource->contributors->first()?->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson']);
+
+        $json = app(DataCiteJsonExporter::class)->export($updatedResource->fresh());
+
+        expect($json['data']['attributes']['creators'])->toHaveCount(1)
+            ->and($json['data']['attributes']['contributors'])->toHaveCount(1)
+            ->and($json['data']['attributes']['contributors'][0]['contributorType'])->toBe('ContactPerson');
     });
 
     it('drops invalid creator contact email and unsafe website values', function () {

--- a/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceContributorContactTest.php
@@ -149,6 +149,40 @@ describe('ResourceStorageService – Contributor Contact Person email/website', 
             ->and($contributor->contributorTypes->pluck('slug')->sort()->values()->all())->toBe(['ContactPerson', 'DataCollector']);
     });
 
+    it('does not reuse a different contributor through an empty ORCID identity key', function () {
+        ContributorType::firstOrCreate(
+            ['slug' => 'DataCollector'],
+            ['name' => 'Data Collector', 'category' => 'person'],
+        );
+
+        $data = contributorResourceData([
+            'firstName' => 'Bailey',
+            'lastName' => 'Contact',
+            'orcid' => 'https://orcid.org/',
+            'roles' => ['DataCollector'],
+            'email' => null,
+            'website' => null,
+        ]);
+        $data['authors'][0]['firstName'] = 'Avery';
+        $data['authors'][0]['lastName'] = 'Author';
+        $data['authors'][0]['orcid'] = 'orcid.org/';
+        $data['authors'][0]['isContact'] = true;
+        $data['authors'][0]['email'] = 'avery.author@example.org';
+        $data['authors'][0]['website'] = 'https://avery.example.org';
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        $resource->load(['contributors.contributorable', 'contributors.contributorTypes']);
+
+        $contributorsByGivenName = $resource->contributors
+            ->keyBy(fn ($contributor): string => $contributor->contributorable->given_name);
+
+        expect($resource->contributors)->toHaveCount(2)
+            ->and($contributorsByGivenName->get('Bailey')?->contributorTypes->pluck('slug')->all())->toBe(['DataCollector'])
+            ->and($contributorsByGivenName->get('Bailey')?->email)->toBeNull()
+            ->and($contributorsByGivenName->get('Avery')?->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson'])
+            ->and($contributorsByGivenName->get('Avery')?->email)->toBe('avery.author@example.org');
+    });
+
     it('does not duplicate an explicitly submitted matching ContactPerson contributor', function () {
         $data = contributorResourceData([
             'firstName' => 'Jane',

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -549,6 +549,41 @@ describe('ResourceStorageService', function () {
             ->and($related->relation_type_information)->toBeNull();
     });
 
+    it('coerces non-array related identifiers to an empty list before storage', function () {
+        $resourceType = ResourceType::first();
+
+        $mock = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+        $mock->shouldNotReceive('resolveBestEffort');
+        $this->app->instance(RelatedIdentifierCitationLabelService::class, $mock);
+
+        $service = app(ResourceStorageService::class);
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Test Resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'John',
+                    'lastName' => 'Doe',
+                    'position' => 0,
+                ],
+            ],
+            'relatedIdentifiers' => 'not-an-array',
+        ];
+
+        [$resource] = $service->store($data, $this->user->id);
+
+        expect($resource->relatedIdentifiers()->count())->toBe(0);
+    });
+
     it('stores controlled GCMD keywords', function () {
         $resourceType = ResourceType::first();
 


### PR DESCRIPTION
This pull request implements a major improvement to how Contact Person (CP) authors and contributors are handled in the data editor, ensuring that legacy DataCite imports and exports work correctly while simplifying the editing experience. Now, when a person is both a creator and a Contact Person contributor, the editor merges them into a single author row with the CP checkbox, email, and website fields. The backend still persists and exports the separate DataCite creator and ContactPerson contributor records as required. Additional changes include updates to Dockerfiles for more reliable Redis extension installation and minor doc and changelog updates.

**Contact Person Author/Contributor Merging Improvements:**

* The editor now merges creators who are also Contact Person contributors into a single author row, displaying the CP checkbox, email, and website fields. The backend maintains the required DataCite separation for storage and export, and standalone Contact Person contributors still appear in the Contributors section. [[1]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R160-R183) [[2]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4L175-R205) [[3]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R234-R268) [[4]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4L231-R289) [[5]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16L159-R162) [[6]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16R211-R386) [[7]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR262-R265)
* Added robust identity matching logic (by ORCID, name, and internal ID) to associate contributors with authors and vice versa, ensuring correct merging and unmerging during data transformation and storage. [[1]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R317-R414) [[2]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16R211-R386)
* Updated documentation and changelog to describe the new Contact Person author merging behavior for users. [[1]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR1067-R1073) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR262-R265)

**Dockerfile Improvements:**

* Updated both `Dockerfile` and `Dockerfile.dev` to install the Redis extension from a specific phpredis source tag for improved reliability and reproducibility. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R5-R6) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R48) [[3]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR15-R16) [[4]](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL159-R167)

**Type and Import Cleanups:**

* Improved type annotations and imports in `EditorDataTransformer.php` for clarity and correctness, especially for model references. [[1]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R10-R18) [[2]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4L491-R644) [[3]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4L512-R665)

**Changelog Update:**

* Updated release date and added a detailed entry describing the Contact Person author merge feature. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR262-R265)