### PR TITLE
Fix: Preserve mixed XML descriptions on upload

### DIFF
--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -41,7 +41,7 @@ class UploadXmlController extends Controller
 
         try {
             $reader = XmlReader::fromString($contents);
-            $result = $this->importParser->parse($reader, $filename);
+            $result = $this->importParser->parse($reader, $filename, $contents);
         } catch (XmlReaderException|XmlRuntimeException $e) {
             $error = UploadError::withMessage(
                 UploadErrorCode::XML_PARSE_ERROR,

--- a/app/Services/Xml/DataCiteXmlImportParser.php
+++ b/app/Services/Xml/DataCiteXmlImportParser.php
@@ -44,7 +44,7 @@ final readonly class DataCiteXmlImportParser
         private XmlKeywordExtractor $keywordExtractor,
     ) {}
 
-    public function parse(XmlReader $reader, string $filename): DataCiteXmlImportResult
+    public function parse(XmlReader $reader, string $filename, ?string $xmlContents = null): DataCiteXmlImportResult
     {
         $identifierData = $this->identifierParser->parse($reader);
         $resourceType = $identifierData['resourceType'];
@@ -58,7 +58,7 @@ final readonly class DataCiteXmlImportParser
         $isoContactInfo = $this->isoContactParser->parse($reader);
         $authors = $this->mergeContactPersonsIntoAuthors($authors, $contactPersons, $isoContactInfo);
 
-        $descriptions = $this->descriptionParser->parse($reader);
+        $descriptions = $this->descriptionParser->parse($reader, $xmlContents);
         $dates = $this->dateParser->parse($reader);
         $coverages = $this->coverageParser->parse($reader, $dates);
 

--- a/app/Services/Xml/Sections/DescriptionSectionParser.php
+++ b/app/Services/Xml/Sections/DescriptionSectionParser.php
@@ -54,17 +54,10 @@ final readonly class DescriptionSectionParser
         $xpath = new DOMXPath($document);
         $descriptionNodes = $xpath->query('//*[local-name()="resource"]/*[local-name()="descriptions"]/*[local-name()="description"]');
 
-        if ($descriptionNodes === false) {
-            return [];
-        }
-
         $descriptions = [];
 
-        foreach ($descriptionNodes as $node) {
-            if (! $node instanceof DOMElement) {
-                continue;
-            }
-
+        foreach ($descriptionNodes ?: [] as $node) {
+            /** @var DOMElement $node */
             $description = self::normalizeDescriptionText(self::descriptionTextFromDomNode($node));
 
             if ($description === '') {
@@ -160,11 +153,7 @@ final readonly class DescriptionSectionParser
             return $text;
         }
 
-        if (is_scalar($content)) {
-            return (string) $content;
-        }
-
-        return '';
+        return is_scalar($content) ? (string) $content : '';
     }
 
     private static function isLineBreakKey(string|int|null $key): bool

--- a/app/Services/Xml/Sections/DescriptionSectionParser.php
+++ b/app/Services/Xml/Sections/DescriptionSectionParser.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace App\Services\Xml\Sections;
 
+use App\Support\Xml\XmlElementHelpers;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+use DOMXPath;
+use Saloon\XmlWrangler\Data\Element;
 use Saloon\XmlWrangler\XmlReader;
 
 /**
@@ -14,7 +21,96 @@ final readonly class DescriptionSectionParser
     /**
      * @return array<int, array{type: string, description: string, language: string|null}>
      */
-    public function parse(XmlReader $reader): array
+    public function parse(XmlReader $reader, ?string $xmlContents = null): array
+    {
+        if (is_string($xmlContents) && trim($xmlContents) !== '') {
+            $domDescriptions = self::parseFromDom($xmlContents);
+
+            if ($domDescriptions !== null) {
+                return $domDescriptions;
+            }
+        }
+
+        return self::parseFromReader($reader);
+    }
+
+    /**
+     * @return array<int, array{type: string, description: string, language: string|null}>|null
+     */
+    private static function parseFromDom(string $xmlContents): ?array
+    {
+        $document = new DOMDocument;
+        $previousLibxmlSetting = libxml_use_internal_errors(true);
+
+        $loaded = $document->loadXML($xmlContents, LIBXML_NONET);
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousLibxmlSetting);
+
+        if ($loaded === false) {
+            return null;
+        }
+
+        $xpath = new DOMXPath($document);
+        $descriptionNodes = $xpath->query('//*[local-name()="resource"]/*[local-name()="descriptions"]/*[local-name()="description"]');
+
+        if ($descriptionNodes === false) {
+            return [];
+        }
+
+        $descriptions = [];
+
+        foreach ($descriptionNodes as $node) {
+            if (! $node instanceof DOMElement) {
+                continue;
+            }
+
+            $description = self::normalizeDescriptionText(self::descriptionTextFromDomNode($node));
+
+            if ($description === '') {
+                continue;
+            }
+
+            $descriptionType = $node->getAttribute('descriptionType');
+            $descLang = $node->getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang');
+
+            $descriptions[] = [
+                'type' => $descriptionType !== '' ? $descriptionType : 'Other',
+                'description' => $description,
+                'language' => trim($descLang) !== '' ? trim($descLang) : null,
+            ];
+        }
+
+        return $descriptions;
+    }
+
+    private static function descriptionTextFromDomNode(DOMNode $node): string
+    {
+        $text = '';
+
+        foreach ($node->childNodes as $childNode) {
+            if ($childNode instanceof DOMText) {
+                $text .= $childNode->wholeText;
+
+                continue;
+            }
+
+            if ($childNode instanceof DOMElement && $childNode->localName === 'br') {
+                $text .= "\n";
+
+                continue;
+            }
+
+            $text .= self::descriptionTextFromDomNode($childNode);
+        }
+
+        return $text;
+    }
+
+    /**
+     * @return array<int, array{type: string, description: string, language: string|null}>
+     */
+    private static function parseFromReader(XmlReader $reader): array
     {
         $descriptionElements = $reader
             ->xpathElement('//*[local-name()="resource"]/*[local-name()="descriptions"]/*[local-name()="description"]')
@@ -24,9 +120,11 @@ final readonly class DescriptionSectionParser
 
         foreach ($descriptionElements as $element) {
             $descriptionType = $element->getAttribute('descriptionType');
-            $description = $element->getContent();
+            $description = self::normalizeDescriptionText(
+                self::descriptionTextFromContent($element->getContent())
+            );
 
-            if (! is_string($description) || trim($description) === '') {
+            if ($description === '') {
                 continue;
             }
 
@@ -40,5 +138,62 @@ final readonly class DescriptionSectionParser
         }
 
         return $descriptions;
+    }
+
+    private static function descriptionTextFromContent(mixed $content, string|int|null $key = null): string
+    {
+        if (self::isLineBreakKey($key)) {
+            return self::lineBreakText($content);
+        }
+
+        if ($content instanceof Element) {
+            return self::descriptionTextFromContent($content->getContent());
+        }
+
+        if (is_array($content)) {
+            $text = '';
+
+            foreach ($content as $childKey => $childValue) {
+                $text .= self::descriptionTextFromContent($childValue, $childKey);
+            }
+
+            return $text;
+        }
+
+        if (is_scalar($content)) {
+            return (string) $content;
+        }
+
+        return '';
+    }
+
+    private static function isLineBreakKey(string|int|null $key): bool
+    {
+        return is_string($key) && XmlElementHelpers::localName($key) === 'br';
+    }
+
+    private static function lineBreakText(mixed $content): string
+    {
+        $breakCount = 1;
+
+        if ($content instanceof Element) {
+            $content = $content->getContent();
+        }
+
+        if (is_array($content) && array_is_list($content) && $content !== []) {
+            $breakCount = count($content);
+        }
+
+        return str_repeat("\n", $breakCount);
+    }
+
+    private static function normalizeDescriptionText(string $description): string
+    {
+        $description = str_replace(["\r\n", "\r"], "\n", $description);
+        $description = preg_replace('/[ \t]+/u', ' ', $description) ?? $description;
+        $description = preg_replace('/ *\n */u', "\n", $description) ?? $description;
+        $description = preg_replace('/\n{3,}/u', "\n\n", $description) ?? $description;
+
+        return trim($description);
     }
 }

--- a/app/Services/Xml/Sections/DescriptionSectionParser.php
+++ b/app/Services/Xml/Sections/DescriptionSectionParser.php
@@ -83,7 +83,7 @@ final readonly class DescriptionSectionParser
 
         foreach ($node->childNodes as $childNode) {
             if ($childNode instanceof DOMText) {
-                $text .= $childNode->wholeText;
+                $text .= $childNode->data;
 
                 continue;
             }

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -260,6 +260,10 @@
         ],
         "fixes": [
             {
+                "title": "XML Upload Preserves Mixed Description Text",
+                "description": "XML uploads now keep DataCite descriptions that contain inline XML elements such as <br/>. ERNIE converts line break elements to readable editor line breaks and preserves nested text instead of dropping the whole description during upload."
+            },
+            {
                 "title": "Merged Contact-Person Authors in the Data Editor",
                 "description": "Legacy DataCite imports now load creators who are also Contact Person contributors as a single author row with the CP checkbox, email, and website fields in /editor. ERNIE still persists and exports the required separate DataCite creator and ContactPerson contributor records, while standalone ContactPerson contributors continue to appear normally in the Contributors section."
             },

--- a/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
+++ b/tests/pest/Feature/XmlUpload/XmlUploadDataLossFixTest.php
@@ -126,8 +126,102 @@ XML;
 });
 
 // ──────────────────────────────────────────────────────────────────
-// Fix 3: Coverage date with time and timezone is fully extracted
+// Issue 856: Description mixed XML content is preserved
 // ──────────────────────────────────────────────────────────────────
+
+test('preserves mixed description content with line break elements', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <descriptions>
+    <description descriptionType="Abstract" xml:lang="en">First paragraph.<br/><br/>Second paragraph with fire data.<br/>Third paragraph.</description>
+  </descriptions>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('desc-with-breaks.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataCount(1, 'descriptions');
+    $response->assertSessionDataPath('descriptions.0.type', 'Abstract');
+    $response->assertSessionDataPath('descriptions.0.language', 'en');
+    $response->assertSessionDataPath(
+        'descriptions.0.description',
+        "First paragraph.\n\nSecond paragraph with fire data.\nThird paragraph."
+    );
+});
+
+test('preserves text inside nested mixed description elements', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <descriptions>
+    <description>This keeps <em>emphasized text</em> and <custom>custom child text</custom> intact.</description>
+  </descriptions>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('desc-with-nested-elements.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataCount(1, 'descriptions');
+    $response->assertSessionDataPath('descriptions.0.type', 'Other');
+    $response->assertSessionDataPath(
+        'descriptions.0.description',
+        'This keeps emphasized text and custom child text intact.'
+    );
+});
+
+test('filters mixed descriptions that only contain line breaks and whitespace', function () {
+    $this->actingAs(User::factory()->create());
+
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <identifier identifierType="DOI">10.5072/test</identifier>
+  <creators><creator><creatorName>Test</creatorName></creator></creators>
+  <titles><title>Test</title></titles>
+  <publisher>Test</publisher>
+  <publicationYear>2026</publicationYear>
+  <resourceType resourceTypeGeneral="Dataset"/>
+  <descriptions>
+    <description descriptionType="Methods"> <br/> <custom>   </custom> </description>
+    <description descriptionType="Other">Still useful.</description>
+  </descriptions>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('empty-mixed-description.xml', $xml);
+
+    $response = $this->postJson('/dashboard/upload-xml', ['file' => $file])
+        ->assertOk();
+
+    $response->assertSessionDataCount(1, 'descriptions');
+    $response->assertSessionDataPath('descriptions.0.type', 'Other');
+    $response->assertSessionDataPath('descriptions.0.description', 'Still useful.');
+});
+
+// Coverage date with time and timezone is fully extracted
 
 test('extracts time and timezone from coverage date range', function () {
     $this->actingAs(User::factory()->create());

--- a/tests/pest/Unit/Services/Xml/Sections/DescriptionSectionParserTest.php
+++ b/tests/pest/Unit/Services/Xml/Sections/DescriptionSectionParserTest.php
@@ -32,6 +32,25 @@ XML;
     ]);
 });
 
+test('does not duplicate adjacent text nodes when parsing raw XML descriptions', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Abstract">Before <![CDATA[cdata content]]> after.</description>
+  </descriptions>
+</resource>
+XML;
+
+    expect(parseDescriptions($xml, $xml))->toBe([
+        [
+            'type' => 'Abstract',
+            'description' => 'Before cdata content after.',
+            'language' => null,
+        ],
+    ]);
+});
+
 test('filters empty descriptions when parsing from raw XML', function () {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/pest/Unit/Services/Xml/Sections/DescriptionSectionParserTest.php
+++ b/tests/pest/Unit/Services/Xml/Sections/DescriptionSectionParserTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Xml\Sections\DescriptionSectionParser;
+use Saloon\XmlWrangler\XmlReader;
+
+function parseDescriptions(string $xml, ?string $xmlContents = null): array
+{
+    return (new DescriptionSectionParser)->parse(XmlReader::fromString($xml), $xmlContents);
+}
+
+test('parses mixed description content from raw XML without losing surrounding text', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Abstract" xml:lang="en">
+      First paragraph.<br/><br/>
+      Second paragraph with <em>nested emphasis</em> and <custom>custom text</custom>.
+    </description>
+  </descriptions>
+</resource>
+XML;
+
+    expect(parseDescriptions($xml, $xml))->toBe([
+        [
+            'type' => 'Abstract',
+            'description' => "First paragraph.\n\nSecond paragraph with nested emphasis and custom text.",
+            'language' => 'en',
+        ],
+    ]);
+});
+
+test('filters empty descriptions when parsing from raw XML', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Methods"> <br/> <custom>   </custom> </description>
+    <description>Useful fallback text.</description>
+  </descriptions>
+</resource>
+XML;
+
+    expect(parseDescriptions($xml, $xml))->toBe([
+        [
+            'type' => 'Other',
+            'description' => 'Useful fallback text.',
+            'language' => null,
+        ],
+    ]);
+});
+
+test('falls back to XmlReader parsing when raw XML is unavailable', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Methods" xml:lang="de">  Method text.  </description>
+    <description>Other text.</description>
+    <description descriptionType="TechnicalInfo">   </description>
+  </descriptions>
+</resource>
+XML;
+
+    expect(parseDescriptions($xml))->toBe([
+        [
+            'type' => 'Methods',
+            'description' => 'Method text.',
+            'language' => 'de',
+        ],
+        [
+            'type' => 'Other',
+            'description' => 'Other text.',
+            'language' => null,
+        ],
+    ]);
+});
+
+test('falls back to XmlReader parsing when raw XML cannot be parsed', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Abstract">Fallback abstract.</description>
+  </descriptions>
+</resource>
+XML;
+
+    expect(parseDescriptions($xml, '<resource><descriptions>'))->toBe([
+        [
+            'type' => 'Abstract',
+            'description' => 'Fallback abstract.',
+            'language' => null,
+        ],
+    ]);
+});
+
+test('normalizes mixed XmlReader fallback content without creating empty descriptions', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Abstract"><br/></description>
+    <description descriptionType="Methods"><br/><br/></description>
+    <description><custom>Nested fallback text</custom></description>
+  </descriptions>
+</resource>
+XML;
+
+    expect(parseDescriptions($xml))->toBe([
+        [
+            'type' => 'Other',
+            'description' => 'Nested fallback text',
+            'language' => null,
+        ],
+    ]);
+});


### PR DESCRIPTION
This pull request introduces a robust fix for XML uploads to ensure that DataCite description fields containing mixed content (such as inline XML elements like `<br/>`, `<em>`, or custom tags) are preserved correctly, rather than being dropped or mangled during import. The changes add a DOM-based parsing path that reconstructs the description text, including line breaks and nested elements, and fall back gracefully to the previous parser if needed. Comprehensive tests are included to verify these improvements and prevent regression.

**XML Description Parsing Improvements:**

* Added a new DOM-based parsing method in `DescriptionSectionParser` that reconstructs description text from raw XML, preserving inline elements (like `<br/>` for line breaks and nested tags) and normalizing whitespace and line breaks. If the raw XML cannot be parsed, it falls back to the existing `XmlReader`-based logic. [[1]](diffhunk://#diff-1c0393b1b557b2c3a8fd605b8a36b7cbc5898856e253e5442f82fe65a204b4d8L17-R106) [[2]](diffhunk://#diff-1c0393b1b557b2c3a8fd605b8a36b7cbc5898856e253e5442f82fe65a204b4d8L27-R120) [[3]](diffhunk://#diff-1c0393b1b557b2c3a8fd605b8a36b7cbc5898856e253e5442f82fe65a204b4d8R135-R187)
* Updated the parser interface and its usage so that the raw XML string is passed through the parsing pipeline, enabling the new parsing logic. [[1]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09L44-R44) [[2]](diffhunk://#diff-4d176b6caec2c65dd4fad1dfa5e2dfdc3c9ba17be3ab6603ccc0962aa2a64a8dL47-R47) [[3]](diffhunk://#diff-4d176b6caec2c65dd4fad1dfa5e2dfdc3c9ba17be3ab6603ccc0962aa2a64a8dL61-R61)

**Testing and Validation:**

* Added new feature and unit tests to verify that mixed content in descriptions is preserved, including line breaks, nested elements, and proper filtering of empty/whitespace-only descriptions. These tests also ensure proper fallback to the old parser when necessary. [[1]](diffhunk://#diff-6719b54b1631ab720b79b2691385e5fe075dc5377eb74e8638c0594569b1b281L129-R225) [[2]](diffhunk://#diff-f4a585b76f0ecd9b8696459e271a86d6e3fd94773df8fb003e5e21e659c02dc5R1-R138)

**Documentation and Changelog:**

* Updated the changelog to document that XML uploads now preserve mixed description text, improving data integrity for DataCite records with complex descriptions.