### PR TITLE
Fix: Resolve legacy subject breadcrumb paths

### DIFF
--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -1089,16 +1089,18 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
-            $subjectValue = is_string($value) ? (SubjectBreadcrumbPath::normalize($value) ?? $value) : $value;
+            $rawSubjectValue = is_string($value) ? $value : null;
+            $subjectValue = $rawSubjectValue !== null ? (SubjectBreadcrumbPath::normalize($rawSubjectValue) ?? $value) : $value;
             $subjectScheme = $subjectData['subjectScheme'] ?? null;
             $schemeUri = $this->filledString($subjectData['schemeUri'] ?? null);
             $valueUri = $this->filledString($subjectData['valueUri'] ?? null);
-            $breadcrumbPath = SubjectBreadcrumbPath::normalize(is_string($value) ? $value : null);
+            $classificationCode = $subjectData['classificationCode'] ?? null;
+            $breadcrumbPath = SubjectBreadcrumbPath::preferredPath(null, $rawSubjectValue);
 
             if ($valueUri === null || $schemeUri === null) {
                 $resolvedKeyword = $this->subjectPathResolver()->resolveKeywordFromPath(
                     is_string($subjectScheme) ? $subjectScheme : null,
-                    is_string($value) ? $value : null,
+                    $rawSubjectValue,
                 );
 
                 if ($resolvedKeyword !== null) {
@@ -1108,6 +1110,13 @@ class DataCiteToResourceTransformer
                     $breadcrumbPath = $resolvedKeyword['path'];
                 }
             }
+
+            $breadcrumbPath = $breadcrumbPath ?? $this->subjectPathResolver()->resolve(
+                is_string($subjectScheme) ? $subjectScheme : null,
+                $valueUri,
+                is_string($classificationCode) || is_numeric($classificationCode) ? (string) $classificationCode : null,
+                $rawSubjectValue,
+            );
 
             $schemeUri = $schemeUri ?? $this->subjectPathResolver()->resolveSchemeUri(
                 is_string($subjectScheme) ? $subjectScheme : null,
@@ -1120,7 +1129,7 @@ class DataCiteToResourceTransformer
                 'subject_scheme' => $subjectScheme,
                 'scheme_uri' => $schemeUri,
                 'value_uri' => $valueUri,
-                'classification_code' => $subjectData['classificationCode'] ?? null,
+                'classification_code' => $classificationCode,
                 'breadcrumb_path' => $breadcrumbPath,
             ]);
         }

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -38,6 +38,7 @@ use App\Models\Title;
 use App\Models\TitleType;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Support\OrcidNormalizer;
+use App\Support\SubjectBreadcrumbPath;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -56,6 +57,7 @@ class DataCiteToResourceTransformer
     public function __construct(
         private ?RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService = null,
         private ?RorLookupService $rorLookupService = null,
+        private ?SubjectBreadcrumbPathResolverService $subjectBreadcrumbPathResolver = null,
     ) {}
 
     /**
@@ -1087,16 +1089,57 @@ class DataCiteToResourceTransformer
                 continue;
             }
 
+            $subjectValue = is_string($value) ? (SubjectBreadcrumbPath::normalize($value) ?? $value) : $value;
+            $subjectScheme = $subjectData['subjectScheme'] ?? null;
+            $schemeUri = $this->filledString($subjectData['schemeUri'] ?? null);
+            $valueUri = $this->filledString($subjectData['valueUri'] ?? null);
+            $breadcrumbPath = SubjectBreadcrumbPath::normalize(is_string($value) ? $value : null);
+
+            if ($valueUri === null || $schemeUri === null) {
+                $resolvedKeyword = $this->subjectPathResolver()->resolveKeywordFromPath(
+                    is_string($subjectScheme) ? $subjectScheme : null,
+                    is_string($value) ? $value : null,
+                );
+
+                if ($resolvedKeyword !== null) {
+                    $subjectScheme = $resolvedKeyword['scheme'];
+                    $schemeUri = $schemeUri ?? $resolvedKeyword['schemeURI'];
+                    $valueUri = $valueUri ?? $resolvedKeyword['id'];
+                    $breadcrumbPath = $resolvedKeyword['path'];
+                }
+            }
+
+            $schemeUri = $schemeUri ?? $this->subjectPathResolver()->resolveSchemeUri(
+                is_string($subjectScheme) ? $subjectScheme : null,
+            );
+
             Subject::create([
                 'resource_id' => $resource->id,
-                'value' => $value,
+                'value' => $subjectValue,
                 'language' => $subjectData['lang'] ?? 'en',
-                'subject_scheme' => $subjectData['subjectScheme'] ?? null,
-                'scheme_uri' => $subjectData['schemeUri'] ?? null,
-                'value_uri' => $subjectData['valueUri'] ?? null,
+                'subject_scheme' => $subjectScheme,
+                'scheme_uri' => $schemeUri,
+                'value_uri' => $valueUri,
                 'classification_code' => $subjectData['classificationCode'] ?? null,
+                'breadcrumb_path' => $breadcrumbPath,
             ]);
         }
+    }
+
+    private function subjectPathResolver(): SubjectBreadcrumbPathResolverService
+    {
+        return $this->subjectBreadcrumbPathResolver ??= app(SubjectBreadcrumbPathResolverService::class);
+    }
+
+    private function filledString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
     }
 
     /**

--- a/app/Services/OldDatasetKeywordTransformer.php
+++ b/app/Services/OldDatasetKeywordTransformer.php
@@ -24,6 +24,12 @@ class OldDatasetKeywordTransformer
         'GCMD Instruments' => 'Instruments',
     ];
 
+    private const SCHEME_URI_MAP = [
+        'Science Keywords' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+        'Platforms' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms',
+        'Instruments' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments',
+    ];
+
     /**
      * Extract UUID from old GCMD URI format.
      *
@@ -56,17 +62,10 @@ class OldDatasetKeywordTransformer
      * Transform a keyword from old database format to new format.
      *
      * @param  object  $oldKeyword  Object with properties: keyword, thesaurus, uri, description
-     * @return array<string, string|null>|null Array with keys: id, text, scheme, path, uuid, description
+     * @return array<string, string|null>|null Array with keys: id, text, scheme, schemeURI, path, uuid, description
      */
     public static function transform(object $oldKeyword): ?array
     {
-        // Extract UUID from old URI
-        $uuid = self::extractUuidFromOldUri($oldKeyword->uri ?? null);
-
-        if (! $uuid) {
-            return null;
-        }
-
         // Map to scheme name
         $scheme = self::mapScheme($oldKeyword->thesaurus ?? '');
 
@@ -74,14 +73,35 @@ class OldDatasetKeywordTransformer
             return null;
         }
 
-        // Construct new URI
-        $newUri = self::constructNewUri($uuid);
+        $keyword = trim((string) ($oldKeyword->keyword ?? ''));
+        $schemeUri = self::schemeUriForScheme($scheme);
+
+        // Extract UUID from old URI
+        $uuid = self::extractUuidFromOldUri($oldKeyword->uri ?? null);
+        $newUri = $uuid ? self::constructNewUri($uuid) : null;
+
+        if ($newUri === null && $keyword !== '') {
+            $resolvedKeyword = app(SubjectBreadcrumbPathResolverService::class)
+                ->resolveKeywordFromPath($scheme, $keyword);
+
+            if ($resolvedKeyword !== null) {
+                $newUri = $resolvedKeyword['id'];
+                $uuid = self::extractUuidFromOldUri($newUri);
+                $scheme = $resolvedKeyword['scheme'];
+                $schemeUri = $resolvedKeyword['schemeURI'] ?? self::schemeUriForScheme($scheme);
+            }
+        }
+
+        if ($newUri === null) {
+            return null;
+        }
 
         return [
             'id' => $newUri,
-            'text' => $oldKeyword->keyword ?? '',
+            'text' => $keyword,
             'scheme' => $scheme,
-            'path' => $oldKeyword->keyword ?? '', // The keyword text IS the hierarchical path
+            'schemeURI' => $schemeUri,
+            'path' => $keyword, // The keyword text IS the hierarchical path
             'uuid' => $uuid,
             'description' => $oldKeyword->description ?? null,
         ];
@@ -116,5 +136,10 @@ class OldDatasetKeywordTransformer
     public static function getSupportedThesauri(): array
     {
         return array_keys(self::SCHEME_MAP);
+    }
+
+    private static function schemeUriForScheme(string $scheme): ?string
+    {
+        return self::SCHEME_URI_MAP[$scheme] ?? null;
     }
 }

--- a/app/Services/OldDatasetKeywordTransformer.php
+++ b/app/Services/OldDatasetKeywordTransformer.php
@@ -24,12 +24,6 @@ class OldDatasetKeywordTransformer
         'GCMD Instruments' => 'Instruments',
     ];
 
-    private const SCHEME_URI_MAP = [
-        'Science Keywords' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
-        'Platforms' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms',
-        'Instruments' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments',
-    ];
-
     /**
      * Extract UUID from old GCMD URI format.
      *
@@ -140,6 +134,6 @@ class OldDatasetKeywordTransformer
 
     private static function schemeUriForScheme(string $scheme): ?string
     {
-        return self::SCHEME_URI_MAP[$scheme] ?? null;
+        return app(SubjectBreadcrumbPathResolverService::class)->resolveSchemeUri($scheme);
     }
 }

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -1058,6 +1058,7 @@ class ResourceStorageService
 
             $keywordId = trim((string) ($keyword['id'] ?? ''));
             $keywordText = trim((string) $keyword['text']);
+            $keywordText = SubjectBreadcrumbPath::normalize($keywordText) ?? $keywordText;
             $keywordScheme = trim((string) $keyword['scheme']);
             $keywordSchemeUri = is_string($keyword['schemeURI'] ?? null) ? trim((string) $keyword['schemeURI']) : null;
             $keywordPath = is_string($keyword['path'] ?? null) ? $keyword['path'] : null;

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -49,6 +49,7 @@ class ResourceStorageService
         protected RorLookupService $rorLookupService,
         protected RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService,
         protected RelatedItemStorageService $relatedItemStorage,
+        protected SubjectBreadcrumbPathResolverService $subjectBreadcrumbPathResolver,
     ) {}
 
     /**
@@ -1051,22 +1052,53 @@ class ResourceStorageService
         $controlledKeywordsData = [];
         foreach ($controlledKeywords as $keyword) {
             // Validate required fields (scheme is now the discriminator instead of vocabularyType)
-            if (! empty($keyword['id']) && ! empty($keyword['text']) && ! empty($keyword['scheme'])) {
-                $rawCode = array_key_exists('classificationCode', $keyword) ? trim((string) $keyword['classificationCode']) : '';
-                $classificationCode = $rawCode !== '' ? $rawCode : null;
-                $valueUri = filter_var($keyword['id'], FILTER_VALIDATE_URL) ? $keyword['id'] : null;
-
-                $controlledKeywordsData[] = [
-                    'value' => $keyword['text'],
-                    'subject_scheme' => $keyword['scheme'],
-                    'scheme_uri' => $keyword['schemeURI'] ?? null,
-                    'value_uri' => $valueUri,
-                    'classification_code' => $classificationCode,
-                    'breadcrumb_path' => SubjectBreadcrumbPath::normalize(
-                        is_string($keyword['path'] ?? null) ? $keyword['path'] : null,
-                    ),
-                ];
+            if (empty($keyword['text']) || empty($keyword['scheme'])) {
+                continue;
             }
+
+            $keywordId = trim((string) ($keyword['id'] ?? ''));
+            $keywordText = trim((string) $keyword['text']);
+            $keywordScheme = trim((string) $keyword['scheme']);
+            $keywordSchemeUri = is_string($keyword['schemeURI'] ?? null) ? trim((string) $keyword['schemeURI']) : null;
+            $keywordPath = is_string($keyword['path'] ?? null) ? $keyword['path'] : null;
+
+            if ($keywordId === '' || $keywordSchemeUri === null || $keywordSchemeUri === '') {
+                $resolvedKeyword = $this->subjectBreadcrumbPathResolver->resolveKeywordFromPath(
+                    $keywordScheme,
+                    $keywordPath ?? $keywordText,
+                );
+
+                if ($resolvedKeyword !== null) {
+                    $keywordId = $keywordId !== '' ? $keywordId : $resolvedKeyword['id'];
+                    $keywordText = $keywordText !== '' ? $keywordText : $resolvedKeyword['text'];
+                    $keywordScheme = $resolvedKeyword['scheme'];
+                    $keywordSchemeUri = $keywordSchemeUri !== null && $keywordSchemeUri !== ''
+                        ? $keywordSchemeUri
+                        : $resolvedKeyword['schemeURI'];
+                    $keywordPath = $resolvedKeyword['path'];
+                }
+            }
+
+            if ($keywordId === '' || $keywordText === '' || $keywordScheme === '') {
+                continue;
+            }
+
+            $keywordSchemeUri = $keywordSchemeUri !== null && $keywordSchemeUri !== ''
+                ? $keywordSchemeUri
+                : $this->subjectBreadcrumbPathResolver->resolveSchemeUri($keywordScheme);
+
+            $rawCode = array_key_exists('classificationCode', $keyword) ? trim((string) $keyword['classificationCode']) : '';
+            $classificationCode = $rawCode !== '' ? $rawCode : null;
+            $valueUri = filter_var($keywordId, FILTER_VALIDATE_URL) ? $keywordId : null;
+
+            $controlledKeywordsData[] = [
+                'value' => $keywordText,
+                'subject_scheme' => $keywordScheme,
+                'scheme_uri' => $keywordSchemeUri,
+                'value_uri' => $valueUri,
+                'classification_code' => $classificationCode,
+                'breadcrumb_path' => SubjectBreadcrumbPath::normalize($keywordPath),
+            ];
         }
 
         // Bulk create controlled keywords using Eloquent (handles timestamps automatically)

--- a/app/Services/SubjectBreadcrumbPathResolverService.php
+++ b/app/Services/SubjectBreadcrumbPathResolverService.php
@@ -63,6 +63,9 @@ final class SubjectBreadcrumbPathResolverService
     /** @var array<string, array<string, array{id: string, text: string, path: string, schemeURI: string|null}>> */
     private array $nodesByPath = [];
 
+    /** @var array<string, array<string, array<string, array{id: string, text: string, path: string, schemeURI: string|null}>>> */
+    private array $nodesByLeafPath = [];
+
     /** @var array<string, array<string, true>> */
     private array $ambiguousLeafKeys = [];
 
@@ -124,7 +127,9 @@ final class SubjectBreadcrumbPathResolverService
             return null;
         }
 
-        $node = $this->nodesByPath[$normalizedScheme][$pathKey] ?? null;
+        $node = $this->nodesByPath[$normalizedScheme][$pathKey]
+            ?? $this->resolveUniqueNodeFromLegacyPath($normalizedScheme, $subjectValue);
+
         if ($node === null) {
             return null;
         }
@@ -198,8 +203,7 @@ final class SubjectBreadcrumbPathResolverService
                 }
             }
 
-            $pathKey = $this->normalizePathLookup($currentPath, $scheme);
-            if ($pathKey !== null && $nodeId !== '' && ! isset($this->ambiguousPathKeys[$scheme][$pathKey])) {
+            if ($nodeId !== '') {
                 $schemeUri = $this->filledString($node['schemeURI'] ?? null) ?? $this->fallbackSchemeUri($scheme);
                 $resolvedNode = [
                     'id' => $nodeId,
@@ -208,6 +212,13 @@ final class SubjectBreadcrumbPathResolverService
                     'schemeURI' => $schemeUri,
                 ];
 
+                if ($leafKey !== null) {
+                    $this->nodesByLeafPath[$scheme][$leafKey][$nodeId.'|'.$currentPath] = $resolvedNode;
+                }
+            }
+
+            $pathKey = $this->normalizePathLookup($currentPath, $scheme);
+            if ($pathKey !== null && $nodeId !== '' && ! isset($this->ambiguousPathKeys[$scheme][$pathKey])) {
                 if (! isset($this->nodesByPath[$scheme][$pathKey])) {
                     $this->nodesByPath[$scheme][$pathKey] = $resolvedNode;
                 } elseif ($this->nodesByPath[$scheme][$pathKey] !== $resolvedNode) {
@@ -359,6 +370,93 @@ final class SubjectBreadcrumbPathResolverService
         );
 
         return $normalizedPath !== null ? mb_strtolower($normalizedPath) : null;
+    }
+
+    /**
+     * Some legacy DataCite subjects carry paths from older GCMD hierarchy
+     * versions. If current vocabularies inserted extra intermediate nodes, the
+     * legacy path can still be resolved as long as it identifies exactly one
+     * current node with the same ordered breadcrumb segments.
+     *
+     * @return array{id: string, text: string, path: string, schemeURI: string|null}|null
+     */
+    private function resolveUniqueNodeFromLegacyPath(string $scheme, ?string $path): ?array
+    {
+        $segments = $this->pathSegmentsForLookup($path, $scheme);
+        if (count($segments) < 2) {
+            return null;
+        }
+
+        $leafKey = $segments[array_key_last($segments)];
+        $candidates = $this->nodesByLeafPath[$scheme][$leafKey] ?? [];
+        if ($candidates === []) {
+            return null;
+        }
+
+        $matches = [];
+        foreach ($candidates as $candidateKey => $candidate) {
+            if ($this->isOrderedSubsequence(
+                $segments,
+                $this->pathSegmentsForLookup($candidate['path'], $scheme),
+            )) {
+                $matches[$candidateKey] = $candidate;
+            }
+        }
+
+        if (count($matches) !== 1) {
+            return null;
+        }
+
+        $match = reset($matches);
+
+        return is_array($match) ? $match : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function pathSegmentsForLookup(?string $path, ?string $scheme): array
+    {
+        $segments = SubjectBreadcrumbPath::segments($path);
+        if ($segments === []) {
+            return [];
+        }
+
+        if ($scheme !== null && $this->shouldDropLeadingSegment($segments[0], $scheme)) {
+            array_shift($segments);
+        }
+
+        return array_values(array_map(
+            static fn (string $segment): string => mb_strtolower(trim($segment)),
+            array_filter($segments, static fn (string $segment): bool => trim($segment) !== ''),
+        ));
+    }
+
+    /**
+     * @param  array<int, string>  $needles
+     * @param  array<int, string>  $haystack
+     */
+    private function isOrderedSubsequence(array $needles, array $haystack): bool
+    {
+        if ($needles === [] || count($needles) > count($haystack)) {
+            return false;
+        }
+
+        $needleIndex = 0;
+        $needleCount = count($needles);
+
+        foreach ($haystack as $segment) {
+            if ($segment !== $needles[$needleIndex]) {
+                continue;
+            }
+
+            $needleIndex++;
+            if ($needleIndex === $needleCount) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function fallbackSchemeUri(string $scheme): ?string

--- a/app/Services/SubjectBreadcrumbPathResolverService.php
+++ b/app/Services/SubjectBreadcrumbPathResolverService.php
@@ -407,9 +407,7 @@ final class SubjectBreadcrumbPathResolverService
             return null;
         }
 
-        $match = reset($matches);
-
-        return is_array($match) ? $match : null;
+        return array_values($matches)[0];
     }
 
     /**

--- a/app/Services/SubjectBreadcrumbPathResolverService.php
+++ b/app/Services/SubjectBreadcrumbPathResolverService.php
@@ -11,15 +11,43 @@ use Illuminate\Support\Facades\Storage;
 
 final class SubjectBreadcrumbPathResolverService
 {
-    /** @var array<string, array{file: string, fallback_scheme: string}> */
+    /** @var array<string, array{file: string, fallback_scheme: string, fallback_scheme_uri?: string}> */
     private const SOURCES = [
-        'Science Keywords' => ['file' => 'gcmd-science-keywords.json', 'fallback_scheme' => 'Science Keywords'],
-        'Platforms' => ['file' => 'gcmd-platforms.json', 'fallback_scheme' => 'Platforms'],
-        'Instruments' => ['file' => 'gcmd-instruments.json', 'fallback_scheme' => 'Instruments'],
-        'EPOS MSL vocabulary' => ['file' => 'msl-vocabulary.json', 'fallback_scheme' => 'EPOS MSL vocabulary'],
-        GemetVocabularyParser::SCHEME_TITLE => ['file' => 'gemet-thesaurus.json', 'fallback_scheme' => GemetVocabularyParser::SCHEME_TITLE],
-        PortalSubjectNormalizer::SCHEME_ICS_CHRONOSTRAT => ['file' => 'chronostrat-timescale.json', 'fallback_scheme' => PortalSubjectNormalizer::SCHEME_ICS_CHRONOSTRAT],
-        PortalSubjectNormalizer::SCHEME_ANALYTICAL_METHODS => ['file' => 'analytical-methods.json', 'fallback_scheme' => PortalSubjectNormalizer::SCHEME_ANALYTICAL_METHODS],
+        'Science Keywords' => [
+            'file' => 'gcmd-science-keywords.json',
+            'fallback_scheme' => 'Science Keywords',
+            'fallback_scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+        ],
+        'Platforms' => [
+            'file' => 'gcmd-platforms.json',
+            'fallback_scheme' => 'Platforms',
+            'fallback_scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms',
+        ],
+        'Instruments' => [
+            'file' => 'gcmd-instruments.json',
+            'fallback_scheme' => 'Instruments',
+            'fallback_scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments',
+        ],
+        'EPOS MSL vocabulary' => [
+            'file' => 'msl-vocabulary.json',
+            'fallback_scheme' => 'EPOS MSL vocabulary',
+            'fallback_scheme_uri' => 'https://epos-msl.uu.nl/voc',
+        ],
+        GemetVocabularyParser::SCHEME_TITLE => [
+            'file' => 'gemet-thesaurus.json',
+            'fallback_scheme' => GemetVocabularyParser::SCHEME_TITLE,
+            'fallback_scheme_uri' => 'http://www.eionet.europa.eu/gemet/concept/',
+        ],
+        PortalSubjectNormalizer::SCHEME_ICS_CHRONOSTRAT => [
+            'file' => 'chronostrat-timescale.json',
+            'fallback_scheme' => PortalSubjectNormalizer::SCHEME_ICS_CHRONOSTRAT,
+            'fallback_scheme_uri' => 'http://resource.geosciml.org/vocabulary/timescale/gts2020',
+        ],
+        PortalSubjectNormalizer::SCHEME_ANALYTICAL_METHODS => [
+            'file' => 'analytical-methods.json',
+            'fallback_scheme' => PortalSubjectNormalizer::SCHEME_ANALYTICAL_METHODS,
+            'fallback_scheme_uri' => 'https://w3id.org/geochem/1.0/analyticalmethod/method',
+        ],
         'European Science Vocabulary (EuroSciVoc)' => ['file' => 'euroscivoc.json', 'fallback_scheme' => 'European Science Vocabulary (EuroSciVoc)'],
     ];
 
@@ -32,8 +60,14 @@ final class SubjectBreadcrumbPathResolverService
     /** @var array<string, array<string, string>> */
     private array $pathsByLeaf = [];
 
+    /** @var array<string, array<string, array{id: string, text: string, path: string, schemeURI: string|null}>> */
+    private array $nodesByPath = [];
+
     /** @var array<string, array<string, true>> */
     private array $ambiguousLeafKeys = [];
+
+    /** @var array<string, array<string, true>> */
+    private array $ambiguousPathKeys = [];
 
     /** @var array<string, true> */
     private array $indexedSchemes = [];
@@ -68,6 +102,47 @@ final class SubjectBreadcrumbPathResolverService
         }
 
         return null;
+    }
+
+    /**
+     * Resolve a controlled keyword from a legacy DataCite subject that only
+     * carries a full breadcrumb path instead of a stable valueURI.
+     *
+     * @return array{id: string, text: string, path: string, scheme: string, schemeURI: string|null}|null
+     */
+    public function resolveKeywordFromPath(?string $subjectScheme, ?string $subjectValue): ?array
+    {
+        $normalizedScheme = PortalSubjectNormalizer::normalizeScheme($subjectScheme);
+        if ($normalizedScheme === null) {
+            return null;
+        }
+
+        $this->buildIndexesForScheme($normalizedScheme);
+
+        $pathKey = $this->normalizePathLookup($subjectValue, $normalizedScheme);
+        if ($pathKey === null || isset($this->ambiguousPathKeys[$normalizedScheme][$pathKey])) {
+            return null;
+        }
+
+        $node = $this->nodesByPath[$normalizedScheme][$pathKey] ?? null;
+        if ($node === null) {
+            return null;
+        }
+
+        return [
+            'id' => $node['id'],
+            'text' => $node['text'] !== '' ? $node['text'] : (SubjectBreadcrumbPath::leaf($node['path']) ?? ''),
+            'path' => $node['path'],
+            'scheme' => $normalizedScheme,
+            'schemeURI' => $node['schemeURI'] ?? $this->fallbackSchemeUri($normalizedScheme),
+        ];
+    }
+
+    public function resolveSchemeUri(?string $subjectScheme): ?string
+    {
+        $normalizedScheme = PortalSubjectNormalizer::normalizeScheme($subjectScheme);
+
+        return $normalizedScheme !== null ? $this->fallbackSchemeUri($normalizedScheme) : null;
     }
 
     private function buildIndexesForScheme(string $scheme): void
@@ -120,6 +195,24 @@ final class SubjectBreadcrumbPathResolverService
                 } elseif ($this->pathsByLeaf[$scheme][$leafKey] !== $currentPath) {
                     unset($this->pathsByLeaf[$scheme][$leafKey]);
                     $this->ambiguousLeafKeys[$scheme][$leafKey] = true;
+                }
+            }
+
+            $pathKey = $this->normalizePathLookup($currentPath, $scheme);
+            if ($pathKey !== null && $nodeId !== '' && ! isset($this->ambiguousPathKeys[$scheme][$pathKey])) {
+                $schemeUri = $this->filledString($node['schemeURI'] ?? null) ?? $this->fallbackSchemeUri($scheme);
+                $resolvedNode = [
+                    'id' => $nodeId,
+                    'text' => $nodeText,
+                    'path' => $currentPath,
+                    'schemeURI' => $schemeUri,
+                ];
+
+                if (! isset($this->nodesByPath[$scheme][$pathKey])) {
+                    $this->nodesByPath[$scheme][$pathKey] = $resolvedNode;
+                } elseif ($this->nodesByPath[$scheme][$pathKey] !== $resolvedNode) {
+                    unset($this->nodesByPath[$scheme][$pathKey]);
+                    $this->ambiguousPathKeys[$scheme][$pathKey] = true;
                 }
             }
         }
@@ -194,6 +287,7 @@ final class SubjectBreadcrumbPathResolverService
             'id' => trim((string) ($node['id'] ?? '')),
             'text' => trim((string) ($node['text'] ?? '')),
             'notation' => isset($node['notation']) ? trim((string) $node['notation']) : '',
+            'schemeURI' => $this->filledString($node['schemeURI'] ?? $node['schemeUri'] ?? null) ?? '',
             'scheme' => PortalSubjectNormalizer::normalizeScheme((string) ($node['scheme'] ?? $fallbackScheme)) ?? $fallbackScheme,
             'children' => $children,
         ];
@@ -243,6 +337,44 @@ final class SubjectBreadcrumbPathResolverService
         $normalizedLeaf = trim($leaf);
 
         return $normalizedLeaf !== '' ? mb_strtolower($normalizedLeaf) : null;
+    }
+
+    private function normalizePathLookup(?string $path, ?string $scheme): ?string
+    {
+        $segments = SubjectBreadcrumbPath::segments($path);
+        if ($segments === []) {
+            return null;
+        }
+
+        if ($scheme !== null && $this->shouldDropLeadingSegment($segments[0], $scheme)) {
+            array_shift($segments);
+        }
+
+        if ($segments === []) {
+            return null;
+        }
+
+        $normalizedPath = SubjectBreadcrumbPath::normalize(
+            implode(PortalSubjectNormalizer::BREADCRUMB_SEPARATOR, $segments),
+        );
+
+        return $normalizedPath !== null ? mb_strtolower($normalizedPath) : null;
+    }
+
+    private function fallbackSchemeUri(string $scheme): ?string
+    {
+        return self::SOURCES[$scheme]['fallback_scheme_uri'] ?? null;
+    }
+
+    private function filledString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
     }
 
     /**

--- a/app/Services/SubjectBreadcrumbPathResolverService.php
+++ b/app/Services/SubjectBreadcrumbPathResolverService.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Storage;
 
 final class SubjectBreadcrumbPathResolverService
 {
-    /** @var array<string, array{file: string, fallback_scheme: string, fallback_scheme_uri?: string}> */
+    /** @var array<string, array{file: string, fallback_scheme: string, fallback_scheme_uri?: string, fallback_scheme_uri_config?: string}> */
     private const SOURCES = [
         'Science Keywords' => [
             'file' => 'gcmd-science-keywords.json',
@@ -48,7 +48,11 @@ final class SubjectBreadcrumbPathResolverService
             'fallback_scheme' => PortalSubjectNormalizer::SCHEME_ANALYTICAL_METHODS,
             'fallback_scheme_uri' => 'https://w3id.org/geochem/1.0/analyticalmethod/method',
         ],
-        'European Science Vocabulary (EuroSciVoc)' => ['file' => 'euroscivoc.json', 'fallback_scheme' => 'European Science Vocabulary (EuroSciVoc)'],
+        'European Science Vocabulary (EuroSciVoc)' => [
+            'file' => 'euroscivoc.json',
+            'fallback_scheme' => 'European Science Vocabulary (EuroSciVoc)',
+            'fallback_scheme_uri_config' => 'euroscivoc.concept_scheme_uri',
+        ],
     ];
 
     /** @var array<string, array<string, string>> */
@@ -459,7 +463,20 @@ final class SubjectBreadcrumbPathResolverService
 
     private function fallbackSchemeUri(string $scheme): ?string
     {
-        return self::SOURCES[$scheme]['fallback_scheme_uri'] ?? null;
+        $source = self::SOURCES[$scheme] ?? null;
+        if ($source === null) {
+            return null;
+        }
+
+        $configKey = $source['fallback_scheme_uri_config'] ?? null;
+        if ($configKey !== null) {
+            $configuredSchemeUri = $this->filledString(config($configKey));
+            if ($configuredSchemeUri !== null) {
+                return $configuredSchemeUri;
+            }
+        }
+
+        return $source['fallback_scheme_uri'] ?? null;
     }
 
     private function filledString(mixed $value): ?string

--- a/tests/pest/Feature/Services/DataCiteLegacySubjectPathImportTest.php
+++ b/tests/pest/Feature/Services/DataCiteLegacySubjectPathImportTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Services\DataCiteToResourceTransformer;
+use Database\Seeders\ContributorTypeSeeder;
+use Database\Seeders\DescriptionTypeSeeder;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\LanguageSeeder;
+use Database\Seeders\PublisherSeeder;
+use Database\Seeders\RelationTypeSeeder;
+use Database\Seeders\ResourceTypeSeeder;
+use Database\Seeders\TitleTypeSeeder;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function (): void {
+    test()->seed(ResourceTypeSeeder::class);
+    test()->seed(TitleTypeSeeder::class);
+    test()->seed(DescriptionTypeSeeder::class);
+    test()->seed(ContributorTypeSeeder::class);
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(LanguageSeeder::class);
+    test()->seed(PublisherSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+});
+
+it('hydrates path-only legacy DataCite GCMD subjects during resource import', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
+        'data' => [[
+            'id' => 'earth-science',
+            'text' => 'EARTH SCIENCE',
+            'scheme' => 'NASA/GCMD Earth Science Keywords',
+            'children' => [[
+                'id' => 'biosphere',
+                'text' => 'BIOSPHERE',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [[
+                    'id' => 'terrestrial-ecosystems',
+                    'text' => 'TERRESTRIAL ECOSYSTEMS',
+                    'scheme' => 'NASA/GCMD Earth Science Keywords',
+                    'children' => [[
+                        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/forests',
+                        'text' => 'FORESTS',
+                        'scheme' => 'NASA/GCMD Earth Science Keywords',
+                        'schemeURI' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+                        'children' => [],
+                    ]],
+                ]],
+            ]],
+        ]],
+    ], JSON_THROW_ON_ERROR));
+
+    $user = User::factory()->create();
+    $transformer = new DataCiteToResourceTransformer;
+
+    $resource = $transformer->transform([
+        'attributes' => [
+            'doi' => '10.5880/legacy-subject-path.2026.001',
+            'publicationYear' => 2026,
+            'titles' => [
+                ['title' => 'Legacy subject path import'],
+            ],
+            'creators' => [
+                ['familyName' => 'Importer', 'givenName' => 'Test', 'nameType' => 'Personal'],
+            ],
+            'subjects' => [
+                [
+                    'subject' => 'EARTH SCIENCE &gt; BIOSPHERE &gt; TERRESTRIAL ECOSYSTEMS &gt; FORESTS',
+                    'subjectScheme' => 'NASA/GCMD Earth Science Keywords',
+                ],
+            ],
+        ],
+    ], $user->id);
+
+    $subject = $resource->subjects()->sole();
+
+    expect($subject->value)->toBe('EARTH SCIENCE > BIOSPHERE > TERRESTRIAL ECOSYSTEMS > FORESTS')
+        ->and($subject->subject_scheme)->toBe('Science Keywords')
+        ->and($subject->scheme_uri)->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
+        ->and($subject->value_uri)->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/forests')
+        ->and($subject->breadcrumb_path)->toBe('EARTH SCIENCE > BIOSPHERE > TERRESTRIAL ECOSYSTEMS > FORESTS');
+});

--- a/tests/pest/Feature/Services/DataCiteLegacySubjectPathImportTest.php
+++ b/tests/pest/Feature/Services/DataCiteLegacySubjectPathImportTest.php
@@ -82,3 +82,34 @@ it('hydrates path-only legacy DataCite GCMD subjects during resource import', fu
         ->and($subject->value_uri)->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/forests')
         ->and($subject->breadcrumb_path)->toBe('EARTH SCIENCE > BIOSPHERE > TERRESTRIAL ECOSYSTEMS > FORESTS');
 });
+
+it('does not store breadcrumb paths for free-text DataCite subjects', function (): void {
+    $user = User::factory()->create();
+    $transformer = new DataCiteToResourceTransformer;
+
+    $resource = $transformer->transform([
+        'attributes' => [
+            'doi' => '10.5880/free-text-subject.2026.001',
+            'publicationYear' => 2026,
+            'titles' => [
+                ['title' => 'Free-text subject import'],
+            ],
+            'creators' => [
+                ['familyName' => 'Importer', 'givenName' => 'Test', 'nameType' => 'Personal'],
+            ],
+            'subjects' => [
+                [
+                    'subject' => 'Forest ecology',
+                ],
+            ],
+        ],
+    ], $user->id);
+
+    $subject = $resource->subjects()->sole();
+
+    expect($subject->value)->toBe('Forest ecology')
+        ->and($subject->subject_scheme)->toBeNull()
+        ->and($subject->scheme_uri)->toBeNull()
+        ->and($subject->value_uri)->toBeNull()
+        ->and($subject->breadcrumb_path)->toBeNull();
+});

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -683,8 +683,8 @@ describe('ResourceStorageService', function () {
             'gcmdKeywords' => [
                 [
                     'id' => '',
-                    'text' => 'EARTH SCIENCE > BIOSPHERE > FORESTS',
-                    'path' => 'EARTH SCIENCE > BIOSPHERE > FORESTS',
+                    'text' => 'EARTH SCIENCE &gt;  BIOSPHERE  &gt; FORESTS',
+                    'path' => 'EARTH SCIENCE &gt;  BIOSPHERE  &gt; FORESTS',
                     'scheme' => 'NASA/GCMD Earth Science Keywords',
                 ],
             ],

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -632,6 +632,75 @@ describe('ResourceStorageService', function () {
             ->and($subject->breadcrumb_path)->toBe('EARTH SCIENCE > SOLID EARTH > Test GCMD Keyword');
     });
 
+    it('resolves legacy path-only controlled keywords before storing them', function () {
+        Storage::fake('local');
+        Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
+            'data' => [[
+                'id' => 'earth-science',
+                'text' => 'EARTH SCIENCE',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [[
+                    'id' => 'biosphere',
+                    'text' => 'BIOSPHERE',
+                    'scheme' => 'NASA/GCMD Earth Science Keywords',
+                    'children' => [[
+                        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/forests-uri',
+                        'text' => 'FORESTS',
+                        'scheme' => 'NASA/GCMD Earth Science Keywords',
+                        'schemeURI' => 'https://example.test/sciencekeywords',
+                        'children' => [],
+                    ]],
+                ]],
+            ]],
+        ], JSON_THROW_ON_ERROR));
+
+        $resourceType = ResourceType::first();
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Legacy path keyword resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'position' => 0,
+                ],
+            ],
+            'descriptions' => [
+                [
+                    'descriptionType' => 'Abstract',
+                    'description' => 'Test abstract.',
+                ],
+            ],
+            'gcmdKeywords' => [
+                [
+                    'id' => '',
+                    'text' => 'EARTH SCIENCE > BIOSPHERE > FORESTS',
+                    'path' => 'EARTH SCIENCE > BIOSPHERE > FORESTS',
+                    'scheme' => 'NASA/GCMD Earth Science Keywords',
+                ],
+            ],
+        ];
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $subject = $resource->subjects()->sole();
+
+        expect($subject->value)->toBe('EARTH SCIENCE > BIOSPHERE > FORESTS')
+            ->and($subject->subject_scheme)->toBe('Science Keywords')
+            ->and($subject->scheme_uri)->toBe('https://example.test/sciencekeywords')
+            ->and($subject->value_uri)->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/forests-uri')
+            ->and($subject->breadcrumb_path)->toBe('EARTH SCIENCE > BIOSPHERE > FORESTS');
+    });
+
     it('stores classificationCode for controlled keywords', function () {
         $resourceType = ResourceType::first();
 

--- a/tests/pest/Unit/Services/OldDatasetKeywordTransformerTest.php
+++ b/tests/pest/Unit/Services/OldDatasetKeywordTransformerTest.php
@@ -29,6 +29,7 @@ describe('transform', function () {
             ->and($result['text'])->toBe('EARTH SCIENCE > Atmosphere > Clouds')
             ->and($result['uuid'])->toBe('12345678-abcd-1234-abcd-123456789012')
             ->and($result['id'])->toContain('12345678-abcd-1234-abcd-123456789012')
+            ->and($result['schemeURI'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
             ->and($result['description'])->toBe('Cloud patterns');
     });
 

--- a/tests/pest/Unit/Services/OldDatasetKeywordTransformerTest.php
+++ b/tests/pest/Unit/Services/OldDatasetKeywordTransformerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Services\OldDatasetKeywordTransformer;
+use Illuminate\Support\Facades\Storage;
 
 // Note: covers() is intentionally omitted because OldDatasetKeywordTransformer
 // is excluded from the <source> coverage configuration in phpunit.xml
@@ -90,6 +91,43 @@ describe('transform', function () {
         ];
 
         expect(OldDatasetKeywordTransformer::transform($old))->toBeNull();
+    });
+
+    it('resolves a missing legacy URI from the full GCMD keyword path', function () {
+        Storage::fake('local');
+        Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
+            'data' => [[
+                'id' => 'earth-science',
+                'text' => 'EARTH SCIENCE',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [[
+                    'id' => 'biosphere',
+                    'text' => 'BIOSPHERE',
+                    'scheme' => 'NASA/GCMD Earth Science Keywords',
+                    'children' => [[
+                        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/biomass',
+                        'text' => 'BIOMASS',
+                        'scheme' => 'NASA/GCMD Earth Science Keywords',
+                        'schemeURI' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+                        'children' => [],
+                    ]],
+                ]],
+            ]],
+        ], JSON_THROW_ON_ERROR));
+
+        $old = (object) [
+            'keyword' => 'EARTH SCIENCE > BIOSPHERE > BIOMASS',
+            'thesaurus' => 'NASA/GCMD Earth Science Keywords',
+            'uri' => null,
+            'description' => null,
+        ];
+
+        $result = OldDatasetKeywordTransformer::transform($old);
+
+        expect($result)->not->toBeNull()
+            ->and($result['id'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/biomass')
+            ->and($result['scheme'])->toBe('Science Keywords')
+            ->and($result['schemeURI'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords');
     });
 });
 

--- a/tests/pest/Unit/Services/SubjectBreadcrumbPathResolverTest.php
+++ b/tests/pest/Unit/Services/SubjectBreadcrumbPathResolverTest.php
@@ -85,6 +85,91 @@ it('keeps an embedded hierarchical subject value as the breadcrumb path', functi
     ))->toBe('EARTH SCIENCE > SOLID EARTH > SEISMOLOGY');
 });
 
+it('resolves a controlled keyword from a legacy full path without value_uri', function (): void {
+    Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
+        'data' => [[
+            'id' => 'earth-science',
+            'text' => 'EARTH SCIENCE',
+            'scheme' => 'NASA/GCMD Earth Science Keywords',
+            'children' => [[
+                'id' => 'biosphere',
+                'text' => 'BIOSPHERE',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [[
+                    'id' => 'terrestrial-ecosystems',
+                    'text' => 'TERRESTRIAL ECOSYSTEMS',
+                    'scheme' => 'NASA/GCMD Earth Science Keywords',
+                    'children' => [[
+                        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/forest-uuid',
+                        'text' => 'FORESTS',
+                        'scheme' => 'NASA/GCMD Earth Science Keywords',
+                        'children' => [],
+                    ]],
+                ]],
+            ]],
+        ]],
+    ], JSON_THROW_ON_ERROR));
+
+    $resolver = new SubjectBreadcrumbPathResolverService;
+
+    $result = $resolver->resolveKeywordFromPath(
+        subjectScheme: 'NASA/GCMD Earth Science Keywords',
+        subjectValue: 'EARTH SCIENCE &gt; BIOSPHERE &gt; TERRESTRIAL ECOSYSTEMS &gt; FORESTS',
+    );
+
+    expect($result)->toBe([
+        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/forest-uuid',
+        'text' => 'FORESTS',
+        'path' => 'EARTH SCIENCE > BIOSPHERE > TERRESTRIAL ECOSYSTEMS > FORESTS',
+        'scheme' => 'Science Keywords',
+        'schemeURI' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+    ]);
+});
+
+it('does not resolve a value_uri from ambiguous legacy full paths', function (): void {
+    Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
+        'data' => [[
+            'id' => 'earth-science-a',
+            'text' => 'EARTH SCIENCE',
+            'scheme' => 'NASA/GCMD Earth Science Keywords',
+            'children' => [[
+                'id' => 'shared-a',
+                'text' => 'SHARED',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [],
+            ]],
+        ], [
+            'id' => 'earth-science-b',
+            'text' => 'EARTH SCIENCE',
+            'scheme' => 'NASA/GCMD Earth Science Keywords',
+            'children' => [[
+                'id' => 'shared-b',
+                'text' => 'SHARED',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [],
+            ]],
+        ]],
+    ], JSON_THROW_ON_ERROR));
+
+    $resolver = new SubjectBreadcrumbPathResolverService;
+
+    expect($resolver->resolveKeywordFromPath(
+        subjectScheme: 'NASA/GCMD Earth Science Keywords',
+        subjectValue: 'EARTH SCIENCE > SHARED',
+    ))->toBeNull();
+});
+
+it('infers known scheme URIs from legacy subject scheme names', function (): void {
+    $resolver = new SubjectBreadcrumbPathResolverService;
+
+    expect($resolver->resolveSchemeUri('NASA/GCMD Earth Science Keywords'))
+        ->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
+        ->and($resolver->resolveSchemeUri('NASA/GCMD Instruments'))
+        ->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments')
+        ->and($resolver->resolveSchemeUri('Invented Scheme'))
+        ->toBeNull();
+});
+
 it('returns null when no embedded hierarchy or normalized scheme is available', function (): void {
     $resolver = new SubjectBreadcrumbPathResolverService;
 

--- a/tests/pest/Unit/Services/SubjectBreadcrumbPathResolverTest.php
+++ b/tests/pest/Unit/Services/SubjectBreadcrumbPathResolverTest.php
@@ -126,6 +126,57 @@ it('resolves a controlled keyword from a legacy full path without value_uri', fu
     ]);
 });
 
+it('resolves a controlled keyword from a legacy path that omits a unique intermediate node', function (): void {
+    Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
+        'data' => [[
+            'id' => 'science-root',
+            'text' => 'Science Keywords',
+            'scheme' => 'NASA/GCMD Earth Science Keywords',
+            'children' => [[
+                'id' => 'earth-science',
+                'text' => 'EARTH SCIENCE',
+                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                'children' => [[
+                    'id' => 'biosphere',
+                    'text' => 'BIOSPHERE',
+                    'scheme' => 'NASA/GCMD Earth Science Keywords',
+                    'children' => [[
+                        'id' => 'ecosystems',
+                        'text' => 'ECOSYSTEMS',
+                        'scheme' => 'NASA/GCMD Earth Science Keywords',
+                        'children' => [[
+                            'id' => 'terrestrial-ecosystems',
+                            'text' => 'TERRESTRIAL ECOSYSTEMS',
+                            'scheme' => 'NASA/GCMD Earth Science Keywords',
+                            'children' => [[
+                                'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/forest-uuid',
+                                'text' => 'FORESTS',
+                                'scheme' => 'NASA/GCMD Earth Science Keywords',
+                                'children' => [],
+                            ]],
+                        ]],
+                    ]],
+                ]],
+            ]],
+        ]],
+    ], JSON_THROW_ON_ERROR));
+
+    $resolver = new SubjectBreadcrumbPathResolverService;
+
+    $result = $resolver->resolveKeywordFromPath(
+        subjectScheme: 'NASA/GCMD Earth Science Keywords',
+        subjectValue: 'EARTH SCIENCE &gt; BIOSPHERE &gt; TERRESTRIAL ECOSYSTEMS &gt; FORESTS',
+    );
+
+    expect($result)->toBe([
+        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/forest-uuid',
+        'text' => 'FORESTS',
+        'path' => 'EARTH SCIENCE > BIOSPHERE > ECOSYSTEMS > TERRESTRIAL ECOSYSTEMS > FORESTS',
+        'scheme' => 'Science Keywords',
+        'schemeURI' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+    ]);
+});
+
 it('does not resolve a value_uri from ambiguous legacy full paths', function (): void {
     Storage::disk('local')->put('gcmd-science-keywords.json', json_encode([
         'data' => [[

--- a/tests/pest/Unit/Services/SubjectBreadcrumbPathResolverTest.php
+++ b/tests/pest/Unit/Services/SubjectBreadcrumbPathResolverTest.php
@@ -211,12 +211,16 @@ it('does not resolve a value_uri from ambiguous legacy full paths', function ():
 });
 
 it('infers known scheme URIs from legacy subject scheme names', function (): void {
+    config(['euroscivoc.concept_scheme_uri' => 'http://example.test/euroscivoc/scheme']);
+
     $resolver = new SubjectBreadcrumbPathResolverService;
 
     expect($resolver->resolveSchemeUri('NASA/GCMD Earth Science Keywords'))
         ->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
         ->and($resolver->resolveSchemeUri('NASA/GCMD Instruments'))
         ->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments')
+        ->and($resolver->resolveSchemeUri('European Science Vocabulary (EuroSciVoc)'))
+        ->toBe('http://example.test/euroscivoc/scheme')
         ->and($resolver->resolveSchemeUri('Invented Scheme'))
         ->toBeNull();
 });


### PR DESCRIPTION
This pull request significantly improves how subject keywords and their metadata are handled throughout the resource ingestion and storage pipeline. The main focus is on enhancing the normalization, resolution, and enrichment of subject keywords—especially those coming from legacy or incomplete sources—by leveraging a new `SubjectBreadcrumbPathResolverService`. This ensures that subject schemes, URIs, and hierarchical paths are consistently resolved and stored, improving data quality and interoperability.

**Subject Keyword Normalization and Resolution:**

* Enhanced the `DataCiteToResourceTransformer` and `ResourceStorageService` to use `SubjectBreadcrumbPathResolverService` for resolving and normalizing subject keyword values, schemes, scheme URIs, value URIs, and breadcrumb paths—even when some fields are missing or only a path is provided. This includes fallback lookups and normalization logic for legacy DataCite subjects. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R60) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R1092-R1153) [[3]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16R52) [[4]](diffhunk://#diff-ddd7ba0bdcbc61fe1ba6cf21b61c692103eefdabbfda648a6bbc79035bb56b16L1054-L1070)

* Updated the `OldDatasetKeywordTransformer` to resolve missing URIs and scheme URIs for legacy keywords by consulting the resolver service, ensuring that all stored keywords have consistent and complete metadata. [[1]](diffhunk://#diff-da661d69416750b9215f39802550a055e4bc0664a1c2d3f6b8aa0bf4fb3bbd95L59-R98) [[2]](diffhunk://#diff-da661d69416750b9215f39802550a055e4bc0664a1c2d3f6b8aa0bf4fb3bbd95R134-R138)

**Improvements to Subject Vocabulary Indexing and Lookup:**

* Extended `SubjectBreadcrumbPathResolverService` to index subject nodes by both leaf and full path, detect ambiguities, and provide new methods for resolving keywords and scheme URIs from paths or schemes. This includes fallback URIs and configuration-based lookups for various vocabularies. [[1]](diffhunk://#diff-60d19f9665bfc227f91ad2057ab45268acc078f9a68c59004fdf62823f2b0843L14-R55) [[2]](diffhunk://#diff-60d19f9665bfc227f91ad2057ab45268acc078f9a68c59004fdf62823f2b0843R67-R78) [[3]](diffhunk://#diff-60d19f9665bfc227f91ad2057ab45268acc078f9a68c59004fdf62823f2b0843R114-R156) [[4]](diffhunk://#diff-60d19f9665bfc227f91ad2057ab45268acc078f9a68c59004fdf62823f2b0843R209-R232) [[5]](diffhunk://#diff-60d19f9665bfc227f91ad2057ab45268acc078f9a68c59004fdf62823f2b0843R305)

These changes make the system more robust when handling diverse and sometimes incomplete subject metadata, ensuring better data integrity and discoverability.