### PR TITLE
Fix: Merge duplicate Section Header in Data Editor

### DIFF
--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -84,7 +84,7 @@ export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
 const ABSTRACT_MIN_LENGTH = 50;
 const ABSTRACT_MAX_LENGTH = 17500;
 const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
-const SECTION_TRIGGER_CLASS_NAME = 'py-3 hover:no-underline';
+const SECTION_TRIGGER_CLASS_NAME = 'hover:no-underline';
 
 function normalizeAccordionItems(
     items: readonly string[],

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 
 import { ClickableValidationAlert } from '@/components/curation/clickable-validation-alert';
 import { DoiConflictModal } from '@/components/curation/modals/doi-conflict-modal';
-import { SectionHeader } from '@/components/curation/section-header';
+import { AccordionSectionHeader, SectionHelpAction } from '@/components/curation/section-header';
 import { mapBackendErrors, type MappedError } from '@/components/curation/utils/error-field-mapper';
 import { scheduleScrollToError } from '@/components/curation/utils/scroll-to-error';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
@@ -84,6 +84,7 @@ export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
 const ABSTRACT_MIN_LENGTH = 50;
 const ABSTRACT_MAX_LENGTH = 17500;
 const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
+const SECTION_TRIGGER_CLASS_NAME = 'py-3 hover:no-underline';
 
 function normalizeAccordionItems(
     items: readonly string[],
@@ -2286,6 +2287,13 @@ export default function DataCiteForm({
         </>
     );
 
+    const renderSectionActions = (label: string, tooltip?: string) => (
+        <>
+            <SectionHelpAction label={label} tooltip={tooltip} />
+            {renderAccordionActions()}
+        </>
+    );
+
     // Build global error messages array for ValidationAlert when no mapped navigation errors are present.
     const globalErrorMessages = useMemo(() => {
         if (errorMessage && mappedValidationErrors.length === 0) {
@@ -2336,19 +2344,18 @@ export default function DataCiteForm({
             )}
             <Accordion type="multiple" value={visibleOpenAccordionItems} onValueChange={handleAccordionValueChange} className="w-full">
                 <AccordionItem value="resource-info">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Resource Information</span>
-                            {renderStatusBadge(resourceInfoStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="space-y-6">
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Resource Information', 'Required fields: Year, Resource Type, Main Title, Language, Datacenter')}
+                    >
+                        <AccordionSectionHeader
                             label="Resource Information"
                             description="Basic metadata about your dataset including identifiers and type."
-                            tooltip="Required fields: Year, Resource Type, Main Title, Language, Datacenter"
                             required
+                            status={renderStatusBadge(resourceInfoStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent className="space-y-6">
                         <div className="grid gap-4 md:grid-cols-12">
                             <InputField
                                 id="doi"
@@ -2478,20 +2485,22 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="licenses-rights">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Licenses and Rights</span>
-                            {renderStatusBadge(licensesStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions(
+                            'Licenses and Rights',
+                            'At least one license is required. Choose a license that matches your data sharing policy.',
+                        )}
+                    >
+                        <AccordionSectionHeader
                             label="Licenses and Rights"
                             description="Specify usage rights and restrictions for your dataset."
-                            tooltip="At least one license is required. Choose a license that matches your data sharing policy."
                             required
                             counter={{ current: licenseEntries.length, max: MAX_LICENSES }}
+                            status={renderStatusBadge(licensesStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         <div className="space-y-4">
                             {licenseEntries.map((entry, index) => (
                                 <LicenseField
@@ -2518,20 +2527,19 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="authors">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Authors</span>
-                            {renderStatusBadge(authorsStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Authors', 'At least one author is required. Drag to reorder authors.')}
+                    >
+                        <AccordionSectionHeader
                             label="Authors"
                             description="People or institutions who created this work."
-                            tooltip="At least one author is required. Drag to reorder authors."
                             required
                             counter={{ current: authors.length, max: 100 }}
+                            status={renderStatusBadge(authorsStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         {/* Validation issues notification (only after save attempt — Issue #625) */}
                         {hasAttemptedSubmit && <ValidationAlert severity="error" title="Required fields missing" messages={authorValidationIssues} />}
                         {authorRoleNames.length > 0 && (
@@ -2543,19 +2551,18 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="contributors">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Contributors</span>
-                            {renderStatusBadge(contributorsStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Contributors', 'Optional. Contributors can have different roles like Editor, Data Curator, etc.')}
+                    >
+                        <AccordionSectionHeader
                             label="Contributors"
                             description="Additional people who contributed to this work."
-                            tooltip="Optional. Contributors can have different roles like Editor, Data Curator, etc."
                             counter={{ current: contributors.length, max: 100 }}
+                            status={renderStatusBadge(contributorsStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         <ContributorField
                             contributors={contributors}
                             onChange={setContributors}
@@ -2566,19 +2573,21 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="descriptions">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Descriptions</span>
-                            {renderStatusBadge(descriptionsStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions(
+                            'Descriptions',
+                            `Abstract is required (${ABSTRACT_MIN_LENGTH}-${ABSTRACT_MAX_LENGTH.toLocaleString('en-US')} characters). Other description types are optional.`,
+                        )}
+                    >
+                        <AccordionSectionHeader
                             label="Descriptions"
                             description="Detailed information about your dataset."
-                            tooltip={`Abstract is required (${ABSTRACT_MIN_LENGTH}-${ABSTRACT_MAX_LENGTH.toLocaleString('en-US')} characters). Other description types are optional.`}
                             required
+                            status={renderStatusBadge(descriptionsStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         <DescriptionField
                             descriptions={descriptions}
                             onChange={handleDescriptionChange}
@@ -2590,19 +2599,18 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="controlled-vocabularies" ref={controlledVocabulariesRef}>
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Controlled Vocabularies</span>
-                            {renderStatusBadge(controlledVocabulariesStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Controlled Vocabularies', 'Improves discoverability by using NASA GCMD and MSL keywords.')}
+                    >
+                        <AccordionSectionHeader
                             label="Controlled Vocabularies"
                             description="Select keywords from standardized vocabularies."
-                            tooltip="Improves discoverability by using NASA GCMD and MSL keywords."
                             counter={{ current: gcmdKeywords.length, max: 100 }}
+                            status={renderStatusBadge(controlledVocabulariesStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         {isLoadingVocabularies ? (
                             <div className="py-8 text-center text-muted-foreground">Loading vocabularies...</div>
                         ) : (
@@ -2629,57 +2637,57 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="free-keywords">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Free Keywords</span>
-                            {renderStatusBadge(freeKeywordsStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Free Keywords', 'Separate keywords with commas or press Enter.')}
+                    >
+                        <AccordionSectionHeader
                             label="Free Keywords"
                             description="Custom keywords for your dataset."
-                            tooltip="Separate keywords with commas or press Enter."
                             counter={{ current: freeKeywords.length, max: 100 }}
+                            status={renderStatusBadge(freeKeywordsStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         <FreeKeywordsField keywords={freeKeywords} onChange={setFreeKeywords} />
                     </AccordionContent>
                 </AccordionItem>
                 {shouldShowMSLSection && (
                     <AccordionItem value="msl-laboratories">
-                        <AccordionTrigger actions={renderAccordionActions()}>
-                            <div className="flex items-center gap-2">
-                                <span>🔬 Originating Multi-Scale Laboratories</span>
-                                <span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium">EPOS/MSL</span>
-                                {renderStatusBadge(mslLaboratoriesStatus)}
-                            </div>
-                        </AccordionTrigger>
-                        <AccordionContent>
-                            <SectionHeader
+                        <AccordionTrigger
+                            className={SECTION_TRIGGER_CLASS_NAME}
+                            actions={renderSectionActions(
+                                'Originating Multi-Scale Laboratories',
+                                'Appears when EPOS/MSL keywords are detected in your dataset.',
+                            )}
+                        >
+                            <AccordionSectionHeader
                                 label="Originating Multi-Scale Laboratories"
                                 description="Select associated EPOS/MSL laboratories."
-                                tooltip="Appears when EPOS/MSL keywords are detected in your dataset."
                                 counter={{ current: mslLaboratories.length, max: 20 }}
+                                badge={<span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium">EPOS/MSL</span>}
+                                status={renderStatusBadge(mslLaboratoriesStatus)}
                             />
+                        </AccordionTrigger>
+                        <AccordionContent>
                             {mslValidationInfo && <ValidationAlert severity="info" title="Recommendation" messages={[mslValidationInfo.message]} />}
                             <MSLLaboratoriesField selectedLaboratories={mslLaboratories} onChange={setMslLaboratories} />
                         </AccordionContent>
                     </AccordionItem>
                 )}
                 <AccordionItem value="spatial-temporal-coverage">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Spatial and Temporal Coverage</span>
-                            {renderStatusBadge(spatialTemporalCoverageStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Spatial and Temporal Coverage', 'Supports points, boxes, and polygons for geographic coverage.')}
+                    >
+                        <AccordionSectionHeader
                             label="Spatial and Temporal Coverage"
                             description="Geographic and time boundaries of your dataset."
-                            tooltip="Supports points, boxes, and polygons for geographic coverage."
                             counter={{ current: spatialTemporalCoverages.length, max: 50 }}
+                            status={renderStatusBadge(spatialTemporalCoverageStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         <SpatialTemporalCoverageField
                             coverages={spatialTemporalCoverages}
                             apiKey={googleMapsApiKey}
@@ -2688,19 +2696,18 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="dates">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Dates</span>
-                            {renderStatusBadge(datesStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent>
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Dates', 'Add dates like collection period, validity, or other relevant temporal information.')}
+                    >
+                        <AccordionSectionHeader
                             label="Dates"
                             description="Important dates for your dataset."
-                            tooltip="Add dates like collection period, validity, or other relevant temporal information."
                             counter={{ current: dates.length, max: MAX_DATES }}
+                            status={renderStatusBadge(datesStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent>
                         {hasAttemptedSubmit && <ValidationAlert severity="error" title="Date validation issues" messages={dateValidationIssues} />}
                         <div className="space-y-4">
                             {dates.length === 0 ? (
@@ -2751,19 +2758,22 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="related-work" data-testid="related-work-section">
-                    <AccordionTrigger data-testid="related-work-accordion-trigger" actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Related Work</span>
-                            {renderStatusBadge(relatedWorkStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent data-testid="related-work-accordion-content">
-                        <SectionHeader
+                    <AccordionTrigger
+                        data-testid="related-work-accordion-trigger"
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions(
+                            'Related Work',
+                            'DOIs, URLs, Handles, and other DataCite identifier types are supported. Add entries, refine citation labels, and drag cards to reorder them.',
+                        )}
+                    >
+                        <AccordionSectionHeader
                             label="Related Work"
                             description="Links to related publications and datasets."
-                            tooltip="DOIs, URLs, Handles, and other DataCite identifier types are supported. Add entries, refine citation labels, and drag cards to reorder them."
                             counter={{ current: relatedWorks.length, max: 100 }}
+                            status={renderStatusBadge(relatedWorkStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent data-testid="related-work-accordion-content">
                         <RelatedWorkField
                             relatedWorks={relatedWorks}
                             onChange={setRelatedWorks}
@@ -2773,53 +2783,58 @@ export default function DataCiteForm({
                     </AccordionContent>
                 </AccordionItem>
                 <AccordionItem value="citations" data-testid="citations-section">
-                    <AccordionTrigger data-testid="citations-accordion-trigger" actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Citations</span>
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent data-testid="citations-accordion-content">
-                        <SectionHeader
+                    <AccordionTrigger
+                        data-testid="citations-accordion-trigger"
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions(
+                            'Citations',
+                            'Use the Citation Manager to add publications cited by or supplementing this dataset. Each entry carries full metadata (authors, title, year, pages).',
+                        )}
+                    >
+                        <AccordionSectionHeader
                             label="Citations"
                             description="Inline citation metadata (DataCite 4.7 relatedItem)."
-                            tooltip="Use the Citation Manager to add publications cited by or supplementing this dataset. Each entry carries full metadata (authors, title, year, pages)."
                         />
+                    </AccordionTrigger>
+                    <AccordionContent data-testid="citations-accordion-content">
                         <CitationsField resourceId={resolvedResourceId} />
                     </AccordionContent>
                 </AccordionItem>
                 {shouldShowUsedInstrumentsSection && (
                     <AccordionItem value="used-instruments" data-testid="used-instruments-section">
-                        <AccordionTrigger data-testid="used-instruments-accordion-trigger" actions={renderAccordionActions()}>
-                            <div className="flex items-center gap-2">
-                                <span>Used Instruments</span>
-                                {renderStatusBadge(instrumentsStatus)}
-                            </div>
-                        </AccordionTrigger>
-                        <AccordionContent data-testid="used-instruments-accordion-content">
-                            <SectionHeader
+                        <AccordionTrigger
+                            data-testid="used-instruments-accordion-trigger"
+                            className={SECTION_TRIGGER_CLASS_NAME}
+                            actions={renderSectionActions(
+                                'Used Instruments',
+                                'Select instruments from the PID4INST / b2inst registry. Instruments will be linked via Handle PIDs as DataCite relatedIdentifiers.',
+                            )}
+                        >
+                            <AccordionSectionHeader
                                 label="Used Instruments"
                                 description="Research instruments used for data collection."
-                                tooltip="Select instruments from the PID4INST / b2inst registry. Instruments will be linked via Handle PIDs as DataCite relatedIdentifiers."
                                 counter={{ current: instruments.length, max: 100 }}
+                                status={renderStatusBadge(instrumentsStatus)}
                             />
+                        </AccordionTrigger>
+                        <AccordionContent data-testid="used-instruments-accordion-content">
                             <UsedInstrumentsField selectedInstruments={instruments} onChange={setInstruments} />
                         </AccordionContent>
                     </AccordionItem>
                 )}
                 <AccordionItem value="funding-references">
-                    <AccordionTrigger actions={renderAccordionActions()}>
-                        <div className="flex items-center gap-2">
-                            <span>Funding References</span>
-                            {renderStatusBadge(fundingReferencesStatus)}
-                        </div>
-                    </AccordionTrigger>
-                    <AccordionContent id="funding-references-section">
-                        <SectionHeader
+                    <AccordionTrigger
+                        className={SECTION_TRIGGER_CLASS_NAME}
+                        actions={renderSectionActions('Funding References', 'ROR lookup available for funder identification. Include grant numbers when available.')}
+                    >
+                        <AccordionSectionHeader
                             label="Funding References"
                             description="Grant and funder information."
-                            tooltip="ROR lookup available for funder identification. Include grant numbers when available."
                             counter={{ current: fundingReferences.length, max: 50 }}
+                            status={renderStatusBadge(fundingReferencesStatus)}
                         />
+                    </AccordionTrigger>
+                    <AccordionContent id="funding-references-section">
                         <FundingReferenceField value={fundingReferences} onChange={setFundingReferences} />
                     </AccordionContent>
                 </AccordionItem>

--- a/resources/js/components/curation/section-header.tsx
+++ b/resources/js/components/curation/section-header.tsx
@@ -5,6 +5,11 @@ import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
+interface SectionCounter {
+    current: number;
+    max: number;
+}
+
 interface SectionHeaderProps {
     /** Main label text for the section */
     label: string;
@@ -15,10 +20,7 @@ interface SectionHeaderProps {
     /** Whether the section contains required fields */
     required?: boolean;
     /** Counter showing current/max items (e.g., "3 / 10") */
-    counter?: {
-        current: number;
-        max: number;
-    };
+    counter?: SectionCounter;
     /** Action buttons (e.g., CSV Import) aligned to the right */
     actions?: React.ReactNode;
     /** Additional CSS classes for the container */
@@ -27,6 +29,96 @@ interface SectionHeaderProps {
     id?: string;
     /** Test ID for Playwright tests */
     'data-testid'?: string;
+}
+
+interface AccordionSectionHeaderProps {
+    /** Main label text for the section */
+    label: string;
+    /** Short description displayed below the label in muted color */
+    description?: string;
+    /** Whether the section contains required fields */
+    required?: boolean;
+    /** Counter showing current/max items (e.g., "3 / 10") */
+    counter?: SectionCounter;
+    /** Validation/completion indicator shown next to the title */
+    status?: React.ReactNode;
+    /** Optional badge shown next to the title, e.g. "EPOS/MSL" */
+    badge?: React.ReactNode;
+    /** Additional CSS classes for the container */
+    className?: string;
+    /** ID for the label text (useful for aria-labelledby) */
+    id?: string;
+    /** Test ID for Playwright/Vitest tests */
+    'data-testid'?: string;
+}
+
+interface SectionHelpActionProps {
+    /** Section label used for the help button accessible name */
+    label: string;
+    /** Tooltip content shown when hovering/focusing the help icon */
+    tooltip?: string;
+}
+
+export function SectionHelpAction({ label, tooltip }: SectionHelpActionProps) {
+    if (!tooltip) {
+        return null;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    className="inline-flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    aria-label={`Help for ${label}`}
+                >
+                    <HelpCircle className="h-4 w-4" />
+                </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+                {tooltip}
+            </TooltipContent>
+        </Tooltip>
+    );
+}
+
+export function AccordionSectionHeader({
+    label,
+    description,
+    required,
+    counter,
+    status,
+    badge,
+    className,
+    id,
+    'data-testid': dataTestId,
+}: AccordionSectionHeaderProps) {
+    return (
+        <div className={cn('min-w-0 flex-1 space-y-1', className)} data-testid={dataTestId}>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <span id={id} className="text-sm font-semibold">
+                    {label}
+                    {required && (
+                        <span className="ml-0.5 font-bold text-destructive" aria-label="Required">
+                            *
+                        </span>
+                    )}
+                </span>
+
+                {counter && (
+                    <span className="text-sm font-normal text-muted-foreground">
+                        ({counter.current} / {counter.max})
+                    </span>
+                )}
+
+                {badge}
+
+                {status && <span className="inline-flex shrink-0 items-center">{status}</span>}
+            </div>
+
+            {description && <p className="text-sm leading-snug font-normal text-muted-foreground">{description}</p>}
+        </div>
+    );
 }
 
 /**
@@ -76,22 +168,7 @@ export function SectionHeader({
                         )}
                     </Label>
 
-                    {tooltip && (
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <button
-                                    type="button"
-                                    className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                    aria-label={`Help for ${label}`}
-                                >
-                                    <HelpCircle className="h-4 w-4" />
-                                </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="top" className="max-w-xs">
-                                {tooltip}
-                            </TooltipContent>
-                        </Tooltip>
-                    )}
+                    <SectionHelpAction label={label} tooltip={tooltip} />
 
                     {counter && (
                         <span className="text-sm text-muted-foreground">

--- a/resources/js/components/curation/section-header.tsx
+++ b/resources/js/components/curation/section-header.tsx
@@ -69,7 +69,7 @@ export function SectionHelpAction({ label, tooltip }: SectionHelpActionProps) {
             <TooltipTrigger asChild>
                 <button
                     type="button"
-                    className="inline-flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    className="inline-flex items-center justify-center rounded-sm text-muted-foreground ring-offset-background hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                     aria-label={`Help for ${label}`}
                 >
                     <HelpCircle className="h-4 w-4" />

--- a/resources/js/components/curation/section-header.tsx
+++ b/resources/js/components/curation/section-header.tsx
@@ -1,6 +1,7 @@
 import { HelpCircle } from 'lucide-react';
 import * as React from 'react';
 
+import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
@@ -67,13 +68,15 @@ export function SectionHelpAction({ label, tooltip }: SectionHelpActionProps) {
     return (
         <Tooltip>
             <TooltipTrigger asChild>
-                <button
+                <Button
                     type="button"
-                    className="inline-flex items-center justify-center rounded-sm text-muted-foreground ring-offset-background hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
                     aria-label={`Help for ${label}`}
                 >
-                    <HelpCircle className="h-4 w-4" />
-                </button>
+                    <HelpCircle className="h-4 w-4" aria-hidden="true" />
+                </Button>
             </TooltipTrigger>
             <TooltipContent side="top" className="max-w-xs">
                 {tooltip}

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -410,6 +410,57 @@ describe('DataCiteForm', () => {
             />,
         );
 
+    describe('Consolidated accordion section headers', () => {
+        it('renders Resource Information as one visible section header with metadata in the trigger', () => {
+            renderDataCiteForm();
+
+            const resourceTrigger = getAccordionTrigger(/Resource Information/i);
+
+            expect(screen.getAllByText('Resource Information')).toHaveLength(1);
+            expect(within(resourceTrigger).getByText('Resource Information')).toBeInTheDocument();
+            expect(within(resourceTrigger).getByText('Basic metadata about your dataset including identifiers and type.')).toBeInTheDocument();
+            expect(within(resourceTrigger).getByLabelText('Required')).toBeInTheDocument();
+            expect(within(resourceTrigger).getByLabelText('Section incomplete or has errors')).toBeInTheDocument();
+
+            const helpButton = screen.getByRole('button', { name: /Help for Resource Information/i });
+            expect(helpButton.closest('[data-slot="accordion-trigger"]')).toBeNull();
+        });
+
+        it('keeps counters and status indicators in accordion triggers without duplicate content headings', () => {
+            renderDataCiteForm();
+
+            const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
+            const authorsTrigger = getAccordionTrigger(/Authors/i);
+            const contributorsTrigger = getAccordionTrigger(/Contributors/i);
+
+            expect(screen.getAllByText('Licenses and Rights')).toHaveLength(1);
+            expect(within(licensesTrigger).getByText('Specify usage rights and restrictions for your dataset.')).toBeInTheDocument();
+            expect(within(licensesTrigger).getByText('(1 / 99)')).toBeInTheDocument();
+            expect(within(licensesTrigger).getByLabelText('Required')).toBeInTheDocument();
+            expect(within(licensesTrigger).getByLabelText('Section incomplete or has errors')).toBeInTheDocument();
+
+            expect(screen.getAllByText('Authors')).toHaveLength(1);
+            expect(within(authorsTrigger).getByText('(0 / 100)')).toBeInTheDocument();
+            expect(within(authorsTrigger).getByLabelText('Required')).toBeInTheDocument();
+
+            expect(screen.getAllByText('Contributors')).toHaveLength(1);
+            expect(within(contributorsTrigger).getByText('(0 / 100)')).toBeInTheDocument();
+            expect(within(contributorsTrigger).getByLabelText('Optional section')).toBeInTheDocument();
+        });
+
+        it('keeps help actions outside accordion trigger buttons', () => {
+            renderDataCiteForm();
+
+            const resourceTrigger = getAccordionTrigger(/Resource Information/i);
+            const resourceHelp = screen.getByRole('button', { name: /Help for Resource Information/i });
+            const licenseHelp = screen.getByRole('button', { name: /Help for Licenses and Rights/i });
+
+            expect(resourceTrigger).toHaveAttribute('data-slot', 'accordion-trigger');
+            expect(resourceHelp.closest('[data-slot="accordion-trigger"]')).toBeNull();
+            expect(licenseHelp.closest('[data-slot="accordion-trigger"]')).toBeNull();
+        });
+    });
+
     describe('Accordion bulk controls', () => {
         it('renders collapse-all actions next to visible field group triggers and hides expand-all while all are open', async () => {
             renderDataCiteForm();

--- a/tests/vitest/components/curation/section-header.test.tsx
+++ b/tests/vitest/components/curation/section-header.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@tests/vitest/utils/render';
 import { Upload } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 
-import { SectionHeader } from '@/components/curation/section-header';
+import { AccordionSectionHeader, SectionHeader, SectionHelpAction } from '@/components/curation/section-header';
 import { Button } from '@/components/ui/button';
 
 describe('SectionHeader', () => {
@@ -196,5 +196,51 @@ describe('SectionHeader', () => {
             const flexContainer = container.querySelector('.flex.items-center.justify-between');
             expect(flexContainer).toBeInTheDocument();
         });
+    });
+});
+
+describe('AccordionSectionHeader', () => {
+    it('renders title, description, required indicator, counter, badge, and status', () => {
+        render(
+            <AccordionSectionHeader
+                label="Authors"
+                description="People or institutions who created this work."
+                required
+                counter={{ current: 2, max: 100 }}
+                badge={<span>EPOS/MSL</span>}
+                status={<span aria-label="Section incomplete or has errors">status</span>}
+                data-testid="accordion-section-header"
+            />,
+        );
+
+        expect(screen.getByTestId('accordion-section-header')).toBeInTheDocument();
+        expect(screen.getByText('Authors')).toBeInTheDocument();
+        expect(screen.getByText('People or institutions who created this work.')).toBeInTheDocument();
+        expect(screen.getByLabelText('Required')).toBeInTheDocument();
+        expect(screen.getByText('(2 / 100)')).toBeInTheDocument();
+        expect(screen.getByText('EPOS/MSL')).toBeInTheDocument();
+        expect(screen.getByLabelText('Section incomplete or has errors')).toBeInTheDocument();
+    });
+
+    it('omits optional metadata when not provided', () => {
+        render(<AccordionSectionHeader label="Citations" />);
+
+        expect(screen.getByText('Citations')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Required')).not.toBeInTheDocument();
+        expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
+    });
+});
+
+describe('SectionHelpAction', () => {
+    it('renders a help button when tooltip content is provided', () => {
+        render(<SectionHelpAction label="Resource Information" tooltip="Required fields: Year and Resource Type" />);
+
+        expect(screen.getByRole('button', { name: /help for resource information/i })).toBeInTheDocument();
+    });
+
+    it('renders nothing when tooltip content is missing', () => {
+        const { container } = render(<SectionHelpAction label="Resource Information" />);
+
+        expect(container).toBeEmptyDOMElement();
     });
 });


### PR DESCRIPTION
This pull request refactors the section headers and action areas within the `DataCiteForm` component to improve consistency, clarity, and maintainability. The main changes involve introducing a new `AccordionSectionHeader` component, consolidating section actions (such as help tooltips and status badges), and ensuring a uniform appearance and behavior for all accordion sections.

**Component and UI Refactoring:**

* Replaced the use of the `SectionHeader` component with the new `AccordionSectionHeader` component across all accordion sections for a more consistent and flexible section header presentation. (`resources/js/components/curation/datacite-form.tsx`) [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L9-R9) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2339-R2358) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2481-R2503) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2521-R2542) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2546-R2565) [[6]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2569-R2590) [[7]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2593-R2613) [[8]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2632-R2690) [[9]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2691-R2710) [[10]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2754-R2776)

* Added a `SectionHelpAction` component to each section's action area, displaying context-specific tooltips for improved user guidance. (`resources/js/components/curation/datacite-form.tsx`) [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L9-R9) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R2290-R2296)

* Consolidated section actions (help tooltips, status badges, and other actions) into a single `renderSectionActions` helper, which is now passed to each `AccordionTrigger` for a cleaner and more maintainable structure. (`resources/js/components/curation/datacite-form.tsx`)

**Styling and Consistency:**

* Standardized the styling of all `AccordionTrigger` components by introducing a shared `SECTION_TRIGGER_CLASS_NAME` constant, ensuring uniform hover and focus behavior for all section headers. (`resources/js/components/curation/datacite-form.tsx`)

These changes collectively improve the user experience and code maintainability by unifying section header logic, making it easier to update or extend section-level actions and presentation in the future.