### PR TITLE
Fix: Dashboard shows only recent Drafts

### DIFF
--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -109,15 +109,18 @@ type DashboardPageProps = SharedData & {
     dataInstitutionCount?: number;
     igsnInstitutionCount?: number;
     draftCount?: number;
-    recentDrafts?: Array<{
+    recentResources?: Array<{
         id: number;
         title: string;
         updated_at: string | null;
+        status?: 'draft' | 'curation' | 'review' | 'published';
     }>;
     guidedTour?: GuidedTourAutostartPayload | null;
     phpVersion?: string;
     laravelVersion?: string;
 };
+
+type RecentResource = NonNullable<DashboardPageProps['recentResources']>[number];
 
 type DashboardQuickAction = {
     title: string;
@@ -183,6 +186,21 @@ function OverviewMetric({ label, value, description }: { label: string; value: s
     );
 }
 
+function formatResourceStatus(status?: RecentResource['status']) {
+    switch (status) {
+        case 'draft':
+            return 'Draft';
+        case 'curation':
+            return 'Curation';
+        case 'review':
+            return 'Review';
+        case 'published':
+            return 'Published';
+        default:
+            return null;
+    }
+}
+
 function EnvironmentVersionRow({
     label,
     href,
@@ -214,7 +232,7 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
         dataInstitutionCount,
         igsnInstitutionCount,
         draftCount,
-        recentDrafts,
+        recentResources,
         pendingAssistanceTotalCount,
         guidedTour = null,
         phpVersion = '8.4.12',
@@ -236,7 +254,8 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
     const dataInstitutions = typeof dataInstitutionCount === 'number' ? dataInstitutionCount : 0;
     const igsnInstitutions = typeof igsnInstitutionCount === 'number' ? igsnInstitutionCount : 0;
 
-    const recentDraftHref = recentDrafts?.[0] ? editorRoute({ query: { resourceId: recentDrafts[0].id } }).url : '/resources';
+    const hasRecentResources = Boolean(recentResources?.length);
+    const recentResourceHref = recentResources?.[0] ? editorRoute({ query: { resourceId: recentResources[0].id } }).url : '/resources';
 
     const quickActions = useMemo<DashboardQuickAction[]>(() => {
         const actions: DashboardQuickAction[] = [
@@ -248,12 +267,12 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
                 variant: 'default',
             },
             {
-                title: draftCount && draftCount > 0 ? 'Resume latest draft' : 'Browse resources',
+                title: hasRecentResources ? 'Resume latest resource' : 'Browse resources',
                 description:
-                    draftCount && draftCount > 0
-                        ? `Jump back into your most recent draft and keep the momentum.`
+                    hasRecentResources
+                        ? `Jump back into the resource you edited most recently.`
                         : 'Open the resource list to review published and draft records.',
-                href: recentDraftHref,
+                href: recentResourceHref,
                 icon: FolderClock,
             },
             {
@@ -293,7 +312,7 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
         }
 
         return actions;
-    }, [auth.user, draftCount, recentDraftHref]);
+    }, [auth.user, hasRecentResources, recentResourceHref]);
 
     // Easter Egg: Reset everything
     const resetEasterEgg = useCallback(() => {
@@ -442,7 +461,7 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
                                         <div className="space-y-1.5">
                                             <CardTitle className="text-2xl leading-tight break-words">Hello {auth.user.name}!</CardTitle>
                                             <CardDescription className="max-w-2xl text-sm leading-6">
-                                                Start from the task you actually need right now: resume a draft, create a new record, or jump into import without hunting through the navigation.
+                                                Start from the task you actually need right now: resume recent work, create a new record, or jump into import without hunting through the navigation.
                                             </CardDescription>
                                         </div>
                                     </div>
@@ -468,36 +487,47 @@ export default function Dashboard({ onXmlFiles = handleXmlFiles, onJsonFiles = h
                             <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                 <div className="space-y-1">
                                     <CardTitle className="text-lg">Continue where you left off</CardTitle>
-                                    <CardDescription>Your current drafts stay close at hand so you can jump back into work immediately.</CardDescription>
+                                    <CardDescription>Resources you recently edited stay close at hand so you can jump back into work immediately.</CardDescription>
                                 </div>
-                                {(draftCount ?? 0) > 0 && (
+                                {hasRecentResources && (
                                     <Button asChild variant="ghost" className="px-0 text-sm">
-                                        <Link href={recentDraftHref}>Open latest draft</Link>
+                                        <Link href={recentResourceHref}>Open latest resource</Link>
                                     </Button>
                                 )}
                             </CardHeader>
                             <CardContent className="pt-0">
-                                {recentDrafts && recentDrafts.length > 0 ? (
+                                {recentResources && recentResources.length > 0 ? (
                                     <div className="grid gap-3 md:grid-cols-2">
-                                        {recentDrafts.slice(0, 4).map((draft) => (
-                                            <Link
-                                                key={draft.id}
-                                                href={editorRoute({ query: { resourceId: draft.id } }).url}
-                                                className="group rounded-xl border bg-card px-4 py-3 transition-colors hover:border-primary/40 hover:bg-accent/30"
-                                            >
-                                                <p className="line-clamp-2 font-medium leading-6 text-foreground transition-colors group-hover:text-primary">{draft.title}</p>
-                                                <p className="mt-1 text-sm text-muted-foreground">
-                                                    {draft.updated_at ? `Updated ${new Date(draft.updated_at).toLocaleDateString()}` : 'Draft available to resume'}
-                                                </p>
-                                            </Link>
-                                        ))}
+                                        {recentResources.slice(0, 4).map((resource) => {
+                                            const statusLabel = formatResourceStatus(resource.status);
+
+                                            return (
+                                                <Link
+                                                    key={resource.id}
+                                                    href={editorRoute({ query: { resourceId: resource.id } }).url}
+                                                    className="group rounded-xl border bg-card px-4 py-3 transition-colors hover:border-primary/40 hover:bg-accent/30"
+                                                >
+                                                    <div className="flex min-w-0 items-start justify-between gap-2">
+                                                        <p className="line-clamp-2 font-medium leading-6 text-foreground transition-colors group-hover:text-primary">{resource.title}</p>
+                                                        {statusLabel && (
+                                                            <Badge variant="secondary" className="shrink-0 rounded-full text-[0.68rem]">
+                                                                {statusLabel}
+                                                            </Badge>
+                                                        )}
+                                                    </div>
+                                                    <p className="mt-1 text-sm text-muted-foreground">
+                                                        {resource.updated_at ? `Updated ${new Date(resource.updated_at).toLocaleDateString()}` : 'Resource available to resume'}
+                                                    </p>
+                                                </Link>
+                                            );
+                                        })}
                                     </div>
                                 ) : (
                                     <div className="rounded-xl border border-dashed bg-muted/30 p-2">
                                         <EmptyState
                                             icon={<FolderClock className="h-8 w-8" />}
-                                            title="No drafts waiting"
-                                            description="Start a fresh metadata record or import an existing file to create your next working draft."
+                                            title="No recent resources"
+                                            description="Create a metadata record or edit an existing resource to build your personal recent work list."
                                         />
                                     </div>
                                 )}

--- a/routes/web.php
+++ b/routes/web.php
@@ -586,7 +586,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         $draftCount = $draftQuery->count();
 
-        $recentResources = Resource::query()
+        $recentResourceQuery = Resource::query();
+
+        $applyNonIgsnResourceFilter($recentResourceQuery);
+
+        $recentResources = $recentResourceQuery
             ->with([
                 'titles.titleType',
                 'creators',

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,8 +17,8 @@ use App\Http\Controllers\IgsnController;
 use App\Http\Controllers\IgsnImportController;
 use App\Http\Controllers\IgsnMapController;
 use App\Http\Controllers\LandingPageController;
-use App\Http\Controllers\LandingPageDownloadRedirectController;
 use App\Http\Controllers\LandingPageDomainController;
+use App\Http\Controllers\LandingPageDownloadRedirectController;
 use App\Http\Controllers\LandingPagePreviewController;
 use App\Http\Controllers\LandingPagePublicController;
 use App\Http\Controllers\LandingPageTemplateController;
@@ -35,8 +35,8 @@ use App\Http\Controllers\ResourceDoiRegistrationController;
 use App\Http\Controllers\ResourceExportController;
 use App\Http\Controllers\ResourceFilterController;
 use App\Http\Controllers\Settings\PidSettingsController;
-use App\Http\Controllers\StatisticsController;
 use App\Http\Controllers\Settings\ThesaurusSettingsController;
+use App\Http\Controllers\StatisticsController;
 use App\Http\Controllers\TestHelperController;
 use App\Http\Controllers\UploadIgsnCsvController;
 use App\Http\Controllers\UploadJsonController;
@@ -48,6 +48,7 @@ use App\Models\Resource;
 use App\Models\ResourceCreator;
 use App\Models\User;
 use App\Services\GuidedTours\GuidedTourAssignmentService;
+use App\Services\ResourceCacheService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
@@ -515,7 +516,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             shouldAutostart: (bool) $request->session()->get('guided_tours.autostart_after_login', false),
         );
 
-        $physicalObjectTypeId = app(\App\Services\ResourceCacheService::class)->getPhysicalObjectTypeId();
+        $physicalObjectTypeId = app(ResourceCacheService::class)->getPhysicalObjectTypeId();
 
         $applyNonIgsnResourceFilter = static function ($query) use ($physicalObjectTypeId): void {
             if ($physicalObjectTypeId === null) {
@@ -562,38 +563,52 @@ Route::middleware(['auth', 'verified'])->group(function () {
         $applyNonIgsnResourceFilter($draftQuery);
 
         $draftQuery->where(function ($q) {
-                $q->whereNull('publication_year')
-                    ->orWhereNull('resource_type_id')
-                    ->orWhereDoesntHave('creators')
-                    ->orWhereDoesntHave('rights')
-                    ->orWhere(function ($titleQ) {
-                        // No Main Title with non-empty trimmed value
-                        // (legacy: NULL title_type_id counts as MainTitle)
-                        $titleQ->whereDoesntHave('titles', function ($tq) {
-                            $tq->whereRaw("TRIM(value) != ''")
-                                ->where(function ($typeQ) {
-                                    $typeQ->whereNull('title_type_id')
-                                        ->orWhereHas('titleType', fn ($tt) => $tt->where('slug', 'MainTitle'));
-                                });
-                        });
-                    })
-                    ->orWhereDoesntHave('descriptions', function ($dq) {
-                        $dq->whereRaw("TRIM(value) != ''")
-                            ->whereHas('descriptionType', fn ($dt) => $dt->where('slug', 'Abstract'));
+            $q->whereNull('publication_year')
+                ->orWhereNull('resource_type_id')
+                ->orWhereDoesntHave('creators')
+                ->orWhereDoesntHave('rights')
+                ->orWhere(function ($titleQ) {
+                    // No Main Title with non-empty trimmed value
+                    // (legacy: NULL title_type_id counts as MainTitle)
+                    $titleQ->whereDoesntHave('titles', function ($tq) {
+                        $tq->whereRaw("TRIM(value) != ''")
+                            ->where(function ($typeQ) {
+                                $typeQ->whereNull('title_type_id')
+                                    ->orWhereHas('titleType', fn ($tt) => $tt->where('slug', 'MainTitle'));
+                            });
                     });
-            });
+                })
+                ->orWhereDoesntHave('descriptions', function ($dq) {
+                    $dq->whereRaw("TRIM(value) != ''")
+                        ->whereHas('descriptionType', fn ($dt) => $dt->where('slug', 'Abstract'));
+                });
+        });
 
         $draftCount = $draftQuery->count();
 
-        $recentDrafts = (clone $draftQuery)
-            ->with('titles.titleType')
+        $recentResources = Resource::query()
+            ->with([
+                'titles.titleType',
+                'creators',
+                'rights',
+                'descriptions.descriptionType',
+                'landingPage',
+            ])
+            ->where(function ($q) use ($user) {
+                $q->where('updated_by_user_id', $user->id)
+                    ->orWhere(function ($createdQ) use ($user) {
+                        $createdQ->whereNull('updated_by_user_id')
+                            ->where('created_by_user_id', $user->id);
+                    });
+            })
             ->orderBy('updated_at', 'desc')
             ->take(5)
             ->get()
             ->map(fn (Resource $r) => [
                 'id' => $r->id,
-                'title' => $r->mainTitle ?? 'Untitled Draft',
+                'title' => $r->mainTitle ?? 'Untitled Resource',
                 'updated_at' => $r->updated_at?->toISOString(),
+                'status' => $r->publicStatus(),
             ])
             ->all();
 
@@ -601,7 +616,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             'dataInstitutionCount' => $dataInstitutionCount,
             'igsnInstitutionCount' => $igsnInstitutionCount,
             'draftCount' => $draftCount,
-            'recentDrafts' => $recentDrafts,
+            'recentResources' => $recentResources,
             'phpVersion' => PHP_VERSION,
             'laravelVersion' => app()->version(),
             'guidedTour' => $guidedTour,

--- a/tests/pest/Feature/DashboardTest.php
+++ b/tests/pest/Feature/DashboardTest.php
@@ -417,6 +417,35 @@ test('dashboard includes resources created by the authenticated user when they h
         );
 });
 
+test('dashboard recent resources exclude IGSNs because they use the separate IGSN workflow', function () {
+    $user = User::factory()->create();
+    $datasetType = ResourceType::create(['name' => 'Dataset', 'slug' => 'dataset']);
+    $physicalObjectType = ResourceType::create(['name' => 'PhysicalObject', 'slug' => 'physical-object']);
+
+    $datasetResource = createDashboardResource([
+        'resource_type_id' => $datasetType->id,
+        'created_by_user_id' => $user->id,
+        'updated_by_user_id' => null,
+        'updated_at' => now()->subMinutes(10),
+    ], 'Dataset resource');
+
+    createDashboardResource([
+        'resource_type_id' => $physicalObjectType->id,
+        'created_by_user_id' => $user->id,
+        'updated_by_user_id' => null,
+        'updated_at' => now(),
+    ], 'IGSN resource');
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->has('recentResources', 1)
+            ->where('recentResources.0.id', $datasetResource->id)
+            ->where('recentResources.0.title', 'Dataset resource')
+        );
+});
+
 test('dashboard excludes resources created by the user when another user was the last editor', function () {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();

--- a/tests/pest/Feature/DashboardTest.php
+++ b/tests/pest/Feature/DashboardTest.php
@@ -2,17 +2,21 @@
 
 use App\Enums\CacheKey;
 use App\Models\Affiliation;
+use App\Models\Description;
 use App\Models\GuidedTour;
 use App\Models\Person;
 use App\Models\Resource;
 use App\Models\ResourceCreator;
 use App\Models\ResourceType;
-use App\Models\UserGuidedTourAssignment;
+use App\Models\Right;
+use App\Models\Title;
 use App\Models\User;
+use App\Models\UserGuidedTourAssignment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Inertia\Testing\AssertableInertia;
 
-uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+uses(RefreshDatabase::class);
 
 beforeEach(function () {
     if (method_exists(Cache::getStore(), 'tags')) {
@@ -23,6 +27,33 @@ beforeEach(function () {
 
     Cache::flush();
 });
+
+function createDashboardResource(array $attributes = [], ?string $title = null): Resource
+{
+    $resource = Resource::factory()->create($attributes);
+
+    if ($title !== null) {
+        Title::factory()->create([
+            'resource_id' => $resource->id,
+            'value' => $title,
+        ]);
+    }
+
+    return $resource;
+}
+
+function completeDashboardResource(Resource $resource): Resource
+{
+    if ($resource->titles()->count() === 0) {
+        Title::factory()->create(['resource_id' => $resource->id]);
+    }
+
+    ResourceCreator::factory()->create(['resource_id' => $resource->id]);
+    Description::factory()->abstract()->create(['resource_id' => $resource->id]);
+    $resource->rights()->attach(Right::factory()->create());
+
+    return $resource;
+}
 
 test('guests are redirected to the login page', function () {
     $this->get(route('dashboard'))->assertRedirect(route('login'));
@@ -336,7 +367,114 @@ test('dashboard treats all resources as non-IGSN when physical object type is mi
             ->where('dataInstitutionCount', 1)
             ->where('igsnInstitutionCount', 0)
             ->where('draftCount', 1)
-            ->has('recentDrafts', 1)
+            ->has('recentResources', 0)
+        );
+});
+
+test('dashboard shows resources last updated by the authenticated user', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $myResource = createDashboardResource([
+        'created_by_user_id' => $otherUser->id,
+        'updated_by_user_id' => $user->id,
+        'updated_at' => now()->subMinutes(5),
+    ], 'Resource I edited');
+
+    createDashboardResource([
+        'created_by_user_id' => $otherUser->id,
+        'updated_by_user_id' => $otherUser->id,
+        'updated_at' => now(),
+    ], 'Resource edited by someone else');
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->has('recentResources', 1)
+            ->where('recentResources.0.id', $myResource->id)
+            ->where('recentResources.0.title', 'Resource I edited')
+            ->where('recentResources.0.status', 'draft')
+        );
+});
+
+test('dashboard includes resources created by the authenticated user when they have never been updated separately', function () {
+    $user = User::factory()->create();
+
+    $createdResource = createDashboardResource([
+        'created_by_user_id' => $user->id,
+        'updated_by_user_id' => null,
+        'updated_at' => now()->subMinutes(10),
+    ], 'Freshly created resource');
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->has('recentResources', 1)
+            ->where('recentResources.0.id', $createdResource->id)
+            ->where('recentResources.0.title', 'Freshly created resource')
+        );
+});
+
+test('dashboard excludes resources created by the user when another user was the last editor', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    createDashboardResource([
+        'created_by_user_id' => $user->id,
+        'updated_by_user_id' => $otherUser->id,
+        'updated_at' => now(),
+    ], 'Taken over by another editor');
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->has('recentResources', 0)
+        );
+});
+
+test('dashboard recent resources include non-draft resources', function () {
+    $user = User::factory()->create();
+
+    $completeResource = completeDashboardResource(createDashboardResource([
+        'doi' => null,
+        'created_by_user_id' => User::factory()->create()->id,
+        'updated_by_user_id' => $user->id,
+        'updated_at' => now(),
+    ], 'Complete curation resource'));
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->has('recentResources', 1)
+            ->where('recentResources.0.id', $completeResource->id)
+            ->where('recentResources.0.title', 'Complete curation resource')
+            ->where('recentResources.0.status', 'curation')
+        );
+});
+
+test('dashboard recent resources are sorted by update time and limited to five', function () {
+    $user = User::factory()->create();
+
+    $resources = collect(range(0, 6))->map(fn (int $index): Resource => createDashboardResource([
+        'created_by_user_id' => User::factory()->create()->id,
+        'updated_by_user_id' => $user->id,
+        'updated_at' => now()->subMinutes($index),
+    ], "Recent resource {$index}"));
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('dashboard')
+            ->has('recentResources', 5)
+            ->where('recentResources.0.id', $resources[0]->id)
+            ->where('recentResources.1.id', $resources[1]->id)
+            ->where('recentResources.2.id', $resources[2]->id)
+            ->where('recentResources.3.id', $resources[3]->id)
+            ->where('recentResources.4.id', $resources[4]->id)
         );
 });
 

--- a/tests/vitest/pages/__tests__/dashboard.test.tsx
+++ b/tests/vitest/pages/__tests__/dashboard.test.tsx
@@ -159,7 +159,33 @@ describe('Dashboard', () => {
         expect(screen.getByRole('link', { name: /arctic campaign dataset/i })).toHaveAttribute('href', '/editor?resourceId=12');
         expect(screen.getByText('Curation')).toBeInTheDocument();
         expect(screen.getByText('Draft')).toBeInTheDocument();
+        expect(screen.getByText('Resource available to resume')).toBeInTheDocument();
         expect(screen.getByText(/updated/i)).toBeInTheDocument();
+    });
+
+    it('renders review and published status labels while skipping unknown status labels', () => {
+        usePageMock.mockReturnValueOnce({
+            props: {
+                auth: { user: { name: 'Jane' } },
+                dataResourceCount: 17,
+                igsnCount: 5,
+                dataInstitutionCount: 3,
+                igsnInstitutionCount: 2,
+                draftCount: 2,
+                recentResources: [
+                    { id: 21, title: 'Review resource', updated_at: null, status: 'review' },
+                    { id: 22, title: 'Published resource', updated_at: null, status: 'published' },
+                    { id: 23, title: 'Resource without status', updated_at: null },
+                ],
+            },
+        });
+
+        render(<Dashboard />);
+
+        expect(screen.getByText('Review')).toBeInTheDocument();
+        expect(screen.getByText('Published')).toBeInTheDocument();
+        expect(screen.getByText('Resource without status')).toBeInTheDocument();
+        expect(screen.getAllByText('Resource available to resume')).toHaveLength(3);
     });
 
     it('keeps the page container overflow-safe and surfaces the import hub in the side column', () => {

--- a/tests/vitest/pages/__tests__/dashboard.test.tsx
+++ b/tests/vitest/pages/__tests__/dashboard.test.tsx
@@ -87,9 +87,9 @@ describe('Dashboard', () => {
                 phpVersion: '8.4.12',
                 laravelVersion: '12.28.1',
                 draftCount: 2,
-                recentDrafts: [
-                    { id: 12, title: 'Arctic campaign dataset', updated_at: '2026-05-11T10:00:00Z' },
-                    { id: 15, title: 'Rock core collection', updated_at: null },
+                recentResources: [
+                    { id: 12, title: 'Arctic campaign dataset', updated_at: '2026-05-11T10:00:00Z', status: 'curation' },
+                    { id: 15, title: 'Rock core collection', updated_at: null, status: 'draft' },
                 ],
             } 
         });
@@ -149,14 +149,16 @@ describe('Dashboard', () => {
         expect(screen.getByText('0 institutions with sample records')).toBeInTheDocument();
     });
 
-    it('renders role-aware quick actions and recent drafts', () => {
+    it('renders role-aware quick actions and recent resources', () => {
         render(<Dashboard />);
 
         expect(screen.getByRole('link', { name: /create resource/i })).toHaveAttribute('href', '/editor');
-        expect(screen.getByRole('link', { name: /resume latest draft/i })).toHaveAttribute('href', '/editor?resourceId=12');
+        expect(screen.getByRole('link', { name: /resume latest resource/i })).toHaveAttribute('href', '/editor?resourceId=12');
         expect(screen.getByRole('link', { name: /review assistance/i })).toHaveAttribute('href', '/assistance');
         expect(screen.getByRole('link', { name: /adjust settings/i })).toHaveAttribute('href', '/settings');
         expect(screen.getByRole('link', { name: /arctic campaign dataset/i })).toHaveAttribute('href', '/editor?resourceId=12');
+        expect(screen.getByText('Curation')).toBeInTheDocument();
+        expect(screen.getByText('Draft')).toBeInTheDocument();
         expect(screen.getByText(/updated/i)).toBeInTheDocument();
     });
 
@@ -181,7 +183,7 @@ describe('Dashboard', () => {
         expect(screen.queryByRole('link', { name: /upload metadata/i })).not.toBeInTheDocument();
     });
 
-    it('renders an actionable empty state when there are no drafts', () => {
+    it('renders an actionable empty state when there are no recent resources', () => {
         usePageMock.mockReturnValueOnce({
             props: {
                 auth: { user: { name: 'Jane' } },
@@ -190,13 +192,13 @@ describe('Dashboard', () => {
                 dataInstitutionCount: 3,
                 igsnInstitutionCount: 2,
                 draftCount: 0,
-                recentDrafts: [],
+                recentResources: [],
             },
         });
 
         render(<Dashboard />);
 
-        expect(screen.getByText('No drafts waiting')).toBeInTheDocument();
+        expect(screen.getByText('No recent resources')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /browse resources/i })).toHaveAttribute('href', '/resources');
     });
 
@@ -493,4 +495,3 @@ describe('handleJsonFiles', () => {
         document.cookie = 'XSRF-TOKEN=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     });
 });
-


### PR DESCRIPTION
This pull request updates the dashboard to show a list of recently edited resources instead of just drafts, making it easier for users to resume any recent work regardless of its status. The backend now provides a list of up to five recently edited or created resources (excluding IGSNs), each with its status, and the frontend displays these with improved labels and logic. The test suite is expanded to cover the new behavior and edge cases.

**Dashboard resource recency & status improvements:**

* The backend replaces the old `recentDrafts` logic with a new `recentResources` query that collects up to five resources recently edited or created by the authenticated user, including their status and excluding IGSNs. The returned structure includes `id`, `title`, `updated_at`, and `status` for each resource.
* The frontend updates all references from `recentDrafts` to `recentResources`, adapts UI labels (e.g., "Resume latest draft" → "Resume latest resource"), and displays the resource status using a new `formatResourceStatus` function. [[1]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL112-R124) [[2]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL217-R235) [[3]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL239-R258) [[4]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL251-R275) [[5]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL296-R315) [[6]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL445-R464) [[7]](diffhunk://#diff-7338e728a7e43c85ef3cacc41877d8f6ef157ecd12999065e95a043ba3388a2bL471-R530)

**Test coverage enhancements:**

* The test suite now includes new helper functions for creating resources and fully populating them with related data.
* Additional tests verify that the dashboard correctly lists recent resources by the authenticated user, handles resources created but not updated, excludes IGSNs, omits resources last edited by another user, includes non-draft resources, and limits the list to five sorted by update time.

**Minor codebase cleanups:**

* Small improvements to route imports and usage of the resource cache service for consistency. [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL20-R21) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL38-R39) [[3]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR51) [[4]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL518-R519)
* Test imports are reorganized for clarity and consistency.

These changes collectively make the dashboard more useful for users by showing all their recent work, not just drafts, and ensure robust test coverage for the new behavior.