### PR TITLE
Fix: Handle missing FK drops in resource_rights migrations

### DIFF
--- a/database/migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php
+++ b/database/migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -121,9 +122,20 @@ return new class extends Migration
             return;
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table) use ($constraint): void {
-            $table->dropForeign($constraint);
-        });
+        $this->dropForeignKeyNamed($constraint);
+    }
+
+    private function dropForeignKeyNamed(string $constraint): void
+    {
+        try {
+            Schema::table(self::TABLE, function (Blueprint $table) use ($constraint): void {
+                $table->dropForeign($constraint);
+            });
+        } catch (QueryException $exception) {
+            if (! $this->isMissingForeignKeyDropError($exception)) {
+                throw $exception;
+            }
+        }
     }
 
     private function foreignKeyName(string $column): ?string
@@ -144,6 +156,16 @@ return new class extends Migration
         return is_string($result->constraint_name ?? null)
             ? $result->constraint_name
             : null;
+    }
+
+    private function isMissingForeignKeyDropError(QueryException $exception): bool
+    {
+        $sqlState = (string) ($exception->errorInfo[0] ?? '');
+        $driverCode = (string) ($exception->errorInfo[1] ?? '');
+
+        return $driverCode === '1091'
+            && in_array($sqlState, ['42000', '42S02'], true)
+            && str_contains($exception->getMessage(), "Can't DROP");
     }
 
     /**

--- a/database/migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php
+++ b/database/migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
@@ -163,9 +165,7 @@ return new class extends Migration
         $sqlState = (string) ($exception->errorInfo[0] ?? '');
         $driverCode = (string) ($exception->errorInfo[1] ?? '');
 
-        return $driverCode === '1091'
-            && in_array($sqlState, ['42000', '42S02'], true)
-            && str_contains($exception->getMessage(), "Can't DROP");
+        return $sqlState === '42000' && $driverCode === '1091';
     }
 
     /**

--- a/database/migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php
+++ b/database/migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php
@@ -155,7 +155,11 @@ return new class extends Migration
             [self::TABLE, $column],
         );
 
-        return is_string($result->constraint_name ?? null)
+        if ($result === null) {
+            return null;
+        }
+
+        return is_string($result->constraint_name)
             ? $result->constraint_name
             : null;
     }

--- a/database/migrations/2026_06_16_000001_repair_resource_rights_raw_fields_schema.php
+++ b/database/migrations/2026_06_16_000001_repair_resource_rights_raw_fields_schema.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -114,9 +115,20 @@ return new class extends Migration
             return;
         }
 
-        Schema::table(self::TABLE, function (Blueprint $table) use ($constraint): void {
-            $table->dropForeign($constraint);
-        });
+        $this->dropForeignKeyNamed($constraint);
+    }
+
+    private function dropForeignKeyNamed(string $constraint): void
+    {
+        try {
+            Schema::table(self::TABLE, function (Blueprint $table) use ($constraint): void {
+                $table->dropForeign($constraint);
+            });
+        } catch (QueryException $exception) {
+            if (! $this->isMissingForeignKeyDropError($exception)) {
+                throw $exception;
+            }
+        }
     }
 
     private function foreignKeyName(string $column): ?string
@@ -151,5 +163,15 @@ return new class extends Migration
         }
 
         return null;
+    }
+
+    private function isMissingForeignKeyDropError(QueryException $exception): bool
+    {
+        $sqlState = (string) ($exception->errorInfo[0] ?? '');
+        $driverCode = (string) ($exception->errorInfo[1] ?? '');
+
+        return $driverCode === '1091'
+            && in_array($sqlState, ['42000', '42S02'], true)
+            && str_contains($exception->getMessage(), "Can't DROP");
     }
 };

--- a/database/migrations/2026_06_16_000001_repair_resource_rights_raw_fields_schema.php
+++ b/database/migrations/2026_06_16_000001_repair_resource_rights_raw_fields_schema.php
@@ -147,7 +147,11 @@ return new class extends Migration
                 [self::TABLE, $column],
             );
 
-            return is_string($result->constraint_name ?? null)
+            if ($result === null) {
+                return null;
+            }
+
+            return is_string($result->constraint_name)
                 ? $result->constraint_name
                 : null;
         }

--- a/database/migrations/2026_06_16_000001_repair_resource_rights_raw_fields_schema.php
+++ b/database/migrations/2026_06_16_000001_repair_resource_rights_raw_fields_schema.php
@@ -170,8 +170,6 @@ return new class extends Migration
         $sqlState = (string) ($exception->errorInfo[0] ?? '');
         $driverCode = (string) ($exception->errorInfo[1] ?? '');
 
-        return $driverCode === '1091'
-            && in_array($sqlState, ['42000', '42S02'], true)
-            && str_contains($exception->getMessage(), "Can't DROP");
+        return $sqlState === '42000' && $driverCode === '1091';
     }
 };

--- a/tests/pest/Feature/Database/RepairResourceRightsRawFieldsSchemaMigrationTest.php
+++ b/tests/pest/Feature/Database/RepairResourceRightsRawFieldsSchemaMigrationTest.php
@@ -19,6 +19,13 @@ function loadRepairResourceRightsRawFieldsSchemaMigration(): Migration
     return $migration;
 }
 
+function dropRepairResourceRightsForeignKeyNamed(Migration $migration, string $constraint): void
+{
+    $method = new ReflectionMethod($migration, 'dropForeignKeyNamed');
+    $method->setAccessible(true);
+    $method->invoke($migration, $constraint);
+}
+
 function skipUnlessMysqlForResourceRightsRepair(): void
 {
     $driver = DB::connection()->getDriverName();
@@ -123,6 +130,21 @@ it('repairs resource_rights when rights_id has a non-standard foreign key name',
     expect($foreignKey->CONSTRAINT_NAME)->toBe('resource_rights_rights_id_foreign')
         ->and($foreignKey->DELETE_RULE)->toBe('SET NULL')
         ->and(Schema::hasIndex('resource_rights', 'resource_rights_resource_source_idx'))->toBeTrue();
+});
+
+it('ignores a stale rights_id foreign key name that is already absent during repair', function (): void {
+    skipUnlessMysqlForResourceRightsRepair();
+    recreateLegacyResourceRightsTable(null);
+
+    $migration = loadRepairResourceRightsRawFieldsSchemaMigration();
+
+    dropRepairResourceRightsForeignKeyNamed($migration, 'resource_rights_rights_id_foreign');
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(resourceRightsColumn('rights_id')->IS_NULLABLE)->toBe('YES')
+        ->and(resourceRightsRightsForeignKey()->DELETE_RULE)->toBe('SET NULL');
 });
 
 it('repairs resource_rights when the rights_id foreign key is already missing', function (): void {

--- a/tests/pest/Feature/Database/RepairResourceRightsRawFieldsSchemaMigrationTest.php
+++ b/tests/pest/Feature/Database/RepairResourceRightsRawFieldsSchemaMigrationTest.php
@@ -9,6 +9,16 @@ use Illuminate\Support\Facades\Schema;
 
 uses()->group('database', 'mysql-sensitive');
 
+function loadAddRawRightsFieldsToResourceRightsMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path(
+        'migrations/2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php'
+    );
+
+    return $migration;
+}
+
 function loadRepairResourceRightsRawFieldsSchemaMigration(): Migration
 {
     /** @var Migration $migration */
@@ -17,6 +27,13 @@ function loadRepairResourceRightsRawFieldsSchemaMigration(): Migration
     );
 
     return $migration;
+}
+
+function dropAddRawRightsFieldsForeignKeyNamed(Migration $migration, string $constraint): void
+{
+    $method = new ReflectionMethod($migration, 'dropForeignKeyNamed');
+    $method->setAccessible(true);
+    $method->invoke($migration, $constraint);
 }
 
 function dropRepairResourceRightsForeignKeyNamed(Migration $migration, string $constraint): void
@@ -130,6 +147,30 @@ it('repairs resource_rights when rights_id has a non-standard foreign key name',
     expect($foreignKey->CONSTRAINT_NAME)->toBe('resource_rights_rights_id_foreign')
         ->and($foreignKey->DELETE_RULE)->toBe('SET NULL')
         ->and(Schema::hasIndex('resource_rights', 'resource_rights_resource_source_idx'))->toBeTrue();
+});
+
+it('ignores a stale rights_id foreign key name in the original raw rights migration', function (): void {
+    skipUnlessMysqlForResourceRightsRepair();
+    recreateLegacyResourceRightsTable(null);
+
+    $migration = loadAddRawRightsFieldsToResourceRightsMigration();
+
+    dropAddRawRightsFieldsForeignKeyNamed($migration, 'resource_rights_rights_id_foreign');
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(resourceRightsColumn('rights_id')->IS_NULLABLE)->toBe('YES')
+        ->and(resourceRightsRightsForeignKey()->DELETE_RULE)->toBe('SET NULL')
+        ->and(Schema::hasColumns('resource_rights', [
+            'rights_text',
+            'rights_uri',
+            'rights_identifier',
+            'rights_identifier_scheme',
+            'scheme_uri',
+            'language',
+            'source',
+        ]))->toBeTrue();
 });
 
 it('ignores a stale rights_id foreign key name that is already absent during repair', function (): void {


### PR DESCRIPTION
This pull request improves the robustness of two database migrations (`2026_06_10_000001_add_raw_rights_fields_to_resource_rights.php` and `2026_06_16_000001_repair_resource_rights_raw_fields_schema.php`) by making foreign key drops idempotent and handling cases where a foreign key constraint may already be missing. It also adds comprehensive tests to verify these behaviors.

**Migration robustness improvements:**

* Refactored both migrations to extract foreign key dropping logic into a new `dropForeignKeyNamed` method, which now catches and ignores errors when a foreign key constraint is already absent, ensuring idempotency. [[1]](diffhunk://#diff-68f68b4f6ba21970465cb7c6d9a93420adba24643095a2ffdd8682c8266334c6R127-R140) [[2]](diffhunk://#diff-244d16a6ad5ba5082f85b0a8abf0d8da3639a33d4236aa38e331628157ed76edR118-R131)
* Added a helper method `isMissingForeignKeyDropError` to detect and safely ignore MySQL error 1091 (attempt to drop a non-existent foreign key), preventing migration failures in those cases. [[1]](diffhunk://#diff-68f68b4f6ba21970465cb7c6d9a93420adba24643095a2ffdd8682c8266334c6L144-R174) [[2]](diffhunk://#diff-244d16a6ad5ba5082f85b0a8abf0d8da3639a33d4236aa38e331628157ed76edR171-R178)
* Improved the `foreignKeyName` methods to explicitly return `null` when no constraint is found, clarifying intent and avoiding potential issues. [[1]](diffhunk://#diff-68f68b4f6ba21970465cb7c6d9a93420adba24643095a2ffdd8682c8266334c6L144-R174) [[2]](diffhunk://#diff-244d16a6ad5ba5082f85b0a8abf0d8da3639a33d4236aa38e331628157ed76edL138-R154)

**Testing enhancements:**

* Added new test helpers and test cases in `RepairResourceRightsRawFieldsSchemaMigrationTest.php` to directly invoke the new foreign key drop logic and verify that migrations proceed without error when foreign keys are already missing. [[1]](diffhunk://#diff-0b94d8a29f7517f52a71537ddb73ce57b52c1aaf2f5f5e7e0bbd67ae5a249d6cR12-R21) [[2]](diffhunk://#diff-0b94d8a29f7517f52a71537ddb73ce57b52c1aaf2f5f5e7e0bbd67ae5a249d6cR32-R45) [[3]](diffhunk://#diff-0b94d8a29f7517f52a71537ddb73ce57b52c1aaf2f5f5e7e0bbd67ae5a249d6cR152-R190)