### PR TITLE
Fix: Prefer embedded DataCite XML rights on import

### DIFF
--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -37,11 +37,13 @@ use App\Models\Title;
 use App\Models\TitleType;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\Rights\ResourceRightsStorageService;
+use App\Services\Xml\Sections\RightsSectionParser;
 use App\Support\OrcidNormalizer;
 use App\Support\SubjectBreadcrumbPath;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Saloon\XmlWrangler\XmlReader;
 
 /**
  * Transforms DataCite API JSON responses into ERNIE Resource models.
@@ -59,6 +61,7 @@ class DataCiteToResourceTransformer
         private ?ResourceRightsStorageService $resourceRightsStorage = null,
         private ?RorLookupService $rorLookupService = null,
         private ?SubjectBreadcrumbPathResolverService $subjectBreadcrumbPathResolver = null,
+        private ?RightsSectionParser $xmlRightsParser = null,
     ) {}
 
     /**
@@ -140,6 +143,8 @@ class DataCiteToResourceTransformer
      */
     private function prepareAttributes(array $attributes): array
     {
+        $attributes = $this->preferOriginalXmlRights($attributes);
+
         $relatedIdentifiers = $attributes['relatedIdentifiers'] ?? null;
 
         if (! is_array($relatedIdentifiers)) {
@@ -189,6 +194,67 @@ class DataCiteToResourceTransformer
         $attributes['relatedIdentifiers'] = $relatedIdentifiers;
 
         return $attributes;
+    }
+
+    /**
+     * Prefer the embedded original DataCite XML rights over API-normalized rights.
+     *
+     * The `/resources` legacy import consumes the DataCite REST API. That API may
+     * expose SPDX-like fields in `attributes.rightsList` even when the deposited
+     * XML only contained a plain legacy rights statement. For import review, the
+     * embedded original XML is the source of truth; SPDX completion belongs to
+     * the assistant workflow.
+     *
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    private function preferOriginalXmlRights(array $attributes): array
+    {
+        $xml = $this->decodedOriginalXml($attributes['xml'] ?? null);
+
+        if ($xml === null) {
+            return $attributes;
+        }
+
+        try {
+            $rightsList = ($this->xmlRightsParser ??= new RightsSectionParser)
+                ->parseRawRights(XmlReader::fromString($xml));
+        } catch (\Throwable $exception) {
+            Log::debug('Could not parse original DataCite XML rights during import; using API rightsList fallback.', [
+                'doi' => $attributes['doi'] ?? null,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return $attributes;
+        }
+
+        if ($rightsList === []) {
+            return $attributes;
+        }
+
+        $attributes['rightsList'] = array_map(
+            function (array $statement): array {
+                $statement['source'] = 'datacite-import';
+
+                return $statement;
+            },
+            $rightsList,
+        );
+
+        return $attributes;
+    }
+
+    private function decodedOriginalXml(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = trim($value);
+        $decoded = base64_decode($value, true);
+        $xml = $decoded === false ? $value : $decoded;
+
+        return str_contains($xml, '<') ? $xml : null;
     }
 
     private function citationLabelService(): RelatedIdentifierCitationLabelService

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -10,10 +10,12 @@ use App\Models\Publisher;
 use App\Models\Resource;
 use App\Models\ResourceRight;
 use App\Models\ResourceType;
+use App\Models\Right;
 use App\Models\TitleType;
 use App\Models\User;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\DataCiteToResourceTransformer;
+use App\Services\Spdx\SpdxRightsMatchInputProvider;
 use Database\Seeders\ContributorTypeSeeder;
 use Database\Seeders\DateTypeSeeder;
 use Database\Seeders\DescriptionTypeSeeder;
@@ -68,6 +70,69 @@ describe('DataCiteToResourceTransformer - rights import', function (): void {
             ->and($resourceRight->rights_uri)->toBe('http://creativecommons.org/licenses/by/4.0')
             ->and($resourceRight->language)->toBe('en')
             ->and($resourceRight->source)->toBe('datacite-import');
+    });
+
+    it('prefers embedded DataCite XML rights over API-normalized SPDX rights during legacy import', function (): void {
+        Right::create([
+            'identifier' => 'CC-BY-4.0',
+            'name' => 'Creative Commons Attribution 4.0 International',
+            'uri' => 'https://spdx.org/licenses/CC-BY-4.0.html',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+        ]);
+
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $originalXml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <rightsList>
+    <rights rightsURI="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</rights>
+  </rightsList>
+</resource>
+XML;
+
+        $doiData = [
+            'attributes' => [
+                'doi' => '10.5880/fidgeo.2026.052',
+                'publicationYear' => 2026,
+                'language' => 'en',
+                'titles' => [['title' => 'Original XML rights test']],
+                'creators' => [
+                    ['familyName' => 'Tester', 'givenName' => 'Rights', 'nameType' => 'Personal'],
+                ],
+                'rightsList' => [
+                    [
+                        'rights' => 'Creative Commons Attribution 4.0 International',
+                        'rightsUri' => 'https://creativecommons.org/licenses/by/4.0/legalcode',
+                        'rightsIdentifier' => 'cc-by-4.0',
+                        'rightsIdentifierScheme' => 'SPDX',
+                        'schemeUri' => 'https://spdx.org/licenses/',
+                    ],
+                ],
+                'xml' => base64_encode($originalXml),
+            ],
+        ];
+
+        $resource = $transformer->transform($doiData, $user->id);
+        $resourceRight = ResourceRight::where('resource_id', $resource->id)->sole();
+
+        expect($resourceRight->rights_id)->toBeNull()
+            ->and($resourceRight->rights_text)->toBe('CC BY 4.0')
+            ->and($resourceRight->rights_uri)->toBe('http://creativecommons.org/licenses/by/4.0/')
+            ->and($resourceRight->rights_identifier)->toBeNull()
+            ->and($resourceRight->rights_identifier_scheme)->toBeNull()
+            ->and($resourceRight->scheme_uri)->toBeNull()
+            ->and($resourceRight->source)->toBe('datacite-import');
+
+        $pendingInputs = (new SpdxRightsMatchInputProvider)
+            ->pendingInputs()
+            ->where('resourceId', $resource->id)
+            ->values();
+
+        expect($pendingInputs)->toHaveCount(1)
+            ->and($pendingInputs->first()->rightsText)->toBe('CC BY 4.0')
+            ->and($pendingInputs->first()->rightsIdentifier)->toBeNull();
     });
 });
 


### PR DESCRIPTION
This pull request updates the `DataCiteToResourceTransformer` service to prefer rights information embedded in the original DataCite XML over the API-normalized SPDX rights during legacy imports. This ensures that the import process uses the most accurate and original rights statements, improving data fidelity for downstream workflows. The change is covered by a new feature test.

**Improvements to rights handling during import:**

* The transformer now attempts to extract rights information from the embedded DataCite XML (if present) using the `RightsSectionParser`, falling back to the API-provided rights list only if XML parsing fails or no rights are found. This gives priority to the source-of-truth rights statements deposited in the original XML. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R146-R147) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R199-R259)
* The constructor of `DataCiteToResourceTransformer` and its dependencies are updated to support the new XML rights parser. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R40-R46) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R64)

**Testing and validation:**

* A new feature test verifies that, when both API-normalized SPDX rights and embedded XML rights are present, the transformer prefers the XML rights. The test checks that the resulting `ResourceRight` record matches the XML data and that SPDX completion is deferred to the assistant workflow.
* Additional imports and setup in the test file support the new test scenario.