### PR TITLE
Fix: Style of Funding Reference Cards

### DIFF
--- a/resources/js/components/curation/fields/funding-reference/funding-reference-item.tsx
+++ b/resources/js/components/curation/fields/funding-reference/funding-reference-item.tsx
@@ -123,7 +123,7 @@ export function FundingReferenceItem({
 
     return (
         <section
-            className="rounded-lg border border-l-4 border-input border-l-gfz-primary/70 bg-background p-6 shadow-sm transition-colors focus-within:border-ring focus-within:border-l-gfz-primary focus-within:ring-[3px] focus-within:ring-ring/50 hover:border-ring/70 hover:border-l-gfz-primary"
+            className="rounded-lg border border-l-4 border-border border-l-gfz-primary bg-card p-6 text-card-foreground shadow-md transition-[border-color,box-shadow] focus-within:border-ring focus-within:border-l-gfz-primary focus-within:ring-[3px] focus-within:ring-ring/50 hover:border-ring/70 hover:border-l-gfz-primary hover:shadow-lg"
             aria-labelledby={`${funding.id}-heading`}
             data-testid="funding-reference-card"
         >

--- a/tests/vitest/components/curation/fields/funding-reference/__tests__/funding-reference-item.test.tsx
+++ b/tests/vitest/components/curation/fields/funding-reference/__tests__/funding-reference-item.test.tsx
@@ -73,10 +73,12 @@ describe('FundingReferenceItem', () => {
         render(<FundingReferenceItem {...defaultProps} funding={validFunding} />);
 
         const card = screen.getByTestId('funding-reference-card');
-        expect(card).toHaveClass('bg-background');
-        expect(card).toHaveClass('border-input');
+        expect(card).toHaveClass('bg-card');
+        expect(card).toHaveClass('text-card-foreground');
+        expect(card).toHaveClass('border-border');
         expect(card).toHaveClass('border-l-4');
-        expect(card).toHaveClass('border-l-gfz-primary/70');
+        expect(card).toHaveClass('border-l-gfz-primary');
+        expect(card).toHaveClass('shadow-md');
         expect(card).toHaveClass('focus-within:ring-[3px]');
         expect(card).not.toHaveClass('bg-muted');
         expect(card).not.toHaveClass('bg-muted/30');


### PR DESCRIPTION
This pull request updates the visual styling of the `FundingReferenceItem` component and its corresponding test to use new color and shadow classes, aligning it with the latest design system tokens.

Styling updates:

* Updated the `FundingReferenceItem` component to use `bg-card`, `text-card-foreground`, `border-border`, and `shadow-md` classes, replacing the previous `bg-background`, `border-input`, and lighter shadow classes. This also removes the `/70` opacity modifier from the left border color. (`resources/js/components/curation/fields/funding-reference/funding-reference-item.tsx`)

Test updates:

* Updated the test for `FundingReferenceItem` to assert the presence of the new classes and ensure the component uses the updated design tokens. (`tests/vitest/components/curation/fields/funding-reference/__tests__/funding-reference-item.test.tsx`)