### PR TITLE
Fix: Draft saving with incomplete Resources

### DIFF
--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -469,16 +469,20 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             // Normalize roles
-            $roles = [];
-            $rawRoles = $contributor['roles'] ?? [];
+            $roles = null;
+            $rawRoles = $contributor['roles'] ?? null;
 
             if (is_array($rawRoles)) {
+                $roles = [];
+
                 foreach ($rawRoles as $role) {
                     $normalizedRole = trim((string) $role);
                     if ($normalizedRole !== '') {
                         $roles[] = $normalizedRole;
                     }
                 }
+            } elseif (array_key_exists('roles', $contributor)) {
+                $roles = $rawRoles;
             }
 
             if (! in_array($type, ['person', 'institution'], true)) {
@@ -892,6 +896,7 @@ class StoreDraftResourceRequest extends FormRequest
             // Contributors
             'contributors.*.type.required' => '[Contributors] Contributor #:position must have a type (person or institution).',
             'contributors.*.type.in' => '[Contributors] Contributor #:position has an invalid type.',
+            'contributors.*.roles.array' => '[Contributors] Contributor #:position roles must be a valid list.',
             'contributors.*.roles.required' => '[Contributors] Contributor #:position must have at least one role.',
             'contributors.*.roles.min' => '[Contributors] Contributor #:position must have at least one role.',
             'contributors.*.email.email' => '[Contributors] Contributor #:position has an invalid email address.',

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -482,10 +482,7 @@ class StoreDraftResourceRequest extends FormRequest
                         continue;
                     }
 
-                    $normalizedRole = trim($role);
-                    if ($normalizedRole !== '') {
-                        $roles[$roleIndex] = $normalizedRole;
-                    }
+                    $roles[$roleIndex] = trim($role);
                 }
             } elseif (array_key_exists('roles', $contributor)) {
                 $roles = $rawRoles;

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -17,8 +17,9 @@ use Illuminate\Validation\Validator;
 /**
  * Relaxed validation for saving draft resources (Issue #548).
  *
- * Only requires a Main Title. All other fields are optional but still
- * structurally validated when provided (e.g. valid email format, existing FKs).
+ * Only requires a Main Title. All other fields are optional. Complete related
+ * entries are structurally validated when provided, while incomplete draft-only
+ * author/contributor rows are ignored until they can be saved safely.
  */
 class StoreDraftResourceRequest extends FormRequest
 {
@@ -88,7 +89,7 @@ class StoreDraftResourceRequest extends FormRequest
             'contributors' => ['nullable', 'array'],
             'contributors.*.type' => ['required', Rule::in(['person', 'institution'])],
             'contributors.*.position' => ['required', 'integer', 'min:0'],
-            'contributors.*.roles' => ['required', 'array', 'min:1'],
+            'contributors.*.roles' => ['nullable', 'array'],
             'contributors.*.roles.*' => ['required', 'string', 'max:255'],
             'contributors.*.orcid' => ['nullable', 'string', 'max:255'],
             'contributors.*.firstName' => ['nullable', 'string', 'max:255'],
@@ -286,7 +287,7 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             $typeCandidate = isset($author['type']) ? trim((string) $author['type']) : '';
-            $type = in_array($typeCandidate, ['person', 'institution'], true) ? $typeCandidate : 'person';
+            $type = $typeCandidate !== '' ? $typeCandidate : 'person';
 
             $affiliations = [];
             $seenAffiliations = [];
@@ -346,6 +347,16 @@ class StoreDraftResourceRequest extends FormRequest
                 }
             }
 
+            if (! in_array($type, ['person', 'institution'], true)) {
+                $authors[] = [
+                    'type' => $type,
+                    'affiliations' => $affiliations,
+                    'position' => (int) $index,
+                ];
+
+                continue;
+            }
+
             if ($type === 'institution') {
                 $authors[] = [
                     'type' => 'institution',
@@ -381,6 +392,11 @@ class StoreDraftResourceRequest extends FormRequest
             ];
         }
 
+        $authors = array_values(array_filter(
+            $authors,
+            fn (array $author): bool => $this->shouldKeepDraftAuthor($author),
+        ));
+
         /** @var array<int, array<string, mixed>|mixed> $rawContributors */
         $rawContributors = $this->input('contributors', []);
 
@@ -392,7 +408,7 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             $typeCandidate = isset($contributor['type']) ? trim((string) $contributor['type']) : '';
-            $type = in_array($typeCandidate, ['person', 'institution'], true) ? $typeCandidate : 'person';
+            $type = $typeCandidate !== '' ? $typeCandidate : 'person';
 
             $affiliations = [];
             $seenAffiliations = [];
@@ -465,6 +481,17 @@ class StoreDraftResourceRequest extends FormRequest
                 }
             }
 
+            if (! in_array($type, ['person', 'institution'], true)) {
+                $contributors[] = [
+                    'type' => $type,
+                    'roles' => $roles,
+                    'affiliations' => $affiliations,
+                    'position' => (int) $index,
+                ];
+
+                continue;
+            }
+
             if ($type === 'institution') {
                 $contributors[] = [
                     'type' => 'institution',
@@ -491,6 +518,11 @@ class StoreDraftResourceRequest extends FormRequest
                 'position' => (int) $index,
             ];
         }
+
+        $contributors = array_values(array_filter(
+            $contributors,
+            fn (array $contributor): bool => $this->shouldKeepDraftContributor($contributor),
+        ));
 
         // Normalize descriptions
         /** @var array<int, array<string, mixed>|mixed> $rawDescriptions */
@@ -994,97 +1026,6 @@ class StoreDraftResourceRequest extends FormRequest
                     );
                 }
             },
-            // Validate person authors have lastName if provided, contact persons have email
-            function (Validator $validator): void {
-                /** @var mixed $candidateAuthors */
-                $candidateAuthors = $this->input('authors', []);
-
-                if (! is_array($candidateAuthors) || count($candidateAuthors) === 0) {
-                    // Authors are optional for drafts
-                    return;
-                }
-
-                foreach ($candidateAuthors as $index => $author) {
-                    if (! is_array($author)) {
-                        $validator->errors()->add(
-                            "authors.$index",
-                            '[Authors] Author #'.($index + 1).' must be a valid entry.',
-                        );
-
-                        continue;
-                    }
-
-                    $type = $author['type'] ?? 'person';
-
-                    if ($type === 'person') {
-                        if (empty($author['lastName'])) {
-                            $validator->errors()->add(
-                                "authors.$index.lastName",
-                                '[Authors] Author #'.($index + 1).' requires a last name.',
-                            );
-                        }
-
-                        $isContact = BooleanNormalizer::isTrue($author['isContact'] ?? false);
-                        $email = $author['email'] ?? null;
-
-                        if ($isContact && ($email === null || $email === '')) {
-                            $validator->errors()->add(
-                                "authors.$index.email",
-                                '[Authors] Author #'.($index + 1).' requires a contact email when marked as contact person.',
-                            );
-                        }
-
-                        continue;
-                    }
-
-                    if (empty($author['institutionName'])) {
-                        $validator->errors()->add(
-                            "authors.$index.institutionName",
-                            '[Authors] Author #'.($index + 1).' requires an institution name.',
-                        );
-                    }
-                }
-            },
-            // Validate contributor structure if provided
-            function (Validator $validator): void {
-                /** @var mixed $candidateContributors */
-                $candidateContributors = $this->input('contributors', []);
-
-                if (! is_array($candidateContributors)) {
-                    return;
-                }
-
-                foreach ($candidateContributors as $index => $contributor) {
-                    if (! is_array($contributor)) {
-                        $validator->errors()->add(
-                            "contributors.$index",
-                            '[Contributors] Contributor #'.($index + 1).' must be a valid entry.',
-                        );
-
-                        continue;
-                    }
-
-                    $type = $contributor['type'] ?? 'person';
-
-                    if ($type === 'person') {
-                        if (empty($contributor['lastName'])) {
-                            $validator->errors()->add(
-                                "contributors.$index.lastName",
-                                '[Contributors] Contributor #'.($index + 1).' requires a last name.',
-                            );
-                        }
-                    } else {
-                        if (empty($contributor['institutionName'])) {
-                            $validator->errors()->add(
-                                "contributors.$index.institutionName",
-                                '[Contributors] Contributor #'.($index + 1).' requires an institution name.',
-                            );
-                        }
-                    }
-
-                    // Skip roles-empty check — already enforced by 'contributors.*.roles' => ['required', 'array', 'min:1'] in rules()
-                }
-            },
             // Validate polygon coverages have at least 3 points
             function (Validator $validator): void {
                 $coverages = $this->input('spatialTemporalCoverages', []);
@@ -1146,5 +1087,47 @@ class StoreDraftResourceRequest extends FormRequest
         }
 
         return null;
+    }
+
+    /**
+     * Keep invalid typed entries so validation can report them, but drop draft
+     * rows that cannot be represented by the current creator tables yet.
+     *
+     * @param  array<string, mixed>  $author
+     */
+    private function shouldKeepDraftAuthor(array $author): bool
+    {
+        $type = $author['type'] ?? null;
+
+        if ($type === 'person') {
+            return $this->normalizeString($author['lastName'] ?? null) !== null;
+        }
+
+        if ($type === 'institution') {
+            return $this->normalizeString($author['institutionName'] ?? null) !== null;
+        }
+
+        return true;
+    }
+
+    /**
+     * Keep invalid typed entries so validation can report them, but drop draft
+     * rows that cannot be represented by the current contributor tables yet.
+     *
+     * @param  array<string, mixed>  $contributor
+     */
+    private function shouldKeepDraftContributor(array $contributor): bool
+    {
+        $type = $contributor['type'] ?? null;
+
+        if ($type === 'person') {
+            return $this->normalizeString($contributor['lastName'] ?? null) !== null;
+        }
+
+        if ($type === 'institution') {
+            return $this->normalizeString($contributor['institutionName'] ?? null) !== null;
+        }
+
+        return true;
     }
 }

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -348,7 +348,7 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             if (! in_array($type, ['person', 'institution'], true)) {
-                $authors[] = [
+                $authors[$index] = [
                     'type' => $type,
                     'affiliations' => $affiliations,
                     'position' => (int) $index,
@@ -358,7 +358,7 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             if ($type === 'institution') {
-                $authors[] = [
+                $authors[$index] = [
                     'type' => 'institution',
                     'institutionName' => $this->normalizeString($author['institutionName'] ?? null),
                     'rorId' => $this->normalizeString($author['rorId'] ?? null),
@@ -379,7 +379,7 @@ class StoreDraftResourceRequest extends FormRequest
                 $website = null;
             }
 
-            $authors[] = [
+            $authors[$index] = [
                 'type' => 'person',
                 'orcid' => $this->normalizeString($author['orcid'] ?? null),
                 'firstName' => $this->normalizeString($author['firstName'] ?? null),
@@ -392,10 +392,10 @@ class StoreDraftResourceRequest extends FormRequest
             ];
         }
 
-        $authors = array_values(array_filter(
+        $authors = array_filter(
             $authors,
             fn (array $author): bool => $this->shouldKeepDraftAuthor($author),
-        ));
+        );
 
         /** @var array<int, array<string, mixed>|mixed> $rawContributors */
         $rawContributors = $this->input('contributors', []);
@@ -482,7 +482,7 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             if (! in_array($type, ['person', 'institution'], true)) {
-                $contributors[] = [
+                $contributors[$index] = [
                     'type' => $type,
                     'roles' => $roles,
                     'affiliations' => $affiliations,
@@ -493,7 +493,7 @@ class StoreDraftResourceRequest extends FormRequest
             }
 
             if ($type === 'institution') {
-                $contributors[] = [
+                $contributors[$index] = [
                     'type' => 'institution',
                     'institutionName' => $this->normalizeString($contributor['institutionName'] ?? null),
                     'identifier' => $this->normalizeString($contributor['identifier'] ?? null),
@@ -506,7 +506,7 @@ class StoreDraftResourceRequest extends FormRequest
                 continue;
             }
 
-            $contributors[] = [
+            $contributors[$index] = [
                 'type' => 'person',
                 'orcid' => $this->normalizeString($contributor['orcid'] ?? null),
                 'firstName' => $this->normalizeString($contributor['firstName'] ?? null),
@@ -519,10 +519,10 @@ class StoreDraftResourceRequest extends FormRequest
             ];
         }
 
-        $contributors = array_values(array_filter(
+        $contributors = array_filter(
             $contributors,
             fn (array $contributor): bool => $this->shouldKeepDraftContributor($contributor),
-        ));
+        );
 
         // Normalize descriptions
         /** @var array<int, array<string, mixed>|mixed> $rawDescriptions */

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -475,10 +475,16 @@ class StoreDraftResourceRequest extends FormRequest
             if (is_array($rawRoles)) {
                 $roles = [];
 
-                foreach ($rawRoles as $role) {
-                    $normalizedRole = trim((string) $role);
+                foreach ($rawRoles as $roleIndex => $role) {
+                    if (! is_string($role)) {
+                        $roles[$roleIndex] = $role;
+
+                        continue;
+                    }
+
+                    $normalizedRole = trim($role);
                     if ($normalizedRole !== '') {
-                        $roles[] = $normalizedRole;
+                        $roles[$roleIndex] = $normalizedRole;
                     }
                 }
             } elseif (array_key_exists('roles', $contributor)) {
@@ -897,8 +903,9 @@ class StoreDraftResourceRequest extends FormRequest
             'contributors.*.type.required' => '[Contributors] Contributor #:position must have a type (person or institution).',
             'contributors.*.type.in' => '[Contributors] Contributor #:position has an invalid type.',
             'contributors.*.roles.array' => '[Contributors] Contributor #:position roles must be a valid list.',
-            'contributors.*.roles.required' => '[Contributors] Contributor #:position must have at least one role.',
-            'contributors.*.roles.min' => '[Contributors] Contributor #:position must have at least one role.',
+            'contributors.*.roles.*.required' => '[Contributors] Contributor #:position has an empty role.',
+            'contributors.*.roles.*.string' => '[Contributors] Contributor #:position roles must contain only text values.',
+            'contributors.*.roles.*.max' => '[Contributors] Contributor #:position role exceeds the maximum length.',
             'contributors.*.email.email' => '[Contributors] Contributor #:position has an invalid email address.',
             'contributors.*.website.url' => '[Contributors] Contributor #:position has an invalid website URL.',
 

--- a/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
+++ b/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
@@ -769,6 +769,53 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->and($websiteErrors[0])->toStartWith('[Contributors]');
     });
 
+    test('draft with invalid author and contributor types still reports validation errors', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'authors' => [
+                [
+                    'type' => 'alien',
+                    'position' => 0,
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'affiliations' => [],
+                ],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'alien',
+                    'position' => 0,
+                    'firstName' => 'John',
+                    'lastName' => 'Smith',
+                    'roles' => ['Data Collector'],
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['authors.0.type', 'contributors.0.type']);
+
+        $allErrors = $response->json('errors');
+        $authorErrors = $allErrors['authors.0.type'] ?? null;
+        $contributorErrors = $allErrors['contributors.0.type'] ?? null;
+
+        expect($authorErrors)->toBeArray()
+            ->and($contributorErrors)->toBeArray()
+            ->and($authorErrors[0])->toStartWith('[Authors]')
+            ->and($contributorErrors[0])->toStartWith('[Contributors]');
+    });
+
     test('draft with polygon with fewer than 3 points returns [Spatial & Temporal Coverage] prefix', function () {
         $user = User::factory()->create();
         seedValidationLookupTables();

--- a/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
+++ b/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
@@ -724,6 +724,50 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->and($roleErrors[0])->toStartWith('[Contributors]');
     });
 
+    test('draft with non-string contributor role items returns [Contributors] prefix', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'John',
+                    'lastName' => 'Smith',
+                    'roles' => [
+                        ['slug' => 'ContactPerson'],
+                        42,
+                    ],
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'contributors.0.roles.0',
+            'contributors.0.roles.1',
+        ]);
+
+        $allErrors = $response->json('errors');
+        $arrayRoleErrors = $allErrors['contributors.0.roles.0'] ?? null;
+        $integerRoleErrors = $allErrors['contributors.0.roles.1'] ?? null;
+
+        expect($arrayRoleErrors)->toBeArray()
+            ->and($integerRoleErrors)->toBeArray()
+            ->and($arrayRoleErrors[0])->toStartWith('[Contributors]')
+            ->and($integerRoleErrors[0])->toStartWith('[Contributors]');
+    });
+
     test('draft with malformed author contact fields still returns [Authors] prefix', function () {
         $user = User::factory()->create();
         seedValidationLookupTables();

--- a/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
+++ b/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use App\Enums\ContributorCategory;
+use App\Models\ContributorType;
 use App\Models\Datacenter;
 use App\Models\DescriptionType;
 use App\Models\Language;
+use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\Right;
 use App\Models\TitleType;
@@ -57,6 +60,26 @@ function seedValidationLookupTables(): int
         'is_active' => true,
         'is_elmo_active' => true,
     ]);
+
+    ContributorType::firstOrCreate(
+        ['slug' => 'ContactPerson'],
+        [
+            'name' => 'Contact Person',
+            'category' => ContributorCategory::PERSON,
+            'is_active' => true,
+            'is_elmo_active' => true,
+        ]
+    );
+
+    ContributorType::firstOrCreate(
+        ['slug' => 'Other'],
+        [
+            'name' => 'Other',
+            'category' => ContributorCategory::BOTH,
+            'is_active' => true,
+            'is_elmo_active' => true,
+        ]
+    );
 
     Datacenter::create(['name' => 'Test Datacenter']);
 
@@ -505,7 +528,52 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
         expect($errors[0])->toStartWith('[Resource Information]');
     });
 
-    test('draft with author without lastName returns [Authors] prefix', function () {
+    test('draft with contact author without email succeeds and stores nullable contact info', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'isContact' => true,
+                    'email' => '',
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::query()
+            ->with(['creators.creatorable', 'contributors.contributorTypes'])
+            ->findOrFail($response->json('resource.id'));
+
+        $creator = $resource->creators->first();
+        expect($creator)->not->toBeNull()
+            ->and($creator->is_contact)->toBeTrue()
+            ->and($creator->email)->toBeNull()
+            ->and($creator->creatorable->family_name)->toBe('Doe')
+            ->and($creator->creatorable->given_name)->toBe('Jane');
+
+        $contributor = $resource->contributors->first();
+        expect($contributor)->not->toBeNull()
+            ->and($contributor->email)->toBeNull()
+            ->and($contributor->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson']);
+    });
+
+    test('draft with incomplete authors succeeds and skips unpersistable author rows', function () {
         $user = User::factory()->create();
         seedValidationLookupTables();
 
@@ -523,6 +591,125 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
                     'lastName' => '',
                     'affiliations' => [],
                 ],
+                [
+                    'type' => 'institution',
+                    'position' => 1,
+                    'institutionName' => '',
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::query()
+            ->with('creators')
+            ->findOrFail($response->json('resource.id'));
+
+        expect($resource->creators)->toHaveCount(0);
+    });
+
+    test('draft with incomplete contributors succeeds and skips unpersistable contributor rows', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'John',
+                    'lastName' => '',
+                    'roles' => ['Data Collector'],
+                    'affiliations' => [],
+                ],
+                [
+                    'type' => 'institution',
+                    'position' => 1,
+                    'institutionName' => '',
+                    'roles' => ['Hosting Institution'],
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::query()
+            ->with('contributors')
+            ->findOrFail($response->json('resource.id'));
+
+        expect($resource->contributors)->toHaveCount(0);
+    });
+
+    test('draft with contributor without roles succeeds and falls back to other role', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'John',
+                    'lastName' => 'Smith',
+                    'roles' => [],
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::query()
+            ->with('contributors.contributorTypes')
+            ->findOrFail($response->json('resource.id'));
+
+        $contributor = $resource->contributors->first();
+        expect($contributor)->not->toBeNull()
+            ->and($contributor->contributorTypes->pluck('slug')->all())->toBe(['Other']);
+    });
+
+    test('draft with malformed author contact fields still returns [Authors] prefix', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'isContact' => true,
+                    'email' => 'not-an-email',
+                    'website' => 'not-a-url',
+                    'affiliations' => [],
+                ],
             ],
         ];
 
@@ -530,11 +717,56 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->postJson(route('editor.resources.store-draft'), $payload);
 
         $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['authors.0.email', 'authors.0.website']);
 
         $allErrors = $response->json('errors');
-        $errors = $allErrors['authors.0.lastName'] ?? null;
-        expect($errors)->toBeArray();
-        expect($errors[0])->toStartWith('[Authors]');
+        $emailErrors = $allErrors['authors.0.email'] ?? null;
+        $websiteErrors = $allErrors['authors.0.website'] ?? null;
+
+        expect($emailErrors)->toBeArray()
+            ->and($websiteErrors)->toBeArray()
+            ->and($emailErrors[0])->toStartWith('[Authors]')
+            ->and($websiteErrors[0])->toStartWith('[Authors]');
+    });
+
+    test('draft with malformed contributor contact fields still returns [Contributors] prefix', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'roles' => ['ContactPerson'],
+                    'email' => 'not-an-email',
+                    'website' => 'not-a-url',
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['contributors.0.email', 'contributors.0.website']);
+
+        $allErrors = $response->json('errors');
+        $emailErrors = $allErrors['contributors.0.email'] ?? null;
+        $websiteErrors = $allErrors['contributors.0.website'] ?? null;
+
+        expect($emailErrors)->toBeArray()
+            ->and($websiteErrors)->toBeArray()
+            ->and($emailErrors[0])->toStartWith('[Contributors]')
+            ->and($websiteErrors[0])->toStartWith('[Contributors]');
     });
 
     test('draft with polygon with fewer than 3 points returns [Spatial & Temporal Coverage] prefix', function () {

--- a/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
+++ b/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
@@ -769,7 +769,7 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->and($websiteErrors[0])->toStartWith('[Contributors]');
     });
 
-    test('draft with invalid author and contributor types still reports validation errors', function () {
+    test('draft with invalid author and contributor types preserves original error indexes after filtering', function () {
         $user = User::factory()->create();
         seedValidationLookupTables();
 
@@ -781,8 +781,15 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ],
             'authors' => [
                 [
-                    'type' => 'alien',
+                    'type' => 'person',
                     'position' => 0,
+                    'firstName' => 'Filtered',
+                    'lastName' => '',
+                    'affiliations' => [],
+                ],
+                [
+                    'type' => 'alien',
+                    'position' => 1,
                     'firstName' => 'Jane',
                     'lastName' => 'Doe',
                     'affiliations' => [],
@@ -790,8 +797,16 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ],
             'contributors' => [
                 [
-                    'type' => 'alien',
+                    'type' => 'person',
                     'position' => 0,
+                    'firstName' => 'Filtered',
+                    'lastName' => '',
+                    'roles' => ['Data Collector'],
+                    'affiliations' => [],
+                ],
+                [
+                    'type' => 'alien',
+                    'position' => 1,
                     'firstName' => 'John',
                     'lastName' => 'Smith',
                     'roles' => ['Data Collector'],
@@ -804,16 +819,17 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->postJson(route('editor.resources.store-draft'), $payload);
 
         $response->assertStatus(422);
-        $response->assertJsonValidationErrors(['authors.0.type', 'contributors.0.type']);
+        $response->assertJsonValidationErrors(['authors.1.type', 'contributors.1.type']);
 
         $allErrors = $response->json('errors');
-        $authorErrors = $allErrors['authors.0.type'] ?? null;
-        $contributorErrors = $allErrors['contributors.0.type'] ?? null;
+        $authorErrors = $allErrors['authors.1.type'] ?? null;
+        $contributorErrors = $allErrors['contributors.1.type'] ?? null;
 
         expect($authorErrors)->toBeArray()
             ->and($contributorErrors)->toBeArray()
             ->and($authorErrors[0])->toStartWith('[Authors]')
-            ->and($contributorErrors[0])->toStartWith('[Contributors]');
+            ->and($contributorErrors[0])->toStartWith('[Contributors]')
+            ->and($allErrors)->not->toHaveKeys(['authors.0.type', 'contributors.0.type']);
     });
 
     test('draft with polygon with fewer than 3 points returns [Spatial & Temporal Coverage] prefix', function () {

--- a/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
+++ b/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
@@ -768,6 +768,42 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->and($integerRoleErrors[0])->toStartWith('[Contributors]');
     });
 
+    test('draft with empty contributor role item returns [Contributors] prefix', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'John',
+                    'lastName' => 'Smith',
+                    'roles' => ['   '],
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['contributors.0.roles.0']);
+
+        $allErrors = $response->json('errors');
+        $roleErrors = $allErrors['contributors.0.roles.0'] ?? null;
+
+        expect($roleErrors)->toBeArray()
+            ->and($roleErrors[0])->toStartWith('[Contributors]')
+            ->and($roleErrors[0])->toContain('empty role');
+    });
+
     test('draft with malformed author contact fields still returns [Authors] prefix', function () {
         $user = User::factory()->create();
         seedValidationLookupTables();

--- a/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
+++ b/tests/pest/Feature/Resources/StoreResourceValidationMessagesTest.php
@@ -689,6 +689,41 @@ describe('Store Draft Resource – Section-Prefixed Validation Messages (Issue #
             ->and($contributor->contributorTypes->pluck('slug')->all())->toBe(['Other']);
     });
 
+    test('draft with non-array contributor roles returns [Contributors] prefix', function () {
+        $user = User::factory()->create();
+        seedValidationLookupTables();
+
+        $payload = [
+            'resourceId' => null,
+            'doi' => null,
+            'titles' => [
+                ['title' => 'Draft Title', 'titleType' => 'main-title'],
+            ],
+            'contributors' => [
+                [
+                    'type' => 'person',
+                    'position' => 0,
+                    'firstName' => 'John',
+                    'lastName' => 'Smith',
+                    'roles' => 'ContactPerson',
+                    'affiliations' => [],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store-draft'), $payload);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['contributors.0.roles']);
+
+        $allErrors = $response->json('errors');
+        $roleErrors = $allErrors['contributors.0.roles'] ?? null;
+
+        expect($roleErrors)->toBeArray()
+            ->and($roleErrors[0])->toStartWith('[Contributors]');
+    });
+
     test('draft with malformed author contact fields still returns [Authors] prefix', function () {
         $user = User::factory()->create();
         seedValidationLookupTables();


### PR DESCRIPTION
This pull request updates the draft resource saving logic to better handle incomplete or in-progress author and contributor entries. The validation and normalization processes are now more tolerant of partial/incomplete data, allowing users to save drafts even if some author or contributor rows are not fully filled out. The most important changes are grouped below:

**Relaxed Validation and Filtering for Drafts:**

* The draft resource request now only requires a main title; all other fields are optional, and incomplete author/contributor rows are ignored until they can be safely saved. This is clarified in the class docblock.
* Added new filtering logic (`shouldKeepDraftAuthor` and `shouldKeepDraftContributor` methods) to remove incomplete author and contributor entries that cannot be represented in the database, while still keeping invalid-typed entries for validation error reporting. [[1]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R395-R399) [[2]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R529-R533) [[3]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R1100-R1141)

**Contributor and Author Normalization:**

* Changed how author and contributor arrays are built and filtered, using array keys instead of appending, and improved how the `type` field is handled for unknown types. [[1]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L289-R290) [[2]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R350-R361) [[3]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L371-R382) [[4]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L395-R411) [[5]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L456-R503) [[6]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L482-R516)
* Contributor `roles` are now nullable and only structurally validated if present, rather than always required. [[1]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L91-R92) [[2]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L456-R503)

**Validation and Error Messages:**

* Removed strict validation checks for required fields on authors and contributors when saving drafts, allowing incomplete rows in draft mode.
* Updated validation error messages for contributors’ roles to match the new, more relaxed validation rules.