### PR TITLE
Fix: Datacenter Mapping at Import of Legacy Resources

### DIFF
--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -221,7 +221,7 @@ class LegacyMetaworksDatacenterLookupService
     {
         return DB::connection(self::CONNECTION)
             ->table($table)
-            ->whereRaw('LOWER(doi) = ?', [strtolower($doi)])
+            ->where('doi', $doi)
             ->exists();
     }
 

--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -57,6 +57,10 @@ class LegacyMetaworksDatacenterLookupService
 
     private const CONNECTION = 'legacy_metaworks';
 
+    public function __construct(
+        private readonly DoiSuggestionService $doiSuggestionService,
+    ) {}
+
     /**
      * DOI suffix patterns that identify datacenters in legacy SUMARIO records.
      *
@@ -253,9 +257,9 @@ class LegacyMetaworksDatacenterLookupService
     {
         $doi = trim($doi);
 
-        $doi = preg_replace('/^(?:https?:\/\/(?:dx\.)?doi\.org\/|doi:)/i', '', $doi) ?? $doi;
+        $doi = preg_replace('/^doi:\s*/i', '', $doi) ?? $doi;
 
-        return trim($doi);
+        return $this->doiSuggestionService->normalizeDoi($doi);
     }
 
     private function doiSuffix(string $doi): ?string

--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -11,36 +11,173 @@ use Illuminate\Support\Facades\Log;
 
 class LegacyMetaworksDatacenterLookupService
 {
+    public const ARBODAT_DATACENTER = 'ArboDat 2016';
+
+    public const CRC1211DB_DATACENTER = 'CRC1211DB CRC 1211 Database';
+
+    public const DEKORP_DATACENTER = 'DEKORP - German Continental Seismic Reflection Program';
+
+    public const DIGIS_DATACENTER = 'DIGIS Geochemical Data for GEOROC 2.0';
+
+    public const ENMAP_DATACENTER = 'EnMAP';
+
+    public const FID_GEO_DATACENTER = 'FID GEO';
+
     public const DEFAULT_DATACENTER = 'GFZ German Research Centre for Geosciences';
+
     public const GIPP_DATACENTER = 'GIPP Geophysical Instrument Pool Potsdam';
+
+    public const ICGEM_DATACENTER = 'ICGEM International Centre for Global Earth Models';
+
+    public const IGETS_DATACENTER = 'IGETS International Geodynamics and Earth Tide Service';
+
+    public const INTERMAGNET_DATACENTER = 'INTERMAGNET';
+
+    public const ISDC_DATACENTER = 'ISDC Information System and Data Center';
+
+    public const ISG_DATACENTER = 'ISG International Service for the Geoid';
+
+    public const PIK_DATACENTER = 'PIK Potsdam Institute for Climate Impact Research';
+
+    public const RIESGOS_DATACENTER = 'Riesgos';
+
     public const SDDB_DATACENTER = 'SDDB Scientific Drilling Database';
 
+    public const SFB806_DATACENTER = 'SFB806 and CRC806-Database';
+
+    public const SPP2238_DATACENTER = 'SPP 2238 - Dynamics of Ore Metals Enrichment - DOME';
+
+    public const TERENO_DATACENTER = 'TERENO';
+
+    public const TR32DB_DATACENTER = 'TR32DB CRC/Transregio 32 Database';
+
+    public const TRR228DB_DATACENTER = 'TRR228DB CRC/Transregio 228 Database';
+
+    public const WDS_DATACENTER = 'WDS World Stress Map';
+
     private const CONNECTION = 'legacy_metaworks';
+
+    /**
+     * DOI suffix patterns that identify datacenters in legacy SUMARIO records.
+     *
+     * @var list<array{pattern: string, datacenters: list<string>}>
+     */
+    private const DOI_SUFFIX_DATACENTER_RULES = [
+        [
+            'pattern' => '/^ha[-_]?arbodat(?:[-_]|$)/',
+            'datacenters' => [self::ARBODAT_DATACENTER],
+        ],
+        [
+            'pattern' => '/^crc1211db(?:[._-]|$)/',
+            'datacenters' => [self::CRC1211DB_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])dekorp(?:[.\/_-]|$)/',
+            'datacenters' => [self::DEKORP_DATACENTER],
+        ],
+        [
+            'pattern' => '/^digis(?:[._-]|[0-9]|$)/',
+            'datacenters' => [self::DIGIS_DATACENTER],
+        ],
+        [
+            'pattern' => '/^enmap(?:[._-]|$)/',
+            'datacenters' => [self::ENMAP_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])fid(?:geo)?(?:[.\/_-]|$)/',
+            'datacenters' => [self::FID_GEO_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])gipp(?:[.\/_-]|$)/',
+            'datacenters' => [self::GIPP_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])icgem(?:[.\/_-]|$)/',
+            'datacenters' => [self::ICGEM_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])igets(?:[.\/_-]|$)/',
+            'datacenters' => [self::IGETS_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])intermagnet(?:[.\/_-]|$)/',
+            'datacenters' => [self::INTERMAGNET_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])isdc(?:[.\/_-]|$)/',
+            'datacenters' => [self::ISDC_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])isg(?:[.\/_-]|$)/',
+            'datacenters' => [self::ISG_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])pik(?:[.\/_-]|$)/',
+            'datacenters' => [self::PIK_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])riesgos(?:[.\/_-]|$)/',
+            'datacenters' => [self::RIESGOS_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])sddb(?:[.\/_-]|$)/',
+            'datacenters' => [self::SDDB_DATACENTER],
+        ],
+        [
+            'pattern' => '/^(?:sfb806|crc806)(?:[._-]|$)/',
+            'datacenters' => [self::SFB806_DATACENTER],
+        ],
+        [
+            'pattern' => '/^spp[-_]?2238(?:[._-]|$)/',
+            'datacenters' => [self::SPP2238_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])tereno(?:[.\/_-]|$)/',
+            'datacenters' => [self::TERENO_DATACENTER],
+        ],
+        [
+            'pattern' => '/^tr32db(?:[._-]|$)/',
+            'datacenters' => [self::TR32DB_DATACENTER],
+        ],
+        [
+            'pattern' => '/^trr228db(?:[._-]|$)/',
+            'datacenters' => [self::TRR228DB_DATACENTER],
+        ],
+        [
+            'pattern' => '/(?:^|[.\/_-])w(?:ds|sm)(?:[.\/_-]|$)/',
+            'datacenters' => [self::WDS_DATACENTER],
+        ],
+    ];
 
     /**
      * @return list<string>
      */
     public function resolveDatacenterNames(string $doi): array
     {
-        try {
-            $datacenters = [];
+        $normalizedDoi = $this->normalizeDoi($doi);
+        $patternDatacenters = $this->resolveDatacenterNamesFromDoiPattern($normalizedDoi);
 
-            if ($this->doiExistsInTable('gipp_dataset', $doi)) {
+        try {
+            $datacenters = $patternDatacenters;
+
+            if ($this->doiExistsInTable('gipp_dataset', $normalizedDoi)) {
                 $datacenters[] = self::GIPP_DATACENTER;
             }
 
-            if ($this->doiExistsInTable('sddb_dataset', $doi)) {
+            if ($this->doiExistsInTable('sddb_dataset', $normalizedDoi)) {
                 $datacenters[] = self::SDDB_DATACENTER;
             }
 
+            $datacenters = $this->uniqueDatacenters($datacenters);
+
             return $datacenters !== [] ? $datacenters : [self::DEFAULT_DATACENTER];
         } catch (\Throwable $exception) {
-            Log::warning('Legacy Metaworks datacenter lookup failed; using default datacenter', [
+            Log::warning('Legacy Metaworks datacenter lookup failed; using DOI pattern or default datacenter', [
                 'doi' => $doi,
                 'error' => $exception->getMessage(),
             ]);
 
-            return [self::DEFAULT_DATACENTER];
+            return $patternDatacenters !== [] ? $patternDatacenters : [self::DEFAULT_DATACENTER];
         }
     }
 
@@ -84,7 +221,62 @@ class LegacyMetaworksDatacenterLookupService
     {
         return DB::connection(self::CONNECTION)
             ->table($table)
-            ->where('doi', $doi)
+            ->whereRaw('LOWER(doi) = ?', [strtolower($doi)])
             ->exists();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveDatacenterNamesFromDoiPattern(string $doi): array
+    {
+        $suffix = $this->doiSuffix($doi);
+
+        if ($suffix === null) {
+            return [];
+        }
+
+        $datacenters = [];
+
+        foreach (self::DOI_SUFFIX_DATACENTER_RULES as $rule) {
+            if (preg_match($rule['pattern'], $suffix) !== 1) {
+                continue;
+            }
+
+            array_push($datacenters, ...$rule['datacenters']);
+        }
+
+        return $this->uniqueDatacenters($datacenters);
+    }
+
+    private function normalizeDoi(string $doi): string
+    {
+        $doi = trim($doi);
+
+        $doi = preg_replace('/^(?:https?:\/\/(?:dx\.)?doi\.org\/|doi:)/i', '', $doi) ?? $doi;
+
+        return trim($doi);
+    }
+
+    private function doiSuffix(string $doi): ?string
+    {
+        $doi = strtolower($doi);
+
+        if (preg_match('/^10\.[^\/]+\/+(.+)$/', $doi, $matches) !== 1) {
+            return null;
+        }
+
+        $suffix = ltrim((string) $matches[1], '/');
+
+        return $suffix !== '' ? $suffix : null;
+    }
+
+    /**
+     * @param  list<string>  $datacenters
+     * @return list<string>
+     */
+    private function uniqueDatacenters(array $datacenters): array
+    {
+        return array_values(array_unique($datacenters));
     }
 }

--- a/app/Services/SumarioPendingResourceImportService.php
+++ b/app/Services/SumarioPendingResourceImportService.php
@@ -143,10 +143,7 @@ class SumarioPendingResourceImportService
     {
         return OldDataset::query()
             ->where('publicstatus', 'pending')
-            ->where(function ($query) use ($doi): void {
-                $query->where('identifier', $doi)
-                    ->orWhere('identifier', strtoupper($doi));
-            })
+            ->whereRaw('LOWER(identifier) = ?', [strtolower($doi)])
             ->first();
     }
 

--- a/app/Services/SumarioPendingResourceImportService.php
+++ b/app/Services/SumarioPendingResourceImportService.php
@@ -143,7 +143,7 @@ class SumarioPendingResourceImportService
     {
         return OldDataset::query()
             ->where('publicstatus', 'pending')
-            ->whereRaw('LOWER(identifier) = ?', [strtolower($doi)])
+            ->where('identifier', $doi)
             ->first();
     }
 

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -56,12 +56,12 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
 
         Schema::connection('legacy_metaworks')->create('gipp_dataset', function (Blueprint $table): void {
             $table->id();
-            $table->string('doi')->nullable();
+            $table->string('doi')->nullable()->collation('NOCASE');
         });
 
         Schema::connection('legacy_metaworks')->create('sddb_dataset', function (Blueprint $table): void {
             $table->id();
-            $table->string('doi')->nullable();
+            $table->string('doi')->nullable()->collation('NOCASE');
         });
 
         foreach (legacyImportDatacenterNames() as $name) {

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\Datacenter;
 use App\Models\Resource;
+use App\Services\DoiSuggestionService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -77,7 +78,7 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             'doi' => '10.5880/sddb.dataset',
         ]);
 
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames('10.5880/gipp.dataset'))
             ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER])
@@ -86,7 +87,7 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
     });
 
     it('resolves datacenters from legacy DOI patterns', function (string $doi, array $expectedDatacenters): void {
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames($doi))->toBe($expectedDatacenters);
     })->with([
@@ -205,7 +206,7 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
     ]);
 
     it('normalises DOI URLs and doi scheme before matching datacenter patterns', function (string $doi): void {
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames($doi))
             ->toBe([LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER]);
@@ -215,19 +216,33 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
         'doi scheme' => ['doi:10.5880/hA-ArboDat_AK1'],
     ]);
 
+    it('delegates DOI normalization after stripping the doi scheme prefix', function () {
+        $doiSuggestionService = Mockery::mock(DoiSuggestionService::class);
+        $doiSuggestionService
+            ->shouldReceive('normalizeDoi')
+            ->once()
+            ->with('10.5880/hA-ArboDat_AK1')
+            ->andReturn('10.5880/ha-arbodat_ak1');
+
+        $service = new LegacyMetaworksDatacenterLookupService($doiSuggestionService);
+
+        expect($service->resolveDatacenterNames('doi:10.5880/hA-ArboDat_AK1'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER]);
+    });
+
     it('matches legacy Metaworks table DOIs case-insensitively', function () {
         DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
             'doi' => '10.5880/Legacy.Table.Mixed',
         ]);
 
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames('https://doi.org/10.5880/legacy.table.mixed'))
             ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
     });
 
     it('does not infer the GFZ datacenter from GFZ-prefixed specialist DOI namespaces', function () {
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames('10.5880/GFZ.DEKORP-1-8701.001'))
             ->toBe([LegacyMetaworksDatacenterLookupService::DEKORP_DATACENTER])
@@ -237,7 +252,7 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
     it('uses DOI pattern datacenters when the legacy Metaworks tables are unavailable', function () {
         Schema::connection('legacy_metaworks')->drop('gipp_dataset');
 
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames('10.5880/GFZ.DEKORP-1-8701.001'))
             ->toBe([LegacyMetaworksDatacenterLookupService::DEKORP_DATACENTER]);
@@ -248,14 +263,14 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             'doi' => '10.5880/GIPP-MT.202403.1',
         ]);
 
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames('10.5880/GIPP-MT.202403.1'))
             ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
     });
 
     it('falls back to the GFZ datacenter when no specialised table contains the DOI', function () {
-        $service = new LegacyMetaworksDatacenterLookupService;
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames('10.5880/default.dataset'))
             ->toBe([LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
@@ -268,7 +283,7 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
 
         $resource = Resource::factory()->create(['doi' => '10.5880/gipp.sync']);
 
-        (new LegacyMetaworksDatacenterLookupService)->syncDatacenters($resource, '10.5880/gipp.sync');
+        app(LegacyMetaworksDatacenterLookupService::class)->syncDatacenters($resource, '10.5880/gipp.sync');
 
         expect($resource->fresh()->datacenters->pluck('name')->all())
             ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
@@ -277,7 +292,7 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
     it('syncs DOI pattern datacenters onto the imported resource', function () {
         $resource = Resource::factory()->create(['doi' => '10.5880/hA-ArboDat_AK1']);
 
-        (new LegacyMetaworksDatacenterLookupService)->syncDatacenters($resource, '10.5880/hA-ArboDat_AK1');
+        app(LegacyMetaworksDatacenterLookupService::class)->syncDatacenters($resource, '10.5880/hA-ArboDat_AK1');
 
         expect($resource->fresh()->datacenters->pluck('name')->all())
             ->toBe([LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER]);

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -13,6 +13,37 @@ use Illuminate\Support\Facades\Schema;
 
 uses(RefreshDatabase::class);
 
+/**
+ * @return list<string>
+ */
+function legacyImportDatacenterNames(): array
+{
+    return [
+        LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::CRC1211DB_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::DEKORP_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::DIGIS_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::ENMAP_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::FID_GEO_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::ICGEM_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::IGETS_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::INTERMAGNET_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::ISDC_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::ISG_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::PIK_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::RIESGOS_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::SFB806_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::SPP2238_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::TERENO_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::TR32DB_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::TRR228DB_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::WDS_DATACENTER,
+    ];
+}
+
 describe('LegacyMetaworksDatacenterLookupService', function () {
     beforeEach(function () {
         Config::set('database.connections.legacy_metaworks', [
@@ -33,9 +64,9 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             $table->string('doi')->nullable();
         });
 
-        Datacenter::query()->create(['name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
-        Datacenter::query()->create(['name' => LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
-        Datacenter::query()->create(['name' => LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER]);
+        foreach (legacyImportDatacenterNames() as $name) {
+            Datacenter::query()->create(['name' => $name]);
+        }
     });
 
     it('resolves GIPP and SDDB datacenters from true Metaworks tables', function () {
@@ -52,6 +83,175 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER])
             ->and($service->resolveDatacenterNames('10.5880/sddb.dataset'))
             ->toBe([LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER]);
+    });
+
+    it('resolves datacenters from legacy DOI patterns', function (string $doi, array $expectedDatacenters): void {
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames($doi))->toBe($expectedDatacenters);
+    })->with([
+        'ArboDat underscore DOI' => [
+            '10.5880/hA-ArboDat_AK1',
+            [LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER],
+        ],
+        'ArboDat hyphen DOI' => [
+            '10.5880/hA-ArboDat-AK66',
+            [LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER],
+        ],
+        'CRC1211DB DOI' => [
+            '10.5880/CRC1211DB.2024.001',
+            [LegacyMetaworksDatacenterLookupService::CRC1211DB_DATACENTER],
+        ],
+        'DEKORP DOI with GFZ namespace' => [
+            '10.5880/GFZ.DEKORP-1-8701.001',
+            [LegacyMetaworksDatacenterLookupService::DEKORP_DATACENTER],
+        ],
+        'DIGIS DOI' => [
+            '10.5880/digis.e.2024.001',
+            [LegacyMetaworksDatacenterLookupService::DIGIS_DATACENTER],
+        ],
+        'DIGIS compact DOI' => [
+            '10.5880/digis2024.002',
+            [LegacyMetaworksDatacenterLookupService::DIGIS_DATACENTER],
+        ],
+        'EnMAP DOI' => [
+            '10.5880/enmap.2024.001',
+            [LegacyMetaworksDatacenterLookupService::ENMAP_DATACENTER],
+        ],
+        'FID GEO DOI' => [
+            '10.5880/fidgeo.2026.059',
+            [LegacyMetaworksDatacenterLookupService::FID_GEO_DATACENTER],
+        ],
+        'FID GEO short DOI' => [
+            '10.5880/fid.2018.006',
+            [LegacyMetaworksDatacenterLookupService::FID_GEO_DATACENTER],
+        ],
+        'FID GEO DOI with GFZ namespace' => [
+            '10.5880/GFZ-fidgeo.blueprint',
+            [LegacyMetaworksDatacenterLookupService::FID_GEO_DATACENTER],
+        ],
+        'GIPP-MT DOI' => [
+            '10.5880/GIPP-MT.202403.1',
+            [LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER],
+        ],
+        'ICGEM DOI inside COST-G namespace' => [
+            '10.5880/COST-G.ICGEM_02_L2',
+            [LegacyMetaworksDatacenterLookupService::ICGEM_DATACENTER],
+        ],
+        'IGETS DOI' => [
+            '10.5880/igets.2024.001',
+            [LegacyMetaworksDatacenterLookupService::IGETS_DATACENTER],
+        ],
+        'INTERMAGNET DOI' => [
+            '10.5880/intermagnet.2025.001',
+            [LegacyMetaworksDatacenterLookupService::INTERMAGNET_DATACENTER],
+        ],
+        'ISDC DOI' => [
+            '10.5880/isdc.2024.001',
+            [LegacyMetaworksDatacenterLookupService::ISDC_DATACENTER],
+        ],
+        'ISG DOI' => [
+            '10.5880/isg.2024.001',
+            [LegacyMetaworksDatacenterLookupService::ISG_DATACENTER],
+        ],
+        'PIK DOI' => [
+            '10.5880/pik.2024.001',
+            [LegacyMetaworksDatacenterLookupService::PIK_DATACENTER],
+        ],
+        'Riesgos DOI' => [
+            '10.5880/riesgos.2024.001',
+            [LegacyMetaworksDatacenterLookupService::RIESGOS_DATACENTER],
+        ],
+        'SDDB DOI with GFZ namespace' => [
+            '10.1594/GFZ.SDDB.1003',
+            [LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER],
+        ],
+        'SFB806 DOI' => [
+            '10.5880/SFB806.2024.001',
+            [LegacyMetaworksDatacenterLookupService::SFB806_DATACENTER],
+        ],
+        'CRC806 DOI' => [
+            '10.5880/CRC806.2024.001',
+            [LegacyMetaworksDatacenterLookupService::SFB806_DATACENTER],
+        ],
+        'SPP 2238 hyphen DOI' => [
+            '10.5880/SPP-2238.2024.001',
+            [LegacyMetaworksDatacenterLookupService::SPP2238_DATACENTER],
+        ],
+        'SPP 2238 compact DOI' => [
+            '10.5880/spp2238.2024.001',
+            [LegacyMetaworksDatacenterLookupService::SPP2238_DATACENTER],
+        ],
+        'TERENO DOI' => [
+            '10.5880/tereno.2024.001',
+            [LegacyMetaworksDatacenterLookupService::TERENO_DATACENTER],
+        ],
+        'TR32DB DOI' => [
+            '10.5880/TR32DB.2024.001',
+            [LegacyMetaworksDatacenterLookupService::TR32DB_DATACENTER],
+        ],
+        'TRR228DB DOI' => [
+            '10.5880/TRR228DB.2024.001',
+            [LegacyMetaworksDatacenterLookupService::TRR228DB_DATACENTER],
+        ],
+        'WDS DOI using WSM namespace' => [
+            '10.5880/WSM.2025.001',
+            [LegacyMetaworksDatacenterLookupService::WDS_DATACENTER],
+        ],
+        'WDS DOI' => [
+            '10.5880/wds.2025.001',
+            [LegacyMetaworksDatacenterLookupService::WDS_DATACENTER],
+        ],
+    ]);
+
+    it('normalises DOI URLs and doi scheme before matching datacenter patterns', function (string $doi): void {
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames($doi))
+            ->toBe([LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER]);
+    })->with([
+        'https DOI URL' => ['https://doi.org/10.5880/hA-ArboDat_AK1'],
+        'http dx.doi URL' => ['http://dx.doi.org/10.5880/hA-ArboDat_AK1'],
+        'doi scheme' => ['doi:10.5880/hA-ArboDat_AK1'],
+    ]);
+
+    it('matches legacy Metaworks table DOIs case-insensitively', function () {
+        DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
+            'doi' => '10.5880/Legacy.Table.Mixed',
+        ]);
+
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames('https://doi.org/10.5880/legacy.table.mixed'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
+    });
+
+    it('does not infer the GFZ datacenter from GFZ-prefixed specialist DOI namespaces', function () {
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames('10.5880/GFZ.DEKORP-1-8701.001'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::DEKORP_DATACENTER])
+            ->not->toContain(LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER);
+    });
+
+    it('uses DOI pattern datacenters when the legacy Metaworks tables are unavailable', function () {
+        Schema::connection('legacy_metaworks')->drop('gipp_dataset');
+
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames('10.5880/GFZ.DEKORP-1-8701.001'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::DEKORP_DATACENTER]);
+    });
+
+    it('deduplicates datacenters when DOI pattern and Metaworks table point to the same datacenter', function () {
+        DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
+            'doi' => '10.5880/GIPP-MT.202403.1',
+        ]);
+
+        $service = new LegacyMetaworksDatacenterLookupService;
+
+        expect($service->resolveDatacenterNames('10.5880/GIPP-MT.202403.1'))
+            ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
     });
 
     it('falls back to the GFZ datacenter when no specialised table contains the DOI', function () {
@@ -72,5 +272,14 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
 
         expect($resource->fresh()->datacenters->pluck('name')->all())
             ->toBe([LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER]);
+    });
+
+    it('syncs DOI pattern datacenters onto the imported resource', function () {
+        $resource = Resource::factory()->create(['doi' => '10.5880/hA-ArboDat_AK1']);
+
+        (new LegacyMetaworksDatacenterLookupService)->syncDatacenters($resource, '10.5880/hA-ArboDat_AK1');
+
+        expect($resource->fresh()->datacenters->pluck('name')->all())
+            ->toBe([LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER]);
     });
 });

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -33,7 +33,7 @@ describe('SumarioPendingResourceImportService', function () {
         Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
             $table->id();
             $table->string('publicstatus')->nullable();
-            $table->string('identifier')->nullable();
+            $table->string('identifier')->nullable()->collation('NOCASE');
             $table->integer('publicationyear')->nullable();
             $table->string('title')->nullable();
         });
@@ -165,12 +165,12 @@ describe('SumarioPendingResourceImportService', function () {
 
         Schema::connection('legacy_metaworks')->create('gipp_dataset', function (Blueprint $table): void {
             $table->id();
-            $table->string('doi')->nullable();
+            $table->string('doi')->nullable()->collation('NOCASE');
         });
 
         Schema::connection('legacy_metaworks')->create('sddb_dataset', function (Blueprint $table): void {
             $table->id();
-            $table->string('doi')->nullable();
+            $table->string('doi')->nullable()->collation('NOCASE');
         });
 
         DB::connection('metaworks')->table('resource')->insert([

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -154,6 +154,102 @@ describe('SumarioPendingResourceImportService', function () {
             ->and($resource->landingPage->ftp_url)->toBe('https://datapub.gfz.de/pending-one.zip');
     });
 
+    it('uses DOI pattern datacenters when importing mixed-case pending SUMARIO resources', function () {
+        Config::set('database.connections.legacy_metaworks', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+        DB::purge('legacy_metaworks');
+
+        Schema::connection('legacy_metaworks')->create('gipp_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable();
+        });
+
+        Schema::connection('legacy_metaworks')->create('sddb_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable();
+        });
+
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 57,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/hA-ArboDat_AK1',
+            'publicationyear' => 2024,
+            'title' => 'ArboDat Pending Dataset',
+        ]);
+
+        $user = User::factory()->create();
+        Datacenter::query()->create([
+            'name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+        ]);
+        $arbodat = Datacenter::query()->create([
+            'name' => LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER,
+        ]);
+
+        $editorLoader = Mockery::mock(OldDatasetEditorLoader::class);
+        $editorLoader
+            ->shouldReceive('loadForEditor')
+            ->once()
+            ->with(57)
+            ->andReturn([
+                'doi' => '10.5880/hA-ArboDat_AK1',
+                'year' => '2024',
+                'language' => 'en',
+                'titles' => [
+                    ['title' => 'ArboDat Pending Dataset', 'titleType' => 'main-title'],
+                ],
+                'initialRights' => [],
+                'authors' => [],
+                'contributors' => [],
+                'descriptions' => [],
+                'dates' => [],
+                'gcmdKeywords' => [],
+                'freeKeywords' => [],
+                'geoLocations' => [],
+                'relatedWorks' => [],
+                'fundingReferences' => [],
+                'mslLaboratories' => [],
+            ]);
+
+        $resourceStorage = Mockery::mock(ResourceStorageService::class);
+        $resourceStorage
+            ->shouldReceive('store')
+            ->once()
+            ->andReturnUsing(function (array $payload, int $userId) use ($user, $arbodat): array {
+                expect($userId)->toBe($user->id)
+                    ->and($payload['doi'])->toBe('10.5880/ha-arbodat_ak1')
+                    ->and($payload['datacenters'])->toBe([$arbodat->id]);
+
+                return [
+                    Resource::factory()->create(['doi' => $payload['doi']]),
+                    false,
+                ];
+            });
+
+        $downloadUrlService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $downloadUrlService
+            ->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/ha-arbodat_ak1')
+            ->andReturn(['files' => [], 'allPublic' => false]);
+
+        $service = new SumarioPendingResourceImportService(
+            editorLoader: $editorLoader,
+            resourceStorage: $resourceStorage,
+            datacenterLookup: new LegacyMetaworksDatacenterLookupService,
+            downloadUrlService: $downloadUrlService,
+            landingPageImport: new LegacyLandingPageImportService,
+            doiSuggestionService: app(DoiSuggestionService::class),
+        );
+
+        $result = $service->importPendingByDoi('10.5880/hA-ArboDat_AK1', $user->id);
+
+        expect($result['status'])->toBe('imported');
+    });
+
     it('skips a pending SUMARIO resource when the DOI already exists in ERNIE', function () {
         DB::connection('metaworks')->table('resource')->insert([
             'id' => 56,

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -239,7 +239,7 @@ describe('SumarioPendingResourceImportService', function () {
         $service = new SumarioPendingResourceImportService(
             editorLoader: $editorLoader,
             resourceStorage: $resourceStorage,
-            datacenterLookup: new LegacyMetaworksDatacenterLookupService,
+            datacenterLookup: app(LegacyMetaworksDatacenterLookupService::class),
             downloadUrlService: $downloadUrlService,
             landingPageImport: new LegacyLandingPageImportService,
             doiSuggestionService: app(DoiSuggestionService::class),


### PR DESCRIPTION
This pull request significantly enhances the `LegacyMetaworksDatacenterLookupService` to improve the accuracy and robustness of datacenter resolution for legacy DOIs. The changes introduce pattern-based datacenter inference, DOI normalization, and case-insensitive matching, and are thoroughly tested with new and expanded unit tests.

**Enhancements to datacenter resolution logic:**

- Added a comprehensive set of constant datacenter names and a new `DOI_SUFFIX_DATACENTER_RULES` array to map DOI suffix patterns to specific datacenters, enabling pattern-based inference when a DOI is not found in legacy tables.
- Implemented new private methods in `LegacyMetaworksDatacenterLookupService` for:
  - Extracting and normalizing DOI suffixes (`normalizeDoi`, `doiSuffix`)
  - Resolving datacenters from DOI patterns (`resolveDatacenterNamesFromDoiPattern`)
  - Deduplicating datacenter results (`uniqueDatacenters`)
- Updated the main resolution method to:
  - Normalize DOIs before lookup
  - Prefer pattern-based inference, then check legacy tables, and deduplicate results
  - Use pattern-based inference as a fallback if legacy tables are unavailable

**Testing improvements:**

- Expanded unit tests to cover:
  - All new DOI pattern rules for datacenter inference
  - DOI normalization (including URL and scheme variants)
  - Case-insensitive matching in legacy tables
  - Deduplication of datacenter results
  - Fallback behaviors and sync logic for resources [[1]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R17-R47) [[2]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343L28-R70) [[3]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343L49-R273) [[4]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343L71-R299)
- Updated test database schemas to ensure case-insensitive matching by setting `NOCASE` collation on relevant columns [[1]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343L28-R70) [[2]](diffhunk://#diff-da642b56ec18f2779883c21f8bacec066201a0620bfd1d495bb08fd2043ad436L36-R36)

**Other improvements:**

- Changed the dependency injection for `DoiSuggestionService` in the service constructor and updated tests to use the application container for instantiation [[1]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R7) [[2]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343L49-R273)

**Minor fixes:**

- Simplified the pending dataset lookup in `SumarioPendingResourceImportService` to match identifiers case-sensitively, relying on the database collation for case-insensitive matching

These changes make datacenter resolution for legacy DOIs more flexible, maintainable, and reliable, especially for edge cases and previously unsupported DOI patterns.