### PR TITLE
Feature: Custom Licenses in Data Editor

### DIFF
--- a/app/Http/Controllers/EditorController.php
+++ b/app/Http/Controllers/EditorController.php
@@ -256,7 +256,7 @@ class EditorController extends Controller
                 'language',
                 'titles.titleType',
                 'rights',
-                'resourceRights',
+                'resourceRights.right',
                 'creators.creatorable',
                 'creators.affiliations',
                 'contributors.contributorable',

--- a/app/Http/Controllers/LicenseController.php
+++ b/app/Http/Controllers/LicenseController.php
@@ -23,7 +23,7 @@ class LicenseController extends Controller
     {
         $rights = Right::query()
             ->orderByName()
-            ->get(['id', 'identifier', 'name']);
+            ->get(['id', 'identifier', 'name', 'uri', 'scheme_uri']);
 
         return response()->json($rights);
     }
@@ -37,7 +37,7 @@ class LicenseController extends Controller
             ->active()
             ->elmoActive()
             ->orderByName()
-            ->get(['id', 'identifier', 'name']);
+            ->get(['id', 'identifier', 'name', 'uri', 'scheme_uri']);
 
         return response()->json($rights);
     }
@@ -60,7 +60,7 @@ class LicenseController extends Controller
             ->elmoActive()
             ->availableForResourceType($resourceType->id)
             ->orderByName()
-            ->get(['id', 'identifier', 'name']);
+            ->get(['id', 'identifier', 'name', 'uri', 'scheme_uri']);
 
         return response()->json($rights);
     }
@@ -73,7 +73,7 @@ class LicenseController extends Controller
         $rights = Right::query()
             ->active()
             ->orderByUsageCount()
-            ->get(['id', 'identifier', 'name']);
+            ->get(['id', 'identifier', 'name', 'uri', 'scheme_uri']);
 
         return response()->json($rights);
     }

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests;
 use App\Http\Requests\Concerns\ValidatesEditorDates;
 use App\Models\RelatedIdentifier;
 use App\Models\TitleType;
+use App\Rules\SafeUrl;
 use App\Services\DoiSuggestionService;
 use App\Support\BooleanNormalizer;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -66,6 +67,10 @@ class StoreDraftResourceRequest extends FormRequest
             // Licenses are optional for drafts
             'licenses' => ['nullable', 'array'],
             'licenses.*' => ['string', 'distinct', Rule::exists('rights', 'identifier')],
+            'customLicenses' => ['nullable', 'array'],
+            'customLicenses.*.name' => ['required', 'string', 'max:255'],
+            'customLicenses.*.uri' => ['required', 'string', new SafeUrl('[Licenses & Rights]'), 'max:512'],
+            'customLicenses.*.sourceResourceRightId' => ['nullable', 'integer', Rule::exists('resource_rights', 'id')],
             'rawRights' => ['nullable', 'array'],
             'rawRights.*.rights' => ['nullable', 'string'],
             'rawRights.*.rightsUri' => ['nullable', 'string', 'max:512'],
@@ -798,6 +803,12 @@ class StoreDraftResourceRequest extends FormRequest
             'fundingReferences' => $fundingReferences,
         ]);
 
+        if ($this->has('customLicenses')) {
+            $this->merge([
+                'customLicenses' => $this->normalizeCustomLicensesInput($this->input('customLicenses', [])),
+            ]);
+        }
+
         $this->titleTypeDbSlugSet = $titleTypeDbSlugSet;
     }
 
@@ -846,6 +857,44 @@ class StoreDraftResourceRequest extends FormRequest
         return $rawRights;
     }
 
+    /**
+     * @return array<int, array<string, mixed>>|mixed
+     */
+    private function normalizeCustomLicensesInput(mixed $customLicensesInput): mixed
+    {
+        if (! is_array($customLicensesInput)) {
+            return $customLicensesInput;
+        }
+
+        $customLicenses = [];
+
+        foreach ($customLicensesInput as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $normalized = [
+                'name' => $this->rightsStringValue($entry, ['name', 'rights', 'rights_text']),
+                'uri' => $this->rightsStringValue($entry, ['uri', 'rightsUri', 'rightsURI', 'rights_uri']),
+            ];
+
+            if (array_key_exists('sourceResourceRightId', $entry) || array_key_exists('source_resource_right_id', $entry)) {
+                $sourceId = $entry['sourceResourceRightId'] ?? $entry['source_resource_right_id'];
+                $normalized['sourceResourceRightId'] = is_numeric($sourceId) ? (int) $sourceId : $sourceId;
+            }
+
+            if ($normalized['name'] === null && $normalized['uri'] === null && ! array_key_exists('sourceResourceRightId', $normalized)) {
+                continue;
+            }
+
+            $customLicenses[] = array_filter(
+                $normalized,
+                fn (mixed $value): bool => $value !== null,
+            );
+        }
+
+        return $customLicenses;
+    }
     /**
      * @param  array<string, mixed>  $statement
      * @param  list<string>  $keys
@@ -897,6 +946,11 @@ class StoreDraftResourceRequest extends FormRequest
             // Licenses & Rights
             'licenses.*.exists' => '[Licenses & Rights] License #:position is not a recognized license.',
             'licenses.*.distinct' => '[Licenses & Rights] License #:position is a duplicate.',
+            'customLicenses.*.name.required' => '[Licenses & Rights] Custom license #:position requires a name.',
+            'customLicenses.*.name.max' => '[Licenses & Rights] Custom license #:position name exceeds the maximum length of :max characters.',
+            'customLicenses.*.uri.required' => '[Licenses & Rights] Custom license #:position requires a license text URL.',
+            'customLicenses.*.uri.max' => '[Licenses & Rights] Custom license #:position URL exceeds the maximum length of :max characters.',
+            'customLicenses.*.sourceResourceRightId.exists' => '[Licenses & Rights] Custom license #:position cannot be linked to the imported rights statement.',
 
             // Authors
             'authors.*.type.required' => '[Authors] Author #:position must have a type (person or institution).',

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -883,7 +883,7 @@ class StoreDraftResourceRequest extends FormRequest
                 $normalized['sourceResourceRightId'] = is_numeric($sourceId) ? (int) $sourceId : $sourceId;
             }
 
-            if ($normalized['name'] === null && $normalized['uri'] === null && ! array_key_exists('sourceResourceRightId', $normalized)) {
+            if ($normalized['name'] === null || $normalized['uri'] === null) {
                 continue;
             }
 

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -895,6 +895,7 @@ class StoreDraftResourceRequest extends FormRequest
 
         return $customLicenses;
     }
+
     /**
      * @param  array<string, mixed>  $statement
      * @param  list<string>  $keys
@@ -1018,6 +1019,18 @@ class StoreDraftResourceRequest extends FormRequest
             // Datacenters
             'datacenters.*.exists' => '[Resource Information] Datacenter #:position is not a valid datacenter.',
             'datacenters.*.distinct' => '[Resource Information] Datacenter #:position is a duplicate.',
+        ];
+    }
+
+    /**
+     * Human-readable labels for rule messages that interpolate :attribute.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'customLicenses.*.uri' => 'Custom license #:position license text URL',
         ];
     }
 

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -1006,6 +1006,7 @@ class StoreResourceRequest extends FormRequest
 
         return false;
     }
+
     /**
      * @param  array<string, mixed>  $statement
      * @param  list<string>  $keys
@@ -1178,6 +1179,18 @@ class StoreResourceRequest extends FormRequest
             'instruments.*.name.required' => '[Used Instruments] Instrument #:position requires a name.',
             'instruments.*.pidType.required' => '[Used Instruments] Instrument #:position requires a PID type.',
             'instruments.*.pidType.in' => '[Used Instruments] Instrument #:position has an invalid PID type.',
+        ];
+    }
+
+    /**
+     * Human-readable labels for rule messages that interpolate :attribute.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'customLicenses.*.uri' => 'Custom license #:position license text URL',
         ];
     }
 

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -11,6 +11,7 @@ use App\Models\RelatedItem;
 use App\Models\ResourceType;
 use App\Models\TitleType;
 use App\Rules\HasMainTitle;
+use App\Rules\SafeUrl;
 use App\Services\DoiSuggestionService;
 use App\Support\BooleanNormalizer;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -60,6 +61,10 @@ class StoreResourceRequest extends FormRequest
             'titles.*.language' => ['nullable', 'string', 'max:10'],
             'licenses' => ['nullable', 'array'],
             'licenses.*' => ['string', 'distinct', Rule::exists('rights', 'identifier')],
+            'customLicenses' => ['nullable', 'array'],
+            'customLicenses.*.name' => ['required', 'string', 'max:255'],
+            'customLicenses.*.uri' => ['required', 'string', new SafeUrl('[Licenses & Rights]'), 'max:512'],
+            'customLicenses.*.sourceResourceRightId' => ['nullable', 'integer', Rule::exists('resource_rights', 'id')],
             'rawRights' => ['nullable', 'array'],
             'rawRights.*.rights' => ['nullable', 'string'],
             'rawRights.*.rightsUri' => ['nullable', 'string', 'max:512'],
@@ -865,6 +870,12 @@ class StoreResourceRequest extends FormRequest
             'fundingReferences' => $fundingReferences,
         ]);
 
+        if ($this->has('customLicenses')) {
+            $this->merge([
+                'customLicenses' => $this->normalizeCustomLicensesInput($this->input('customLicenses', [])),
+            ]);
+        }
+
         $this->titleTypeDbSlugSet = $titleTypeDbSlugSet;
     }
 
@@ -935,6 +946,66 @@ class StoreResourceRequest extends FormRequest
         return false;
     }
 
+    /**
+     * @return array<int, array<string, mixed>>|mixed
+     */
+    private function normalizeCustomLicensesInput(mixed $customLicensesInput): mixed
+    {
+        if (! is_array($customLicensesInput)) {
+            return $customLicensesInput;
+        }
+
+        $customLicenses = [];
+
+        foreach ($customLicensesInput as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $normalized = [
+                'name' => $this->rightsStringValue($entry, ['name', 'rights', 'rights_text']),
+                'uri' => $this->rightsStringValue($entry, ['uri', 'rightsUri', 'rightsURI', 'rights_uri']),
+            ];
+
+            if (array_key_exists('sourceResourceRightId', $entry) || array_key_exists('source_resource_right_id', $entry)) {
+                $sourceId = $entry['sourceResourceRightId'] ?? $entry['source_resource_right_id'];
+                $normalized['sourceResourceRightId'] = is_numeric($sourceId) ? (int) $sourceId : $sourceId;
+            }
+
+            if ($normalized['name'] === null && $normalized['uri'] === null && ! array_key_exists('sourceResourceRightId', $normalized)) {
+                continue;
+            }
+
+            $customLicenses[] = array_filter(
+                $normalized,
+                fn (mixed $value): bool => $value !== null,
+            );
+        }
+
+        return $customLicenses;
+    }
+
+    /**
+     * @param  array<int, mixed>  $customLicenses
+     */
+    private function customLicensesContainEvidence(array $customLicenses): bool
+    {
+        foreach ($customLicenses as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            foreach (['name', 'uri'] as $key) {
+                $value = $entry[$key] ?? null;
+
+                if ($value !== null && ! is_array($value) && ! is_object($value) && trim((string) $value) !== '') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
     /**
      * @param  array<string, mixed>  $statement
      * @param  list<string>  $keys
@@ -1028,6 +1099,11 @@ class StoreResourceRequest extends FormRequest
             'licenses.min' => '[Licenses & Rights] At least one license is required.',
             'licenses.*.exists' => '[Licenses & Rights] License #:position is not a recognized license.',
             'licenses.*.distinct' => '[Licenses & Rights] License #:position is a duplicate.',
+            'customLicenses.*.name.required' => '[Licenses & Rights] Custom license #:position requires a name.',
+            'customLicenses.*.name.max' => '[Licenses & Rights] Custom license #:position name exceeds the maximum length of :max characters.',
+            'customLicenses.*.uri.required' => '[Licenses & Rights] Custom license #:position requires a license text URL.',
+            'customLicenses.*.uri.max' => '[Licenses & Rights] Custom license #:position URL exceeds the maximum length of :max characters.',
+            'customLicenses.*.sourceResourceRightId.exists' => '[Licenses & Rights] Custom license #:position cannot be linked to the imported rights statement.',
 
             // Authors
             'authors.required' => '[Authors] At least one author is required.',
@@ -1115,14 +1191,16 @@ class StoreResourceRequest extends FormRequest
             function (Validator $validator): void {
                 $licenses = $this->input('licenses', []);
                 $rawRights = $this->input('rawRights', []);
+                $customLicenses = $this->input('customLicenses', []);
 
                 $hasSelectedLicense = is_array($licenses) && count($licenses) > 0;
                 $hasRawRightsEvidence = is_array($rawRights) && $this->rawRightsContainEvidence($rawRights);
+                $hasCustomLicenseEvidence = is_array($customLicenses) && $this->customLicensesContainEvidence($customLicenses);
 
-                if (! $hasSelectedLicense && ! $hasRawRightsEvidence) {
+                if (! $hasSelectedLicense && ! $hasRawRightsEvidence && ! $hasCustomLicenseEvidence) {
                     $validator->errors()->add(
                         'licenses',
-                        '[Licenses & Rights] At least one license or imported rights statement is required.',
+                        '[Licenses & Rights] At least one license, custom license, or imported rights statement is required.',
                     );
                 }
             },

--- a/app/Rules/SafeUrl.php
+++ b/app/Rules/SafeUrl.php
@@ -26,6 +26,8 @@ use Illuminate\Contracts\Validation\ValidationRule;
  */
 final class SafeUrl implements ValidationRule
 {
+    public function __construct(private readonly ?string $messagePrefix = null) {}
+
     /**
      * Allowed URL schemes for safe rendering in HTML href attributes.
      *
@@ -47,7 +49,7 @@ final class SafeUrl implements ValidationRule
 
         // Must be a string
         if (! is_string($value)) {
-            $fail('The :attribute must be a string.');
+            $this->fail($fail, 'The :attribute must be a string.');
 
             return;
         }
@@ -57,7 +59,7 @@ final class SafeUrl implements ValidationRule
 
         // If parsing fails completely, the URL is malformed
         if ($uri === null) {
-            $fail('The :attribute must be a valid URL.');
+            $this->fail($fail, 'The :attribute must be a valid URL.');
 
             return;
         }
@@ -67,7 +69,7 @@ final class SafeUrl implements ValidationRule
 
         // Check for missing scheme (relative URLs like "example.com/path")
         if ($scheme === null) {
-            $fail('The :attribute must include a URL scheme (http or https).');
+            $this->fail($fail, 'The :attribute must include a URL scheme (http or https).');
 
             return;
         }
@@ -75,7 +77,7 @@ final class SafeUrl implements ValidationRule
         // For http/https URLs, we require a host (reject "http://" without host)
         if (in_array(strtolower($scheme), self::ALLOWED_SCHEMES, true)) {
             if ($host === null || $host === '') {
-                $fail('The :attribute must be a valid URL.');
+                $this->fail($fail, 'The :attribute must be a valid URL.');
 
                 return;
             }
@@ -86,6 +88,14 @@ final class SafeUrl implements ValidationRule
 
         // Reject other schemes (javascript:, data:, vbscript:, ftp:, file:, etc.)
         // This is the XSS protection
-        $fail('The :attribute must use http or https protocol.');
+        $this->fail($fail, 'The :attribute must use http or https protocol.');
+    }
+
+    /**
+     * @param  Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    private function fail(Closure $fail, string $message): void
+    {
+        $fail($this->messagePrefix !== null ? $this->messagePrefix.' '.$message : $message);
     }
 }

--- a/app/Services/DataCiteJsonExporter.php
+++ b/app/Services/DataCiteJsonExporter.php
@@ -18,6 +18,7 @@ use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\Right;
 use App\Services\SizeFormat\SizeFormatFormatNormalizerService;
+use App\Services\Rights\CustomRightCatalogService;
 use App\Services\Spdx\SpdxLicenseLookup;
 use App\Services\Traits\DataCiteExporterHelpers;
 use App\Support\OrcidNormalizer;
@@ -780,9 +781,10 @@ class DataCiteJsonExporter
             if ($right instanceof Right) {
                 $rightsText = $right->name;
                 $rightsUri = $right->uri ?? $resourceRight->rights_uri;
-                $rightsIdentifier = $right->identifier;
-                $identifierScheme = SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME;
-                $schemeUri = $right->scheme_uri ?? $resourceRight->scheme_uri;
+                $isSpdxRight = CustomRightCatalogService::isSpdxRight($right);
+                $rightsIdentifier = $isSpdxRight ? $right->identifier : null;
+                $identifierScheme = $isSpdxRight ? SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME : null;
+                $schemeUri = $isSpdxRight ? ($right->scheme_uri ?? $resourceRight->scheme_uri) : null;
             } else {
                 $rightsText = $resourceRight->rights_text;
                 $rightsUri = $resourceRight->rights_uri;

--- a/app/Services/DataCiteXmlExporter.php
+++ b/app/Services/DataCiteXmlExporter.php
@@ -14,6 +14,7 @@ use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\Right;
 use App\Services\SizeFormat\SizeFormatFormatNormalizerService;
+use App\Services\Rights\CustomRightCatalogService;
 use App\Services\Spdx\SpdxLicenseLookup;
 use App\Services\Traits\DataCiteExporterHelpers;
 use DOMDocument;
@@ -1155,9 +1156,10 @@ class DataCiteXmlExporter
             if ($right instanceof Right) {
                 $rightsText = $right->name;
                 $rightsUri = $right->uri ?? $resourceRight->rights_uri;
-                $rightsIdentifier = $right->identifier;
-                $identifierScheme = SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME;
-                $schemeUri = $right->scheme_uri ?? $resourceRight->scheme_uri;
+                $isSpdxRight = CustomRightCatalogService::isSpdxRight($right);
+                $rightsIdentifier = $isSpdxRight ? $right->identifier : null;
+                $identifierScheme = $isSpdxRight ? SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME : null;
+                $schemeUri = $isSpdxRight ? ($right->scheme_uri ?? $resourceRight->scheme_uri) : null;
             } else {
                 $rightsText = $resourceRight->rights_text;
                 $rightsUri = $resourceRight->rights_uri;

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -17,7 +17,9 @@ use App\Models\Resource;
 use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\ResourceDate;
+use App\Models\Right;
 use App\Models\Setting;
+use App\Services\Rights\CustomRightCatalogService;
 use App\Support\GemetVocabularyParser;
 use App\Support\OrcidNormalizer;
 use App\Support\SubjectBreadcrumbPath;
@@ -129,32 +131,42 @@ class EditorDataTransformer
      */
     public function transformLicenses(Resource $resource): array
     {
-        return $resource->rights->pluck('identifier')->toArray();
+        return $resource->rights
+            ->filter(fn (Right $right): bool => CustomRightCatalogService::isSpdxRight($right))
+            ->pluck('identifier')
+            ->values()
+            ->toArray();
     }
 
     /**
-     * Transform stored resource-rights statements back to the hidden import
-     * context expected by the editor.
+     * Transform stored resource-rights statements to editable custom/import rows.
      *
-     * These values are not displayed as editable UI. They only travel with the
-     * form so a regular resource update does not discard unresolved imported
-     * rights before a reviewer has accepted or declined SPDX suggestions.
+     * SPDX catalog rows remain in `initialLicenses`; unresolved imports and
+     * linked custom catalog rights are shown as custom license rows in the editor.
      *
-     * @return array<int, array<string, string>>
+     * @return array<int, array<string, mixed>>
      */
     public function transformRawRights(Resource $resource): array
     {
         return $resource->resourceRights
+            ->sortBy('id')
             ->map(function ($resourceRight): array {
+                $right = $resourceRight->right;
+
+                if (CustomRightCatalogService::isSpdxRight($right)) {
+                    return [];
+                }
+
                 return array_filter([
-                    'rights' => $resourceRight->rights_text,
-                    'rightsUri' => $resourceRight->rights_uri,
-                    'rightsIdentifier' => $resourceRight->rights_identifier,
-                    'rightsIdentifierScheme' => $resourceRight->rights_identifier_scheme,
-                    'schemeUri' => $resourceRight->scheme_uri,
+                    'sourceResourceRightId' => $resourceRight->id,
+                    'rights' => $right instanceof Right ? $right->name : $resourceRight->rights_text,
+                    'rightsUri' => $right instanceof Right ? ($right->uri ?? $resourceRight->rights_uri) : $resourceRight->rights_uri,
+                    'rightsIdentifier' => $right instanceof Right ? null : $resourceRight->rights_identifier,
+                    'rightsIdentifierScheme' => $right instanceof Right ? null : $resourceRight->rights_identifier_scheme,
+                    'schemeUri' => $right instanceof Right ? null : $resourceRight->scheme_uri,
                     'lang' => $resourceRight->language,
                     'source' => $resourceRight->source,
-                ], fn (?string $value): bool => $value !== null && trim($value) !== '');
+                ], fn (mixed $value): bool => $value !== null && (! is_string($value) || trim($value) !== ''));
             })
             ->filter(fn (array $statement): bool => $statement !== [])
             ->values()

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -157,6 +157,18 @@ class EditorDataTransformer
                     return [];
                 }
 
+                $hasRawEvidence = false;
+                foreach ([$resourceRight->rights_text, $resourceRight->rights_uri, $resourceRight->rights_identifier] as $value) {
+                    if (is_string($value) && trim($value) !== '') {
+                        $hasRawEvidence = true;
+                        break;
+                    }
+                }
+
+                if (! $right instanceof Right && ! $hasRawEvidence) {
+                    return [];
+                }
+
                 return array_filter([
                     'sourceResourceRightId' => $resourceRight->id,
                     'rights' => $right instanceof Right ? $right->name : $resourceRight->rights_text,

--- a/app/Services/LandingPageResourceTransformer.php
+++ b/app/Services/LandingPageResourceTransformer.php
@@ -28,6 +28,7 @@ use App\Models\ResourceDate;
 use App\Models\Right;
 use App\Models\Subject;
 use App\Models\Title;
+use App\Services\Rights\CustomRightCatalogService;
 use App\Support\PortalSubjectNormalizer;
 use App\Support\SubjectBreadcrumbPath;
 use Illuminate\Database\Eloquent\Collection;
@@ -312,13 +313,14 @@ final class LandingPageResourceTransformer
             ])
             ->all();
 
-        // Transform rights to licenses with frontend-compatible field names
+        // Transform rights to licenses with frontend-compatible field names.
         $resourceData['licenses'] = $resource->rights
             ->map(static fn (Right $right): array => [
                 'id' => $right->id,
                 'name' => $right->name,
-                'spdx_id' => $right->identifier,
+                'spdx_id' => CustomRightCatalogService::isSpdxRight($right) ? $right->identifier : null,
                 'reference' => $right->uri,
+                'scheme_uri' => $right->scheme_uri,
             ])
             ->all();
 

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -23,6 +23,7 @@ use App\Services\Citations\RelatedItemStorageService;
 use App\Services\Entities\AffiliationService;
 use App\Services\Entities\InstitutionService;
 use App\Services\Entities\PersonService;
+use App\Services\Rights\CustomRightCatalogService;
 use App\Services\Rights\ResourceRightsStorageService;
 use App\Support\OrcidNormalizer;
 use App\Support\SubjectBreadcrumbPath;
@@ -50,6 +51,7 @@ class ResourceStorageService
         protected RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService,
         protected RelatedItemStorageService $relatedItemStorage,
         protected ResourceRightsStorageService $resourceRightsStorage,
+        protected CustomRightCatalogService $customRightCatalog,
         protected SubjectBreadcrumbPathResolverService $subjectBreadcrumbPathResolver,
     ) {}
 
@@ -453,14 +455,25 @@ class ResourceStorageService
      */
     private function syncLicenses(Resource $resource, array $data): void
     {
-        // Sync selected catalog rights and keep raw imported statements. This
-        // lets an import store "CC BY 4.0" as-is while the SPDX assistant later
-        // proposes whether it should link to the shared SPDX catalog entry.
+        $licenseIdentifiers = $this->licenseIdentifierList($data['licenses'] ?? []);
+        $sourceResourceRightLinks = [];
+
+        foreach ($this->customLicenseList($data['customLicenses'] ?? []) as $customLicense) {
+            $right = $this->customRightCatalog->findOrCreate($customLicense['name'], $customLicense['uri']);
+            $licenseIdentifiers[] = $right->identifier;
+
+            if (isset($customLicense['sourceResourceRightId'])) {
+                $sourceResourceRightLinks[$customLicense['sourceResourceRightId']] = (int) $right->id;
+            }
+        }
+
         $this->resourceRightsStorage->syncEditorRights(
             $resource,
-            $this->licenseIdentifierList($data['licenses'] ?? []),
+            array_values(array_unique($licenseIdentifiers)),
             $this->rawRightsList($data['rawRights'] ?? []),
             $resource->language?->code,
+            $sourceResourceRightLinks,
+            array_key_exists('customLicenses', $data),
         );
     }
 
@@ -482,6 +495,48 @@ class ResourceStorageService
         }
 
         return $identifiers;
+    }
+
+    /**
+     * @return list<array{name: string, uri: string, sourceResourceRightId?: int}>
+     */
+    private function customLicenseList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $customLicenses = [];
+
+        foreach ($value as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $name = isset($entry['name']) && (is_string($entry['name']) || is_numeric($entry['name']))
+                ? trim((string) $entry['name'])
+                : '';
+            $uri = isset($entry['uri']) && (is_string($entry['uri']) || is_numeric($entry['uri']))
+                ? trim((string) $entry['uri'])
+                : '';
+
+            if ($name === '' && $uri === '') {
+                continue;
+            }
+
+            $customLicense = [
+                'name' => $name,
+                'uri' => $uri,
+            ];
+
+            if (isset($entry['sourceResourceRightId']) && is_numeric($entry['sourceResourceRightId'])) {
+                $customLicense['sourceResourceRightId'] = (int) $entry['sourceResourceRightId'];
+            }
+
+            $customLicenses[] = $customLicense;
+        }
+
+        return $customLicenses;
     }
 
     /**

--- a/app/Services/Rights/CustomRightCatalogService.php
+++ b/app/Services/Rights/CustomRightCatalogService.php
@@ -97,6 +97,7 @@ final class CustomRightCatalogService
     {
         $normalizedName = SpdxLicenseLookup::normalizeText($name);
         $normalizedUri = SpdxLicenseLookup::normalizeUri($uri);
+        $uriLikePattern = '%'.$this->escapeSqlLikePattern($normalizedUri).'%';
 
         /** @var Collection<int, Right> $candidates */
         $candidates = Right::query()
@@ -107,13 +108,18 @@ final class CustomRightCatalogService
             })
             ->whereNotNull('uri')
             ->whereRaw('LOWER(TRIM(name)) = ?', [Str::lower(trim($name))])
-            ->whereRaw('LOWER(uri) LIKE ?', ['%'.$normalizedUri.'%'])
+            ->whereRaw("LOWER(uri) LIKE ? ESCAPE '!'", [$uriLikePattern])
             ->get();
 
         return $candidates->first(
             fn (Right $right): bool => SpdxLicenseLookup::normalizeText($right->name) === $normalizedName
                 && SpdxLicenseLookup::normalizeUri($right->uri) === $normalizedUri
         );
+    }
+
+    private function escapeSqlLikePattern(string $value): string
+    {
+        return str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $value);
     }
 
     private function normalizeRequired(string $value, string $field, string $message): string

--- a/app/Services/Rights/CustomRightCatalogService.php
+++ b/app/Services/Rights/CustomRightCatalogService.php
@@ -97,11 +97,14 @@ final class CustomRightCatalogService
 
         /** @var \Illuminate\Database\Eloquent\Collection<int, Right> $candidates */
         $candidates = Right::query()
+            ->select(['id', 'identifier', 'name', 'uri', 'scheme_uri', 'is_active', 'is_elmo_active'])
             ->where(function ($query): void {
                 $query->whereNull('scheme_uri')
                     ->orWhere('scheme_uri', '!=', SpdxLicenseLookup::SCHEME_URI);
             })
             ->whereNotNull('uri')
+            ->whereRaw('LOWER(TRIM(name)) = ?', [Str::lower(trim($name))])
+            ->whereRaw('LOWER(uri) LIKE ?', ['%'.$normalizedUri.'%'])
             ->get();
 
         return $candidates->first(

--- a/app/Services/Rights/CustomRightCatalogService.php
+++ b/app/Services/Rights/CustomRightCatalogService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Rights;
+
+use App\Models\Right;
+use App\Services\Spdx\SpdxLicenseLookup;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+final class CustomRightCatalogService
+{
+    public const string IDENTIFIER_PREFIX = 'CUSTOM-';
+
+    private const int MAX_SLUG_LENGTH = 180;
+
+    public function findOrCreate(string $name, string $uri): Right
+    {
+        $name = $this->normalizeRequired($name, 'customLicenses.*.name', 'Custom license name is required.');
+        $uri = $this->normalizeRequired($uri, 'customLicenses.*.uri', 'Custom license URL is required.');
+        $identifier = $this->identifierFor($name, $uri);
+
+        /** @var Right|null $existingByIdentifier */
+        $existingByIdentifier = Right::query()
+            ->where('identifier', $identifier)
+            ->first();
+
+        if ($existingByIdentifier instanceof Right) {
+            return $this->activateCustomRight($existingByIdentifier);
+        }
+
+        $existingByNameAndUri = $this->findExistingCustomRight($name, $uri);
+
+        if ($existingByNameAndUri instanceof Right) {
+            return $this->activateCustomRight($existingByNameAndUri);
+        }
+
+        /** @var Right $right */
+        $right = Right::query()->create([
+            'identifier' => $identifier,
+            'name' => $name,
+            'uri' => $uri,
+            'scheme_uri' => null,
+            'is_active' => true,
+            'is_elmo_active' => false,
+            'usage_count' => 0,
+        ]);
+
+        return $right;
+    }
+
+    public static function isSpdxRight(?Right $right): bool
+    {
+        return $right instanceof Right
+            && $right->scheme_uri === SpdxLicenseLookup::SCHEME_URI;
+    }
+
+    public static function isCustomRight(?Right $right): bool
+    {
+        return $right instanceof Right
+            && ! self::isSpdxRight($right);
+    }
+
+    public function identifierFor(string $name, string $uri): string
+    {
+        $slug = Str::slug($name, '-');
+        $slug = $slug !== '' ? $slug : 'license';
+        $slug = mb_strtoupper(mb_substr($slug, 0, self::MAX_SLUG_LENGTH));
+        $hash = substr(hash('sha256', Str::lower(trim($name)).'|'.SpdxLicenseLookup::normalizeUri($uri)), 0, 12);
+
+        return self::IDENTIFIER_PREFIX.$slug.'-'.mb_strtoupper($hash);
+    }
+
+    private function activateCustomRight(Right $right): Right
+    {
+        if (self::isSpdxRight($right)) {
+            throw ValidationException::withMessages([
+                'customLicenses' => '[Licenses & Rights] The generated custom license identifier conflicts with an SPDX license.',
+            ]);
+        }
+
+        if (! $right->is_active || $right->is_elmo_active) {
+            $right->forceFill([
+                'is_active' => true,
+                'is_elmo_active' => false,
+            ])->save();
+        }
+
+        return $right;
+    }
+
+    private function findExistingCustomRight(string $name, string $uri): ?Right
+    {
+        $normalizedName = SpdxLicenseLookup::normalizeText($name);
+        $normalizedUri = SpdxLicenseLookup::normalizeUri($uri);
+
+        /** @var \Illuminate\Database\Eloquent\Collection<int, Right> $candidates */
+        $candidates = Right::query()
+            ->where(function ($query): void {
+                $query->whereNull('scheme_uri')
+                    ->orWhere('scheme_uri', '!=', SpdxLicenseLookup::SCHEME_URI);
+            })
+            ->whereNotNull('uri')
+            ->get();
+
+        return $candidates->first(
+            fn (Right $right): bool => SpdxLicenseLookup::normalizeText($right->name) === $normalizedName
+                && SpdxLicenseLookup::normalizeUri($right->uri) === $normalizedUri
+        );
+    }
+
+    private function normalizeRequired(string $value, string $field, string $message): string
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            throw ValidationException::withMessages([
+                $field => '[Licenses & Rights] '.$message,
+            ]);
+        }
+
+        return $value;
+    }
+}

--- a/app/Services/Rights/CustomRightCatalogService.php
+++ b/app/Services/Rights/CustomRightCatalogService.php
@@ -6,6 +6,7 @@ namespace App\Services\Rights;
 
 use App\Models\Right;
 use App\Services\Spdx\SpdxLicenseLookup;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
@@ -37,17 +38,19 @@ final class CustomRightCatalogService
         }
 
         /** @var Right $right */
-        $right = Right::query()->create([
-            'identifier' => $identifier,
-            'name' => $name,
-            'uri' => $uri,
-            'scheme_uri' => null,
-            'is_active' => true,
-            'is_elmo_active' => false,
-            'usage_count' => 0,
-        ]);
+        $right = Right::query()->firstOrCreate(
+            ['identifier' => $identifier],
+            [
+                'name' => $name,
+                'uri' => $uri,
+                'scheme_uri' => null,
+                'is_active' => true,
+                'is_elmo_active' => false,
+                'usage_count' => 0,
+            ],
+        );
 
-        return $right;
+        return $this->activateCustomRight($right);
     }
 
     public static function isSpdxRight(?Right $right): bool
@@ -95,7 +98,7 @@ final class CustomRightCatalogService
         $normalizedName = SpdxLicenseLookup::normalizeText($name);
         $normalizedUri = SpdxLicenseLookup::normalizeUri($uri);
 
-        /** @var \Illuminate\Database\Eloquent\Collection<int, Right> $candidates */
+        /** @var Collection<int, Right> $candidates */
         $candidates = Right::query()
             ->select(['id', 'identifier', 'name', 'uri', 'scheme_uri', 'is_active', 'is_elmo_active'])
             ->where(function ($query): void {

--- a/app/Services/Rights/ResourceRightsStorageService.php
+++ b/app/Services/Rights/ResourceRightsStorageService.php
@@ -28,15 +28,19 @@ final class ResourceRightsStorageService
     /**
      * @param  list<string>  $licenseIdentifiers
      * @param  array<int, array<string, mixed>>  $rawRights
+     * @param  array<int, int>  $sourceResourceRightLinks
      */
     public function syncEditorRights(
         Resource $resource,
         array $licenseIdentifiers,
         array $rawRights = [],
         ?string $fallbackLanguage = null,
+        array $sourceResourceRightLinks = [],
+        bool $replaceUnresolvedRawRights = false,
     ): void {
         $selectedRights = $this->rightsByIdentifier($licenseIdentifiers);
         $selectedRightIds = array_values($selectedRights);
+        $sourceResourceRightIds = array_keys($sourceResourceRightLinks);
 
         // The editor owns linked catalog selections, so a normal save should
         // remove linked rows that are no longer selected. Unresolved imported
@@ -49,13 +53,26 @@ final class ResourceRightsStorageService
                 $selectedRightIds !== [],
                 fn ($query) => $query->whereNotIn('rights_id', $selectedRightIds),
             )
+            ->when(
+                $sourceResourceRightIds !== [],
+                fn ($query) => $query->whereKeyNot($sourceResourceRightIds),
+            )
             ->delete();
+
+        $this->linkSourceResourceRightRows($resource, $sourceResourceRightLinks);
 
         foreach ($selectedRightIds as $rightId) {
             ResourceRight::query()->firstOrCreate([
                 'resource_id' => $resource->id,
                 'rights_id' => $rightId,
             ]);
+        }
+
+        if ($replaceUnresolvedRawRights) {
+            ResourceRight::query()
+                ->where('resource_id', $resource->id)
+                ->whereNull('rights_id')
+                ->delete();
         }
 
         $this->persistImportedStatements($resource, $rawRights, 'editor-import', $fallbackLanguage, $selectedRightIds);
@@ -283,6 +300,51 @@ final class ResourceRightsStorageService
 
         if ($dirty) {
             $row->save();
+        }
+    }
+
+    /**
+     * @param  array<int, int>  $sourceResourceRightLinks
+     */
+    private function linkSourceResourceRightRows(Resource $resource, array $sourceResourceRightLinks): void
+    {
+        foreach ($sourceResourceRightLinks as $resourceRightId => $rightId) {
+            /** @var ResourceRight|null $sourceRow */
+            $sourceRow = ResourceRight::query()
+                ->where('resource_id', $resource->id)
+                ->whereKey($resourceRightId)
+                ->first();
+
+            if (! $sourceRow instanceof ResourceRight || $sourceRow->rights_id === $rightId) {
+                continue;
+            }
+
+            /** @var ResourceRight|null $existingLinkedRow */
+            $existingLinkedRow = ResourceRight::query()
+                ->where('resource_id', $resource->id)
+                ->where('rights_id', $rightId)
+                ->whereKeyNot($sourceRow->id)
+                ->first();
+
+            if ($existingLinkedRow instanceof ResourceRight) {
+                $payload = [
+                    'rights_text' => $this->normalizeNullable($sourceRow->rights_text),
+                    'rights_uri' => $this->normalizeNullable($sourceRow->rights_uri),
+                    'rights_identifier' => $this->normalizeNullable($sourceRow->rights_identifier),
+                    'rights_identifier_scheme' => $this->normalizeNullable($sourceRow->rights_identifier_scheme),
+                    'scheme_uri' => $this->normalizeNullable($sourceRow->scheme_uri),
+                    'language' => $this->normalizeNullable($sourceRow->language),
+                    'source' => $this->normalizeNullable($sourceRow->source),
+                ];
+
+                $this->fillEmptyRawColumns($existingLinkedRow, $payload);
+                $sourceRow->delete();
+
+                continue;
+            }
+
+            $sourceRow->rights_id = $rightId;
+            $sourceRow->save();
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
-      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+      "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
       "dev": true,
       "funding": [
         {
@@ -5001,9 +5001,9 @@
       "license": "MIT"
     },
     "node_modules/@types/google.maps": {
-      "version": "3.65.1",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.1.tgz",
-      "integrity": "sha512-O9monmoXfyWsuyR4Wz3TZU26qai9y7jUV7DSRySluae6O5tQt3Obw5ETt0HKfNsjctnlF/yx/Tfn3WQNmKRXZA==",
+      "version": "3.65.2",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.2.tgz",
+      "integrity": "sha512-e52bmOhGCQSNabFpL48iQlwJybq6rfns8NUVJ20MR7CdPlHQ2RmSCnPbJfrUYJfogrE4OiHQTZ4LXpop+eer1w==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -5041,9 +5041,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5345,9 +5345,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10158,9 +10158,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10962,9 +10962,9 @@
       "license": "MIT"
     },
     "node_modules/papaparse": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+      "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
       "license": "MIT"
     },
     "node_modules/parse-entities": {
@@ -11614,9 +11614,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.79.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
-      "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
+      "version": "7.80.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.80.0.tgz",
+      "integrity": "sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -12539,9 +12539,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/srvx": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
-      "integrity": "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==",
+      "version": "0.11.17",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.17.tgz",
+      "integrity": "sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/resources/data/openapi.json
+++ b/resources/data/openapi.json
@@ -125,7 +125,16 @@
                                     "items": {
                                         "$ref": "#/components/schemas/License"
                                     }
-                                }
+                                },
+                                "example": [
+                                    {
+                                        "id": 1,
+                                        "identifier": "CC-BY-4.0",
+                                        "name": "Creative Commons Attribution 4.0 International",
+                                        "uri": "https://creativecommons.org/licenses/by/4.0/",
+                                        "scheme_uri": "https://spdx.org/licenses/"
+                                    }
+                                ]
                             }
                         }
                     },
@@ -178,12 +187,16 @@
                                     {
                                         "id": 1,
                                         "identifier": "MIT",
-                                        "name": "MIT License"
+                                        "name": "MIT License",
+                                        "uri": "https://spdx.org/licenses/MIT.html",
+                                        "scheme_uri": "https://spdx.org/licenses/"
                                     },
                                     {
                                         "id": 2,
                                         "identifier": "GPL-3.0-or-later",
-                                        "name": "GNU General Public License v3.0 or later"
+                                        "name": "GNU General Public License v3.0 or later",
+                                        "uri": "https://spdx.org/licenses/GPL-3.0-or-later.html",
+                                        "scheme_uri": "https://spdx.org/licenses/"
                                     }
                                 ]
                             }
@@ -1692,7 +1705,7 @@
             },
             "License": {
                 "type": "object",
-                "description": "A license that can be applied to research data",
+                "description": "A license or reusable rights statement that can be applied to research data",
                 "properties": {
                     "id": {
                         "type": "integer",
@@ -1701,15 +1714,27 @@
                     },
                     "identifier": {
                         "type": "string",
-                        "description": "SPDX license identifier",
+                        "description": "License/right identifier. Catalog licenses usually use SPDX identifiers; reusable custom rights use generated identifiers.",
                         "example": "CC-BY-4.0"
                     },
                     "name": {
                         "type": "string",
                         "example": "Creative Commons Attribution 4.0 International"
+                    },
+                    "uri": {
+                        "type": ["string", "null"],
+                        "format": "uri",
+                        "description": "URL of the license or rights text, when known.",
+                        "example": "https://creativecommons.org/licenses/by/4.0/"
+                    },
+                    "scheme_uri": {
+                        "type": ["string", "null"],
+                        "format": "uri",
+                        "description": "URI of the identifier scheme, such as SPDX. Null when no scheme is available.",
+                        "example": "https://spdx.org/licenses/"
                     }
                 },
-                "required": ["id", "identifier", "name"]
+                "required": ["id", "identifier", "name", "uri", "scheme_uri"]
             },
             "Language": {
                 "type": "object",

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -69,6 +69,9 @@ import {
     canAddDate,
     canAddLicense,
     canAddTitle,
+    hasAnyLicenseEntryContent,
+    hasCompleteLicenseEntry,
+    isHttpUrl,
     mapInitialAuthorToEntry,
     mapInitialContributorToEntry,
     normalizeTitleTypeSlug,
@@ -238,14 +241,49 @@ export default function DataCiteForm({
         });
     });
 
-    const [licenseEntries, setLicenseEntries] = useState<LicenseEntry[]>(
-        initialLicenses.length
-            ? initialLicenses.map((l) => ({
-                  id: crypto.randomUUID(),
-                  license: l,
-              }))
-            : [{ id: crypto.randomUUID(), license: '' }],
-    );
+    const [licenseEntries, setLicenseEntries] = useState<LicenseEntry[]>(() => {
+        const entries: LicenseEntry[] = [];
+        const licensesByIdentifier = new Map(licenses.map((license) => [license.identifier, license]));
+
+        initialLicenses.forEach((identifier) => {
+            const catalogLicense = licensesByIdentifier.get(identifier);
+
+            if (catalogLicense && (catalogLicense.scheme_uri === null || catalogLicense.identifier.startsWith('CUSTOM-'))) {
+                entries.push({
+                    id: crypto.randomUUID(),
+                    mode: 'custom',
+                    name: catalogLicense.name,
+                    uri: catalogLicense.uri ?? '',
+                });
+                return;
+            }
+
+            entries.push({
+                id: crypto.randomUUID(),
+                mode: 'catalog',
+                license: identifier,
+            });
+        });
+
+        initialRawRights.forEach((rawRight) => {
+            const name = (rawRight.rights ?? rawRight.rightsIdentifier ?? '').trim();
+            const uri = (rawRight.rightsUri ?? '').trim();
+
+            if (!name && !uri) {
+                return;
+            }
+
+            entries.push({
+                id: crypto.randomUUID(),
+                mode: 'custom',
+                name,
+                uri,
+                sourceResourceRightId: rawRight.sourceResourceRightId ?? undefined,
+            });
+        });
+
+        return entries.length > 0 ? entries : [{ id: crypto.randomUUID(), mode: 'catalog', license: '' }];
+    });
 
     const [authors, setAuthors] = useState<AuthorEntry[]>(() => {
         if (initialAuthors.length > 0) {
@@ -607,10 +645,18 @@ export default function DataCiteForm({
         },
     ];
 
-    // License validation rules (primary license is required)
+    // License validation rules (at least one complete license row is required)
     const primaryLicenseValidationRules: ValidationRule[] = [
         {
             validate: (value) => {
+                if (typeof value === 'object' && value !== null && 'mode' in value) {
+                    if (!hasCompleteLicenseEntry(value as LicenseEntry)) {
+                        return { severity: 'error', message: 'At least one license is required.' };
+                    }
+
+                    return null;
+                }
+
                 const result = validateRequired(String(value || ''), 'Primary license');
                 if (!result.isValid) {
                     return { severity: 'error', message: result.error! };
@@ -1257,9 +1303,33 @@ export default function DataCiteForm({
             appendValidationMessage(errors, 'language', 'Language is required.');
         }
 
-        if (!licenseEntries[0]?.license?.trim()) {
-            appendValidationMessage(errors, 'licenses.0.license', 'Primary License is required.');
+        if (!licenseEntries.some(hasCompleteLicenseEntry)) {
+            appendValidationMessage(errors, 'licenses', 'At least one License is required.');
         }
+
+        let customLicenseIndex = 0;
+        licenseEntries.forEach((entry) => {
+            if (entry.mode !== 'custom') {
+                return;
+            }
+
+            const hasContent = hasAnyLicenseEntryContent(entry);
+            if (!hasContent) {
+                return;
+            }
+
+            if (!entry.name.trim()) {
+                appendValidationMessage(errors, `customLicenses.${customLicenseIndex}.name`, 'Custom license name is required.');
+            }
+
+            if (!entry.uri.trim()) {
+                appendValidationMessage(errors, `customLicenses.${customLicenseIndex}.uri`, 'Custom license URL is required.');
+            } else if (!isHttpUrl(entry.uri.trim())) {
+                appendValidationMessage(errors, `customLicenses.${customLicenseIndex}.uri`, 'Custom license URL must use http or https.');
+            }
+
+            customLicenseIndex += 1;
+        });
 
         if (authors.length === 0) {
             appendValidationMessage(errors, 'authors', 'At least one author is required.');
@@ -1347,8 +1417,12 @@ export default function DataCiteForm({
     }, [titles, form.year, form.resourceType, form.language, selectedDatacenters, getFieldState]);
 
     const licensesStatus = useMemo(() => {
-        const primaryLicense = licenseEntries[0]?.license?.trim();
-        if (!primaryLicense) {
+        const hasCompleteLicense = licenseEntries.some(hasCompleteLicenseEntry);
+        const hasInvalidCustomLicense = licenseEntries.some(
+            (entry) => entry.mode === 'custom' && hasAnyLicenseEntryContent(entry) && (!entry.name.trim() || !entry.uri.trim() || !isHttpUrl(entry.uri.trim())),
+        );
+
+        if (!hasCompleteLicense || hasInvalidCustomLicense) {
             return 'invalid';
         }
         return 'valid';
@@ -1609,19 +1683,64 @@ export default function DataCiteForm({
         }
     };
 
-    const handleLicenseChange = (index: number, value: string) => {
-        setLicenseEntries((prev) => {
-            const next = [...prev];
-            next[index] = { ...next[index], license: value };
+    const validatePrimaryLicenseEntry = (entry: LicenseEntry) => {
+        validateField({
+            fieldId: 'license-0',
+            value: entry,
+            rules: primaryLicenseValidationRules,
+            formData: form,
+        });
+    };
 
-            // Validate primary license (index 0)
+    const handleLicenseModeChange = (index: number, mode: LicenseEntry['mode']) => {
+        setLicenseEntries((prev) => {
+            const current = prev[index];
+            if (!current || current.mode === mode) return prev;
+
+            const next = [...prev];
+            const updated: LicenseEntry =
+                mode === 'custom'
+                    ? { id: current.id, mode: 'custom', name: '', uri: '' }
+                    : { id: current.id, mode: 'catalog', license: '' };
+
+            next[index] = updated;
+
             if (index === 0) {
-                validateField({
-                    fieldId: 'license-0',
-                    value,
-                    rules: primaryLicenseValidationRules,
-                    formData: form,
-                });
+                validatePrimaryLicenseEntry(updated);
+            }
+
+            return next;
+        });
+    };
+
+    const handleCatalogLicenseChange = (index: number, value: string) => {
+        setLicenseEntries((prev) => {
+            const current = prev[index];
+            if (!current) return prev;
+
+            const next = [...prev];
+            const updated: LicenseEntry = { id: current.id, mode: 'catalog', license: value };
+            next[index] = updated;
+
+            if (index === 0) {
+                validatePrimaryLicenseEntry(updated);
+            }
+
+            return next;
+        });
+    };
+
+    const handleCustomLicenseChange = (index: number, field: 'name' | 'uri', value: string) => {
+        setLicenseEntries((prev) => {
+            const current = prev[index];
+            if (!current || current.mode !== 'custom') return prev;
+
+            const next = [...prev];
+            const updated: LicenseEntry = { ...current, [field]: value };
+            next[index] = updated;
+
+            if (index === 0) {
+                validatePrimaryLicenseEntry(updated);
             }
 
             return next;
@@ -1630,7 +1749,7 @@ export default function DataCiteForm({
 
     const addLicense = () => {
         if (licenseEntries.length >= MAX_LICENSES) return;
-        setLicenseEntries((prev) => [...prev, { id: crypto.randomUUID(), license: '' }]);
+        setLicenseEntries((prev) => [...prev, { id: crypto.randomUUID(), mode: 'catalog', license: '' }]);
     };
 
     const removeLicense = (index: number) => {
@@ -1818,6 +1937,7 @@ export default function DataCiteForm({
             language: string;
             titles: { title: string; titleType: string; language?: string | null }[];
             licenses: string[];
+            customLicenses: { name: string; uri: string; sourceResourceRightId?: number | null }[];
             authors: SerializedAuthor[];
             contributors: SerializedContributor[];
             mslLaboratories: {
@@ -1886,8 +2006,17 @@ export default function DataCiteForm({
                 titleType: entry.titleType,
                 language: entry.language ?? null,
             })),
-            licenses: licenseEntries.map((entry) => entry.license).filter((license): license is string => Boolean(license)),
-            rawRights: initialRawRights ?? [],
+            licenses: licenseEntries
+                .filter((entry) => entry.mode === 'catalog' && entry.license.trim() !== '')
+                .map((entry) => (entry.mode === 'catalog' ? entry.license : '')),
+            customLicenses: licenseEntries
+                .filter((entry) => entry.mode === 'custom' && hasAnyLicenseEntryContent(entry))
+                .map((entry) => ({
+                    name: entry.mode === 'custom' ? entry.name.trim() : '',
+                    uri: entry.mode === 'custom' ? entry.uri.trim() : '',
+                    ...(entry.mode === 'custom' && entry.sourceResourceRightId != null ? { sourceResourceRightId: entry.sourceResourceRightId } : {}),
+                })),
+            rawRights: [],
             authors: serializedAuthors,
             contributors: serializedContributors,
             mslLaboratories: mslLaboratories.map((lab) => ({
@@ -1982,7 +2111,6 @@ export default function DataCiteForm({
         gcmdKeywords,
         importedCreatedDate,
         initialRelatedItems,
-        initialRawRights,
         instruments,
         licenseEntries,
         mslLaboratories,
@@ -2567,12 +2695,14 @@ export default function DataCiteForm({
                                 <LicenseField
                                     key={entry.id}
                                     id={entry.id}
-                                    license={entry.license}
+                                    entry={entry}
                                     options={licenses.map((l) => ({
                                         value: l.identifier,
                                         label: l.name,
                                     }))}
-                                    onLicenseChange={(val) => handleLicenseChange(index, val)}
+                                    onModeChange={(mode) => handleLicenseModeChange(index, mode)}
+                                    onCatalogLicenseChange={(val) => handleCatalogLicenseChange(index, val)}
+                                    onCustomLicenseChange={(field, val) => handleCustomLicenseChange(index, field, val)}
                                     onAdd={addLicense}
                                     onRemove={() => removeLicense(index)}
                                     isFirst={index === 0}
@@ -2582,6 +2712,8 @@ export default function DataCiteForm({
                                     touched={index === 0 ? getFieldState('license-0').touched : undefined}
                                     onValidationBlur={index === 0 ? () => markFieldTouched('license-0') : undefined}
                                     data-testid={`license-select-${index}`}
+                                    customNameTestId={`custom-license-name-${index}`}
+                                    customUriTestId={`custom-license-uri-${index}`}
                                 />
                             ))}
                         </div>

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -55,11 +55,13 @@ import { type TagInputItem } from './fields/tag-input-field';
 import TitleField from './fields/title-field';
 import UsedInstrumentsField from './fields/used-instruments-field';
 import {
+    type CustomLicenseEntry,
     type DataCiteFormData,
     type DataCiteFormProps,
     type DateEntry,
     type LicenseEntry,
     MAIN_TITLE_SLUG,
+    type RawRightsInput,
     type SerializedAuthor,
     type SerializedContributor,
     type TitleEntry,
@@ -67,7 +69,6 @@ import {
 import { type DateMode, isDateRangeCapable, isEditableDateType, normalizeDateTypeSlug } from './utils/date-rules';
 import {
     canAddDate,
-    canAddLicense,
     canAddTitle,
     hasAnyLicenseEntryContent,
     hasCompleteLicenseEntry,
@@ -117,6 +118,31 @@ function appendValidationMessage(errors: Record<string, string[]>, backendKey: s
     }
 
     errors[backendKey] = [message];
+}
+
+function isRawRightsOnlyLicenseEntry(entry: LicenseEntry): entry is CustomLicenseEntry {
+    return entry.mode === 'custom' && entry.rawRight !== undefined && entry.uri.trim() === '' && entry.name.trim() !== '';
+}
+
+function isCustomLicensePayloadEntry(entry: LicenseEntry): entry is CustomLicenseEntry {
+    return entry.mode === 'custom' && hasAnyLicenseEntryContent(entry) && !isRawRightsOnlyLicenseEntry(entry);
+}
+
+function hasLicenseEntryEvidence(entry: LicenseEntry | undefined): boolean {
+    return hasCompleteLicenseEntry(entry) || (entry !== undefined && isRawRightsOnlyLicenseEntry(entry));
+}
+
+function canAddLicenseEntry(licenseEntries: LicenseEntry[], maxLicenses: number): boolean {
+    return licenseEntries.length < maxLicenses && licenseEntries.length > 0 && hasLicenseEntryEvidence(licenseEntries[licenseEntries.length - 1]);
+}
+
+function serializeRawRightsOnlyLicenseEntry(entry: CustomLicenseEntry): RawRightsInput {
+    return {
+        ...entry.rawRight,
+        rights: entry.name.trim(),
+        rightsUri: null,
+        sourceResourceRightId: entry.sourceResourceRightId ?? entry.rawRight?.sourceResourceRightId ?? null,
+    };
 }
 
 function isDatacenterErrorKey(backendKey: string): boolean {
@@ -279,6 +305,7 @@ export default function DataCiteForm({
                 name,
                 uri,
                 sourceResourceRightId: rawRight.sourceResourceRightId ?? undefined,
+                rawRight,
             });
         });
 
@@ -290,7 +317,7 @@ export default function DataCiteForm({
         let customLicenseIndex = 0;
 
         licenseEntries.forEach((entry) => {
-            if (entry.mode !== 'custom' || !hasAnyLicenseEntryContent(entry)) {
+            if (!isCustomLicensePayloadEntry(entry)) {
                 return;
             }
 
@@ -661,22 +688,14 @@ export default function DataCiteForm({
         },
     ];
 
-    // License validation rules (at least one complete license row is required)
-    const primaryLicenseValidationRules: ValidationRule[] = [
+    // License validation rules (at least one complete license row or imported raw rights statement is required)
+    const primaryLicenseValidationRules: ValidationRule<LicenseEntry[]>[] = [
         {
             validate: (value) => {
-                if (typeof value === 'object' && value !== null && 'mode' in value) {
-                    if (!hasCompleteLicenseEntry(value as LicenseEntry)) {
-                        return { severity: 'error', message: 'At least one license is required.' };
-                    }
-
-                    return null;
+                if (!value.some(hasLicenseEntryEvidence)) {
+                    return { severity: 'error', message: 'At least one license is required.' };
                 }
 
-                const result = validateRequired(String(value || ''), 'Primary license');
-                if (!result.isValid) {
-                    return { severity: 'error', message: result.error! };
-                }
                 return null;
             },
         },
@@ -1319,18 +1338,13 @@ export default function DataCiteForm({
             appendValidationMessage(errors, 'language', 'Language is required.');
         }
 
-        if (!licenseEntries.some(hasCompleteLicenseEntry)) {
+        if (!licenseEntries.some(hasLicenseEntryEvidence)) {
             appendValidationMessage(errors, 'licenses', 'At least one License is required.');
         }
 
         let customLicenseIndex = 0;
         licenseEntries.forEach((entry) => {
-            if (entry.mode !== 'custom') {
-                return;
-            }
-
-            const hasContent = hasAnyLicenseEntryContent(entry);
-            if (!hasContent) {
+            if (!isCustomLicensePayloadEntry(entry)) {
                 return;
             }
 
@@ -1433,9 +1447,9 @@ export default function DataCiteForm({
     }, [titles, form.year, form.resourceType, form.language, selectedDatacenters, getFieldState]);
 
     const licensesStatus = useMemo(() => {
-        const hasCompleteLicense = licenseEntries.some(hasCompleteLicenseEntry);
+        const hasCompleteLicense = licenseEntries.some(hasLicenseEntryEvidence);
         const hasInvalidCustomLicense = licenseEntries.some(
-            (entry) => entry.mode === 'custom' && hasAnyLicenseEntryContent(entry) && (!entry.name.trim() || !entry.uri.trim() || !isHttpUrl(entry.uri.trim())),
+            (entry) => isCustomLicensePayloadEntry(entry) && (!entry.name.trim() || !entry.uri.trim() || !isHttpUrl(entry.uri.trim())),
         );
 
         if (!hasCompleteLicense || hasInvalidCustomLicense) {
@@ -1699,10 +1713,10 @@ export default function DataCiteForm({
         }
     };
 
-    const validatePrimaryLicenseEntry = (entry: LicenseEntry) => {
+    const validatePrimaryLicenseEntries = (entries: LicenseEntry[]) => {
         validateField({
             fieldId: 'license-0',
-            value: entry,
+            value: entries,
             rules: primaryLicenseValidationRules,
             formData: form,
         });
@@ -1721,9 +1735,7 @@ export default function DataCiteForm({
 
             next[index] = updated;
 
-            if (index === 0) {
-                validatePrimaryLicenseEntry(updated);
-            }
+            validatePrimaryLicenseEntries(next);
 
             return next;
         });
@@ -1738,9 +1750,7 @@ export default function DataCiteForm({
             const updated: LicenseEntry = { id: current.id, mode: 'catalog', license: value };
             next[index] = updated;
 
-            if (index === 0) {
-                validatePrimaryLicenseEntry(updated);
-            }
+            validatePrimaryLicenseEntries(next);
 
             return next;
         });
@@ -1755,9 +1765,7 @@ export default function DataCiteForm({
             const updated: LicenseEntry = { ...current, [field]: value };
             next[index] = updated;
 
-            if (index === 0) {
-                validatePrimaryLicenseEntry(updated);
-            }
+            validatePrimaryLicenseEntries(next);
 
             return next;
         });
@@ -1765,11 +1773,19 @@ export default function DataCiteForm({
 
     const addLicense = () => {
         if (licenseEntries.length >= MAX_LICENSES) return;
-        setLicenseEntries((prev) => [...prev, { id: crypto.randomUUID(), mode: 'catalog', license: '' }]);
+        setLicenseEntries((prev) => {
+            const next: LicenseEntry[] = [...prev, { id: crypto.randomUUID(), mode: 'catalog', license: '' }];
+            validatePrimaryLicenseEntries(next);
+            return next;
+        });
     };
 
     const removeLicense = (index: number) => {
-        setLicenseEntries((prev) => prev.filter((_, i) => i !== index));
+        setLicenseEntries((prev) => {
+            const next = prev.filter((_, i) => i !== index);
+            validatePrimaryLicenseEntries(next);
+            return next;
+        });
     };
 
     const handleDateChange = (index: number, field: keyof Omit<DateEntry, 'id'>, value: string) => {
@@ -2026,13 +2042,15 @@ export default function DataCiteForm({
                 .filter((entry) => entry.mode === 'catalog' && entry.license.trim() !== '')
                 .map((entry) => (entry.mode === 'catalog' ? entry.license : '')),
             customLicenses: licenseEntries
-                .filter((entry) => entry.mode === 'custom' && hasAnyLicenseEntryContent(entry))
+                .filter(isCustomLicensePayloadEntry)
                 .map((entry) => ({
-                    name: entry.mode === 'custom' ? entry.name.trim() : '',
-                    uri: entry.mode === 'custom' ? entry.uri.trim() : '',
-                    ...(entry.mode === 'custom' && entry.sourceResourceRightId != null ? { sourceResourceRightId: entry.sourceResourceRightId } : {}),
+                    name: entry.name.trim(),
+                    uri: entry.uri.trim(),
+                    ...(entry.sourceResourceRightId != null ? { sourceResourceRightId: entry.sourceResourceRightId } : {}),
                 })),
-            rawRights: [],
+            rawRights: licenseEntries
+                .filter(isRawRightsOnlyLicenseEntry)
+                .map(serializeRawRightsOnlyLicenseEntry),
             authors: serializedAuthors,
             contributors: serializedContributors,
             mslLaboratories: mslLaboratories.map((lab) => ({
@@ -2725,8 +2743,10 @@ export default function DataCiteForm({
                                         onAdd={addLicense}
                                         onRemove={() => removeLicense(index)}
                                         isFirst={index === 0}
-                                        canAdd={canAddLicense(licenseEntries, MAX_LICENSES)}
+                                        canAdd={canAddLicenseEntry(licenseEntries, MAX_LICENSES)}
                                         required={index === 0}
+                                        customNameRequired={index === 0}
+                                        customUriRequired={index === 0 && !isRawRightsOnlyLicenseEntry(entry)}
                                         validationMessages={index === 0 ? getFieldState('license-0').messages : undefined}
                                         touched={index === 0 ? getFieldState('license-0').touched : undefined}
                                         onValidationBlur={index === 0 ? () => markFieldTouched('license-0') : undefined}

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -128,6 +128,10 @@ function isCustomLicensePayloadEntry(entry: LicenseEntry): entry is CustomLicens
     return entry.mode === 'custom' && hasAnyLicenseEntryContent(entry) && !isRawRightsOnlyLicenseEntry(entry);
 }
 
+function isCatalogLicensePayloadEntry(entry: LicenseEntry): entry is Extract<LicenseEntry, { mode: 'catalog' }> {
+    return entry.mode === 'catalog' && entry.license.trim() !== '';
+}
+
 function hasLicenseEntryEvidence(entry: LicenseEntry | undefined): boolean {
     return hasCompleteLicenseEntry(entry) || (entry !== undefined && isRawRightsOnlyLicenseEntry(entry));
 }
@@ -2039,8 +2043,8 @@ export default function DataCiteForm({
                 language: entry.language ?? null,
             })),
             licenses: licenseEntries
-                .filter((entry) => entry.mode === 'catalog' && entry.license.trim() !== '')
-                .map((entry) => (entry.mode === 'catalog' ? entry.license : '')),
+                .filter(isCatalogLicensePayloadEntry)
+                .map((entry) => entry.license),
             customLicenses: licenseEntries
                 .filter(isCustomLicensePayloadEntry)
                 .map((entry) => ({

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -285,6 +285,22 @@ export default function DataCiteForm({
         return entries.length > 0 ? entries : [{ id: crypto.randomUUID(), mode: 'catalog', license: '' }];
     });
 
+    const customLicensePayloadIndexesByEntryId = useMemo(() => {
+        const indexes = new Map<string, number>();
+        let customLicenseIndex = 0;
+
+        licenseEntries.forEach((entry) => {
+            if (entry.mode !== 'custom' || !hasAnyLicenseEntryContent(entry)) {
+                return;
+            }
+
+            indexes.set(entry.id, customLicenseIndex);
+            customLicenseIndex += 1;
+        });
+
+        return indexes;
+    }, [licenseEntries]);
+
     const [authors, setAuthors] = useState<AuthorEntry[]>(() => {
         if (initialAuthors.length > 0) {
             const mapped = initialAuthors.map((author) => mapInitialAuthorToEntry(author)).filter((author): author is AuthorEntry => Boolean(author));
@@ -2691,31 +2707,35 @@ export default function DataCiteForm({
                     </AccordionTrigger>
                     <AccordionContent>
                         <div className="space-y-4">
-                            {licenseEntries.map((entry, index) => (
-                                <LicenseField
-                                    key={entry.id}
-                                    id={entry.id}
-                                    entry={entry}
-                                    options={licenses.map((l) => ({
-                                        value: l.identifier,
-                                        label: l.name,
-                                    }))}
-                                    onModeChange={(mode) => handleLicenseModeChange(index, mode)}
-                                    onCatalogLicenseChange={(val) => handleCatalogLicenseChange(index, val)}
-                                    onCustomLicenseChange={(field, val) => handleCustomLicenseChange(index, field, val)}
-                                    onAdd={addLicense}
-                                    onRemove={() => removeLicense(index)}
-                                    isFirst={index === 0}
-                                    canAdd={canAddLicense(licenseEntries, MAX_LICENSES)}
-                                    required={index === 0}
-                                    validationMessages={index === 0 ? getFieldState('license-0').messages : undefined}
-                                    touched={index === 0 ? getFieldState('license-0').touched : undefined}
-                                    onValidationBlur={index === 0 ? () => markFieldTouched('license-0') : undefined}
-                                    data-testid={`license-select-${index}`}
-                                    customNameTestId={`custom-license-name-${index}`}
-                                    customUriTestId={`custom-license-uri-${index}`}
-                                />
-                            ))}
+                            {licenseEntries.map((entry, index) => {
+                                const customLicensePayloadIndex = entry.mode === 'custom' ? customLicensePayloadIndexesByEntryId.get(entry.id) : undefined;
+
+                                return (
+                                    <LicenseField
+                                        key={entry.id}
+                                        id={entry.id}
+                                        entry={entry}
+                                        options={licenses.map((l) => ({
+                                            value: l.identifier,
+                                            label: l.name,
+                                        }))}
+                                        onModeChange={(mode) => handleLicenseModeChange(index, mode)}
+                                        onCatalogLicenseChange={(val) => handleCatalogLicenseChange(index, val)}
+                                        onCustomLicenseChange={(field, val) => handleCustomLicenseChange(index, field, val)}
+                                        onAdd={addLicense}
+                                        onRemove={() => removeLicense(index)}
+                                        isFirst={index === 0}
+                                        canAdd={canAddLicense(licenseEntries, MAX_LICENSES)}
+                                        required={index === 0}
+                                        validationMessages={index === 0 ? getFieldState('license-0').messages : undefined}
+                                        touched={index === 0 ? getFieldState('license-0').touched : undefined}
+                                        onValidationBlur={index === 0 ? () => markFieldTouched('license-0') : undefined}
+                                        data-testid={`license-select-${index}`}
+                                        customNameTestId={customLicensePayloadIndex !== undefined ? `custom-license-name-${customLicensePayloadIndex}` : undefined}
+                                        customUriTestId={customLicensePayloadIndex !== undefined ? `custom-license-uri-${customLicensePayloadIndex}` : undefined}
+                                    />
+                                );
+                            })}
                         </div>
                     </AccordionContent>
                 </AccordionItem>

--- a/resources/js/components/curation/fields/license-field.tsx
+++ b/resources/js/components/curation/fields/license-field.tsx
@@ -73,7 +73,7 @@ export function LicenseField({
     return (
         <div className={cn('grid gap-4 md:grid-cols-[1fr_40px]', className)}>
             <div className="space-y-3">
-                <div className="inline-flex rounded-md border bg-background p-1" aria-label="License entry type">
+                <div className="inline-flex rounded-md border bg-background p-1" role="group" aria-label="License entry type">
                     <Button
                         type="button"
                         variant={entry.mode === 'catalog' ? 'default' : 'ghost'}

--- a/resources/js/components/curation/fields/license-field.tsx
+++ b/resources/js/components/curation/fields/license-field.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button';
 import type { ValidationMessage } from '@/hooks/use-form-validation';
 import { cn } from '@/lib/utils';
 
+import type { CustomLicenseEntry, LicenseEntry } from '../types/datacite-form-types';
+import InputField from './input-field';
 import { SelectField } from './select-field';
 
 interface Option {
@@ -13,9 +15,11 @@ interface Option {
 
 interface LicenseFieldProps {
     id: string;
-    license: string;
+    entry: LicenseEntry;
     options: Option[];
-    onLicenseChange: (value: string) => void;
+    onModeChange: (mode: LicenseEntry['mode']) => void;
+    onCatalogLicenseChange: (value: string) => void;
+    onCustomLicenseChange: (field: keyof Pick<CustomLicenseEntry, 'name' | 'uri'>, value: string) => void;
     onAdd: () => void;
     onRemove: () => void;
     isFirst: boolean;
@@ -26,13 +30,17 @@ interface LicenseFieldProps {
     touched?: boolean;
     onValidationBlur?: () => void;
     'data-testid'?: string;
+    customNameTestId?: string;
+    customUriTestId?: string;
 }
 
 export function LicenseField({
     id,
-    license,
+    entry,
     options,
-    onLicenseChange,
+    onModeChange,
+    onCatalogLicenseChange,
+    onCustomLicenseChange,
     onAdd,
     onRemove,
     isFirst,
@@ -43,35 +51,90 @@ export function LicenseField({
     touched,
     onValidationBlur,
     'data-testid': dataTestId,
+    customNameTestId,
+    customUriTestId,
 }: LicenseFieldProps) {
+    const actionButton = isFirst ? (
+        canAdd ? (
+            <Button type="button" variant="outline" size="icon" aria-label="Add license" onClick={onAdd}>
+                <Plus className="h-4 w-4" />
+            </Button>
+        ) : null
+    ) : (
+        <Button type="button" variant="outline" size="icon" aria-label="Remove license" onClick={onRemove}>
+            <Minus className="h-4 w-4" />
+        </Button>
+    );
+
     return (
         <div className={cn('grid gap-4 md:grid-cols-[1fr_40px]', className)}>
-            <SelectField
-                id={`${id}-license`}
-                label="License"
-                value={license}
-                onValueChange={onLicenseChange}
-                onValidationBlur={onValidationBlur}
-                validationMessages={validationMessages}
-                touched={touched}
-                options={options}
-                hideLabel={!isFirst}
-                required={required}
-                data-testid={dataTestId}
-            />
-            <div className="flex items-end">
-                {isFirst ? (
-                    canAdd ? (
-                        <Button type="button" variant="outline" size="icon" aria-label="Add license" onClick={onAdd}>
-                            <Plus className="h-4 w-4" />
-                        </Button>
-                    ) : null
-                ) : (
-                    <Button type="button" variant="outline" size="icon" aria-label="Remove license" onClick={onRemove}>
-                        <Minus className="h-4 w-4" />
+            <div className="space-y-3">
+                <div className="inline-flex rounded-md border bg-background p-1" aria-label="License entry type">
+                    <Button
+                        type="button"
+                        variant={entry.mode === 'catalog' ? 'default' : 'ghost'}
+                        size="sm"
+                        className="h-8 px-3"
+                        aria-pressed={entry.mode === 'catalog'}
+                        onClick={() => onModeChange('catalog')}
+                    >
+                        Catalog
                     </Button>
+                    <Button
+                        type="button"
+                        variant={entry.mode === 'custom' ? 'default' : 'ghost'}
+                        size="sm"
+                        className="h-8 px-3"
+                        aria-pressed={entry.mode === 'custom'}
+                        onClick={() => onModeChange('custom')}
+                    >
+                        Custom
+                    </Button>
+                </div>
+
+                {entry.mode === 'catalog' ? (
+                    <SelectField
+                        id={`${id}-license`}
+                        label="License"
+                        value={entry.license}
+                        onValueChange={onCatalogLicenseChange}
+                        onValidationBlur={onValidationBlur}
+                        validationMessages={validationMessages}
+                        touched={touched}
+                        options={options}
+                        hideLabel={!isFirst}
+                        required={required}
+                        data-testid={dataTestId}
+                    />
+                ) : (
+                    <div className="grid gap-3 md:grid-cols-2">
+                        <InputField
+                            id={`${id}-custom-name`}
+                            label="License name"
+                            value={entry.name}
+                            onChange={(event) => onCustomLicenseChange('name', event.target.value)}
+                            onValidationBlur={onValidationBlur}
+                            validationMessages={validationMessages}
+                            touched={touched}
+                            required={required}
+                            data-testid={customNameTestId}
+                        />
+                        <InputField
+                            id={`${id}-custom-uri`}
+                            label="License text URL"
+                            type="url"
+                            value={entry.uri}
+                            onChange={(event) => onCustomLicenseChange('uri', event.target.value)}
+                            onValidationBlur={onValidationBlur}
+                            validationMessages={validationMessages}
+                            touched={touched}
+                            required={required}
+                            data-testid={customUriTestId}
+                        />
+                    </div>
                 )}
             </div>
+            <div className="flex items-end">{actionButton}</div>
         </div>
     );
 }

--- a/resources/js/components/curation/fields/license-field.tsx
+++ b/resources/js/components/curation/fields/license-field.tsx
@@ -26,6 +26,8 @@ interface LicenseFieldProps {
     canAdd?: boolean;
     className?: string;
     required?: boolean;
+    customNameRequired?: boolean;
+    customUriRequired?: boolean;
     validationMessages?: ValidationMessage[];
     touched?: boolean;
     onValidationBlur?: () => void;
@@ -47,6 +49,8 @@ export function LicenseField({
     canAdd = true,
     className,
     required = false,
+    customNameRequired = required,
+    customUriRequired = required,
     validationMessages,
     touched,
     onValidationBlur,
@@ -116,7 +120,7 @@ export function LicenseField({
                             onValidationBlur={onValidationBlur}
                             validationMessages={validationMessages}
                             touched={touched}
-                            required={required}
+                            required={customNameRequired}
                             data-testid={customNameTestId}
                         />
                         <InputField
@@ -128,7 +132,7 @@ export function LicenseField({
                             onValidationBlur={onValidationBlur}
                             validationMessages={validationMessages}
                             touched={touched}
-                            required={required}
+                            required={customUriRequired}
                             data-testid={customUriTestId}
                         />
                     </div>

--- a/resources/js/components/curation/types/datacite-form-types.ts
+++ b/resources/js/components/curation/types/datacite-form-types.ts
@@ -73,6 +73,7 @@ export type CustomLicenseEntry = {
     name: string;
     uri: string;
     sourceResourceRightId?: number | null;
+    rawRight?: RawRightsInput;
 };
 
 export type LicenseEntry = CatalogLicenseEntry | CustomLicenseEntry;

--- a/resources/js/components/curation/types/datacite-form-types.ts
+++ b/resources/js/components/curation/types/datacite-form-types.ts
@@ -58,12 +58,24 @@ export interface RawRightsInput {
     schemeUri?: string | null;
     lang?: string | null;
     source?: string | null;
+    sourceResourceRightId?: number | null;
 }
 
-export interface LicenseEntry {
+export type CatalogLicenseEntry = {
     id: string;
+    mode: 'catalog';
     license: string;
-}
+};
+
+export type CustomLicenseEntry = {
+    id: string;
+    mode: 'custom';
+    name: string;
+    uri: string;
+    sourceResourceRightId?: number | null;
+};
+
+export type LicenseEntry = CatalogLicenseEntry | CustomLicenseEntry;
 
 export interface DateEntry {
     id: string;

--- a/resources/js/components/curation/utils/error-field-mapper.ts
+++ b/resources/js/components/curation/utils/error-field-mapper.ts
@@ -175,7 +175,13 @@ function resolveFieldSelector(backendKey: string): string | null {
             case 'licenses':
                 return `[data-testid="license-select-${index}"]`;
             case 'customLicenses':
-                return subfield === 'uri' ? `[data-testid="custom-license-uri-${index}"]` : `[data-testid="custom-license-name-${index}"]`;
+                if (subfield === 'name') {
+                    return `[data-testid="custom-license-name-${index}"]`;
+                }
+                if (subfield === 'uri') {
+                    return `[data-testid="custom-license-uri-${index}"]`;
+                }
+                return null;
             // The following field components do not have stable data-testid attributes yet.
             // Return null to fall back to opening the correct accordion section.
             case 'fundingReferences':
@@ -226,7 +232,11 @@ function resolveFieldId(backendKey: string): string | null {
         return 'title-0';
     }
 
-    if ((prefix === 'licenses' || prefix === 'customLicenses') && index === '0') {
+    if (prefix === 'licenses' && index === '0') {
+        return 'license-0';
+    }
+
+    if (prefix === 'customLicenses' && index === '0' && (subfield === 'name' || subfield === 'uri')) {
         return 'license-0';
     }
 

--- a/resources/js/components/curation/utils/error-field-mapper.ts
+++ b/resources/js/components/curation/utils/error-field-mapper.ts
@@ -44,6 +44,7 @@ const SECTION_MAP: Record<string, SectionMapping> = {
     titles: { sectionId: 'resource-info', sectionName: 'Resource Information' },
     datacenters: { sectionId: 'resource-info', sectionName: 'Resource Information' },
     licenses: { sectionId: 'licenses-rights', sectionName: 'Licenses & Rights' },
+    customLicenses: { sectionId: 'licenses-rights', sectionName: 'Licenses & Rights' },
     authors: { sectionId: 'authors', sectionName: 'Authors' },
     contributors: { sectionId: 'contributors', sectionName: 'Contributors' },
     descriptions: { sectionId: 'descriptions', sectionName: 'Descriptions' },
@@ -173,6 +174,8 @@ function resolveFieldSelector(backendKey: string): string | null {
                 return '#datacenter';
             case 'licenses':
                 return `[data-testid="license-select-${index}"]`;
+            case 'customLicenses':
+                return subfield === 'uri' ? `[data-testid="custom-license-uri-${index}"]` : `[data-testid="custom-license-name-${index}"]`;
             // The following field components do not have stable data-testid attributes yet.
             // Return null to fall back to opening the correct accordion section.
             case 'fundingReferences':
@@ -223,7 +226,7 @@ function resolveFieldId(backendKey: string): string | null {
         return 'title-0';
     }
 
-    if (prefix === 'licenses' && index === '0') {
+    if ((prefix === 'licenses' || prefix === 'customLicenses') && index === '0') {
         return 'license-0';
     }
 

--- a/resources/js/components/curation/utils/form-helpers.ts
+++ b/resources/js/components/curation/utils/form-helpers.ts
@@ -350,6 +350,8 @@ export const mapInitialContributorToEntry = (contributor: InitialContributor): C
 
 import type { DateEntry, LicenseEntry, TitleEntry } from '../types/datacite-form-types';
 
+type LicenseEntryLike = LicenseEntry | { license?: string | null };
+
 /**
  * Check if a new title can be added based on current state.
  */
@@ -357,11 +359,44 @@ export function canAddTitle(titles: TitleEntry[], maxTitles: number): boolean {
     return titles.length < maxTitles && titles.length > 0 && !!titles[titles.length - 1].title;
 }
 
+export function hasCompleteLicenseEntry(entry: LicenseEntryLike | undefined): boolean {
+    if (!entry) {
+        return false;
+    }
+
+    if ('mode' in entry && entry.mode === 'custom') {
+        return entry.name.trim() !== '' && entry.uri.trim() !== '';
+    }
+
+    return typeof entry.license === 'string' && entry.license.trim() !== '';
+}
+
+export function hasAnyLicenseEntryContent(entry: LicenseEntryLike | undefined): boolean {
+    if (!entry) {
+        return false;
+    }
+
+    if ('mode' in entry && entry.mode === 'custom') {
+        return entry.name.trim() !== '' || entry.uri.trim() !== '';
+    }
+
+    return typeof entry.license === 'string' && entry.license.trim() !== '';
+}
+
+export function isHttpUrl(value: string): boolean {
+    try {
+        const url = new URL(value);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Check if a new license can be added based on current state.
  */
-export function canAddLicense(licenseEntries: LicenseEntry[], maxLicenses: number): boolean {
-    return licenseEntries.length < maxLicenses && licenseEntries.length > 0 && !!licenseEntries[licenseEntries.length - 1].license;
+export function canAddLicense(licenseEntries: LicenseEntryLike[], maxLicenses: number): boolean {
+    return licenseEntries.length < maxLicenses && licenseEntries.length > 0 && hasCompleteLicenseEntry(licenseEntries[licenseEntries.length - 1]);
 }
 
 /**

--- a/resources/js/components/curation/utils/form-helpers.ts
+++ b/resources/js/components/curation/utils/form-helpers.ts
@@ -10,7 +10,7 @@ import type { AffiliationTag } from '@/types/affiliations';
 
 import type { AuthorEntry, InstitutionAuthorEntry, PersonAuthorEntry } from '../fields/author';
 import type { ContributorEntry, ContributorRoleTag, InstitutionContributorEntry, PersonContributorEntry } from '../fields/contributor';
-import type { InitialAffiliationInput, InitialAuthor, InitialContributor, SerializedAffiliation } from '../types/datacite-form-types';
+import type { DateEntry, InitialAffiliationInput, InitialAuthor, InitialContributor, LicenseEntry, SerializedAffiliation, TitleEntry } from '../types/datacite-form-types';
 
 // ============================================================================
 // String Normalization
@@ -348,7 +348,6 @@ export const mapInitialContributorToEntry = (contributor: InitialContributor): C
 // Form State Validators
 // ============================================================================
 
-import type { DateEntry, LicenseEntry, TitleEntry } from '../types/datacite-form-types';
 
 type LicenseEntryLike = LicenseEntry | { license?: string | null };
 

--- a/resources/js/pages/LandingPages/components/FilesSection.tsx
+++ b/resources/js/pages/LandingPages/components/FilesSection.tsx
@@ -165,13 +165,13 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
                                 {licenses.map((license) => (
                                     <a
                                         key={license.id}
-                                        href={license.reference}
+                                        href={license.reference ?? undefined}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="inline-flex items-center gap-2 rounded-md bg-green-100 px-3 py-2 text-sm font-medium text-green-800 transition-colors hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300 dark:hover:bg-green-900/50"
-                                        title={`SPDX: ${license.spdx_id}`}
+                                        title={license.spdx_id ? `SPDX: ${license.spdx_id}` : license.name}
                                     >
-                                        <CreativeCommonsIcon spdxId={license.spdx_id} className="h-4 w-4" />
+                                        {license.spdx_id ? <CreativeCommonsIcon spdxId={license.spdx_id} className="h-4 w-4" /> : <ExternalLink className="h-4 w-4" />}
                                         <span>{license.name}</span>
                                     </a>
                                 ))}

--- a/resources/js/pages/LandingPages/components/FilesSection.tsx
+++ b/resources/js/pages/LandingPages/components/FilesSection.tsx
@@ -162,19 +162,45 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
                         <div className="mt-4 space-y-2">
                             <p className="text-xs font-medium text-gray-500 dark:text-gray-400">License</p>
                             <div className="flex flex-col gap-2">
-                                {licenses.map((license) => (
-                                    <a
-                                        key={license.id}
-                                        href={license.reference ?? undefined}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="inline-flex items-center gap-2 rounded-md bg-green-100 px-3 py-2 text-sm font-medium text-green-800 transition-colors hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300 dark:hover:bg-green-900/50"
-                                        title={license.spdx_id ? `SPDX: ${license.spdx_id}` : license.name}
-                                    >
-                                        {license.spdx_id ? <CreativeCommonsIcon spdxId={license.spdx_id} className="h-4 w-4" /> : <ExternalLink className="h-4 w-4" />}
-                                        <span>{license.name}</span>
-                                    </a>
-                                ))}
+                                {licenses.map((license) => {
+                                    const title = license.spdx_id ? `SPDX: ${license.spdx_id}` : license.name;
+                                    const icon = license.spdx_id ? (
+                                        <CreativeCommonsIcon spdxId={license.spdx_id} className="h-4 w-4" />
+                                    ) : license.reference ? (
+                                        <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                                    ) : null;
+                                    const badgeContent = (
+                                        <>
+                                            {icon}
+                                            <span>{license.name}</span>
+                                        </>
+                                    );
+
+                                    if (!license.reference) {
+                                        return (
+                                            <span
+                                                key={license.id}
+                                                className="inline-flex items-center gap-2 rounded-md bg-green-100 px-3 py-2 text-sm font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300"
+                                                title={title}
+                                            >
+                                                {badgeContent}
+                                            </span>
+                                        );
+                                    }
+
+                                    return (
+                                        <a
+                                            key={license.id}
+                                            href={license.reference}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="inline-flex items-center gap-2 rounded-md bg-green-100 px-3 py-2 text-sm font-medium text-green-800 transition-colors hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300 dark:hover:bg-green-900/50"
+                                            title={title}
+                                        >
+                                            {badgeContent}
+                                        </a>
+                                    );
+                                })}
                             </div>
                         </div>
                     )}

--- a/resources/js/schemas/resource.schema.ts
+++ b/resources/js/schemas/resource.schema.ts
@@ -32,10 +32,38 @@ export const titlesArraySchema = z.array(titleSchema).min(1, 'At least one title
 // License Schema
 // =============================================================================
 
-export const licenseSchema = z.object({
+const customLicenseUrlSchema = z
+    .string()
+    .url('Custom license URL is invalid')
+    .refine((value) => {
+        try {
+            const url = new URL(value);
+            return url.protocol === 'http:' || url.protocol === 'https:';
+        } catch {
+            return false;
+        }
+    }, 'Custom license URL must use http or https');
+
+const legacyLicenseSchema = z.object({
     id: z.string(),
     license: z.string().min(1, 'License is required'),
 });
+
+const catalogLicenseSchema = z.object({
+    id: z.string(),
+    mode: z.literal('catalog'),
+    license: z.string().min(1, 'License is required'),
+});
+
+const customLicenseSchema = z.object({
+    id: z.string(),
+    mode: z.literal('custom'),
+    name: z.string().min(1, 'Custom license name is required'),
+    uri: customLicenseUrlSchema,
+    sourceResourceRightId: z.number().nullable().optional(),
+});
+
+export const licenseSchema = z.union([legacyLicenseSchema, catalogLicenseSchema, customLicenseSchema]);
 
 export type LicenseFormData = z.infer<typeof licenseSchema>;
 
@@ -49,11 +77,20 @@ export const rawRightsSchema = z.object({
     schemeUri: z.string().nullable().optional(),
     lang: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
+    sourceResourceRightId: z.number().nullable().optional(),
 });
 
 export type RawRightsFormData = z.infer<typeof rawRightsSchema>;
 
 export const rawRightsArraySchema = z.array(rawRightsSchema).default([]);
+
+export const customLicensePayloadSchema = z.object({
+    name: z.string().min(1, 'Custom license name is required'),
+    uri: customLicenseUrlSchema,
+    sourceResourceRightId: z.number().nullable().optional(),
+});
+
+export const customLicensesPayloadArraySchema = z.array(customLicensePayloadSchema).default([]);
 
 // =============================================================================
 // Date Schema
@@ -147,6 +184,7 @@ const resourceBaseSchema = z.object({
 
     // Licenses / imported rights (validated together below)
     licenses: licensesArraySchema,
+    customLicenses: customLicensesPayloadArraySchema.optional(),
     rawRights: rawRightsArraySchema,
 
     // Descriptions (optional)
@@ -178,16 +216,24 @@ const resourceBaseSchema = z.object({
 type RightsEvidenceData = {
     licenses: z.infer<typeof licensesArraySchema>;
     rawRights: z.infer<typeof rawRightsArraySchema>;
+    customLicenses?: z.infer<typeof customLicensesPayloadArraySchema>;
 };
 
 const requireRightsEvidence = (data: RightsEvidenceData, ctx: z.RefinementCtx) => {
-    const hasLicense = data.licenses.some((entry) => entry.license.trim() !== '');
+    const hasLicense = data.licenses.some((entry) => {
+        if ('mode' in entry && entry.mode === 'custom') {
+            return entry.name.trim() !== '' && entry.uri.trim() !== '';
+        }
+
+        return 'license' in entry && entry.license.trim() !== '';
+    });
+    const hasCustomLicense = (data.customLicenses ?? []).some((entry) => entry.name.trim() !== '' && entry.uri.trim() !== '');
     const hasRawRights = data.rawRights.some((entry) => Boolean(entry.rights?.trim() || entry.rightsUri?.trim() || entry.rightsIdentifier?.trim()));
 
-    if (!hasLicense && !hasRawRights) {
+    if (!hasLicense && !hasCustomLicense && !hasRawRights) {
         ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: 'At least one license or imported rights statement is required',
+            message: 'At least one license, custom license, or imported rights statement is required',
             path: ['licenses'],
         });
     }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -133,6 +133,8 @@ export interface License {
     id: number;
     identifier: string;
     name: string;
+    uri?: string | null;
+    scheme_uri?: string | null;
 }
 
 /**
@@ -144,6 +146,7 @@ export interface Right {
     identifier: string;
     name: string;
     uri?: string | null;
+    scheme_uri?: string | null;
 }
 
 export interface Language {

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -351,10 +351,12 @@ export interface LandingPageLicense {
     id: number;
     /** Display name of the license */
     name: string;
-    /** SPDX identifier (e.g., 'CC-BY-4.0') */
-    spdx_id: string;
+    /** SPDX identifier (e.g., 'CC-BY-4.0'); null for custom licenses */
+    spdx_id: string | null;
     /** URL to license text */
-    reference: string;
+    reference: string | null;
+    /** Rights scheme URI, e.g. SPDX scheme for SPDX licenses */
+    scheme_uri?: string | null;
     /** Legacy: license name */
     rights?: string;
     /** Legacy: license URI */

--- a/tests/pest/Feature/Api/ApiDocEndpointTest.php
+++ b/tests/pest/Feature/Api/ApiDocEndpointTest.php
@@ -103,6 +103,18 @@ it('returns the OpenAPI documentation as JSON', function () {
         ->assertJsonPath('paths./api/v1/title-types/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/TitleType')
         ->assertJsonPath('paths./api/v1/title-types/elmo.get.responses.401.$ref', '#/components/responses/UnauthorizedError')
         ->assertJsonPath('paths./api/v1/licenses/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/License')
+        ->assertJsonPath('paths./api/v1/licenses/elmo.get.responses.200.content.application/json.example.0.uri', 'https://creativecommons.org/licenses/by/4.0/')
+        ->assertJsonPath('paths./api/v1/licenses/elmo.get.responses.200.content.application/json.example.0.scheme_uri', 'https://spdx.org/licenses/')
+        ->assertJsonPath('paths./api/v1/licenses/elmo/{resourceTypeSlug}.get.responses.200.content.application/json.example.0.uri', 'https://spdx.org/licenses/MIT.html')
+        ->assertJsonPath('paths./api/v1/licenses/elmo/{resourceTypeSlug}.get.responses.200.content.application/json.example.0.scheme_uri', 'https://spdx.org/licenses/')
+        ->assertJsonPath('components.schemas.License.properties.uri.type.0', 'string')
+        ->assertJsonPath('components.schemas.License.properties.uri.type.1', 'null')
+        ->assertJsonPath('components.schemas.License.properties.uri.format', 'uri')
+        ->assertJsonPath('components.schemas.License.properties.scheme_uri.type.0', 'string')
+        ->assertJsonPath('components.schemas.License.properties.scheme_uri.type.1', 'null')
+        ->assertJsonPath('components.schemas.License.properties.scheme_uri.format', 'uri')
+        ->assertJsonPath('components.schemas.License.required.3', 'uri')
+        ->assertJsonPath('components.schemas.License.required.4', 'scheme_uri')
         ->assertJsonPath('paths./api/v1/licenses/elmo.get.responses.401.$ref', '#/components/responses/UnauthorizedError')
         ->assertJsonPath('paths./api/v1/languages/elmo.get.responses.200.content.application/json.schema.items.$ref', '#/components/schemas/Language')
         ->assertJsonPath('paths./api/v1/languages/elmo.get.responses.401.$ref', '#/components/responses/UnauthorizedError')
@@ -161,15 +173,15 @@ it('returns the OpenAPI documentation as JSON', function () {
         ->toContain('string', 'null');
 });
 
-    it('serves an OpenAPI 3.2 document without legacy nullable keywords', function () {
-        $spec = getJson('/api/v1/doc')
+it('serves an OpenAPI 3.2 document without legacy nullable keywords', function () {
+    $spec = getJson('/api/v1/doc')
         ->assertOk()
         ->json();
 
-        expect($spec['openapi'])->toBe('3.2.0')
+    expect($spec['openapi'])->toBe('3.2.0')
         ->and($spec['info']['license'])->not->toHaveKey('url')
         ->and(containsArrayKeyRecursively($spec, 'nullable'))->toBeFalse();
-    });
+});
 
 it('returns 500 when the OpenAPI file is missing (JSON)', function () {
     File::shouldReceive('exists')

--- a/tests/pest/Feature/Api/RightsApiTest.php
+++ b/tests/pest/Feature/Api/RightsApiTest.php
@@ -14,6 +14,8 @@ function createElmoRights(): Right
     $enabled = Right::create([
         'identifier' => 'MIT',
         'name' => 'MIT License',
+        'uri' => 'https://spdx.org/licenses/MIT.html',
+        'scheme_uri' => 'https://spdx.org/licenses/',
         'is_active' => true,
         'is_elmo_active' => true,
     ]);
@@ -45,7 +47,9 @@ it('lists ELMO-active licenses', function () {
     $this->getJson('/api/v1/licenses/elmo', ['X-API-Key' => 'test-api-key'])
         ->assertOk()
         ->assertJsonCount(1)
-        ->assertJsonPath('0.identifier', $enabled->identifier);
+        ->assertJsonPath('0.identifier', $enabled->identifier)
+        ->assertJsonPath('0.uri', $enabled->uri)
+        ->assertJsonPath('0.scheme_uri', $enabled->scheme_uri);
 });
 
 it('lists ERNIE-active licenses', function () {
@@ -88,7 +92,9 @@ it('allows license requests with a valid API key header', function () {
     $this->getJson('/api/v1/licenses/elmo', ['X-API-Key' => 'test-api-key'])
         ->assertOk()
         ->assertJsonCount(1)
-        ->assertJsonPath('0.identifier', $enabled->identifier);
+        ->assertJsonPath('0.identifier', $enabled->identifier)
+        ->assertJsonPath('0.uri', $enabled->uri)
+        ->assertJsonPath('0.scheme_uri', $enabled->scheme_uri);
 });
 
 it('rejects API keys in query parameters for security', function () {

--- a/tests/pest/Feature/Http/Requests/StoreDraftResourceRequestContributorTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreDraftResourceRequestContributorTest.php
@@ -42,6 +42,39 @@ describe('licenses validation (draft)', function () {
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['licenses']);
     });
+
+    it('ignores incomplete custom license rows in draft mode', function () {
+        $data = [
+            'titles' => [
+                ['title' => 'Draft Resource', 'titleType' => 'main-title'],
+            ],
+            'customLicenses' => [
+                [
+                    'name' => 'Started custom license',
+                    'uri' => null,
+                ],
+                [
+                    'name' => '',
+                    'uri' => 'https://example.test/licenses/missing-name',
+                ],
+                [
+                    'sourceResourceRightId' => 999999,
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources/draft', $data);
+
+        $response->assertCreated()
+            ->assertJsonMissingValidationErrors([
+                'customLicenses.0.uri',
+                'customLicenses.1.name',
+                'customLicenses.2.name',
+                'customLicenses.2.uri',
+                'customLicenses.2.sourceResourceRightId',
+            ]);
+    });
 });
 
 describe('contributor email/website validation (draft)', function () {

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -844,6 +844,10 @@ describe('custom licenses validation', function () {
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['customLicenses.0.uri']);
 
-        expect($response->json('errors.customLicenses.0.uri.0'))->toStartWith('[Licenses & Rights]');
+        $errors = $response->json('errors');
+        $message = $errors['customLicenses.0.uri'][0] ?? null;
+
+        expect($message)->toBeString();
+        expect($message)->toStartWith('[Licenses & Rights]');
     });
 });

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -789,3 +789,61 @@ describe('contributor contact person validation', function () {
         $response->assertJsonValidationErrors(['contributors.0.website']);
     });
 });
+
+// =========================================================================
+// Custom licenses validation
+// =========================================================================
+
+describe('custom licenses validation', function () {
+    it('accepts a custom license when no catalog license is selected', function () {
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['licenses'] = [];
+        $data['customLicenses'] = [
+            [
+                'name' => 'Community Data License',
+                'uri' => 'https://example.test/licenses/community-data',
+            ],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data);
+
+        $response->assertJsonMissingValidationErrors(['licenses', 'customLicenses.0.name', 'customLicenses.0.uri']);
+    });
+
+    it('requires a URL for custom licenses', function () {
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['licenses'] = [];
+        $data['customLicenses'] = [
+            [
+                'name' => 'Community Data License',
+            ],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['customLicenses.0.uri'])
+            ->assertJsonMissingValidationErrors(['licenses']);
+    });
+
+    it('rejects unsafe custom license URL schemes', function () {
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['licenses'] = [];
+        $data['customLicenses'] = [
+            [
+                'name' => 'Unsafe License',
+                'uri' => 'javascript:alert(1)',
+            ],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['customLicenses.0.uri']);
+
+        expect($response->json('errors.customLicenses.0.uri.0'))->toStartWith('[Licenses & Rights]');
+    });
+});

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -862,7 +862,7 @@ describe('custom licenses validation', function () {
         $errors = $response->json('errors');
         $message = $errors['customLicenses.0.uri'][0] ?? null;
 
-        expect($message)->toBeString();
-        expect($message)->toStartWith('[Licenses & Rights]');
+        expect($message)->toBe('[Licenses & Rights] The Custom license #1 license text URL must use http or https protocol.');
+        expect($message)->not->toContain('customLicenses.0.uri');
     });
 });

--- a/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
+++ b/tests/pest/Feature/Http/Requests/StoreResourceRequestTest.php
@@ -103,7 +103,6 @@ describe('required fields', function () {
     });
 });
 
-
 // =========================================================================
 // Date period validation
 // =========================================================================
@@ -266,6 +265,22 @@ describe('licenses validation', function () {
             ->postJson('/editor/resources', $data);
 
         $response->assertJsonMissingValidationErrors(['licenses']);
+    });
+
+    it('accepts text-only imported raw rights when no catalog license is selected', function () {
+        $data = validResourcePayload($this->resourceType->id, $this->right->identifier);
+        $data['licenses'] = [];
+        $data['rawRights'] = [
+            [
+                'rights' => 'HyMap imagery is available under commercial End User Licencing Agreements',
+                'source' => 'legacy-sumario',
+            ],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/editor/resources', $data);
+
+        $response->assertJsonMissingValidationErrors(['licenses', 'rawRights.0.rightsUri']);
     });
 
     it('accepts null licenses when imported raw rights evidence is present', function () {

--- a/tests/pest/Feature/Rules/SafeUrlTest.php
+++ b/tests/pest/Feature/Rules/SafeUrlTest.php
@@ -120,4 +120,14 @@ describe('SafeUrl Validation Rule', function () {
 
         expect($validator->fails())->toBeTrue();
     });
+
+    test('can prefix validation messages for section-aware requests', function () {
+        $validator = Validator::make(
+            ['url' => 'javascript:alert(1)'],
+            ['url' => ['nullable', new SafeUrl('[Licenses & Rights]')]]
+        );
+
+        expect($validator->fails())->toBeTrue()
+            ->and($validator->errors()->first('url'))->toStartWith('[Licenses & Rights]');
+    });
 });

--- a/tests/pest/Feature/Services/CustomRightCatalogServiceTest.php
+++ b/tests/pest/Feature/Services/CustomRightCatalogServiceTest.php
@@ -6,6 +6,7 @@ use App\Models\Right;
 use App\Services\Rights\CustomRightCatalogService;
 use App\Services\Spdx\SpdxLicenseLookup;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
@@ -78,6 +79,34 @@ it('reuses the matching custom right when unrelated reusable rights exist', func
         ->and($right->fresh()->is_active)->toBeTrue()
         ->and($right->fresh()->is_elmo_active)->toBeFalse()
         ->and(Right::query()->where('name', 'Community Data License')->count())->toBe(1);
+});
+
+it('escapes SQL LIKE wildcards when searching reusable custom rights', function (): void {
+    Right::query()->create([
+        'identifier' => 'CUSTOM-WILDCARD-NOISE',
+        'name' => 'Wildcard License',
+        'uri' => 'https://example.test/licenses/aX2fbZunderZscore',
+        'scheme_uri' => null,
+        'is_active' => false,
+        'is_elmo_active' => true,
+    ]);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $right = $this->service->findOrCreate('Wildcard License', 'https://example.test/licenses/a%2Fb_under_score');
+
+    DB::disableQueryLog();
+
+    $likeQuery = collect(DB::getQueryLog())->first(
+        fn (array $query): bool => str_contains((string) $query['query'], 'LOWER(uri) LIKE')
+    );
+
+    expect($likeQuery)->not->toBeNull()
+        ->and($likeQuery['query'])->toContain("ESCAPE '!'")
+        ->and($likeQuery['bindings'])->toContain('%example.test/licenses/a!%2fb!_under!_score%')
+        ->and($right->uri)->toBe('https://example.test/licenses/a%2Fb_under_score')
+        ->and(Right::query()->count())->toBe(2);
 });
 
 it('distinguishes SPDX catalog rights from custom rights by scheme URI', function (): void {

--- a/tests/pest/Feature/Services/CustomRightCatalogServiceTest.php
+++ b/tests/pest/Feature/Services/CustomRightCatalogServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Right;
+use App\Services\Rights\CustomRightCatalogService;
+use App\Services\Spdx\SpdxLicenseLookup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+covers(CustomRightCatalogService::class, Right::class);
+
+beforeEach(function (): void {
+    $this->service = app(CustomRightCatalogService::class);
+});
+
+it('creates deterministic active custom rights with internal identifiers', function (): void {
+    $right = $this->service->findOrCreate('  Community Data License  ', ' https://example.test/licenses/community ');
+
+    expect($right->identifier)->toStartWith('CUSTOM-COMMUNITY-DATA-LICENSE-')
+        ->and($right->name)->toBe('Community Data License')
+        ->and($right->uri)->toBe('https://example.test/licenses/community')
+        ->and($right->scheme_uri)->toBeNull()
+        ->and($right->is_active)->toBeTrue()
+        ->and($right->is_elmo_active)->toBeFalse()
+        ->and($right->usage_count)->toBe(0);
+
+    $sameRight = $this->service->findOrCreate('Community Data License', 'https://example.test/licenses/community');
+
+    expect($sameRight->id)->toBe($right->id)
+        ->and(Right::query()->count())->toBe(1);
+});
+
+it('reuses inactive custom rights with matching normalized name and URI', function (): void {
+    $existing = Right::query()->create([
+        'identifier' => 'CUSTOM-LEGACY-ID',
+        'name' => 'Legacy Custom License',
+        'uri' => 'https://example.test/license',
+        'scheme_uri' => null,
+        'is_active' => false,
+        'is_elmo_active' => true,
+        'usage_count' => 7,
+    ]);
+
+    $right = $this->service->findOrCreate(' legacy custom license ', 'https://example.test/license/');
+
+    expect($right->id)->toBe($existing->id)
+        ->and($right->fresh()->is_active)->toBeTrue()
+        ->and($right->fresh()->is_elmo_active)->toBeFalse()
+        ->and(Right::query()->count())->toBe(1);
+});
+
+it('distinguishes SPDX catalog rights from custom rights by scheme URI', function (): void {
+    $spdx = Right::query()->create([
+        'identifier' => 'MIT',
+        'name' => 'MIT License',
+        'uri' => 'https://spdx.org/licenses/MIT.html',
+        'scheme_uri' => SpdxLicenseLookup::SCHEME_URI,
+    ]);
+
+    $custom = Right::query()->create([
+        'identifier' => 'CUSTOM-MIT-LIKE',
+        'name' => 'MIT-like internal license',
+        'uri' => 'https://example.test/mit-like',
+        'scheme_uri' => null,
+    ]);
+
+    expect(CustomRightCatalogService::isSpdxRight($spdx))->toBeTrue()
+        ->and(CustomRightCatalogService::isCustomRight($spdx))->toBeFalse()
+        ->and(CustomRightCatalogService::isSpdxRight($custom))->toBeFalse()
+        ->and(CustomRightCatalogService::isCustomRight($custom))->toBeTrue();
+});

--- a/tests/pest/Feature/Services/CustomRightCatalogServiceTest.php
+++ b/tests/pest/Feature/Services/CustomRightCatalogServiceTest.php
@@ -51,6 +51,35 @@ it('reuses inactive custom rights with matching normalized name and URI', functi
         ->and(Right::query()->count())->toBe(1);
 });
 
+it('reuses the matching custom right when unrelated reusable rights exist', function (): void {
+    foreach (range(1, 20) as $index) {
+        Right::query()->create([
+            'identifier' => 'CUSTOM-NOISE-'.$index,
+            'name' => 'Unrelated Custom License '.$index,
+            'uri' => 'https://example.test/unrelated/'.$index,
+            'scheme_uri' => null,
+            'is_active' => true,
+            'is_elmo_active' => false,
+        ]);
+    }
+
+    $existing = Right::query()->create([
+        'identifier' => 'CUSTOM-LEGACY-COMMUNITY',
+        'name' => 'Community Data License',
+        'uri' => 'https://example.test/licenses/community-data',
+        'scheme_uri' => null,
+        'is_active' => false,
+        'is_elmo_active' => true,
+    ]);
+
+    $right = $this->service->findOrCreate(' community data license ', 'https://example.test/licenses/community-data/');
+
+    expect($right->id)->toBe($existing->id)
+        ->and($right->fresh()->is_active)->toBeTrue()
+        ->and($right->fresh()->is_elmo_active)->toBeFalse()
+        ->and(Right::query()->where('name', 'Community Data License')->count())->toBe(1);
+});
+
 it('distinguishes SPDX catalog rights from custom rights by scheme URI', function (): void {
     $spdx = Right::query()->create([
         'identifier' => 'MIT',

--- a/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
@@ -404,6 +404,7 @@ describe('DataCiteJsonExporter - Rights/Licenses', function () {
             [
                 'name' => 'Creative Commons Attribution 4.0 International',
                 'uri' => 'https://creativecommons.org/licenses/by/4.0/',
+                'scheme_uri' => 'https://spdx.org/licenses/',
             ]
         );
         $resource->rights()->attach($license->id);

--- a/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
@@ -490,6 +490,33 @@ describe('DataCiteJsonExporter - Rights/Licenses', function () {
         ]);
     });
 
+    test('exports linked custom rights without internal identifiers', function () {
+        $resource = Resource::factory()->create();
+        $customRight = Right::query()->create([
+            'identifier' => 'CUSTOM-COMMUNITY-123456789ABC',
+            'name' => 'Community Data License',
+            'uri' => 'https://example.test/licenses/community-data',
+            'scheme_uri' => null,
+        ]);
+
+        ResourceRight::query()->create([
+            'resource_id' => $resource->id,
+            'rights_id' => $customRight->id,
+            'language' => 'de',
+        ]);
+
+        $result = $this->exporter->export($resource);
+        $rights = $result['data']['attributes']['rightsList'][0];
+
+        expect($rights)->toMatchArray([
+            'rights' => 'Community Data License',
+            'rightsURI' => 'https://example.test/licenses/community-data',
+            'lang' => 'de',
+        ])
+            ->and($rights)->not->toHaveKey('rightsIdentifier')
+            ->and($rights)->not->toHaveKey('rightsIdentifierScheme')
+            ->and($rights)->not->toHaveKey('schemeURI');
+    });
     test('uses already loaded resource rights instead of querying them again', function () {
         $resource = Resource::factory()->create();
         $license = Right::factory()->ccBy4()->create();

--- a/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
@@ -619,6 +619,30 @@ describe('DataCiteXmlExporter - Rights', function () {
             ->and($xml)->not->toContain('rightsIdentifierScheme="LocalScheme"');
     });
 
+    test('exports linked custom rights without internal identifiers', function () {
+        $resource = Resource::factory()->create();
+        $customRight = Right::query()->create([
+            'identifier' => 'CUSTOM-COMMUNITY-123456789ABC',
+            'name' => 'Community Data License',
+            'uri' => 'https://example.test/licenses/community-data',
+            'scheme_uri' => null,
+        ]);
+
+        ResourceRight::query()->create([
+            'resource_id' => $resource->id,
+            'rights_id' => $customRight->id,
+            'language' => 'de',
+        ]);
+
+        $xml = $this->exporter->export($resource);
+
+        expect($xml)->toContain('rightsURI="https://example.test/licenses/community-data"')
+            ->and($xml)->toContain('xml:lang="de"')
+            ->and($xml)->toContain('Community Data License</rights>')
+            ->and($xml)->not->toContain('rightsIdentifier="CUSTOM-COMMUNITY-123456789ABC"')
+            ->and($xml)->not->toContain('rightsIdentifierScheme="SPDX"')
+            ->and($xml)->not->toContain('schemeURI="https://spdx.org/licenses/"');
+    });
     test('uses already loaded resource rights instead of querying them again', function () {
         $resource = Resource::factory()->create();
         $right = Right::factory()->ccBy4()->create();

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -206,6 +206,27 @@ describe('transformLicenses', function (): void {
 
         expect($result)->toBeEmpty();
     });
+    it('keeps custom catalog rights out of SPDX license identifiers', function (): void {
+        $spdxRight = Right::factory()->ccBy4()->create();
+        $customRight = Right::query()->create([
+            'identifier' => 'CUSTOM-COMMUNITY-123456789ABC',
+            'name' => 'Community Data License',
+            'uri' => 'https://example.test/licenses/community-data',
+            'scheme_uri' => null,
+        ]);
+
+        ResourceRight::query()->create([
+            'resource_id' => $this->resource->id,
+            'rights_id' => $spdxRight->id,
+        ]);
+        ResourceRight::query()->create([
+            'resource_id' => $this->resource->id,
+            'rights_id' => $customRight->id,
+        ]);
+        $this->resource->load(['rights', 'resourceRights.right']);
+
+        expect($this->transformer->transformLicenses($this->resource))->toBe(['CC-BY-4.0']);
+    });
 });
 
 // =========================================================================
@@ -234,8 +255,8 @@ describe('transformRawRights', function (): void {
 
         $result = $this->transformer->transformRawRights($this->resource);
 
-        expect($result)->toBe([
-            [
+        expect($result)->toHaveCount(1)
+            ->and($result[0])->toMatchArray([
                 'rights' => 'CC BY 4.0',
                 'rightsUri' => 'http://creativecommons.org/licenses/by/4.0',
                 'rightsIdentifier' => 'CC-BY-4.0',
@@ -243,6 +264,29 @@ describe('transformRawRights', function (): void {
                 'schemeUri' => 'https://spdx.org/licenses/',
                 'lang' => 'en',
                 'source' => 'xml-upload',
+            ])
+            ->and($result[0]['sourceResourceRightId'])->toBeInt();
+    });
+    it('returns linked custom catalog rights as editable raw rights rows', function (): void {
+        $customRight = Right::query()->create([
+            'identifier' => 'CUSTOM-COMMUNITY-123456789ABC',
+            'name' => 'Community Data License',
+            'uri' => 'https://example.test/licenses/community-data',
+            'scheme_uri' => null,
+        ]);
+        $resourceRight = ResourceRight::query()->create([
+            'resource_id' => $this->resource->id,
+            'rights_id' => $customRight->id,
+        ]);
+        $this->resource->load('resourceRights.right');
+
+        $result = $this->transformer->transformRawRights($this->resource);
+
+        expect($result)->toBe([
+            [
+                'sourceResourceRightId' => $resourceRight->id,
+                'rights' => 'Community Data License',
+                'rightsUri' => 'https://example.test/licenses/community-data',
             ],
         ]);
     });

--- a/tests/pest/Feature/Services/ResourceRightsStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceRightsStorageServiceTest.php
@@ -205,3 +205,107 @@ it('keeps round-tripped raw import context linked when the matching right is sti
         ->and($linkedStatement->rights_uri)->toBe('http://creativecommons.org/licenses/by/4.0')
         ->and(ResourceRight::where('resource_id', $this->resource->id)->whereNull('rights_id')->exists())->toBeFalse();
 });
+
+it('links imported rights rows to selected custom catalog rights', function (): void {
+    $customRight = Right::query()->create([
+        'identifier' => 'CUSTOM-COMMUNITY-123456789ABC',
+        'name' => 'Community License',
+        'uri' => 'https://example.test/community-license',
+        'scheme_uri' => null,
+        'is_active' => true,
+        'is_elmo_active' => false,
+    ]);
+    $sourceRow = ResourceRight::query()->create([
+        'resource_id' => $this->resource->id,
+        'rights_text' => 'Community License',
+        'rights_uri' => 'https://example.test/community-license',
+        'source' => 'xml-upload',
+    ]);
+
+    $this->service->syncEditorRights(
+        $this->resource,
+        [$customRight->identifier],
+        [],
+        null,
+        [$sourceRow->id => $customRight->id],
+        true,
+    );
+
+    $sourceRow->refresh();
+
+    expect($sourceRow->rights_id)->toBe($customRight->id)
+        ->and($sourceRow->rights_text)->toBe('Community License')
+        ->and($sourceRow->rights_uri)->toBe('https://example.test/community-license')
+        ->and(ResourceRight::query()->where('resource_id', $this->resource->id)->whereNull('rights_id')->exists())->toBeFalse();
+});
+
+it('updates retained custom source rows before removing unselected linked rights', function (): void {
+    $oldCustomRight = Right::query()->create([
+        'identifier' => 'CUSTOM-OLD-123456789ABC',
+        'name' => 'Old Custom License',
+        'uri' => 'https://example.test/old-license',
+        'scheme_uri' => null,
+    ]);
+    $newCustomRight = Right::query()->create([
+        'identifier' => 'CUSTOM-NEW-123456789ABC',
+        'name' => 'New Custom License',
+        'uri' => 'https://example.test/new-license',
+        'scheme_uri' => null,
+    ]);
+    $sourceRow = ResourceRight::query()->create([
+        'resource_id' => $this->resource->id,
+        'rights_id' => $oldCustomRight->id,
+        'rights_text' => 'Old Custom License',
+        'rights_uri' => 'https://example.test/old-license',
+    ]);
+
+    $this->service->syncEditorRights(
+        $this->resource,
+        [$newCustomRight->identifier],
+        [],
+        null,
+        [$sourceRow->id => $newCustomRight->id],
+        true,
+    );
+
+    $sourceRow->refresh();
+
+    expect($sourceRow->rights_id)->toBe($newCustomRight->id)
+        ->and(ResourceRight::query()->where('resource_id', $this->resource->id)->count())->toBe(1);
+});
+
+it('merges imported source rows into existing linked custom rows', function (): void {
+    $customRight = Right::query()->create([
+        'identifier' => 'CUSTOM-MERGE-123456789ABC',
+        'name' => 'Merged Custom License',
+        'uri' => 'https://example.test/merged-license',
+        'scheme_uri' => null,
+    ]);
+    $linkedRow = ResourceRight::query()->create([
+        'resource_id' => $this->resource->id,
+        'rights_id' => $customRight->id,
+    ]);
+    $sourceRow = ResourceRight::query()->create([
+        'resource_id' => $this->resource->id,
+        'rights_text' => 'Merged Custom License',
+        'rights_uri' => 'https://example.test/merged-license',
+        'source' => 'xml-upload',
+    ]);
+
+    $this->service->syncEditorRights(
+        $this->resource,
+        [$customRight->identifier],
+        [],
+        null,
+        [$sourceRow->id => $customRight->id],
+        true,
+    );
+
+    $linkedRow->refresh();
+
+    expect(ResourceRight::query()->where('resource_id', $this->resource->id)->count())->toBe(1)
+        ->and($linkedRow->rights_text)->toBe('Merged Custom License')
+        ->and($linkedRow->rights_uri)->toBe('https://example.test/merged-license')
+        ->and($linkedRow->source)->toBe('xml-upload')
+        ->and(ResourceRight::query()->find($sourceRow->id))->toBeNull();
+});

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\DescriptionType;
 use App\Models\FunderIdentifierType;
 use App\Models\IdentifierType;
 use App\Models\LandingPage;
@@ -1456,6 +1457,10 @@ describe('ResourceStorageService - Issue #371: Date Created Handling', function 
 
     it('stores custom licenses as reusable rights catalog entries', function () {
         $resourceType = ResourceType::first();
+        DescriptionType::firstOrCreate(
+            ['slug' => 'Abstract'],
+            ['name' => 'Abstract']
+        );
 
         $data = [
             'resourceId' => null,

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -1453,4 +1453,57 @@ describe('ResourceStorageService - Issue #371: Date Created Handling', function 
                 ->and($funding->scheme_uri)->toBeNull();
         });
     });
+
+    it('stores custom licenses as reusable rights catalog entries', function () {
+        $resourceType = ResourceType::first();
+
+        $data = [
+            'resourceId' => null,
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Custom license resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'licenses' => [],
+            'customLicenses' => [
+                [
+                    'name' => 'Community Data License',
+                    'uri' => 'https://example.test/licenses/community-data',
+                ],
+            ],
+            'rawRights' => [],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'Ada',
+                    'lastName' => 'Lovelace',
+                    'position' => 0,
+                ],
+            ],
+            'descriptions' => [
+                [
+                    'descriptionType' => 'Abstract',
+                    'description' => 'Custom licenses should be persisted as catalog rights.',
+                ],
+            ],
+        ];
+
+        [$resource] = $this->service->store($data, $this->user->id);
+
+        $right = Right::query()->where('name', 'Community Data License')->sole();
+        $resourceRight = ResourceRight::query()
+            ->where('resource_id', $resource->id)
+            ->where('rights_id', $right->id)
+            ->sole();
+
+        expect($right->identifier)->toStartWith('CUSTOM-COMMUNITY-DATA-LICENSE-')
+            ->and($right->uri)->toBe('https://example.test/licenses/community-data')
+            ->and($right->scheme_uri)->toBeNull()
+            ->and($right->is_active)->toBeTrue()
+            ->and($right->is_elmo_active)->toBeFalse()
+            ->and($resourceRight->rights_id)->toBe($right->id);
+    });
 });

--- a/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
@@ -256,6 +256,7 @@ it('uses position-aware safe URL messages for draft custom license URLs', functi
     expect($message)->toBe('[Licenses & Rights] The Custom license #1 license text URL must use http or https protocol.')
         ->and($message)->not->toContain('customLicenses.0.uri');
 });
+
 it('normalizes custom licenses for draft saves', function (): void {
     $request = StoreDraftResourceRequest::create('/editor/resources/draft', 'POST', [
         'titles' => [
@@ -268,8 +269,15 @@ it('normalizes custom licenses for draft saves', function (): void {
                 'source_resource_right_id' => '42',
             ],
             [
-                'name' => '   ',
+                'name' => 'Started custom license',
                 'uri' => null,
+            ],
+            [
+                'name' => '   ',
+                'uri' => ' https://example.test/licenses/missing-name ',
+            ],
+            [
+                'sourceResourceRightId' => '43',
             ],
         ],
     ]);

--- a/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
@@ -228,3 +228,32 @@ it('keeps date mode validation aligned between draft and final resource requests
     expect($draftRequest->rules())->toHaveKey('dates.*.dateMode')
         ->and($storeRequest->rules())->toHaveKey('dates.*.dateMode');
 });
+
+it('normalizes custom licenses for draft saves', function (): void {
+    $request = StoreDraftResourceRequest::create('/editor/resources/draft', 'POST', [
+        'titles' => [
+            ['title' => 'Draft Resource', 'titleType' => 'main-title'],
+        ],
+        'customLicenses' => [
+            [
+                'rights_text' => ' Community Data License ',
+                'rightsURI' => ' https://example.test/licenses/community-data ',
+                'source_resource_right_id' => '42',
+            ],
+            [
+                'name' => '   ',
+                'uri' => null,
+            ],
+        ],
+    ]);
+
+    invokeDraftRequestMethod($request, 'prepareForValidation');
+
+    expect($request->input('customLicenses'))->toBe([
+        [
+            'name' => 'Community Data License',
+            'uri' => 'https://example.test/licenses/community-data',
+            'sourceResourceRightId' => 42,
+        ],
+    ]);
+});

--- a/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/StoreDraftResourceRequestTest.php
@@ -135,7 +135,7 @@ it('keeps related-work citation label limits aligned between draft and store req
 /**
  * @param  list<array<string, mixed>>  $dates
  */
-function validateDraftDatePayload(array $dates): \Illuminate\Validation\Validator
+function validateDraftDatePayload(array $dates): Illuminate\Validation\Validator
 {
     $request = StoreDraftResourceRequest::create('/editor/resources/draft', 'POST', [
         'titles' => [
@@ -229,6 +229,33 @@ it('keeps date mode validation aligned between draft and final resource requests
         ->and($storeRequest->rules())->toHaveKey('dates.*.dateMode');
 });
 
+it('uses position-aware safe URL messages for draft custom license URLs', function (): void {
+    $request = new StoreDraftResourceRequest;
+
+    $validator = Validator::make(
+        [
+            'titles' => [
+                ['title' => 'Draft Resource', 'titleType' => 'main-title'],
+            ],
+            'customLicenses' => [
+                [
+                    'name' => 'Unsafe License',
+                    'uri' => 'javascript:alert(1)',
+                ],
+            ],
+        ],
+        $request->rules(),
+        $request->messages(),
+        $request->attributes(),
+    );
+
+    expect($validator->fails())->toBeTrue();
+
+    $message = $validator->errors()->first('customLicenses.0.uri');
+
+    expect($message)->toBe('[Licenses & Rights] The Custom license #1 license text URL must use http or https protocol.')
+        ->and($message)->not->toContain('customLicenses.0.uri');
+});
 it('normalizes custom licenses for draft saves', function (): void {
     $request = StoreDraftResourceRequest::create('/editor/resources/draft', 'POST', [
         'titles' => [

--- a/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
+++ b/tests/pest/Unit/Services/LandingPageResourceTransformerTest.php
@@ -466,6 +466,40 @@ test('transforms rights to licenses with correct field mapping', function () {
         ]);
 });
 
+test('transforms custom licenses without SPDX identifiers', function () {
+    $transformer = new LandingPageResourceTransformer;
+
+    $resource = new Resource;
+
+    $customRight = new Right;
+    $customRight->forceFill([
+        'id' => 7,
+        'identifier' => 'CUSTOM-COMMUNITY-123456789ABC',
+        'name' => 'Community Data License',
+        'uri' => 'https://example.test/licenses/community-data',
+        'scheme_uri' => null,
+    ]);
+
+    $resource->setRelation('rights', new EloquentCollection([$customRight]));
+    $resource->setRelation('titles', new EloquentCollection);
+    $resource->setRelation('creators', new EloquentCollection);
+    $resource->setRelation('contributors', new EloquentCollection);
+    $resource->setRelation('relatedIdentifiers', new EloquentCollection);
+    $resource->setRelation('descriptions', new EloquentCollection);
+    $resource->setRelation('fundingReferences', new EloquentCollection);
+    $resource->setRelation('subjects', new EloquentCollection);
+    $resource->setRelation('geoLocations', new EloquentCollection);
+
+    $data = $transformer->transform($resource);
+
+    expect($data['licenses'][0])->toMatchArray([
+        'id' => 7,
+        'name' => 'Community Data License',
+        'spdx_id' => null,
+        'reference' => 'https://example.test/licenses/community-data',
+        'scheme_uri' => null,
+    ]);
+});
 test('transforms multiple licenses correctly', function () {
     $transformer = new LandingPageResourceTransformer;
 
@@ -477,6 +511,7 @@ test('transforms multiple licenses correctly', function () {
         'identifier' => 'CC-BY-4.0',
         'name' => 'Creative Commons Attribution 4.0 International',
         'uri' => 'https://creativecommons.org/licenses/by/4.0/',
+        'scheme_uri' => 'https://spdx.org/licenses/',
     ]);
 
     $mit = new Right;
@@ -485,6 +520,7 @@ test('transforms multiple licenses correctly', function () {
         'identifier' => 'MIT',
         'name' => 'MIT License',
         'uri' => 'https://opensource.org/licenses/MIT',
+        'scheme_uri' => 'https://spdx.org/licenses/',
     ]);
 
     $resource->setRelation('rights', new EloquentCollection([$ccBy, $mit]));

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2829,6 +2829,46 @@ describe('DataCiteForm', () => {
         expect(body.rawRights).toEqual([]);
     });
 
+    it('indexes custom license inputs by custom payload order when catalog rows come first', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialLicenses={['MIT']}
+                initialRawRights={[
+                    {
+                        sourceResourceRightId: 123,
+                        rights: 'Imported Community License',
+                        rightsUri: 'https://example.test/licenses/imported-community',
+                        source: 'xml-upload',
+                    },
+                ]}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
+        if (licensesTrigger.getAttribute('aria-expanded') === 'false') {
+            await user.click(licensesTrigger);
+        }
+
+        expect(screen.getByTestId('custom-license-name-0')).toHaveValue('Imported Community License');
+        expect(screen.getByTestId('custom-license-uri-0')).toHaveValue('https://example.test/licenses/imported-community');
+        expect(screen.queryByTestId('custom-license-name-1')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('custom-license-uri-1')).not.toBeInTheDocument();
+    });
+
     it('round-trips imported raw rights as custom licenses with source row IDs', { timeout: 60000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -1157,7 +1157,7 @@ describe('DataCiteForm', () => {
         expect(screen.getByRole('button', { name: /^Main Title is required\.$/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /^Publication Year is required\.$/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /^Resource Type is required\.$/i })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /^Primary License is required\.$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^At least one License is required\.$/i })).toBeInTheDocument();
     });
 
     it('shows validation error list on every save attempt, not just the first (Issue #538)', { timeout: 60000 }, async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2869,6 +2869,103 @@ describe('DataCiteForm', () => {
         expect(screen.queryByTestId('custom-license-uri-1')).not.toBeInTheDocument();
     });
 
+    it('accepts a complete later license when the first license row is blank', { timeout: 60000 }, async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Later License Dataset', titleType: 'main-title' }]}
+                initialLicenses={['', 'MIT']}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user);
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        const saveCall = getSaveAxiosCall();
+        expect(saveCall).toBeDefined();
+        const body = JSON.parse((saveCall![1] as RequestInit).body as string);
+
+        expect(screen.queryByRole('button', { name: /^At least one License is required\.$/i })).not.toBeInTheDocument();
+        expect(body.licenses).toEqual(['MIT']);
+    });
+
+    it('preserves imported raw rights without a URL as raw rights', { timeout: 60000 }, async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Text Only Rights Dataset', titleType: 'main-title' }]}
+                initialRawRights={[
+                    {
+                        sourceResourceRightId: 456,
+                        rights: 'HyMap imagery is available under commercial End User Licencing Agreements',
+                        source: 'legacy-sumario',
+                    },
+                ]}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
+        if (licensesTrigger.getAttribute('aria-expanded') === 'false') {
+            await user.click(licensesTrigger);
+        }
+
+        expect(screen.getByRole('textbox', { name: /^License name/ })).toHaveValue(
+            'HyMap imagery is available under commercial End User Licencing Agreements',
+        );
+        const licenseTextUrlInput = screen.getByRole('textbox', { name: /^License text URL/ });
+        expect(licenseTextUrlInput).toHaveValue('');
+        expect(licenseTextUrlInput).not.toBeRequired();
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user);
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        const saveCall = getSaveAxiosCall();
+        expect(saveCall).toBeDefined();
+        const body = JSON.parse((saveCall![1] as RequestInit).body as string);
+
+        expect(body.customLicenses).toEqual([]);
+        expect(body.rawRights).toEqual([
+            {
+                rights: 'HyMap imagery is available under commercial End User Licencing Agreements',
+                rightsUri: null,
+                source: 'legacy-sumario',
+                sourceResourceRightId: 456,
+            },
+        ]);
+    });
+
     it('round-trips imported raw rights as custom licenses with source row IDs', { timeout: 60000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 
@@ -2925,6 +3022,7 @@ describe('DataCiteForm', () => {
         ]);
         expect(body.rawRights).toEqual([]);
     });
+
     it('includes the resource identifier when updating an existing dataset', { timeout: 60000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2779,6 +2779,112 @@ describe('DataCiteForm', () => {
         expect(toast.success).toHaveBeenCalledWith('Resource stored!');
     });
 
+    it('submits user-entered custom licenses in the payload', { timeout: 60000 }, async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Custom License Dataset', titleType: 'main-title' }]}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
+        if (licensesTrigger.getAttribute('aria-expanded') === 'false') {
+            await user.click(licensesTrigger);
+        }
+
+        await user.click(screen.getByRole('button', { name: 'Custom' }));
+        await user.type(screen.getByLabelText('License name'), 'Community Data License');
+        await user.type(screen.getByLabelText('License text URL'), 'https://example.test/licenses/community-data');
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user);
+
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        const saveCall = getSaveAxiosCall();
+        expect(saveCall).toBeDefined();
+        const body = JSON.parse((saveCall![1] as RequestInit).body as string);
+
+        expect(body.licenses).toEqual([]);
+        expect(body.customLicenses).toEqual([
+            {
+                name: 'Community Data License',
+                uri: 'https://example.test/licenses/community-data',
+            },
+        ]);
+        expect(body.rawRights).toEqual([]);
+    });
+
+    it('round-trips imported raw rights as custom licenses with source row IDs', { timeout: 60000 }, async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialYear="2024"
+                initialResourceType="1"
+                initialTitles={[{ title: 'Imported Rights Dataset', titleType: 'main-title' }]}
+                initialRawRights={[
+                    {
+                        sourceResourceRightId: 123,
+                        rights: 'Imported Community License',
+                        rightsUri: 'https://example.test/licenses/imported-community',
+                        source: 'xml-upload',
+                    },
+                ]}
+                availableDatacenters={availableDatacenters}
+                initialDatacenters={[1]}
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const licensesTrigger = getAccordionTrigger(/Licenses and Rights/i);
+        if (licensesTrigger.getAttribute('aria-expanded') === 'false') {
+            await user.click(licensesTrigger);
+        }
+
+        expect(screen.getByLabelText('License name')).toHaveValue('Imported Community License');
+        expect(screen.getByLabelText('License text URL')).toHaveValue('https://example.test/licenses/imported-community');
+
+        await fillRequiredAuthor(user);
+        await fillRequiredAbstract(user);
+        await user.click(screen.getByRole('button', { name: /save & validate/i }));
+
+        const saveCall = getSaveAxiosCall();
+        expect(saveCall).toBeDefined();
+        const body = JSON.parse((saveCall![1] as RequestInit).body as string);
+
+        expect(body.customLicenses).toEqual([
+            {
+                name: 'Imported Community License',
+                uri: 'https://example.test/licenses/imported-community',
+                sourceResourceRightId: 123,
+            },
+        ]);
+        expect(body.rawRights).toEqual([]);
+    });
     it('includes the resource identifier when updating an existing dataset', { timeout: 60000 }, async () => {
         const user = userEvent.setup({ pointerEventsCheck: 0 });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -2808,8 +2808,8 @@ describe('DataCiteForm', () => {
         }
 
         await user.click(screen.getByRole('button', { name: 'Custom' }));
-        await user.type(screen.getByLabelText('License name'), 'Community Data License');
-        await user.type(screen.getByLabelText('License text URL'), 'https://example.test/licenses/community-data');
+        await user.type(screen.getByRole('textbox', { name: /^License name/ }), 'Community Data License');
+        await user.type(screen.getByRole('textbox', { name: /^License text URL/ }), 'https://example.test/licenses/community-data');
         await fillRequiredAuthor(user);
         await fillRequiredAbstract(user);
 
@@ -2865,8 +2865,8 @@ describe('DataCiteForm', () => {
             await user.click(licensesTrigger);
         }
 
-        expect(screen.getByLabelText('License name')).toHaveValue('Imported Community License');
-        expect(screen.getByLabelText('License text URL')).toHaveValue('https://example.test/licenses/imported-community');
+        expect(screen.getByRole('textbox', { name: /^License name/ })).toHaveValue('Imported Community License');
+        expect(screen.getByRole('textbox', { name: /^License text URL/ })).toHaveValue('https://example.test/licenses/imported-community');
 
         await fillRequiredAuthor(user);
         await fillRequiredAbstract(user);

--- a/tests/vitest/components/curation/fields/license-field-validation.test.tsx
+++ b/tests/vitest/components/curation/fields/license-field-validation.test.tsx
@@ -1,79 +1,95 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import LicenseField from '@/components/curation/fields/license-field';
+import type { LicenseEntry } from '@/components/curation/types/datacite-form-types';
 import type { ValidationMessage } from '@/hooks/use-form-validation';
 
-describe('LicenseField Validation Integration', () => {
-    const defaultProps = {
+const options = [
+    { value: 'cc-by-4.0', label: 'CC BY 4.0' },
+    { value: 'cc0-1.0', label: 'CC0 1.0' },
+    { value: 'mit', label: 'MIT License' },
+];
+
+const catalogEntry = (license = ''): LicenseEntry => ({
+    id: 'test-license',
+    mode: 'catalog',
+    license,
+});
+
+const customEntry = (name = '', uri = ''): LicenseEntry => ({
+    id: 'test-license',
+    mode: 'custom',
+    name,
+    uri,
+});
+
+const renderLicenseField = (props: Partial<ComponentProps<typeof LicenseField>> = {}) => {
+    const defaultProps: ComponentProps<typeof LicenseField> = {
         id: 'test-license',
-        license: '',
-        options: [
-            { value: 'cc-by-4.0', label: 'CC BY 4.0' },
-            { value: 'cc0-1.0', label: 'CC0 1.0' },
-            { value: 'mit', label: 'MIT License' },
-        ],
-        onLicenseChange: () => {},
-        onAdd: () => {},
-        onRemove: () => {},
+        entry: catalogEntry(),
+        options,
+        onModeChange: vi.fn(),
+        onCatalogLicenseChange: vi.fn(),
+        onCustomLicenseChange: vi.fn(),
+        onAdd: vi.fn(),
+        onRemove: vi.fn(),
         isFirst: true,
         canAdd: true,
         required: true,
     };
 
+    return render(<LicenseField {...defaultProps} {...props} />);
+};
+
+describe('LicenseField Validation Integration', () => {
     describe('Basic Rendering', () => {
-        it('renders without validation props', () => {
-            render(<LicenseField {...defaultProps} />);
-            
-            expect(screen.getByLabelText(/^License/)).toBeInTheDocument();
+        it('renders catalog mode by default', () => {
+            renderLicenseField();
+
+            expect(screen.getByRole('button', { name: 'Catalog' })).toHaveAttribute('aria-pressed', 'true');
+            expect(screen.getByRole('combobox')).toBeInTheDocument();
         });
 
         it('renders with required indicator when required is true', () => {
-            render(<LicenseField {...defaultProps} required={true} />);
-            
-            const select = screen.getByLabelText(/^License/);
-            expect(select).toBeRequired();
+            renderLicenseField({ required: true });
+
+            const select = screen.getByRole('combobox');
+            expect(select).toHaveAttribute('aria-required', 'true');
         });
 
-        it('does not show required indicator for secondary licenses', () => {
-            render(<LicenseField {...defaultProps} isFirst={false} required={false} />);
-            
-            const select = screen.getByLabelText(/^License/);
-            expect(select).not.toBeRequired();
+        it('does not mark secondary licenses as required', () => {
+            renderLicenseField({ isFirst: false, required: false });
+
+            const select = screen.getByRole('combobox');
+            expect(select).not.toHaveAttribute('aria-required', 'true');
+        });
+
+        it('renders custom license inputs in custom mode', () => {
+            renderLicenseField({ entry: customEntry() });
+
+            expect(screen.getByRole('button', { name: 'Custom' })).toHaveAttribute('aria-pressed', 'true');
+            expect(screen.getByRole('textbox', { name: /^License name/ })).toBeInTheDocument();
+            expect(screen.getByRole('textbox', { name: /^License text URL/ })).toBeInTheDocument();
         });
     });
 
     describe('Validation Messages Display', () => {
         it('displays error messages when touched', () => {
-            const validationMessages: ValidationMessage[] = [
-                { severity: 'error', message: 'Primary license is required' },
-            ];
+            const validationMessages: ValidationMessage[] = [{ severity: 'error', message: 'Primary license is required' }];
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    validationMessages={validationMessages}
-                    touched={true}
-                />
-            );
+            renderLicenseField({ validationMessages, touched: true });
 
             expect(screen.getByText('Primary license is required')).toBeInTheDocument();
             expect(screen.getByRole('alert')).toBeInTheDocument();
         });
 
         it('does not display messages when not touched', () => {
-            const validationMessages: ValidationMessage[] = [
-                { severity: 'error', message: 'Primary license is required' },
-            ];
+            const validationMessages: ValidationMessage[] = [{ severity: 'error', message: 'Primary license is required' }];
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    validationMessages={validationMessages}
-                    touched={false}
-                />
-            );
+            renderLicenseField({ validationMessages, touched: false });
 
             expect(screen.queryByText('Primary license is required')).not.toBeInTheDocument();
         });
@@ -84,13 +100,7 @@ describe('LicenseField Validation Integration', () => {
                 { severity: 'info', message: 'Select an appropriate license for your data' },
             ];
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    validationMessages={validationMessages}
-                    touched={true}
-                />
-            );
+            renderLicenseField({ validationMessages, touched: true });
 
             expect(screen.getByText('Primary license is required')).toBeInTheDocument();
             expect(screen.getByText('Select an appropriate license for your data')).toBeInTheDocument();
@@ -98,47 +108,26 @@ describe('LicenseField Validation Integration', () => {
     });
 
     describe('Accessibility', () => {
-        it('sets aria-invalid when there are error messages and field is touched', () => {
-            const validationMessages: ValidationMessage[] = [
-                { severity: 'error', message: 'Primary license is required' },
-            ];
+        it('sets aria-invalid when catalog field has touched error messages', () => {
+            const validationMessages: ValidationMessage[] = [{ severity: 'error', message: 'Primary license is required' }];
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    validationMessages={validationMessages}
-                    touched={true}
-                />
-            );
+            renderLicenseField({ validationMessages, touched: true });
 
             const trigger = screen.getByRole('combobox');
             expect(trigger).toHaveAttribute('aria-invalid', 'true');
         });
 
-        it('does not set aria-invalid when valid', () => {
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    license="cc-by-4.0"
-                />
-            );
+        it('does not set aria-invalid when catalog field is valid', () => {
+            renderLicenseField({ entry: catalogEntry('cc-by-4.0') });
 
             const trigger = screen.getByRole('combobox');
             expect(trigger).toHaveAttribute('aria-invalid', 'false');
         });
 
-        it('links select to validation feedback via aria-describedby', () => {
-            const validationMessages: ValidationMessage[] = [
-                { severity: 'error', message: 'Primary license is required' },
-            ];
+        it('links catalog select to validation feedback via aria-describedby', () => {
+            const validationMessages: ValidationMessage[] = [{ severity: 'error', message: 'Primary license is required' }];
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    validationMessages={validationMessages}
-                    touched={true}
-                />
-            );
+            renderLicenseField({ validationMessages, touched: true });
 
             const trigger = screen.getByRole('combobox');
             const describedBy = trigger.getAttribute('aria-describedby');
@@ -148,104 +137,90 @@ describe('LicenseField Validation Integration', () => {
     });
 
     describe('Event Handlers', () => {
-        it('calls onValidationBlur when provided', async () => {
+        it('calls onValidationBlur when selecting a catalog license', async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            let blurCalled = false;
-            const handleBlur = () => {
-                blurCalled = true;
-            };
+            const handleBlur = vi.fn();
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    onValidationBlur={handleBlur}
-                />
-            );
+            renderLicenseField({ onValidationBlur: handleBlur });
 
-            const trigger = screen.getByRole('combobox');
-            
-            // SelectField triggers onValidationBlur in handleValueChange
-            // So we select a value to trigger the blur handler
-            await user.click(trigger);
-            const option = await screen.findByText('CC BY 4.0');
-            await user.click(option);
+            await user.click(screen.getByRole('combobox'));
+            await user.click(await screen.findByText('CC BY 4.0'));
 
             await waitFor(() => {
-                expect(blurCalled).toBe(true);
+                expect(handleBlur).toHaveBeenCalled();
             });
         });
 
-        it('calls onLicenseChange when selecting a license', async () => {
+        it('calls onCatalogLicenseChange when selecting a license', async () => {
             const user = userEvent.setup();
-            let selectedValue = '';
-            const handleChange = (value: string) => {
-                selectedValue = value;
-            };
+            const handleChange = vi.fn();
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    onLicenseChange={handleChange}
-                />
-            );
+            renderLicenseField({ onCatalogLicenseChange: handleChange });
 
-            const trigger = screen.getByRole('combobox');
-            await user.click(trigger);
-            
-            const option = await screen.findByText('MIT License');
-            await user.click(option);
+            await user.click(screen.getByRole('combobox'));
+            await user.click(await screen.findByText('MIT License'));
 
-            expect(selectedValue).toBe('mit');
+            expect(handleChange).toHaveBeenCalledWith('mit');
+        });
+
+        it('calls onModeChange when switching modes', async () => {
+            const user = userEvent.setup();
+            const handleModeChange = vi.fn();
+
+            renderLicenseField({ onModeChange: handleModeChange });
+
+            await user.click(screen.getByRole('button', { name: 'Custom' }));
+
+            expect(handleModeChange).toHaveBeenCalledWith('custom');
+        });
+
+        it('calls onCustomLicenseChange for custom name and URL inputs', async () => {
+            const user = userEvent.setup();
+            const handleCustomChange = vi.fn();
+
+            renderLicenseField({ entry: customEntry(), onCustomLicenseChange: handleCustomChange });
+
+            await user.type(screen.getByRole('textbox', { name: /^License name/ }), 'Community License');
+            await user.type(screen.getByRole('textbox', { name: /^License text URL/ }), 'https://example.test/license');
+
+            expect(handleCustomChange).toHaveBeenCalledWith('name', expect.any(String));
+            expect(handleCustomChange).toHaveBeenCalledWith('uri', expect.any(String));
         });
     });
 
     describe('Add/Remove Buttons', () => {
         it('shows add button when isFirst is true and canAdd is true', () => {
-            render(<LicenseField {...defaultProps} isFirst={true} canAdd={true} />);
-            
+            renderLicenseField({ isFirst: true, canAdd: true });
+
             expect(screen.getByLabelText('Add license')).toBeInTheDocument();
         });
 
         it('shows remove button when isFirst is false', () => {
-            render(<LicenseField {...defaultProps} isFirst={false} />);
-            
+            renderLicenseField({ isFirst: false });
+
             expect(screen.getByLabelText('Remove license')).toBeInTheDocument();
         });
 
         it('does not show add button when canAdd is false', () => {
-            render(<LicenseField {...defaultProps} isFirst={true} canAdd={false} />);
-            
+            renderLicenseField({ isFirst: true, canAdd: false });
+
             expect(screen.queryByLabelText('Add license')).not.toBeInTheDocument();
         });
     });
 
     describe('Styling with Validation States', () => {
-        it('applies error styling when validation fails', () => {
-            const validationMessages: ValidationMessage[] = [
-                { severity: 'error', message: 'Primary license is required' },
-            ];
+        it('applies error styling when catalog validation fails', () => {
+            const validationMessages: ValidationMessage[] = [{ severity: 'error', message: 'Primary license is required' }];
 
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    validationMessages={validationMessages}
-                    touched={true}
-                />
-            );
+            renderLicenseField({ validationMessages, touched: true });
 
             const trigger = screen.getByRole('combobox');
             expect(trigger).toHaveAttribute('aria-invalid', 'true');
-            // Border styling is applied via aria-invalid attribute and Tailwind CSS
             expect(trigger).toHaveClass('aria-invalid:border-destructive');
         });
 
-        it('applies normal styling when no validation errors', () => {
-            render(
-                <LicenseField
-                    {...defaultProps}
-                    license="cc-by-4.0"
-                />
-            );
+        it('applies normal styling when no validation errors exist', () => {
+            renderLicenseField({ entry: catalogEntry('cc-by-4.0') });
 
             const trigger = screen.getByRole('combobox');
             expect(trigger).not.toHaveClass('border-destructive');
@@ -253,38 +228,36 @@ describe('LicenseField Validation Integration', () => {
     });
 
     describe('Label Visibility', () => {
-        it('shows label when isFirst is true', () => {
-            render(<LicenseField {...defaultProps} isFirst={true} />);
-            
+        it('shows catalog label when isFirst is true', () => {
+            renderLicenseField({ isFirst: true });
+
             expect(screen.getByText('License')).toBeVisible();
         });
 
-        it('hides label visually when isFirst is false', () => {
-            render(<LicenseField {...defaultProps} isFirst={false} />);
-            
+        it('hides catalog label visually when isFirst is false', () => {
+            renderLicenseField({ isFirst: false });
+
             const label = screen.getByText('License').closest('label');
             expect(label).toHaveClass('sr-only');
         });
     });
 
     describe('Options Display', () => {
-        it('displays all license options when opened', async () => {
+        it('displays all catalog license options when opened', async () => {
             const user = userEvent.setup();
-            
-            render(<LicenseField {...defaultProps} />);
 
-            const trigger = screen.getByRole('combobox');
-            await user.click(trigger);
+            renderLicenseField();
+
+            await user.click(screen.getByRole('combobox'));
 
             expect(await screen.findByText('CC BY 4.0')).toBeInTheDocument();
             expect(await screen.findByText('CC0 1.0')).toBeInTheDocument();
             expect(await screen.findByText('MIT License')).toBeInTheDocument();
         });
 
-        it('displays selected license value', () => {
-            render(<LicenseField {...defaultProps} license="cc-by-4.0" />);
+        it('displays selected catalog license value', () => {
+            renderLicenseField({ entry: catalogEntry('cc-by-4.0') });
 
-            // SelectField shows the label of the selected option
             expect(screen.getByText('CC BY 4.0')).toBeInTheDocument();
         });
     });

--- a/tests/vitest/components/curation/fields/license-field-validation.test.tsx
+++ b/tests/vitest/components/curation/fields/license-field-validation.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import type { ComponentProps } from 'react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import LicenseField from '@/components/curation/fields/license-field';

--- a/tests/vitest/components/curation/fields/license-field-validation.test.tsx
+++ b/tests/vitest/components/curation/fields/license-field-validation.test.tsx
@@ -134,6 +134,15 @@ describe('LicenseField Validation Integration', () => {
             expect(describedBy).toBeTruthy();
             expect(describedBy).toContain('feedback');
         });
+
+        it('groups the license mode toggle buttons with an accessible name', () => {
+            renderLicenseField();
+
+            const group = screen.getByRole('group', { name: 'License entry type' });
+
+            expect(group).toContainElement(screen.getByRole('button', { name: 'Catalog' }));
+            expect(group).toContainElement(screen.getByRole('button', { name: 'Custom' }));
+        });
     });
 
     describe('Event Handlers', () => {

--- a/tests/vitest/components/curation/utils/__tests__/error-field-mapper.test.ts
+++ b/tests/vitest/components/curation/utils/__tests__/error-field-mapper.test.ts
@@ -447,3 +447,18 @@ describe('groupErrorsBySection', () => {
         expect(keys[1]).toBe('resource-info');
     });
 });
+
+describe('custom license error mapping', () => {
+    it('resolves custom license name and URL selectors', () => {
+        const mapped = mapBackendErrors({
+            'customLicenses.0.name': ['[Licenses & Rights] Custom license #1 requires a name.'],
+            'customLicenses.0.uri': ['[Licenses & Rights] Custom license #1 requires a license text URL.'],
+        });
+
+        expect(mapped[0].sectionName).toBe('Licenses & Rights');
+        expect(mapped[0].fieldSelector).toBe('[data-testid="custom-license-name-0"]');
+        expect(mapped[0].fieldId).toBe('license-0');
+        expect(mapped[1].fieldSelector).toBe('[data-testid="custom-license-uri-0"]');
+        expect(mapped[1].fieldId).toBe('license-0');
+    });
+});

--- a/tests/vitest/components/curation/utils/__tests__/error-field-mapper.test.ts
+++ b/tests/vitest/components/curation/utils/__tests__/error-field-mapper.test.ts
@@ -461,4 +461,14 @@ describe('custom license error mapping', () => {
         expect(mapped[1].fieldSelector).toBe('[data-testid="custom-license-uri-0"]');
         expect(mapped[1].fieldId).toBe('license-0');
     });
+
+    it('uses the section fallback for custom license source row errors', () => {
+        const mapped = mapBackendErrors({
+            'customLicenses.0.sourceResourceRightId': ['[Licenses & Rights] Custom license #1 cannot be linked to the imported rights statement.'],
+        });
+
+        expect(mapped[0].sectionName).toBe('Licenses & Rights');
+        expect(mapped[0].fieldSelector).toBeNull();
+        expect(mapped[0].fieldId).toBeNull();
+    });
 });

--- a/tests/vitest/components/curation/utils/__tests__/form-helpers.test.ts
+++ b/tests/vitest/components/curation/utils/__tests__/form-helpers.test.ts
@@ -10,6 +10,9 @@ import {
     createEmptyInstitutionContributor,
     createEmptyPersonAuthor,
     createEmptyPersonContributor,
+    hasAnyLicenseEntryContent,
+    hasCompleteLicenseEntry,
+    isHttpUrl,
     mapInitialAuthorToEntry,
     mapInitialContributorToEntry,
     normaliseInitialAffiliations,
@@ -674,5 +677,25 @@ describe('canAddDate', () => {
     it('returns true when a range date has start and end dates', () => {
         const dates = [{ dateMode: 'range', startDate: '2024-01-01', endDate: '2024-01-31' }];
         expect(canAddDate(dates as Parameters<typeof canAddDate>[0], 5)).toBe(true);
+    });
+});
+
+describe('license entry helpers', () => {
+    it('recognizes complete catalog and custom license entries', () => {
+        expect(hasCompleteLicenseEntry({ id: '1', mode: 'catalog', license: 'MIT' })).toBe(true);
+        expect(hasCompleteLicenseEntry({ id: '2', mode: 'custom', name: 'Community License', uri: 'https://example.test/license' })).toBe(true);
+        expect(hasCompleteLicenseEntry({ id: '3', mode: 'custom', name: 'Community License', uri: '' })).toBe(false);
+    });
+
+    it('detects partial custom license content', () => {
+        expect(hasAnyLicenseEntryContent({ id: '1', mode: 'custom', name: 'Community License', uri: '' })).toBe(true);
+        expect(hasAnyLicenseEntryContent({ id: '2', mode: 'custom', name: '', uri: '' })).toBe(false);
+    });
+
+    it('validates custom license URLs with http and https only', () => {
+        expect(isHttpUrl('https://example.test/license')).toBe(true);
+        expect(isHttpUrl('http://example.test/license')).toBe(true);
+        expect(isHttpUrl('ftp://example.test/license')).toBe(false);
+        expect(isHttpUrl('not-a-url')).toBe(false);
     });
 });

--- a/tests/vitest/components/landing-pages/__tests__/FilesSection.test.tsx
+++ b/tests/vitest/components/landing-pages/__tests__/FilesSection.test.tsx
@@ -267,6 +267,23 @@ describe('FilesSection', () => {
             );
         });
 
+        it('renders a license without reference as a non-link badge', () => {
+            render(
+                <FilesSection
+                    licenses={[
+                        {
+                            id: 3,
+                            name: 'Custom Rights Statement',
+                            spdx_id: null,
+                            reference: null,
+                        },
+                    ]}
+                />,
+            );
+
+            expect(screen.getByText('Custom Rights Statement').closest('a')).toBeNull();
+            expect(screen.queryByRole('link', { name: 'Custom Rights Statement' })).not.toBeInTheDocument();
+        });
         it('does not render license section when no licenses', () => {
             render(<FilesSection licenses={[]} />);
 

--- a/tests/vitest/schemas/__tests__/resource.schema.test.ts
+++ b/tests/vitest/schemas/__tests__/resource.schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    customLicensePayloadSchema,
     dateEntrySchema,
     descriptionSchema,
     gcmdKeywordSchema,
@@ -157,5 +158,56 @@ describe('Resource Schemas', () => {
             });
             expect(result.success).toBe(true);
         });
+    });
+});
+
+describe('custom license schemas', () => {
+    it('accepts custom license form entries with http URLs', () => {
+        expect(
+            licenseSchema.safeParse({
+                id: '1',
+                mode: 'custom',
+                name: 'Community Data License',
+                uri: 'https://example.test/licenses/community-data',
+                sourceResourceRightId: 12,
+            }).success,
+        ).toBe(true);
+    });
+
+    it('rejects custom license URLs with non-http schemes', () => {
+        expect(
+            licenseSchema.safeParse({
+                id: '1',
+                mode: 'custom',
+                name: 'Unsafe License',
+                uri: 'ftp://example.test/license',
+            }).success,
+        ).toBe(false);
+
+        expect(
+            customLicensePayloadSchema.safeParse({
+                name: 'Unsafe License',
+                uri: 'javascript:alert(1)',
+            }).success,
+        ).toBe(false);
+    });
+
+    it('allows resource rights evidence from custom license payloads', () => {
+        const result = resourceSchema.safeParse({
+            resourceType: 'Dataset',
+            language: 'en',
+            titles: [{ id: '1', title: 'Test', titleType: 'main-title' }],
+            authors: [{ id: '1', type: 'person', firstName: 'Jane', lastName: 'Doe' }],
+            contributors: [],
+            licenses: [],
+            customLicenses: [
+                {
+                    name: 'Community Data License',
+                    uri: 'https://example.test/licenses/community-data',
+                },
+            ],
+        });
+
+        expect(result.success).toBe(true);
     });
 });

--- a/tests/vitest/schemas/__tests__/resource.schema.test.ts
+++ b/tests/vitest/schemas/__tests__/resource.schema.test.ts
@@ -162,7 +162,7 @@ describe('Resource Schemas', () => {
 });
 
 describe('custom license schemas', () => {
-    it('accepts custom license form entries with http URLs', () => {
+    it('accepts custom license form entries with http/https URLs', () => {
         expect(
             licenseSchema.safeParse({
                 id: '1',


### PR DESCRIPTION
This pull request introduces support for custom licenses in resource creation and editing, improves validation and error messaging around licenses, and enhances the handling and export of license/rights data. The changes span request validation, normalization, error reporting, and data export, as well as minor improvements to the `SafeUrl` validation rule and data returned by license endpoints.

**Support for custom licenses and improved validation:**

* Added support for submitting custom licenses when creating or updating resources and drafts. This includes new validation rules, normalization logic, and error messages for custom license fields such as `name`, `uri`, and `sourceResourceRightId` in both `StoreResourceRequest` and `StoreDraftResourceRequest`. [[1]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R64-R67) [[2]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R873-R878) [[3]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R949-R1009) [[4]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R1103-R1107) [[5]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R1185-R1196) [[6]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R1207-R1216) [[7]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R10) [[8]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R70-R73) [[9]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R806-R811) [[10]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R860-R898) [[11]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R950-R954) [[12]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R1025-R1036)

* Updated validation error messages and attributes to provide clearer, more user-friendly feedback for custom license fields. [[1]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R1103-R1107) [[2]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48R1185-R1196) [[3]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R950-R954) [[4]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75R1025-R1036)

**Improvements to license and rights data handling:**

* Enhanced the `SafeUrl` validation rule to support an optional message prefix and refactored error handling for more consistent error messages. [[1]](diffhunk://#diff-3e9bfc32e3e4db6323b9571a40c1dddeee583a9c9f4e248c00a0c285ede5e382R29-R30) [[2]](diffhunk://#diff-3e9bfc32e3e4db6323b9571a40c1dddeee583a9c9f4e248c00a0c285ede5e382L50-R52) [[3]](diffhunk://#diff-3e9bfc32e3e4db6323b9571a40c1dddeee583a9c9f4e248c00a0c285ede5e382L60-R62) [[4]](diffhunk://#diff-3e9bfc32e3e4db6323b9571a40c1dddeee583a9c9f4e248c00a0c285ede5e382L70-R80) [[5]](diffhunk://#diff-3e9bfc32e3e4db6323b9571a40c1dddeee583a9c9f4e248c00a0c285ede5e382L89-R99)

* Updated the `LicenseController` endpoints to include `uri` and `scheme_uri` fields in returned license/right data, providing more complete information to clients. [[1]](diffhunk://#diff-3dd40d1f5f148eba26a6e7c28264678d6348946a332d01175ec55ce5245b60ddL26-R26) [[2]](diffhunk://#diff-3dd40d1f5f148eba26a6e7c28264678d6348946a332d01175ec55ce5245b60ddL40-R40) [[3]](diffhunk://#diff-3dd40d1f5f148eba26a6e7c28264678d6348946a332d01175ec55ce5245b60ddL63-R63) [[4]](diffhunk://#diff-3dd40d1f5f148eba26a6e7c28264678d6348946a332d01175ec55ce5245b60ddL76-R76)

**Data export and resource loading enhancements:**

* Improved the DataCite JSON exporter to only include SPDX identifiers and schemes for SPDX rights, using the new `CustomRightCatalogService::isSpdxRight` helper. [[1]](diffhunk://#diff-b455a049403e769a03cc100e9aee67b9b148e3c18f62208c963e249dd85a2128R21) [[2]](diffhunk://#diff-b455a049403e769a03cc100e9aee67b9b148e3c18f62208c963e249dd85a2128L783-R787)

* Adjusted resource loading to eager load the `right` relationship on `resourceRights` for more efficient queries.