### PR TITLE
Fix: Persist uploaded Drafts and Autosave

### DIFF
--- a/app/Exceptions/DuplicateUploadedResourceDoiException.php
+++ b/app/Exceptions/DuplicateUploadedResourceDoiException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class DuplicateUploadedResourceDoiException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $doi,
+        public readonly int $resourceId,
+    ) {
+        parent::__construct("The uploaded DOI {$doi} already exists on resource {$resourceId}.");
+    }
+}

--- a/app/Http/Controllers/UploadJsonController.php
+++ b/app/Http/Controllers/UploadJsonController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Enums\UploadErrorCode;
+use App\Exceptions\DuplicateUploadedResourceDoiException;
 use App\Exceptions\JsonLdConversionException;
 use App\Http\Requests\UploadJsonRequest;
 use App\Models\ResourceType;
@@ -13,12 +14,14 @@ use App\Services\DataCiteJsonLdToJsonConverterService;
 use App\Services\JsonSchemaValidator;
 use App\Services\RelatedIdentifierTypeResolverService;
 use App\Services\UploadLogService;
+use App\Services\Uploads\UploadedResourceDraftService;
 use App\Support\GcmdUriHelper;
 use App\Support\UploadError;
 use App\Support\XmlKeywordExtractor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class UploadJsonController extends Controller
 {
@@ -80,6 +83,7 @@ class UploadJsonController extends Controller
         private readonly DataCiteJsonLdToJsonConverterService $jsonLdConverter,
         private readonly RelatedIdentifierTypeResolverService $relatedIdentifierTypeResolver,
         private readonly RelatedIdentifierCitationLabelService $citationLabelService,
+        private readonly UploadedResourceDraftService $uploadedResourceDraftService,
     ) {}
 
     public function __invoke(UploadJsonRequest $request): JsonResponse
@@ -231,10 +235,7 @@ class UploadJsonController extends Controller
             );
         }
 
-        // Store data in session
-        $sessionKey = 'json_upload_'.Str::random(32);
-
-        session()->put($sessionKey, [
+        $sessionPayload = [
             'doi' => $doi,
             'year' => $year,
             'version' => $version,
@@ -256,13 +257,87 @@ class UploadJsonController extends Controller
             'gemetKeywords' => $gemetKeywords,
             'fundingReferences' => $fundingReferences,
             'mslLaboratories' => $mslLaboratories,
-        ]);
+        ];
+
+        try {
+            $resource = $this->uploadedResourceDraftService->storeFromPayload(
+                $sessionPayload,
+                $filename,
+                $request->user()?->id,
+            );
+        } catch (DuplicateUploadedResourceDoiException $e) {
+            $error = UploadError::withMessage(
+                UploadErrorCode::DUPLICATE_DOI,
+                'The uploaded DOI already exists on resource #'.$e->resourceId.'.'
+            );
+            $this->uploadLogService->logFailure('json', $filename, $error, [
+                'doi' => $e->doi,
+                'resource_id' => $e->resourceId,
+            ]);
+
+            return $this->duplicateDoiResponse($filename, $e->doi, $e->resourceId);
+        } catch (ValidationException $e) {
+            $error = UploadError::withMessage(
+                UploadErrorCode::STORAGE_ERROR,
+                'The uploaded metadata could not be saved as a draft.'
+            );
+            $this->uploadLogService->logFailure('json', $filename, $error, [
+                'errors' => $e->errors(),
+            ]);
+
+            return $this->errorResponse(
+                UploadErrorCode::STORAGE_ERROR,
+                $filename,
+                'The uploaded metadata could not be saved as a draft.',
+            );
+        } catch (\Throwable $e) {
+            $error = UploadError::withMessage(
+                UploadErrorCode::STORAGE_ERROR,
+                'The uploaded metadata could not be saved as a draft.'
+            );
+            $this->uploadLogService->logFailure('json', $filename, $error, [
+                'exception' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return $this->errorResponse(
+                UploadErrorCode::STORAGE_ERROR,
+                $filename,
+                'The uploaded metadata could not be saved as a draft.',
+                500,
+            );
+        }
+
+        // Keep a short-lived session fallback for older editor links and tests.
+        $sessionKey = 'json_upload_'.Str::random(32);
+        session()->put($sessionKey, $sessionPayload);
 
         return response()->json([
+            'success' => true,
+            'resourceId' => $resource->id,
             'sessionKey' => $sessionKey,
         ]);
     }
 
+    private function duplicateDoiResponse(string $filename, string $doi, int $resourceId): JsonResponse
+    {
+        $message = 'The uploaded DOI already exists on resource #'.$resourceId.'.';
+
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'filename' => $filename,
+            'error' => [
+                'category' => UploadErrorCode::DUPLICATE_DOI->category(),
+                'code' => UploadErrorCode::DUPLICATE_DOI->value,
+                'message' => $message,
+                'field' => 'doi',
+                'row' => null,
+                'identifier' => $doi,
+                'resourceId' => $resourceId,
+            ],
+        ], 409);
+    }
     /**
      * Auto-detect format and extract DataCite JSON attributes.
      *

--- a/app/Http/Controllers/UploadJsonController.php
+++ b/app/Http/Controllers/UploadJsonController.php
@@ -338,6 +338,7 @@ class UploadJsonController extends Controller
             ],
         ], 409);
     }
+
     /**
      * Auto-detect format and extract DataCite JSON attributes.
      *

--- a/app/Http/Controllers/UploadXmlController.php
+++ b/app/Http/Controllers/UploadXmlController.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Enums\UploadErrorCode;
+use App\Exceptions\DuplicateUploadedResourceDoiException;
 use App\Http\Requests\UploadXmlRequest;
 use App\Services\UploadLogService;
+use App\Services\Uploads\UploadedResourceDraftService;
 use App\Services\Xml\DataCiteXmlImportParser;
 use App\Support\UploadError;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Saloon\XmlWrangler\Exceptions\XmlReaderException;
 use Saloon\XmlWrangler\XmlReader;
 use VeeWee\Xml\Exception\RuntimeException as XmlRuntimeException;
@@ -20,6 +23,7 @@ class UploadXmlController extends Controller
     public function __construct(
         private readonly UploadLogService $uploadLogService,
         private readonly DataCiteXmlImportParser $importParser,
+        private readonly UploadedResourceDraftService $uploadedResourceDraftService,
     ) {}
 
     public function __invoke(UploadXmlRequest $request): JsonResponse
@@ -73,13 +77,86 @@ class UploadXmlController extends Controller
             );
         }
 
-        // Store data in session to avoid 414 URI Too Long errors
+        $sessionPayload = $result->toSessionPayload();
+
+        try {
+            $resource = $this->uploadedResourceDraftService->storeFromPayload(
+                $sessionPayload,
+                $filename,
+                $request->user()?->id,
+            );
+        } catch (DuplicateUploadedResourceDoiException $e) {
+            $error = UploadError::withMessage(
+                UploadErrorCode::DUPLICATE_DOI,
+                'The uploaded DOI already exists on resource #'.$e->resourceId.'.'
+            );
+            $this->uploadLogService->logFailure('xml', $filename, $error, [
+                'doi' => $e->doi,
+                'resource_id' => $e->resourceId,
+            ]);
+
+            return $this->duplicateDoiResponse($filename, $e->doi, $e->resourceId);
+        } catch (ValidationException $e) {
+            $error = UploadError::withMessage(
+                UploadErrorCode::STORAGE_ERROR,
+                'The uploaded metadata could not be saved as a draft.'
+            );
+            $this->uploadLogService->logFailure('xml', $filename, $error, [
+                'errors' => $e->errors(),
+            ]);
+
+            return $this->errorResponse(
+                UploadErrorCode::STORAGE_ERROR,
+                $filename,
+                'The uploaded metadata could not be saved as a draft.',
+            );
+        } catch (\Throwable $e) {
+            $error = UploadError::withMessage(
+                UploadErrorCode::STORAGE_ERROR,
+                'The uploaded metadata could not be saved as a draft.'
+            );
+            $this->uploadLogService->logFailure('xml', $filename, $error, [
+                'exception' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return $this->errorResponse(
+                UploadErrorCode::STORAGE_ERROR,
+                $filename,
+                'The uploaded metadata could not be saved as a draft.',
+                500,
+            );
+        }
+
+        // Keep a short-lived session fallback for older editor links and tests.
         $sessionKey = 'xml_upload_'.Str::random(32);
-        session()->put($sessionKey, $result->toSessionPayload());
+        session()->put($sessionKey, $sessionPayload);
 
         return response()->json([
+            'success' => true,
+            'resourceId' => $resource->id,
             'sessionKey' => $sessionKey,
         ]);
+    }
+
+    private function duplicateDoiResponse(string $filename, string $doi, int $resourceId): JsonResponse
+    {
+        $message = 'The uploaded DOI already exists on resource #'.$resourceId.'.';
+
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'filename' => $filename,
+            'error' => [
+                'category' => UploadErrorCode::DUPLICATE_DOI->category(),
+                'code' => UploadErrorCode::DUPLICATE_DOI->value,
+                'message' => $message,
+                'field' => 'doi',
+                'row' => null,
+                'identifier' => $doi,
+                'resourceId' => $resourceId,
+            ],
+        ], 409);
     }
 
     /**

--- a/app/Services/ResourceStorageService.php
+++ b/app/Services/ResourceStorageService.php
@@ -29,6 +29,7 @@ use App\Support\OrcidNormalizer;
 use App\Support\SubjectBreadcrumbPath;
 use App\Support\UriHelper;
 use Carbon\Carbon;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -62,6 +63,7 @@ class ResourceStorageService
      * @param  int|null  $userId  ID of the user performing the operation
      * @return array{0: Resource, 1: bool} Returns [$resource, $isUpdate]
      *
+     * @throws QueryException
      * @throws ValidationException
      */
     #[\NoDiscard('Stored resource and update flag must be used')]

--- a/app/Services/Uploads/UploadedResourceDraftService.php
+++ b/app/Services/Uploads/UploadedResourceDraftService.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace App\Services\Uploads;
 
 use App\Exceptions\DuplicateUploadedResourceDoiException;
+use App\Models\DateType;
+use App\Models\DescriptionType;
+use App\Models\IdentifierType;
+use App\Models\RelationType;
 use App\Models\Resource;
 use App\Models\Right;
+use App\Models\TitleType;
 use App\Services\DoiSuggestionService;
 use App\Services\ResourceStorageService;
 use Illuminate\Support\Str;
@@ -23,6 +28,8 @@ final class UploadedResourceDraftService
      */
     public function storeFromPayload(array $payload, string $filename, ?int $userId): Resource
     {
+        $this->ensureControlledVocabularyRows();
+
         $storagePayload = $this->buildStoragePayload($payload, $filename);
 
         $doi = $storagePayload['doi'] ?? null;
@@ -60,7 +67,8 @@ final class UploadedResourceDraftService
             'authors' => $this->positionedList($payload['authors'] ?? []),
             'contributors' => $this->positionedList($payload['contributors'] ?? []),
             'descriptions' => $this->descriptionList($payload['descriptions'] ?? []),
-            'dates' => $this->positionedList($payload['dates'] ?? []),
+            'dates' => $this->dateList($payload['dates'] ?? []),
+            'importedCreatedDate' => $this->importedCreatedDate($payload['dates'] ?? []),
             'freeKeywords' => $this->freeKeywords($payload['freeKeywords'] ?? []),
             'gcmdKeywords' => $this->controlledKeywords($payload),
             'spatialTemporalCoverages' => $this->coverageList($payload),
@@ -85,7 +93,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $titles
      * @return array<int, array<string, mixed>>
      */
     private function titleList(mixed $titles, string $filename): array
@@ -144,7 +151,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $licenses
      * @return array<int, string>
      */
     private function knownLicenseIdentifiers(mixed $licenses): array
@@ -175,7 +181,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $items
      * @return array<int, array<string, mixed>>
      */
     private function descriptionList(mixed $items): array
@@ -241,7 +246,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $items
      * @return array<int, string>
      */
     private function freeKeywords(mixed $items): array
@@ -256,6 +260,69 @@ final class UploadedResourceDraftService
         }
 
         return array_values(array_unique($keywords));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function dateList(mixed $items): array
+    {
+        $dates = [];
+
+        foreach ($this->arrayList($items) as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $dateType = $this->stringOrNull($item['dateType'] ?? null);
+            $dateTypeKey = $dateType !== null ? Str::kebab($dateType) : null;
+            $startDate = $this->stringOrNull($item['startDate'] ?? null);
+            $endDate = $this->stringOrNull($item['endDate'] ?? null);
+
+            if ($dateTypeKey === null || in_array($dateTypeKey, ['coverage', 'created', 'updated'], true)) {
+                continue;
+            }
+
+            if ($startDate === null && $endDate === null) {
+                continue;
+            }
+
+            $supportsPeriod = in_array($dateTypeKey, ['collected', 'valid', 'other'], true);
+            if ($endDate !== null && ($startDate === null || ! $supportsPeriod)) {
+                continue;
+            }
+
+            $date = $item;
+            $date['dateType'] = $dateType;
+            $date['startDate'] = $startDate;
+            $date['endDate'] = $endDate;
+            $date['position'] = $item['position'] ?? $index;
+
+            $dates[] = $date;
+        }
+
+        return $dates;
+    }
+
+    private function importedCreatedDate(mixed $items): ?string
+    {
+        foreach ($this->arrayList($items) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $dateType = $this->stringOrNull($item['dateType'] ?? null);
+            if ($dateType === null || Str::kebab($dateType) !== 'created') {
+                continue;
+            }
+
+            $startDate = $this->stringOrNull($item['startDate'] ?? null);
+            if ($startDate !== null) {
+                return $startDate;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -332,7 +399,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $items
      * @return array<int, array<string, mixed>>
      */
     private function mslLaboratoryList(mixed $items): array
@@ -354,7 +420,7 @@ final class UploadedResourceDraftService
             $laboratories[] = [
                 'identifier' => $identifier ?? $name,
                 'name' => $name ?? $identifier,
-                'affiliation_name' => $this->stringOrNull($item['affiliation_name'] ?? $item['affiliationName'] ?? null),
+                'affiliation_name' => $this->stringOrNull($item['affiliation_name'] ?? $item['affiliationName'] ?? null) ?? '',
                 'affiliation_ror' => $this->stringOrNull($item['affiliation_ror'] ?? $item['affiliationRor'] ?? null),
                 'position' => $item['position'] ?? $index,
             ];
@@ -364,7 +430,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $items
      * @return array<int, array<string, mixed>>
      */
     private function positionedList(mixed $items): array
@@ -384,7 +449,6 @@ final class UploadedResourceDraftService
     }
 
     /**
-     * @param  mixed  $value
      * @return array<int, mixed>
      */
     private function arrayList(mixed $value): array
@@ -410,5 +474,145 @@ final class UploadedResourceDraftService
     private function limit(string $value): string
     {
         return Str::limit($value, 255, '');
+    }
+
+    private function ensureControlledVocabularyRows(): void
+    {
+        $this->ensureTitleTypes();
+        $this->ensureDescriptionTypes();
+        $this->ensureDateTypes();
+        $this->ensureIdentifierTypes();
+        $this->ensureRelationTypes();
+    }
+
+    private function ensureTitleTypes(): void
+    {
+        foreach ([
+            ['name' => 'Main Title', 'slug' => 'MainTitle'],
+            ['name' => 'Alternative Title', 'slug' => 'AlternativeTitle'],
+            ['name' => 'Subtitle', 'slug' => 'Subtitle'],
+            ['name' => 'Translated Title', 'slug' => 'TranslatedTitle'],
+            ['name' => 'Other', 'slug' => 'Other'],
+        ] as $type) {
+            TitleType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
+        }
+    }
+
+    private function ensureDescriptionTypes(): void
+    {
+        foreach ([
+            ['name' => 'Abstract', 'slug' => 'Abstract'],
+            ['name' => 'Methods', 'slug' => 'Methods'],
+            ['name' => 'Series Information', 'slug' => 'SeriesInformation'],
+            ['name' => 'Table of Contents', 'slug' => 'TableOfContents'],
+            ['name' => 'Technical Info', 'slug' => 'TechnicalInfo'],
+            ['name' => 'Other', 'slug' => 'Other'],
+        ] as $type) {
+            DescriptionType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
+        }
+    }
+
+    private function ensureDateTypes(): void
+    {
+        foreach ([
+            ['name' => 'Accepted', 'slug' => 'Accepted'],
+            ['name' => 'Available', 'slug' => 'Available'],
+            ['name' => 'Copyrighted', 'slug' => 'Copyrighted'],
+            ['name' => 'Collected', 'slug' => 'Collected'],
+            ['name' => 'Coverage', 'slug' => 'Coverage', 'is_active' => false],
+            ['name' => 'Created', 'slug' => 'Created'],
+            ['name' => 'Issued', 'slug' => 'Issued'],
+            ['name' => 'Submitted', 'slug' => 'Submitted'],
+            ['name' => 'Updated', 'slug' => 'Updated'],
+            ['name' => 'Valid', 'slug' => 'Valid'],
+            ['name' => 'Withdrawn', 'slug' => 'Withdrawn'],
+            ['name' => 'Other', 'slug' => 'Other'],
+        ] as $type) {
+            DateType::query()->firstOrCreate(
+                ['slug' => $type['slug']],
+                [
+                    'name' => $type['name'],
+                    'is_active' => $type['is_active'] ?? true,
+                ],
+            );
+        }
+    }
+
+    private function ensureIdentifierTypes(): void
+    {
+        foreach ([
+            ['name' => 'ARK', 'slug' => 'ARK'],
+            ['name' => 'arXiv', 'slug' => 'arXiv'],
+            ['name' => 'bibcode', 'slug' => 'bibcode'],
+            ['name' => 'CSTR', 'slug' => 'CSTR'],
+            ['name' => 'DOI', 'slug' => 'DOI'],
+            ['name' => 'EAN13', 'slug' => 'EAN13'],
+            ['name' => 'EISSN', 'slug' => 'EISSN'],
+            ['name' => 'Handle', 'slug' => 'Handle'],
+            ['name' => 'IGSN', 'slug' => 'IGSN'],
+            ['name' => 'ISBN', 'slug' => 'ISBN'],
+            ['name' => 'ISSN', 'slug' => 'ISSN'],
+            ['name' => 'ISTC', 'slug' => 'ISTC'],
+            ['name' => 'LISSN', 'slug' => 'LISSN'],
+            ['name' => 'LSID', 'slug' => 'LSID'],
+            ['name' => 'PMID', 'slug' => 'PMID'],
+            ['name' => 'PURL', 'slug' => 'PURL'],
+            ['name' => 'RAiD', 'slug' => 'RAiD'],
+            ['name' => 'RRID', 'slug' => 'RRID'],
+            ['name' => 'SWHID', 'slug' => 'SWHID'],
+            ['name' => 'UPC', 'slug' => 'UPC'],
+            ['name' => 'URL', 'slug' => 'URL'],
+            ['name' => 'URN', 'slug' => 'URN'],
+            ['name' => 'w3id', 'slug' => 'w3id'],
+        ] as $type) {
+            IdentifierType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
+        }
+    }
+
+    private function ensureRelationTypes(): void
+    {
+        foreach ([
+            ['name' => 'Is Cited By', 'slug' => 'IsCitedBy'],
+            ['name' => 'Cites', 'slug' => 'Cites'],
+            ['name' => 'Is Supplement To', 'slug' => 'IsSupplementTo'],
+            ['name' => 'Is Supplemented By', 'slug' => 'IsSupplementedBy'],
+            ['name' => 'Is Translation Of', 'slug' => 'IsTranslationOf'],
+            ['name' => 'Has Translation', 'slug' => 'HasTranslation'],
+            ['name' => 'Is Continued By', 'slug' => 'IsContinuedBy'],
+            ['name' => 'Continues', 'slug' => 'Continues'],
+            ['name' => 'Is Described By', 'slug' => 'IsDescribedBy'],
+            ['name' => 'Describes', 'slug' => 'Describes'],
+            ['name' => 'Has Metadata', 'slug' => 'HasMetadata'],
+            ['name' => 'Is Metadata For', 'slug' => 'IsMetadataFor'],
+            ['name' => 'Has Version', 'slug' => 'HasVersion'],
+            ['name' => 'Is Version Of', 'slug' => 'IsVersionOf'],
+            ['name' => 'Is New Version Of', 'slug' => 'IsNewVersionOf'],
+            ['name' => 'Is Previous Version Of', 'slug' => 'IsPreviousVersionOf'],
+            ['name' => 'Is Part Of', 'slug' => 'IsPartOf'],
+            ['name' => 'Has Part', 'slug' => 'HasPart'],
+            ['name' => 'Is Published In', 'slug' => 'IsPublishedIn'],
+            ['name' => 'Is Referenced By', 'slug' => 'IsReferencedBy'],
+            ['name' => 'References', 'slug' => 'References'],
+            ['name' => 'Is Documented By', 'slug' => 'IsDocumentedBy'],
+            ['name' => 'Documents', 'slug' => 'Documents'],
+            ['name' => 'Is Compiled By', 'slug' => 'IsCompiledBy'],
+            ['name' => 'Compiles', 'slug' => 'Compiles'],
+            ['name' => 'Is Variant Form Of', 'slug' => 'IsVariantFormOf'],
+            ['name' => 'Is Original Form Of', 'slug' => 'IsOriginalFormOf'],
+            ['name' => 'Is Identical To', 'slug' => 'IsIdenticalTo'],
+            ['name' => 'Is Reviewed By', 'slug' => 'IsReviewedBy'],
+            ['name' => 'Reviews', 'slug' => 'Reviews'],
+            ['name' => 'Is Derived From', 'slug' => 'IsDerivedFrom'],
+            ['name' => 'Is Source Of', 'slug' => 'IsSourceOf'],
+            ['name' => 'Is Required By', 'slug' => 'IsRequiredBy'],
+            ['name' => 'Requires', 'slug' => 'Requires'],
+            ['name' => 'Is Obsoleted By', 'slug' => 'IsObsoletedBy'],
+            ['name' => 'Obsoletes', 'slug' => 'Obsoletes'],
+            ['name' => 'Is Collected By', 'slug' => 'IsCollectedBy'],
+            ['name' => 'Collects', 'slug' => 'Collects'],
+            ['name' => 'Other', 'slug' => 'Other'],
+        ] as $type) {
+            RelationType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
+        }
     }
 }

--- a/app/Services/Uploads/UploadedResourceDraftService.php
+++ b/app/Services/Uploads/UploadedResourceDraftService.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Uploads;
+
+use App\Exceptions\DuplicateUploadedResourceDoiException;
+use App\Models\Resource;
+use App\Models\Right;
+use App\Services\DoiSuggestionService;
+use App\Services\ResourceStorageService;
+use Illuminate\Support\Str;
+
+final class UploadedResourceDraftService
+{
+    public function __construct(
+        private readonly ResourceStorageService $resourceStorageService,
+        private readonly DoiSuggestionService $doiSuggestionService,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function storeFromPayload(array $payload, string $filename, ?int $userId): Resource
+    {
+        $storagePayload = $this->buildStoragePayload($payload, $filename);
+
+        $doi = $storagePayload['doi'] ?? null;
+        if (is_string($doi) && $doi !== '') {
+            $existingResourceId = Resource::query()
+                ->where('doi', $doi)
+                ->value('id');
+
+            if ($existingResourceId !== null) {
+                throw new DuplicateUploadedResourceDoiException($doi, (int) $existingResourceId);
+            }
+        }
+
+        [$resource] = $this->resourceStorageService->store($storagePayload, $userId);
+
+        return $resource;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function buildStoragePayload(array $payload, string $filename): array
+    {
+        return [
+            'resourceId' => null,
+            'doi' => $this->normalizeDoi($payload['doi'] ?? null),
+            'year' => $this->stringOrNull($payload['year'] ?? null),
+            'resourceType' => $payload['resourceType'] ?? null,
+            'version' => $this->stringOrNull($payload['version'] ?? null),
+            'language' => $this->stringOrNull($payload['language'] ?? null),
+            'titles' => $this->titleList($payload['titles'] ?? [], $filename),
+            'licenses' => $this->knownLicenseIdentifiers($payload['licenses'] ?? []),
+            'rawRights' => $this->arrayList($payload['rawRights'] ?? []),
+            'authors' => $this->positionedList($payload['authors'] ?? []),
+            'contributors' => $this->positionedList($payload['contributors'] ?? []),
+            'descriptions' => $this->descriptionList($payload['descriptions'] ?? []),
+            'dates' => $this->positionedList($payload['dates'] ?? []),
+            'freeKeywords' => $this->freeKeywords($payload['freeKeywords'] ?? []),
+            'gcmdKeywords' => $this->controlledKeywords($payload),
+            'spatialTemporalCoverages' => $this->coverageList($payload),
+            'relatedIdentifiers' => $this->relatedIdentifierList($payload),
+            'relatedItems' => $this->arrayList($payload['relatedItems'] ?? []),
+            'fundingReferences' => $this->positionedList($payload['fundingReferences'] ?? []),
+            'mslLaboratories' => $this->mslLaboratoryList($payload['mslLaboratories'] ?? []),
+            'instruments' => $this->positionedList($payload['instruments'] ?? []),
+            'datacenters' => [],
+        ];
+    }
+
+    private function normalizeDoi(mixed $doi): ?string
+    {
+        if (! is_string($doi) && ! is_numeric($doi)) {
+            return null;
+        }
+
+        $normalized = $this->doiSuggestionService->normalizeDoi((string) $doi);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  mixed  $titles
+     * @return array<int, array<string, mixed>>
+     */
+    private function titleList(mixed $titles, string $filename): array
+    {
+        $normalized = [];
+        $hasMainTitle = false;
+
+        foreach ($this->arrayList($titles) as $index => $title) {
+            if (! is_array($title)) {
+                continue;
+            }
+
+            $value = $this->stringOrNull($title['title'] ?? $title['value'] ?? null);
+            if ($value === null) {
+                continue;
+            }
+
+            $titleType = $this->stringOrNull($title['titleType'] ?? $title['type'] ?? null) ?? 'main-title';
+            if (Str::kebab($titleType) === 'main-title') {
+                $hasMainTitle = true;
+            }
+
+            $normalized[] = [
+                'title' => $this->limit($value),
+                'titleType' => $titleType,
+                'language' => $this->stringOrNull($title['language'] ?? null),
+                'position' => $index,
+            ];
+        }
+
+        if (! $hasMainTitle) {
+            array_unshift($normalized, [
+                'title' => $this->fallbackTitle($filename),
+                'titleType' => 'main-title',
+                'language' => null,
+                'position' => 0,
+            ]);
+
+            foreach ($normalized as $index => &$title) {
+                $title['position'] = $index;
+            }
+            unset($title);
+        }
+
+        return $normalized;
+    }
+
+    private function fallbackTitle(string $filename): string
+    {
+        $title = pathinfo($filename, PATHINFO_FILENAME);
+        $title = preg_replace('/[_\-.]+/', ' ', $title) ?? $title;
+        $title = preg_replace('/\s+/', ' ', $title) ?? $title;
+        $title = trim($title);
+
+        return $this->limit($title === '' ? 'Untitled upload' : $title);
+    }
+
+    /**
+     * @param  mixed  $licenses
+     * @return array<int, string>
+     */
+    private function knownLicenseIdentifiers(mixed $licenses): array
+    {
+        $identifiers = [];
+
+        foreach ($this->arrayList($licenses) as $license) {
+            if (is_array($license)) {
+                $identifier = $this->stringOrNull($license['identifier'] ?? $license['rightsIdentifier'] ?? null);
+            } else {
+                $identifier = $this->stringOrNull($license);
+            }
+
+            if ($identifier !== null) {
+                $identifiers[] = $identifier;
+            }
+        }
+
+        $identifiers = array_values(array_unique($identifiers));
+        if ($identifiers === []) {
+            return [];
+        }
+
+        return Right::query()
+            ->whereIn('identifier', $identifiers)
+            ->pluck('identifier')
+            ->all();
+    }
+
+    /**
+     * @param  mixed  $items
+     * @return array<int, array<string, mixed>>
+     */
+    private function descriptionList(mixed $items): array
+    {
+        $descriptions = [];
+
+        foreach ($this->arrayList($items) as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $description = $this->stringOrNull($item['description'] ?? $item['value'] ?? null);
+            if ($description === null) {
+                continue;
+            }
+
+            $descriptions[] = [
+                'description' => $description,
+                'descriptionType' => $this->stringOrNull($item['descriptionType'] ?? $item['type'] ?? null) ?? 'Other',
+                'language' => $this->stringOrNull($item['language'] ?? null),
+                'position' => $index,
+            ];
+        }
+
+        return $descriptions;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, array<string, mixed>>
+     */
+    private function controlledKeywords(array $payload): array
+    {
+        $keywords = [];
+
+        foreach (['gcmdKeywords', 'mslKeywords', 'gemetKeywords'] as $key) {
+            foreach ($this->arrayList($payload[$key] ?? []) as $keyword) {
+                if (! is_array($keyword)) {
+                    continue;
+                }
+
+                $id = $this->stringOrNull($keyword['id'] ?? null);
+                $text = $this->stringOrNull($keyword['text'] ?? null);
+                $path = $this->stringOrNull($keyword['path'] ?? null) ?? $text;
+                $scheme = $this->stringOrNull($keyword['scheme'] ?? null);
+
+                if ($id === null || $text === null || $path === null || $scheme === null) {
+                    continue;
+                }
+
+                $keywords[] = [
+                    'id' => $id,
+                    'text' => $text,
+                    'path' => $path,
+                    'scheme' => $scheme,
+                    'schemeURI' => $this->stringOrNull($keyword['schemeURI'] ?? $keyword['schemeUri'] ?? null),
+                    'language' => $this->stringOrNull($keyword['language'] ?? null),
+                ];
+            }
+        }
+
+        return $keywords;
+    }
+
+    /**
+     * @param  mixed  $items
+     * @return array<int, string>
+     */
+    private function freeKeywords(mixed $items): array
+    {
+        $keywords = [];
+
+        foreach ($this->arrayList($items) as $item) {
+            $keyword = $this->stringOrNull($item);
+            if ($keyword !== null) {
+                $keywords[] = $keyword;
+            }
+        }
+
+        return array_values(array_unique($keywords));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, array<string, mixed>>
+     */
+    private function coverageList(array $payload): array
+    {
+        $coverages = [];
+
+        foreach ($this->arrayList($payload['spatialTemporalCoverages'] ?? $payload['coverages'] ?? []) as $index => $coverage) {
+            if (! is_array($coverage)) {
+                continue;
+            }
+
+            $coverage['position'] = $coverage['position'] ?? $index;
+            $coverage['type'] = $coverage['type'] ?? $this->inferCoverageType($coverage);
+            $coverages[] = $coverage;
+        }
+
+        return $coverages;
+    }
+
+    /**
+     * @param  array<string, mixed>  $coverage
+     */
+    private function inferCoverageType(array $coverage): string
+    {
+        if (! empty($coverage['polygonPoints'])) {
+            return 'polygon';
+        }
+
+        if (($coverage['latMax'] ?? '') !== '' || ($coverage['lonMax'] ?? '') !== '') {
+            return 'box';
+        }
+
+        return 'point';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, array<string, mixed>>
+     */
+    private function relatedIdentifierList(array $payload): array
+    {
+        $items = $this->arrayList($payload['relatedIdentifiers'] ?? []);
+        $items = array_merge($items, $this->arrayList($payload['relatedWorks'] ?? []));
+        $relatedIdentifiers = [];
+
+        foreach ($items as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $identifier = $this->stringOrNull($item['identifier'] ?? null);
+            $identifierType = $this->stringOrNull($item['identifierType'] ?? $item['identifier_type'] ?? null);
+            $relationType = $this->stringOrNull($item['relationType'] ?? $item['relation_type'] ?? null);
+
+            if ($identifier === null || $identifierType === null || $relationType === null) {
+                continue;
+            }
+
+            $relatedIdentifiers[] = [
+                'identifier' => $identifier,
+                'identifierType' => $identifierType,
+                'relationType' => $relationType,
+                'relationTypeInformation' => $this->stringOrNull($item['relationTypeInformation'] ?? $item['relation_type_information'] ?? null),
+                'citationLabel' => $this->stringOrNull($item['citationLabel'] ?? $item['citation_label'] ?? null),
+                'position' => $item['position'] ?? $index,
+            ];
+        }
+
+        return $relatedIdentifiers;
+    }
+
+    /**
+     * @param  mixed  $items
+     * @return array<int, array<string, mixed>>
+     */
+    private function mslLaboratoryList(mixed $items): array
+    {
+        $laboratories = [];
+
+        foreach ($this->arrayList($items) as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $identifier = $this->stringOrNull($item['identifier'] ?? $item['labId'] ?? null);
+            $name = $this->stringOrNull($item['name'] ?? $item['labName'] ?? null);
+
+            if ($identifier === null && $name === null) {
+                continue;
+            }
+
+            $laboratories[] = [
+                'identifier' => $identifier ?? $name,
+                'name' => $name ?? $identifier,
+                'affiliation_name' => $this->stringOrNull($item['affiliation_name'] ?? $item['affiliationName'] ?? null),
+                'affiliation_ror' => $this->stringOrNull($item['affiliation_ror'] ?? $item['affiliationRor'] ?? null),
+                'position' => $item['position'] ?? $index,
+            ];
+        }
+
+        return $laboratories;
+    }
+
+    /**
+     * @param  mixed  $items
+     * @return array<int, array<string, mixed>>
+     */
+    private function positionedList(mixed $items): array
+    {
+        $positioned = [];
+
+        foreach ($this->arrayList($items) as $index => $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $item['position'] = $item['position'] ?? $index;
+            $positioned[] = $item;
+        }
+
+        return $positioned;
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return array<int, mixed>
+     */
+    private function arrayList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values($value);
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function limit(string $value): string
+    {
+        return Str::limit($value, 255, '');
+    }
+}

--- a/app/Services/Uploads/UploadedResourceDraftService.php
+++ b/app/Services/Uploads/UploadedResourceDraftService.php
@@ -14,6 +14,7 @@ use App\Models\Right;
 use App\Models\TitleType;
 use App\Services\DoiSuggestionService;
 use App\Services\ResourceStorageService;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Str;
 
 final class UploadedResourceDraftService
@@ -28,9 +29,8 @@ final class UploadedResourceDraftService
      */
     public function storeFromPayload(array $payload, string $filename, ?int $userId): Resource
     {
-        $this->ensureControlledVocabularyRows();
-
         $storagePayload = $this->buildStoragePayload($payload, $filename);
+        $this->ensureControlledVocabularyRows($storagePayload);
 
         $doi = $storagePayload['doi'] ?? null;
         if (is_string($doi) && $doi !== '') {
@@ -43,7 +43,13 @@ final class UploadedResourceDraftService
             }
         }
 
-        [$resource] = $this->resourceStorageService->store($storagePayload, $userId);
+        try {
+            [$resource] = $this->resourceStorageService->store($storagePayload, $userId);
+        } catch (QueryException $e) {
+            $this->throwDuplicateDoiExceptionIfUniqueDoiViolation($e, $doi);
+
+            throw $e;
+        }
 
         return $resource;
     }
@@ -476,45 +482,98 @@ final class UploadedResourceDraftService
         return Str::limit($value, 255, '');
     }
 
-    private function ensureControlledVocabularyRows(): void
+    private function throwDuplicateDoiExceptionIfUniqueDoiViolation(QueryException $exception, mixed $doi): void
     {
-        $this->ensureTitleTypes();
-        $this->ensureDescriptionTypes();
-        $this->ensureDateTypes();
-        $this->ensureIdentifierTypes();
-        $this->ensureRelationTypes();
+        if (! is_string($doi) || $doi === '' || ! $this->isResourceDoiUniqueViolation($exception)) {
+            return;
+        }
+
+        $existingResourceId = Resource::query()
+            ->where('doi', $doi)
+            ->value('id');
+
+        if ($existingResourceId !== null) {
+            throw new DuplicateUploadedResourceDoiException($doi, (int) $existingResourceId);
+        }
     }
 
-    private function ensureTitleTypes(): void
+    private function isResourceDoiUniqueViolation(QueryException $exception): bool
     {
-        foreach ([
+        $errorInfo = $exception->errorInfo ?? [];
+        $sqlState = isset($errorInfo[0]) ? (string) $errorInfo[0] : '';
+        $driverCode = isset($errorInfo[1]) ? (string) $errorInfo[1] : '';
+
+        if (! in_array($sqlState, ['23000', '23505'], true) && ! in_array($driverCode, ['19', '1062'], true)) {
+            return false;
+        }
+
+        $message = Str::lower($exception->getMessage());
+
+        return str_contains($message, 'resources.doi')
+            || str_contains($message, 'resources_doi_unique')
+            || (str_contains($message, 'duplicate entry') && str_contains($message, 'doi'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function ensureControlledVocabularyRows(array $payload): void
+    {
+        $this->ensureTitleTypes(array_merge(
+            ['main-title'],
+            $this->typeValues($payload['titles'] ?? [], 'titleType'),
+        ));
+        $this->ensureDescriptionTypes($this->typeValues($payload['descriptions'] ?? [], 'descriptionType'));
+        $this->ensureDateTypes(array_merge(
+            ['Created'],
+            $this->typeValues($payload['dates'] ?? [], 'dateType'),
+        ));
+        $this->ensureIdentifierTypes($this->typeValues($payload['relatedIdentifiers'] ?? [], 'identifierType'));
+        $this->ensureRelationTypes(array_merge(
+            $this->typeValues($payload['relatedIdentifiers'] ?? [], 'relationType'),
+            $this->typeValues($payload['relatedItems'] ?? [], 'relation_type_slug'),
+        ));
+    }
+
+    /**
+     * @param  list<string>  $values
+     */
+    private function ensureTitleTypes(array $values): void
+    {
+        foreach ($this->matchingControlledRows($values, [
             ['name' => 'Main Title', 'slug' => 'MainTitle'],
             ['name' => 'Alternative Title', 'slug' => 'AlternativeTitle'],
             ['name' => 'Subtitle', 'slug' => 'Subtitle'],
             ['name' => 'Translated Title', 'slug' => 'TranslatedTitle'],
             ['name' => 'Other', 'slug' => 'Other'],
-        ] as $type) {
+        ]) as $type) {
             TitleType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
         }
     }
 
-    private function ensureDescriptionTypes(): void
+    /**
+     * @param  list<string>  $values
+     */
+    private function ensureDescriptionTypes(array $values): void
     {
-        foreach ([
+        foreach ($this->matchingControlledRows($values, [
             ['name' => 'Abstract', 'slug' => 'Abstract'],
             ['name' => 'Methods', 'slug' => 'Methods'],
             ['name' => 'Series Information', 'slug' => 'SeriesInformation'],
             ['name' => 'Table of Contents', 'slug' => 'TableOfContents'],
             ['name' => 'Technical Info', 'slug' => 'TechnicalInfo'],
             ['name' => 'Other', 'slug' => 'Other'],
-        ] as $type) {
+        ]) as $type) {
             DescriptionType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
         }
     }
 
-    private function ensureDateTypes(): void
+    /**
+     * @param  list<string>  $values
+     */
+    private function ensureDateTypes(array $values): void
     {
-        foreach ([
+        foreach ($this->matchingControlledRows($values, [
             ['name' => 'Accepted', 'slug' => 'Accepted'],
             ['name' => 'Available', 'slug' => 'Available'],
             ['name' => 'Copyrighted', 'slug' => 'Copyrighted'],
@@ -527,7 +586,7 @@ final class UploadedResourceDraftService
             ['name' => 'Valid', 'slug' => 'Valid'],
             ['name' => 'Withdrawn', 'slug' => 'Withdrawn'],
             ['name' => 'Other', 'slug' => 'Other'],
-        ] as $type) {
+        ]) as $type) {
             DateType::query()->firstOrCreate(
                 ['slug' => $type['slug']],
                 [
@@ -538,9 +597,12 @@ final class UploadedResourceDraftService
         }
     }
 
-    private function ensureIdentifierTypes(): void
+    /**
+     * @param  list<string>  $values
+     */
+    private function ensureIdentifierTypes(array $values): void
     {
-        foreach ([
+        foreach ($this->matchingControlledRows($values, [
             ['name' => 'ARK', 'slug' => 'ARK'],
             ['name' => 'arXiv', 'slug' => 'arXiv'],
             ['name' => 'bibcode', 'slug' => 'bibcode'],
@@ -564,14 +626,17 @@ final class UploadedResourceDraftService
             ['name' => 'URL', 'slug' => 'URL'],
             ['name' => 'URN', 'slug' => 'URN'],
             ['name' => 'w3id', 'slug' => 'w3id'],
-        ] as $type) {
+        ]) as $type) {
             IdentifierType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
         }
     }
 
-    private function ensureRelationTypes(): void
+    /**
+     * @param  list<string>  $values
+     */
+    private function ensureRelationTypes(array $values): void
     {
-        foreach ([
+        foreach ($this->matchingControlledRows($values, [
             ['name' => 'Is Cited By', 'slug' => 'IsCitedBy'],
             ['name' => 'Cites', 'slug' => 'Cites'],
             ['name' => 'Is Supplement To', 'slug' => 'IsSupplementTo'],
@@ -611,8 +676,75 @@ final class UploadedResourceDraftService
             ['name' => 'Is Collected By', 'slug' => 'IsCollectedBy'],
             ['name' => 'Collects', 'slug' => 'Collects'],
             ['name' => 'Other', 'slug' => 'Other'],
-        ] as $type) {
+        ]) as $type) {
             RelationType::query()->firstOrCreate(['slug' => $type['slug']], ['name' => $type['name']]);
         }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function typeValues(mixed $items, string ...$keys): array
+    {
+        $values = [];
+
+        foreach ($this->arrayList($items) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            foreach ($keys as $key) {
+                $value = $this->stringOrNull($item[$key] ?? null);
+                if ($value !== null) {
+                    $values[] = $value;
+                }
+            }
+        }
+
+        return array_values(array_unique($values));
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @param  list<array{name: string, slug: string, is_active?: bool}>  $rows
+     * @return list<array{name: string, slug: string, is_active?: bool}>
+     */
+    private function matchingControlledRows(array $values, array $rows): array
+    {
+        $requestedKeys = [];
+
+        foreach ($values as $value) {
+            $key = $this->controlledRowKey($value);
+            if ($key !== null) {
+                $requestedKeys[$key] = true;
+            }
+        }
+
+        if ($requestedKeys === []) {
+            return [];
+        }
+
+        $matches = [];
+        foreach ($rows as $row) {
+            $slugKey = $this->controlledRowKey($row['slug']);
+            $nameKey = $this->controlledRowKey($row['name']);
+
+            if (($slugKey !== null && isset($requestedKeys[$slugKey])) || ($nameKey !== null && isset($requestedKeys[$nameKey]))) {
+                $matches[$row['slug']] = $row;
+            }
+        }
+
+        return array_values($matches);
+    }
+
+    private function controlledRowKey(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = preg_replace('/[^[:alnum:]]+/u', '', trim((string) $value)) ?? '';
+
+        return $normalized === '' ? null : Str::lower($normalized);
     }
 }

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2187,7 +2187,7 @@ export default function DataCiteForm({
         titles,
     ]);
 
-    const markDraftAutosaveSignature = useCallback((payload: ReturnType<typeof buildPayload>, resourceId?: number) => {
+    const updateDraftAutosaveSignature = useCallback((payload: ReturnType<typeof buildPayload>, resourceId?: number) => {
         const savedPayload = resourceId ? { ...payload, resourceId } : payload;
 
         try {
@@ -2196,10 +2196,16 @@ export default function DataCiteForm({
             console.error('Failed to serialize draft autosave signature', error);
             lastDraftAutosaveSignatureRef.current = null;
         }
-
-        setLastDraftAutosaveAt(new Date());
-        setDraftAutosaveStatus('saved');
     }, []);
+
+    const markDraftAutosaveSaved = useCallback(
+        (payload: ReturnType<typeof buildPayload>, resourceId?: number) => {
+            updateDraftAutosaveSignature(payload, resourceId);
+            setLastDraftAutosaveAt(new Date());
+            setDraftAutosaveStatus('saved');
+        },
+        [updateDraftAutosaveSignature],
+    );
 
     useEffect(() => {
         if (resolvedResourceId === null || lastDraftAutosaveSignatureRef.current !== null) {
@@ -2253,14 +2259,14 @@ export default function DataCiteForm({
                 setResolvedResourceId(savedResourceId);
             }
 
-            markDraftAutosaveSignature(payload, savedResourceId);
+            markDraftAutosaveSaved(payload, savedResourceId);
         } catch (error) {
             console.error('Failed to autosave draft', error);
             setDraftAutosaveStatus('error');
         } finally {
             draftAutosaveInFlightRef.current = false;
         }
-    }, [buildPayload, dateValidationIssues.length, draftSaveUrl, isDraftSaveable, isSaving, isSavingDraft, markDraftAutosaveSignature]);
+    }, [buildPayload, dateValidationIssues.length, draftSaveUrl, isDraftSaveable, isSaving, isSavingDraft, markDraftAutosaveSaved]);
 
     useEffect(() => {
         const autosaveTimerId = window.setInterval(() => {
@@ -2524,7 +2530,7 @@ export default function DataCiteForm({
             if (savedResourceId) {
                 setResolvedResourceId(savedResourceId);
             }
-            markDraftAutosaveSignature(payload, savedResourceId);
+            updateDraftAutosaveSignature(payload, savedResourceId);
 
             setHasAttemptedSubmit(false);
 

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -90,6 +90,14 @@ const ABSTRACT_MIN_LENGTH = 50;
 const ABSTRACT_MAX_LENGTH = 17500;
 const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
 const SECTION_TRIGGER_CLASS_NAME = 'hover:no-underline';
+const DRAFT_AUTOSAVE_INTERVAL_MS = 60_000;
+
+type DraftAutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+type DraftSaveResponse = {
+    message?: string;
+    resource?: { id: number };
+};
 
 function normalizeAccordionItems(
     items: readonly string[],
@@ -1219,6 +1227,10 @@ export default function DataCiteForm({
 
     const [isSaving, setIsSaving] = useState(false);
     const [isSavingDraft, setIsSavingDraft] = useState(false);
+    const [draftAutosaveStatus, setDraftAutosaveStatus] = useState<DraftAutosaveStatus>('idle');
+    const [lastDraftAutosaveAt, setLastDraftAutosaveAt] = useState<Date | null>(null);
+    const draftAutosaveInFlightRef = useRef(false);
+    const lastDraftAutosaveSignatureRef = useRef<string | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [mappedValidationErrors, setMappedValidationErrors] = useState<MappedError[]>([]);
     const [validationAlertHeader, setValidationAlertHeader] = useState<string | undefined>(undefined);
@@ -1881,6 +1893,22 @@ export default function DataCiteForm({
     const saveUrl = useMemo(() => store.url(), []);
     const draftSaveUrl = useMemo(() => storeDraft.url(), []);
     const resourcesUrl = useMemo(() => resources.url(), []);
+    const draftAutosaveMessage = useMemo(() => {
+        if (draftAutosaveStatus === 'idle') {
+            return null;
+        }
+
+        if (draftAutosaveStatus === 'saving') {
+            return 'Autosaving draft...';
+        }
+
+        if (draftAutosaveStatus === 'error') {
+            return 'Autosave failed';
+        }
+
+        const savedAt = lastDraftAutosaveAt?.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        return savedAt ? 'Draft autosaved at ' + savedAt : 'Draft autosaved';
+    }, [draftAutosaveStatus, lastDraftAutosaveAt]);
 
     // Shared payload builder for both Save & Validate and Save Draft (Issue #548)
     const buildPayload = useCallback(() => {
@@ -2159,6 +2187,89 @@ export default function DataCiteForm({
         titles,
     ]);
 
+    const markDraftAutosaveSignature = useCallback((payload: ReturnType<typeof buildPayload>, resourceId?: number) => {
+        const savedPayload = resourceId ? { ...payload, resourceId } : payload;
+
+        try {
+            lastDraftAutosaveSignatureRef.current = JSON.stringify(savedPayload);
+        } catch (error) {
+            console.error('Failed to serialize draft autosave signature', error);
+            lastDraftAutosaveSignatureRef.current = null;
+        }
+
+        setLastDraftAutosaveAt(new Date());
+        setDraftAutosaveStatus('saved');
+    }, []);
+
+    useEffect(() => {
+        if (resolvedResourceId === null || lastDraftAutosaveSignatureRef.current !== null) {
+            return;
+        }
+
+        try {
+            lastDraftAutosaveSignatureRef.current = JSON.stringify(buildPayload());
+        } catch (error) {
+            console.error('Failed to initialize draft autosave signature', error);
+            lastDraftAutosaveSignatureRef.current = null;
+        }
+    }, [buildPayload, resolvedResourceId]);
+
+    const saveDraftSilently = useCallback(async () => {
+        if (!isDraftSaveable || dateValidationIssues.length > 0 || isSaving || isSavingDraft || draftAutosaveInFlightRef.current) {
+            return;
+        }
+
+        let payload: ReturnType<typeof buildPayload>;
+        let signature: string;
+
+        try {
+            payload = buildPayload();
+            signature = JSON.stringify(payload);
+        } catch (error) {
+            console.error('Failed to prepare draft autosave payload', error);
+            setDraftAutosaveStatus('error');
+            return;
+        }
+
+        if (signature === lastDraftAutosaveSignatureRef.current) {
+            return;
+        }
+
+        draftAutosaveInFlightRef.current = true;
+        setDraftAutosaveStatus('saving');
+
+        try {
+            const response = await axios.post(draftSaveUrl, payload, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                },
+            });
+
+            const data = response.data as DraftSaveResponse | null;
+            const savedResourceId = data?.resource?.id;
+
+            if (savedResourceId) {
+                setResolvedResourceId(savedResourceId);
+            }
+
+            markDraftAutosaveSignature(payload, savedResourceId);
+        } catch (error) {
+            console.error('Failed to autosave draft', error);
+            setDraftAutosaveStatus('error');
+        } finally {
+            draftAutosaveInFlightRef.current = false;
+        }
+    }, [buildPayload, dateValidationIssues.length, draftSaveUrl, isDraftSaveable, isSaving, isSavingDraft, markDraftAutosaveSignature]);
+
+    useEffect(() => {
+        const autosaveTimerId = window.setInterval(() => {
+            void saveDraftSilently();
+        }, DRAFT_AUTOSAVE_INTERVAL_MS);
+
+        return () => window.clearInterval(autosaveTimerId);
+    }, [saveDraftSilently]);
+
     const revealValidationErrors = useCallback(
         (errors: Record<string, string[]>, headerMessage: string) => {
             const mapped = mapBackendErrors(errors);
@@ -2379,7 +2490,7 @@ export default function DataCiteForm({
         }
     };
 
-    // Save draft with relaxed validation — only requires Main Title (Issue #548)
+    // Save draft with relaxed validation - only requires Main Title (Issue #548)
     const handleSaveDraft = async () => {
         if (!isDraftSaveable) return;
 
@@ -2405,18 +2516,15 @@ export default function DataCiteForm({
                 },
             });
 
-            interface DraftSaveResponse {
-                message?: string;
-                resource?: { id: number };
-            }
-
             const data = response.data as DraftSaveResponse | null;
             const successMsg = data?.message || 'Draft saved successfully.';
 
             // Persist the resource ID so subsequent saves update rather than duplicate (PR #639 review)
-            if (data?.resource?.id) {
-                setResolvedResourceId(data.resource.id);
+            const savedResourceId = data?.resource?.id;
+            if (savedResourceId) {
+                setResolvedResourceId(savedResourceId);
             }
+            markDraftAutosaveSignature(payload, savedResourceId);
 
             setHasAttemptedSubmit(false);
 
@@ -3099,57 +3207,67 @@ export default function DataCiteForm({
                         : []
                 }
             />
-            <div className="flex justify-end gap-3">
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <span tabIndex={0}>
-                            {/* Save Draft is intentionally NOT disabled by hasLegacyKeywords.
-                                Drafts are partial saves — legacy keyword replacement is only
-                                required for full validation (Save & Validate). */}
-                            <Button
-                                type="button"
-                                variant="outline"
-                                data-testid="save-draft-button"
-                                disabled={!isDraftSaveable || isSavingDraft || isSaving}
-                                aria-busy={isSavingDraft}
-                                onClick={handleSaveDraft}
-                            >
-                                <Save className="mr-2 h-4 w-4" />
-                                {isSavingDraft ? 'Saving…' : 'Save Draft'}
-                            </Button>
-                        </span>
-                    </TooltipTrigger>
-                    {!isDraftSaveable && !isSavingDraft && (
-                        <TooltipContent side="top" align="end" className="max-w-sm">
-                            <p className="text-sm">Enter a Main Title to save as draft.</p>
-                        </TooltipContent>
-                    )}
-                </Tooltip>
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <span tabIndex={0}>
-                            <Button
-                                type="submit"
-                                data-testid="save-resource-button"
-                                disabled={isSaving || isSavingDraft || hasLegacyKeywords}
-                                aria-busy={isSaving}
-                                aria-disabled={isSaving || isSavingDraft || hasLegacyKeywords}
-                            >
-                                {isSaving ? 'Saving…' : 'Save & Validate'}
-                            </Button>
-                        </span>
-                    </TooltipTrigger>
-                    {hasLegacyKeywords && !isSaving && (
-                        <TooltipContent side="top" align="end" className="max-w-sm">
-                            <div className="space-y-2">
-                                <p className="text-sm font-semibold">Cannot save: Legacy keywords detected</p>
-                                <p className="text-xs">Please replace all legacy MSL keywords with keywords from the current vocabulary.</p>
-                            </div>
-                        </TooltipContent>
-                    )}
-                </Tooltip>
+            <div className="flex flex-col items-end gap-2">
+                <div className="flex justify-end gap-3">
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span tabIndex={0}>
+                                {/* Save Draft is intentionally NOT disabled by hasLegacyKeywords.
+                                    Drafts are partial saves; legacy keyword replacement is only
+                                    required for full validation (Save & Validate). */}
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    data-testid="save-draft-button"
+                                    disabled={!isDraftSaveable || isSavingDraft || isSaving}
+                                    aria-busy={isSavingDraft}
+                                    onClick={handleSaveDraft}
+                                >
+                                    <Save className="mr-2 h-4 w-4" />
+                                    {isSavingDraft ? 'Saving...' : 'Save Draft'}
+                                </Button>
+                            </span>
+                        </TooltipTrigger>
+                        {!isDraftSaveable && !isSavingDraft && (
+                            <TooltipContent side="top" align="end" className="max-w-sm">
+                                <p className="text-sm">Enter a Main Title to save as draft.</p>
+                            </TooltipContent>
+                        )}
+                    </Tooltip>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span tabIndex={0}>
+                                <Button
+                                    type="submit"
+                                    data-testid="save-resource-button"
+                                    disabled={isSaving || isSavingDraft || hasLegacyKeywords}
+                                    aria-busy={isSaving}
+                                    aria-disabled={isSaving || isSavingDraft || hasLegacyKeywords}
+                                >
+                                    {isSaving ? 'Saving...' : 'Save & Validate'}
+                                </Button>
+                            </span>
+                        </TooltipTrigger>
+                        {hasLegacyKeywords && !isSaving && (
+                            <TooltipContent side="top" align="end" className="max-w-sm">
+                                <div className="space-y-2">
+                                    <p className="text-sm font-semibold">Cannot save: Legacy keywords detected</p>
+                                    <p className="text-xs">Please replace all legacy MSL keywords with keywords from the current vocabulary.</p>
+                                </div>
+                            </TooltipContent>
+                        )}
+                    </Tooltip>
+                </div>
+                {draftAutosaveMessage && (
+                    <p
+                        className={draftAutosaveStatus === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}
+                        data-testid="draft-autosave-status"
+                        aria-live="polite"
+                    >
+                        {draftAutosaveMessage}
+                    </p>
+                )}
             </div>
-
             {/* DOI Conflict Modal */}
             {conflictData && (
                 <DoiConflictModal

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -27,9 +27,14 @@ import { uploadJson as uploadJsonRoute, uploadXml as uploadXmlRoute } from '@/ro
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import type { UploadErrorResponse } from '@/types/upload';
 
+type UploadSessionResponse = {
+    resourceId?: number | string | null;
+    sessionKey?: string | null;
+};
+
 /**
- * Shared helper for session-based file uploads (XML, JSON, JSON-LD).
- * Posts the file to the given route and navigates to the editor with the session key.
+ * Shared helper for file uploads (XML, JSON, JSON-LD).
+ * New uploads open the persisted draft by resource ID, with session key as fallback.
  */
 async function uploadSessionFile(file: File, route: { url: () => string }, sessionQueryKey: string): Promise<void> {
     const csrfHeaders = buildCsrfHeaders();
@@ -69,9 +74,19 @@ async function uploadSessionFile(file: File, route: { url: () => string }, sessi
             throw new Error(message);
         }
 
-        const data: { sessionKey: string } = await response.json();
+        const data: UploadSessionResponse = await response.json();
 
-        router.get(editorRoute({ query: { [sessionQueryKey]: data.sessionKey } }).url);
+        if (data.resourceId !== undefined && data.resourceId !== null && String(data.resourceId).trim() !== '') {
+            router.get(editorRoute({ query: { resourceId: String(data.resourceId) } }).url);
+            return;
+        }
+
+        if (data.sessionKey) {
+            router.get(editorRoute({ query: { [sessionQueryKey]: data.sessionKey } }).url);
+            return;
+        }
+
+        throw new Error('Upload completed but no editor target was returned for ' + filename + '.');
     } catch (error) {
         console.error(`${sessionQueryKey} upload failed`, error);
         if (error instanceof Error) {

--- a/resources/js/types/upload.ts
+++ b/resources/js/types/upload.ts
@@ -17,6 +17,8 @@ export type UploadErrorCategory = 'validation' | 'data' | 'server';
  * Structured upload error from the backend.
  */
 export interface UploadError {
+    /** Resource ID for duplicate-resource errors */
+    resourceId?: number | null;
     /** Error category for grouping and display */
     category: UploadErrorCategory;
     /** Machine-readable error code */
@@ -48,12 +50,14 @@ export interface UploadErrorResponse {
 
 /**
  * Success response from XML upload endpoint.
- * Note: Backend does not include 'success' field, only 'sessionKey'.
+ * New responses include a persisted draft resource ID; sessionKey remains as fallback.
  */
 export interface XmlUploadSuccessResponse {
     success?: true;
+    /** Persisted draft resource ID for editor navigation */
+    resourceId?: number | string | null;
     /** Session key for retrieving parsed XML data */
-    sessionKey: string;
+    sessionKey?: string | null;
 }
 
 /**
@@ -73,11 +77,14 @@ export interface CsvUploadSuccessResponse {
 
 /**
  * Success response from JSON upload endpoint.
- * Same structure as XML upload: contains session key for editor navigation.
+ * Same structure as XML upload: persisted draft ID plus session fallback.
  */
 export interface JsonUploadSuccessResponse {
+    success?: true;
+    /** Persisted draft resource ID for editor navigation */
+    resourceId?: number | string | null;
     /** Session key for retrieving parsed JSON data */
-    sessionKey: string;
+    sessionKey?: string | null;
 }
 
 /**
@@ -93,13 +100,13 @@ export function isUploadError(response: UploadResponse): response is UploadError
 }
 
 /**
- * Type guard to check if a session-based upload (XML or JSON) succeeded.
- * Both XML and JSON uploads return a sessionKey for editor navigation.
+ * Type guard to check if an XML or JSON metadata upload succeeded.
+ * New responses return resourceId; older responses may only include sessionKey.
  */
 export function isSessionUploadSuccess(
     response: UploadResponse,
 ): response is XmlUploadSuccessResponse | JsonUploadSuccessResponse {
-    return 'sessionKey' in response;
+    return !isUploadError(response) && ('resourceId' in response || 'sessionKey' in response);
 }
 
 /**

--- a/tests/pest/Feature/Http/Controllers/DashboardXmlUploadTest.php
+++ b/tests/pest/Feature/Http/Controllers/DashboardXmlUploadTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Resource;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Session;
@@ -9,7 +10,7 @@ beforeEach(function () {
     $this->actingAs(User::factory()->create(['role' => 'curator']));
 });
 
-it('can upload XML file and returns session key', function () {
+it('can upload XML file and persists a draft resource', function () {
     $xmlContent = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <resource xmlns="http://datacite.org/schema/kernel-4">
@@ -31,10 +32,69 @@ XML;
     ]);
 
     $response->assertStatus(200)
-        ->assertJsonStructure(['sessionKey']);
+        ->assertJsonStructure(['resourceId', 'sessionKey']);
 
     $sessionKey = $response->json('sessionKey');
     expect($sessionKey)->toStartWith('xml_upload_');
+
+    $resource = Resource::with('titles')->findOrFail($response->json('resourceId'));
+    expect($resource->created_by_user_id)->toBe(auth()->id())
+        ->and($resource->titles->pluck('value')->all())->toContain('Test Dataset');
+});
+
+it('uses the uploaded XML filename as fallback when no Main Title exists', function () {
+    $xmlContent = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+    <creators>
+        <creator>
+            <creatorName nameType="Personal">Doe, Jane</creatorName>
+        </creator>
+    </creators>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('fallback-dataset.xml', $xmlContent);
+
+    $response = $this->postJson('/dashboard/upload-xml', [
+        'file' => $file,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['resourceId', 'sessionKey']);
+
+    $resource = Resource::with('titles')->findOrFail($response->json('resourceId'));
+    expect($resource->titles->pluck('value')->all())->toContain('fallback dataset');
+});
+
+it('blocks XML upload when the DOI already exists', function () {
+    $existing = Resource::factory()->create(['doi' => '10.5880/test.duplicate']);
+
+    $xmlContent = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+    <identifier identifierType="DOI">https://doi.org/10.5880/test.duplicate</identifier>
+    <titles>
+        <title>Duplicate DOI Dataset</title>
+    </titles>
+    <creators>
+        <creator>
+            <creatorName nameType="Personal">Doe, Jane</creatorName>
+        </creator>
+    </creators>
+</resource>
+XML;
+
+    $file = UploadedFile::fake()->createWithContent('duplicate.xml', $xmlContent);
+
+    $response = $this->postJson('/dashboard/upload-xml', [
+        'file' => $file,
+    ]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('error.code', 'duplicate_doi')
+        ->assertJsonPath('error.identifier', '10.5880/test.duplicate')
+        ->assertJsonPath('error.resourceId', $existing->id);
 });
 
 it('validates XML file is required', function () {

--- a/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
+++ b/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\User;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
@@ -11,7 +12,7 @@ use Illuminate\Http\UploadedFile;
 uses(RefreshDatabase::class);
 
 describe('JSON Upload - DataCite JSON format', function () {
-    test('returns session key for valid DataCite JSON', function () {
+    test('returns resource id and session key for valid DataCite JSON', function () {
         $this->actingAs(User::factory()->create());
 
         $json = dataCiteJson(minimalAttributes());
@@ -20,10 +21,49 @@ describe('JSON Upload - DataCite JSON format', function () {
         $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
 
         $response->assertOk()
-            ->assertJsonStructure(['sessionKey']);
+            ->assertJsonStructure(['resourceId', 'sessionKey']);
 
         $sessionKey = $response->json('sessionKey');
         expect($sessionKey)->toStartWith('json_upload_');
+
+        $resource = Resource::with('titles')->findOrFail($response->json('resourceId'));
+        expect($resource->titles->pluck('value')->all())->toContain('Test Dataset');
+    });
+
+    test('uses the uploaded JSON filename as fallback when no Main Title exists', function () {
+        $this->actingAs(User::factory()->create());
+
+        $json = dataCiteJson(minimalAttributes([
+            'titles' => [
+                ['title' => 'Only Subtitle', 'titleType' => 'Subtitle'],
+            ],
+        ]));
+        $file = UploadedFile::fake()->createWithContent('subtitle-only.json', $json);
+
+        $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
+
+        $response->assertOk()
+            ->assertJsonStructure(['resourceId', 'sessionKey']);
+
+        $resource = Resource::with('titles')->findOrFail($response->json('resourceId'));
+        expect($resource->titles->pluck('value')->all())->toContain('subtitle only');
+    });
+
+    test('blocks JSON upload when the DOI already exists', function () {
+        $this->actingAs(User::factory()->create());
+        $existing = Resource::factory()->create(['doi' => '10.5880/test.json.duplicate']);
+
+        $json = dataCiteJson(minimalAttributes([
+            'doi' => 'https://doi.org/10.5880/test.json.duplicate',
+        ]));
+        $file = UploadedFile::fake()->createWithContent('duplicate.json', $json);
+
+        $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
+
+        $response->assertStatus(409)
+            ->assertJsonPath('error.code', 'duplicate_doi')
+            ->assertJsonPath('error.identifier', '10.5880/test.json.duplicate')
+            ->assertJsonPath('error.resourceId', $existing->id);
     });
 
     test('extracts titles from DataCite JSON', function () {
@@ -446,6 +486,10 @@ describe('JSON Upload - JSON-LD format', function () {
         $file = UploadedFile::fake()->createWithContent('test.jsonld', $jsonLd);
 
         $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
+
+        $response->assertJsonStructure(['resourceId', 'sessionKey']);
+        $resource = Resource::with('titles')->findOrFail($response->json('resourceId'));
+        expect($resource->titles->pluck('value')->all())->toContain('JSON-LD Test');
 
         $data = getJsonUploadData($response);
 

--- a/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
+++ b/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
@@ -81,6 +81,11 @@ describe('JSON Upload - DataCite JSON format', function () {
 
         $data = getJsonUploadData($response);
 
+        $resource = Resource::with('titles.titleType')->findOrFail($response->json('resourceId'));
+
+        expect($resource->titles->pluck('value')->all())->toBe(['Main Title', 'Sub Title'])
+            ->and($resource->titles->pluck('titleType.slug')->all())->toBe(['MainTitle', 'Subtitle']);
+
         expect($data['titles'])->toHaveCount(2);
         expect($data['titles'][0]['title'])->toBe('Main Title');
         expect($data['titles'][0]['titleType'])->toBe('main-title');
@@ -192,6 +197,12 @@ describe('JSON Upload - DataCite JSON format', function () {
 
         $data = getJsonUploadData($response);
 
+        $resource = Resource::with('descriptions.descriptionType')->findOrFail($response->json('resourceId'));
+
+        expect($resource->descriptions)->toHaveCount(2)
+            ->and($resource->descriptions->pluck('value')->all())->toBe(['This is the abstract.', 'Method description.'])
+            ->and($resource->descriptions->pluck('descriptionType.slug')->all())->toBe(['Abstract', 'Methods']);
+
         expect($data['descriptions'])->toHaveCount(2);
         expect($data['descriptions'][0]['description'])->toBe('This is the abstract.');
         expect($data['descriptions'][0]['type'])->toBe('Abstract');
@@ -211,6 +222,19 @@ describe('JSON Upload - DataCite JSON format', function () {
         $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
 
         $data = getJsonUploadData($response);
+
+        $resource = Resource::with('dates.dateType')->findOrFail($response->json('resourceId'));
+
+        $storedDateTypes = $resource->dates->pluck('dateType.slug')->all();
+        $collectedDate = $resource->dates->first(
+            fn ($date) => $date->dateType?->slug === 'Collected',
+        );
+
+        expect($storedDateTypes)->toContain('Created')
+            ->and($storedDateTypes)->toContain('Collected')
+            ->and($collectedDate)->not->toBeNull()
+            ->and((string) $collectedDate?->start_date)->toBe('2025-01-01')
+            ->and((string) $collectedDate?->end_date)->toBe('2025-12-31');
 
         expect($data['dates'])->toHaveCount(2);
         expect($data['dates'][0]['dateType'])->toBe('created');
@@ -364,6 +388,15 @@ describe('JSON Upload - DataCite JSON format', function () {
         $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
 
         $data = getJsonUploadData($response);
+
+        $resource = Resource::with(['relatedIdentifiers.identifierType', 'relatedIdentifiers.relationType', 'instruments'])->findOrFail($response->json('resourceId'));
+
+        expect($resource->relatedIdentifiers)->toHaveCount(1)
+            ->and($resource->relatedIdentifiers[0]->identifier)->toBe('10.1234/related')
+            ->and($resource->relatedIdentifiers[0]->identifierType?->slug)->toBe('DOI')
+            ->and($resource->relatedIdentifiers[0]->relationType?->slug)->toBe('Cites')
+            ->and($resource->relatedIdentifiers[0]->citation_label)->toBe('Doe, J. (2026): Imported citation. Publisher.')
+            ->and($resource->instruments)->toHaveCount(1);
 
         expect($data['relatedWorks'])->toHaveCount(1);
         expect($data['relatedWorks'][0]['identifier'])->toBe('10.1234/related');

--- a/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
+++ b/tests/pest/Feature/JsonUpload/UploadJsonControllerTest.php
@@ -6,6 +6,8 @@ use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\User;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\ResourceStorageService;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 
@@ -64,6 +66,43 @@ describe('JSON Upload - DataCite JSON format', function () {
             ->assertJsonPath('error.code', 'duplicate_doi')
             ->assertJsonPath('error.identifier', '10.5880/test.json.duplicate')
             ->assertJsonPath('error.resourceId', $existing->id);
+    });
+
+    test('returns duplicate DOI response when the storage insert hits the DOI unique constraint', function () {
+        $this->actingAs(User::factory()->create());
+        $doi = '10.5880/test.json.race';
+
+        $mock = Mockery::mock(ResourceStorageService::class);
+        $mock->shouldReceive('store')
+            ->once()
+            ->andReturnUsing(function () use ($doi) {
+                Resource::factory()->create(['doi' => $doi]);
+
+                $previous = new PDOException(
+                    'SQLSTATE[23000]: Integrity constraint violation: 19 UNIQUE constraint failed: resources.doi',
+                    23000,
+                );
+                $previous->errorInfo = ['23000', 19, 'UNIQUE constraint failed: resources.doi'];
+
+                throw new QueryException('sqlite', 'insert into "resources" ("doi") values (?)', [$doi], $previous);
+            });
+        $this->app->instance(ResourceStorageService::class, $mock);
+
+        $json = dataCiteJson(minimalAttributes([
+            'doi' => 'https://doi.org/'.$doi,
+        ]));
+        $file = UploadedFile::fake()->createWithContent('race.json', $json);
+
+        $response = $this->postJson('/dashboard/upload-json', ['file' => $file]);
+
+        $resourceId = (int) Resource::query()
+            ->where('doi', $doi)
+            ->value('id');
+
+        $response->assertStatus(409)
+            ->assertJsonPath('error.code', 'duplicate_doi')
+            ->assertJsonPath('error.identifier', $doi)
+            ->assertJsonPath('error.resourceId', $resourceId);
     });
 
     test('extracts titles from DataCite JSON', function () {

--- a/tests/playwright/critical/smoke.spec.ts
+++ b/tests/playwright/critical/smoke.spec.ts
@@ -6,10 +6,10 @@ import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from '../constants';
 
 /**
  * Critical E2E Smoke Tests
- * 
+ *
  * These tests verify critical end-to-end workflows that require real browser interaction.
  * Simple page load tests are now handled by Pest Browser Tests (tests/pest/Browser/SmokeTest.php).
- * 
+ *
  * Tests here focus on:
  * - File uploads (XML)
  * - Complex UI interactions
@@ -31,25 +31,24 @@ test.describe('Critical E2E Workflows', () => {
     await page.getByLabel('Password').fill(TEST_USER_PASSWORD);
     await page.getByRole('button', { name: 'Log in' }).click();
     await page.waitForURL(/\/dashboard/, { timeout: 15000 });
-    
+
     // Go to dashboard and upload XML
     await page.goto('/dashboard');
     await expect(page.getByTestId('unified-dropzone')).toBeVisible();
-    
+
     const fileInput = page.getByTestId('unified-file-input');
     const xmlFilePath = resolveDatasetExample('datacite-xml-example-full-v4.xml');
     await fileInput.setInputFiles(xmlFilePath);
-    
-    // Verify redirect to editor with session key (session-based workflow)
+
+    // Verify redirect to editor with persisted draft resource ID
     // The 30s timeout accounts for XML parsing, session creation, and database operations.
     // In Docker environments, first requests after container start may be slower due to
     // cache warming and container initialization overhead.
     await page.waitForURL(/\/editor/, { timeout: 30000 });
-    
+
     const currentUrl = page.url();
-    // With session-based workflow, only xmlSession parameter is passed
-    expect(currentUrl).toMatch(/xmlSession=xml_upload_/);
-    
+    expect(currentUrl).toMatch(/resourceId=\d+/);
+
     // Verify editor page loaded successfully by checking for DOI input field
     await expect(page.locator('#doi')).toBeVisible();
   });

--- a/tests/playwright/workflows/03-xml-upload-workflow.spec.ts
+++ b/tests/playwright/workflows/03-xml-upload-workflow.spec.ts
@@ -41,15 +41,12 @@ test.describe('XML Upload', () => {
     await page.waitForURL(/\/editor/, { timeout: 10000 });
 
     const currentUrl = page.url();
-    // With session-based workflow, only xmlSession parameter is passed
-    expect(currentUrl).toMatch(/xmlSession=xml_upload_/);
+    expect(currentUrl).toMatch(/resourceId=\d+/);
 
-    // Validate session key is present in URL
     const urlParams = new URLSearchParams(currentUrl.split('?')[1] || '');
-    const sessionKey = urlParams.get('xmlSession');
-    expect(sessionKey).toBeTruthy();
-    expect(sessionKey).toMatch(/^xml_upload_/);
-    
+    const resourceId = urlParams.get('resourceId');
+    expect(resourceId).toBeTruthy();
+    expect(resourceId).toMatch(/^\d+$/);
     // Verify editor page loaded successfully with form fields
     // Check for DOI input field (id="doi"), which is unique and stable
     await expect(page.locator('#doi')).toBeVisible();

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4881,6 +4881,88 @@ describe('DataCiteForm', () => {
             const { toast } = await import('sonner');
             expect(toast.success).toHaveBeenCalledWith('Draft saved.');
         });
+
+        it('autosaves changed draft data without redirecting', { timeout: 30000 }, async () => {
+            vi.useFakeTimers();
+            const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+            mockedAxios.post = vi.fn().mockResolvedValue({
+                data: { message: 'Draft autosaved.', resource: { id: 42 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            const view = renderDataCiteForm({
+                initialResourceId: '42',
+                initialTitles: [{ title: 'Initial Draft', titleType: 'main-title' }],
+            });
+
+            try {
+                const mainTitleInput = screen.getByRole('textbox', { name: /Title/ });
+                fireEvent.change(mainTitleInput, { target: { value: 'Changed Draft' } });
+
+                await act(async () => {
+                    vi.advanceTimersByTime(60_000);
+                    await Promise.resolve();
+                });
+
+                await act(async () => {
+                    await Promise.resolve();
+                    await Promise.resolve();
+                });
+
+                expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+                expect(mockedAxios.post).toHaveBeenCalledWith(
+                    '/editor/resources/draft',
+                    expect.objectContaining({
+                        resourceId: 42,
+                        titles: [{ title: 'Changed Draft', titleType: 'main-title', language: null }],
+                    }),
+                    expect.objectContaining({
+                        headers: expect.objectContaining({
+                            'Content-Type': 'application/json',
+                            Accept: 'application/json',
+                        }),
+                    }),
+                );
+                expect(mockRouterVisit).not.toHaveBeenCalled();
+                expect(screen.getByTestId('draft-autosave-status')).toHaveTextContent(/Draft autosaved/);
+            } finally {
+                view.unmount();
+                vi.useRealTimers();
+            }
+        });
+
+        it('does not autosave an unchanged loaded draft', { timeout: 30000 }, async () => {
+            vi.useFakeTimers();
+            const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+            mockedAxios.post = vi.fn().mockResolvedValue({
+                data: { message: 'Draft autosaved.', resource: { id: 42 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            const view = renderDataCiteForm({
+                initialResourceId: '42',
+                initialTitles: [{ title: 'Initial Draft', titleType: 'main-title' }],
+            });
+
+            try {
+                await act(async () => {
+                    vi.advanceTimersByTime(60_000);
+                    await Promise.resolve();
+                });
+
+                expect(mockedAxios.post).not.toHaveBeenCalled();
+                expect(screen.queryByTestId('draft-autosave-status')).not.toBeInTheDocument();
+            } finally {
+                view.unmount();
+                vi.useRealTimers();
+            }
+        });
     });
 
     describe('Redirect after saving (Issue #624)', () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4882,6 +4882,54 @@ describe('DataCiteForm', () => {
             expect(toast.success).toHaveBeenCalledWith('Draft saved.');
         });
 
+        it('updates the autosave signature without showing autosave status after manual draft save', { timeout: 60000 }, async () => {
+            vi.useFakeTimers();
+            const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+            mockedAxios.post = vi.fn().mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 42 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            const view = renderDataCiteForm();
+
+            try {
+                const mainTitleInput = screen.getByRole('textbox', { name: /Title/ });
+                await act(async () => {
+                    fireEvent.change(mainTitleInput, { target: { value: 'Draft Dataset' } });
+                });
+
+                const draftButton = screen.getByTestId('save-draft-button');
+                await act(async () => {
+                    fireEvent.click(draftButton);
+                    await Promise.resolve();
+                    await Promise.resolve();
+                });
+
+                expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+                expect(screen.queryByTestId('draft-autosave-status')).not.toBeInTheDocument();
+                expect(mockRouterVisit).toHaveBeenCalledWith(
+                    '/resources',
+                    expect.objectContaining({
+                        onError: expect.any(Function),
+                    }),
+                );
+
+                await act(async () => {
+                    vi.advanceTimersByTime(60_000);
+                    await Promise.resolve();
+                    await Promise.resolve();
+                });
+
+                expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+            } finally {
+                view.unmount();
+                vi.useRealTimers();
+            }
+        });
+
         it('autosaves changed draft data without redirecting', { timeout: 30000 }, async () => {
             vi.useFakeTimers();
             const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };

--- a/tests/vitest/pages/__tests__/dashboard.test.tsx
+++ b/tests/vitest/pages/__tests__/dashboard.test.tsx
@@ -387,15 +387,17 @@ describe('handleXmlFiles', () => {
         document.cookie = 'XSRF-TOKEN=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     });
 
-    it('posts xml file with csrf token and redirects to editor with session key', async () => {
+    it('posts xml file with csrf token and redirects to editor with resource id', async () => {
         const file = new File(['<xml></xml>'], 'test.xml', { type: 'text/xml' });
         const sessionKey = 'xml_upload_test123';
+        const resourceId = 123;
         const fetchMock = vi
             .spyOn(global, 'fetch')
             .mockResolvedValue(
                 {
                     ok: true,
                     json: async () => ({
+                        resourceId,
                         sessionKey,
                     }),
                 } as Response,
@@ -410,12 +412,12 @@ describe('handleXmlFiles', () => {
         expect(routerMock.get).toHaveBeenCalled();
         const [redirectUrl] = routerMock.get.mock.calls[0];
         expect(typeof redirectUrl).toBe('string');
-        expect(redirectUrl).toBe(`/editor?xmlSession=${sessionKey}`);
+        expect(redirectUrl).toBe(`/editor?resourceId=${resourceId}`);
         fetchMock.mockRestore();
         routerMock.get.mockReset();
     });
 
-    it('falls back to the XSRF cookie when the meta token is unavailable', async () => {
+    it('falls back to the XSRF cookie and legacy session redirect when the meta token is unavailable', async () => {
         document.head.innerHTML = '';
         document.cookie = 'XSRF-TOKEN=cookie-token';
 
@@ -492,13 +494,15 @@ describe('handleJsonFiles', () => {
         document.cookie = 'XSRF-TOKEN=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     });
 
-    it('posts json file with csrf token and redirects to editor with session key', async () => {
+    it('posts json file with csrf token and redirects to editor with resource id', async () => {
         const file = new File(['{"title":"Test"}'], 'metadata.json', { type: 'application/json' });
         const sessionKey = 'json_upload_test123';
+        const resourceId = 456;
         const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(
             {
                 ok: true,
                 json: async () => ({
+                    resourceId,
                     sessionKey,
                 }),
             } as Response,
@@ -510,7 +514,7 @@ describe('handleJsonFiles', () => {
         const [url, options] = fetchMock.mock.calls[0];
         expect(normalizeTestUrl(url as string)).toBe('/dashboard/upload-json');
         expect((options as RequestInit).headers).toMatchObject({ 'X-CSRF-TOKEN': 'test-token' });
-        expect(routerMock.get).toHaveBeenCalledWith(`/editor?jsonSession=${sessionKey}`);
+        expect(routerMock.get).toHaveBeenCalledWith(`/editor?resourceId=${resourceId}`);
 
         fetchMock.mockRestore();
         routerMock.get.mockReset();

--- a/tests/vitest/types/upload.test.ts
+++ b/tests/vitest/types/upload.test.ts
@@ -29,6 +29,7 @@ describe('Upload Types', () => {
         it('returns false for success response', () => {
             const response: XmlUploadSuccessResponse = {
                 success: true,
+                resourceId: 123,
                 sessionKey: 'abc123',
             };
 
@@ -40,13 +41,24 @@ describe('Upload Types', () => {
         it('returns true for XML success response with explicit success', () => {
             const response: XmlUploadSuccessResponse = {
                 success: true,
+                resourceId: 123,
                 sessionKey: 'abc123',
             };
 
             expect(isSessionUploadSuccess(response)).toBe(true);
         });
 
-        it('returns true for XML success response without success field (real backend response)', () => {
+        it('returns true for XML success response with resource id (real backend response)', () => {
+            const response = {
+                success: true,
+                resourceId: 123,
+                sessionKey: 'abc123',
+            } as XmlUploadSuccessResponse;
+
+            expect(isSessionUploadSuccess(response)).toBe(true);
+        });
+
+        it('returns true for legacy XML success response with only session key', () => {
             const response = {
                 sessionKey: 'abc123',
             } as XmlUploadSuccessResponse;
@@ -56,6 +68,8 @@ describe('Upload Types', () => {
 
         it('returns true for JSON upload success response', () => {
             const response: JsonUploadSuccessResponse = {
+                success: true,
+                resourceId: 456,
                 sessionKey: 'json_upload_abc123',
             };
 
@@ -109,6 +123,7 @@ describe('Upload Types', () => {
         it('returns false for XML success response', () => {
             const response: XmlUploadSuccessResponse = {
                 success: true,
+                resourceId: 123,
                 sessionKey: 'abc123',
             };
 


### PR DESCRIPTION
This pull request introduces robust handling for duplicate DOI uploads, improves error reporting for draft saves, and adds an autosave feature to the DataCite form. The main changes include new backend exception handling for duplicate DOIs, integration of draft saving logic in both JSON and XML upload controllers, and a frontend autosave mechanism with user feedback.

**Backend: Duplicate DOI handling and draft save improvements**
- Introduced a new exception, `DuplicateUploadedResourceDoiException`, to clearly signal when an uploaded DOI already exists for a resource. This exception is now caught in both `UploadJsonController` and `UploadXmlController`, returning a specific error response and logging the conflict. [[1]](diffhunk://#diff-d2768e450769e9b4585dcb26fe6fab86806d374f13b207616f94a1dbf54f2723R1-R17) [[2]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R8) [[3]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R17-R24) [[4]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R86) [[5]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3L234-R238) [[6]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R260-R341) [[7]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R8-R16) [[8]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09R26) [[9]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09L76-R161)
- Enhanced error handling for draft saves in both upload controllers, including structured responses for validation errors and unexpected exceptions. [[1]](diffhunk://#diff-232974570581b8cb90e9374b172fee351065d9213c9e1095ee1e09156accc6a3R260-R341) [[2]](diffhunk://#diff-d837d136aa21281f77179569f8949ad444961a99be4b6b69fd50ad23fb812e09L76-R161)

**Frontend: DataCite form autosave and feedback**
- Added an autosave feature to the DataCite form that periodically saves drafts in the background, preventing data loss. Autosave status is tracked and displayed to the user, including success timestamps and error messages. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R93-R100) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R1230-R1233) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R1896-R1911) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R2190-R2278) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2382-R2499) [[6]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2408-R2533)
- Updated UI components to show autosave feedback and improved button text consistency. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R3216-R3222) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3118-R3233) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3138-R3253) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3152-R3276)

These changes together improve the user experience by preventing duplicate DOI uploads, making draft saves more resilient, and providing clear feedback during form editing.