### PR TITLE
Fix: Change position of resource type an the doi in resource list

### DIFF
--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1,3 +1,4 @@
+// organize-imports-ignore
 import { Head, router, usePage } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
 import { ArrowDown, ArrowUp, ArrowUpDown, Braces, Eye, PencilLine, Quote, Trash2 } from 'lucide-react';
@@ -9,10 +10,7 @@ import { CitationManagerModal } from '@/components/citations/CitationManagerModa
 import { DataCiteIcon } from '@/components/icons/datacite-icon';
 import { FileJsonIcon, FileXmlIcon } from '@/components/icons/file-icons';
 import SetupLandingPageModal from '@/components/landing-pages/modals/SetupLandingPageModal';
-import {
-    ResourcesBulkActionsToolbar,
-    type ResourcesBulkExportFormat,
-} from '@/components/resources/bulk-actions-toolbar';
+import { ResourcesBulkActionsToolbar, type ResourcesBulkExportFormat } from '@/components/resources/bulk-actions-toolbar';
 import ImportFromDataCiteModal from '@/components/resources/modals/ImportFromDataCiteModal';
 import ImportSingleOldResourceModal from '@/components/resources/modals/ImportSingleOldResourceModal';
 import RegisterDoiModal from '@/components/resources/modals/RegisterDoiModal';
@@ -84,7 +82,7 @@ interface ResourceColumn {
     sortGroupLabel?: string;
 }
 
-const TITLE_COLUMN_WIDTH_CLASSES = 'min-w-[24rem] lg:min-w-[36rem] xl:min-w-[44rem]';
+const DOI_TITLE_COLUMN_WIDTH_CLASSES = 'min-w-[18rem] md:min-w-[24rem]';
 const DATE_COLUMN_CONTAINER_CLASSES = 'flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300';
 const DATE_COLUMN_HEADER_LABEL = (
     <span className="flex flex-col leading-tight normal-case">
@@ -92,10 +90,16 @@ const DATE_COLUMN_HEADER_LABEL = (
         <span>Updated</span>
     </span>
 );
-const IDENTIFIER_COLUMN_HEADER_LABEL = (
+const ID_RESOURCE_TYPE_COLUMN_HEADER_LABEL = (
     <span className="flex flex-col leading-tight normal-case">
         <span>ID</span>
+        <span>Resource Type</span>
+    </span>
+);
+const DOI_TITLE_COLUMN_HEADER_LABEL = (
+    <span className="flex flex-col leading-tight normal-case">
         <span>DOI</span>
+        <span>Title</span>
     </span>
 );
 const ACTIONS_COLUMN_WIDTH_CLASSES = 'w-48 min-w-[12rem]';
@@ -292,9 +296,7 @@ function ResourcesPage({
     const { auth } = usePage<{ auth: { user: AuthUser } }>().props;
     const canManageLandingPages = auth.user?.can_manage_landing_pages ?? false;
     const canRegisterDoi = auth.user?.can_register_production_doi ?? false;
-    const canDeleteDraftResources = auth.user?.role === 'admin'
-        || auth.user?.role === 'group_leader'
-        || auth.user?.role === 'curator';
+    const canDeleteDraftResources = auth.user?.role === 'admin' || auth.user?.role === 'group_leader' || auth.user?.role === 'curator';
 
     const [resources, setResources] = useState<Resource[]>(initialResources);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -592,9 +594,7 @@ function ResourcesPage({
         if (selectedIds.size === 0) {
             return undefined;
         }
-        const selectedWithoutDoi = resources.filter(
-            (r) => typeof r.id === 'number' && selectedIds.has(r.id) && (r.doi === null || r.doi === ''),
-        );
+        const selectedWithoutDoi = resources.filter((r) => typeof r.id === 'number' && selectedIds.has(r.id) && (r.doi === null || r.doi === ''));
         if (selectedWithoutDoi.length === 0) {
             return undefined;
         }
@@ -671,12 +671,16 @@ function ResourcesPage({
             }
             setIsBulkExporting(true);
             try {
-                const response = await axios.post('/resources/batch-export', {
-                    ids: Array.from(selectedIds),
-                    format,
-                }, {
-                    responseType: 'blob',
-                });
+                const response = await axios.post(
+                    '/resources/batch-export',
+                    {
+                        ids: Array.from(selectedIds),
+                        format,
+                    },
+                    {
+                        responseType: 'blob',
+                    },
+                );
 
                 const blob = new Blob([response.data as BlobPart], { type: 'application/zip' });
                 const contentDisposition = response.headers['content-disposition'] as string | undefined;
@@ -770,10 +774,9 @@ function ResourcesPage({
 
     const canDeleteResource = useCallback(
         (resource: Resource): boolean => {
-            return canDeleteDraftResources
-                && resource.publicstatus === 'draft'
-                && typeof resource.id === 'number'
-                && !hasPersistentIdentifier(resource);
+            return (
+                canDeleteDraftResources && resource.publicstatus === 'draft' && typeof resource.id === 'number' && !hasPersistentIdentifier(resource)
+            );
         },
         [canDeleteDraftResources, hasPersistentIdentifier],
     );
@@ -809,45 +812,51 @@ function ResourcesPage({
         [canDeleteResource],
     );
 
-    const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
-        if (!open && !isDeletingResourceRef.current && !isDeletingResource) {
-            isDeletingResourceRef.current = false;
-            setResourcePendingDelete(null);
-        }
-    }, [isDeletingResource]);
-
-    const handleConfirmDelete = useCallback((event: ReactMouseEvent<HTMLButtonElement>) => {
-        event.preventDefault();
-
-        if (isDeletingResourceRef.current || !resourcePendingDelete?.id) {
-            return;
-        }
-
-        const resourceToDelete = resourcePendingDelete;
-
-        isDeletingResourceRef.current = true;
-        setIsDeletingResource(true);
-
-        router.delete(`/resources/${resourceToDelete.id}`, {
-            preserveScroll: true,
-            onSuccess: () => {
-                setSelectedIds((prev) => {
-                    const next = new Set(prev);
-                    next.delete(resourceToDelete.id);
-                    return next;
-                });
-                setResourcePendingDelete(null);
-                toast.success('Draft deleted successfully.');
-            },
-            onError: () => {
-                toast.error('Failed to delete draft resource.');
-            },
-            onFinish: () => {
+    const handleDeleteDialogOpenChange = useCallback(
+        (open: boolean) => {
+            if (!open && !isDeletingResourceRef.current && !isDeletingResource) {
                 isDeletingResourceRef.current = false;
-                setIsDeletingResource(false);
-            },
-        });
-    }, [resourcePendingDelete]);
+                setResourcePendingDelete(null);
+            }
+        },
+        [isDeletingResource],
+    );
+
+    const handleConfirmDelete = useCallback(
+        (event: ReactMouseEvent<HTMLButtonElement>) => {
+            event.preventDefault();
+
+            if (isDeletingResourceRef.current || !resourcePendingDelete?.id) {
+                return;
+            }
+
+            const resourceToDelete = resourcePendingDelete;
+
+            isDeletingResourceRef.current = true;
+            setIsDeletingResource(true);
+
+            router.delete(`/resources/${resourceToDelete.id}`, {
+                preserveScroll: true,
+                onSuccess: () => {
+                    setSelectedIds((prev) => {
+                        const next = new Set(prev);
+                        next.delete(resourceToDelete.id);
+                        return next;
+                    });
+                    setResourcePendingDelete(null);
+                    toast.success('Draft deleted successfully.');
+                },
+                onError: () => {
+                    toast.error('Failed to delete draft resource.');
+                },
+                onFinish: () => {
+                    isDeletingResourceRef.current = false;
+                    setIsDeletingResource(false);
+                },
+            });
+        },
+        [resourcePendingDelete],
+    );
 
     const handleExportDataCiteJson = useCallback(async (resource: Resource) => {
         if (!resource.id) {
@@ -1060,9 +1069,9 @@ function ResourcesPage({
 
     const resourceColumns: ResourceColumn[] = [
         {
-            key: 'id_doi',
-            label: IDENTIFIER_COLUMN_HEADER_LABEL,
-            widthClass: 'min-w-[12rem]',
+            key: 'id_resourcetype',
+            label: ID_RESOURCE_TYPE_COLUMN_HEADER_LABEL,
+            widthClass: 'min-w-[9rem]',
             cellClassName: 'whitespace-normal align-middle',
             sortOptions: [
                 {
@@ -1071,65 +1080,60 @@ function ResourcesPage({
                     description: 'Sort by the resource ID',
                 },
                 {
-                    key: 'doi',
-                    label: 'DOI',
-                    description: 'Sort by the DOI',
-                },
-            ],
-            sortGroupLabel: 'Sort options for ID and DOI',
-            render: (resource: Resource) => {
-                const hasId = resource.id !== undefined && resource.id !== null;
-                const idValue = hasId ? `#${resource.id}` : '-';
-                const identifierValue = resource.doi || 'Not registered';
-                // Lighter gray for "Not registered" text to de-emphasize missing DOI
-                // Dark mode uses lighter shade (400) for better readability on dark backgrounds
-                const identifierClasses = resource.doi
-                    ? 'text-sm text-gray-600 dark:text-gray-300'
-                    : 'text-sm text-gray-500 dark:text-gray-400 italic';
-
-                return (
-                    <div className="flex flex-col gap-1 text-left" aria-label={`Resource ID: ${idValue}. DOI: ${identifierValue}`}>
-                        <span
-                            className={hasId ? 'text-sm font-semibold text-gray-900 dark:text-gray-100' : 'text-sm text-gray-500 dark:text-gray-300'}
-                        >
-                            {idValue}
-                        </span>
-                        <span className={identifierClasses}>{identifierValue}</span>
-                    </div>
-                );
-            },
-        },
-        {
-            key: 'title_resourcetype',
-            label: (
-                <span className="flex flex-col leading-tight normal-case">
-                    <span>Title</span>
-                    <span className="hidden md:inline">Resource Type</span>
-                </span>
-            ),
-            widthClass: TITLE_COLUMN_WIDTH_CLASSES,
-            cellClassName: 'whitespace-normal align-middle',
-            sortOptions: [
-                {
-                    key: 'title',
-                    label: 'Title',
-                    description: 'Sort by the resource title',
-                },
-                {
                     key: 'resourcetypegeneral',
                     label: 'Type',
                     description: 'Sort by the resource type',
                 },
             ],
-            sortGroupLabel: 'Sort options for title and resource type',
+            sortGroupLabel: 'Sort options for ID and resource type',
             render: (resource: Resource) => {
-                const title = resource.title ?? '-';
+                const hasId = resource.id !== undefined && resource.id !== null;
+                const idValue = hasId ? `#${resource.id}` : '-';
                 const resourceType = resource.resourcetypegeneral ?? '-';
 
                 return (
-                    <div className="flex flex-col gap-1 text-left">
+                    <div className="flex flex-col gap-1 text-left" aria-label={`Resource ID: ${idValue}. Resource Type: ${resourceType}`}>
+                        <span
+                            className={hasId ? 'text-sm font-semibold text-gray-900 dark:text-gray-100' : 'text-sm text-gray-500 dark:text-gray-300'}
+                        >
+                            {idValue}
+                        </span>
+                        <span className="text-sm text-gray-600 dark:text-gray-300">{resourceType}</span>
+                    </div>
+                );
+            },
+        },
+        {
+            key: 'doi_title',
+            label: DOI_TITLE_COLUMN_HEADER_LABEL,
+            widthClass: DOI_TITLE_COLUMN_WIDTH_CLASSES,
+            cellClassName: 'whitespace-normal align-middle',
+            sortOptions: [
+                {
+                    key: 'doi',
+                    label: 'DOI',
+                    description: 'Sort by the DOI',
+                },
+                {
+                    key: 'title',
+                    label: 'Title',
+                    description: 'Sort by the resource title',
+                },
+            ],
+            sortGroupLabel: 'Sort options for DOI and title',
+            render: (resource: Resource) => {
+                const title = resource.title ?? '-';
+                const identifierValue = resource.doi || 'Not registered';
+                // Lighter gray for "Not registered" text to de-emphasize missing DOI
+                // Dark mode uses lighter shade (400) for better readability on dark backgrounds
+                const identifierClasses = resource.doi
+                    ? 'text-sm wrap-break-word text-gray-600 dark:text-gray-300'
+                    : 'text-sm text-gray-500 dark:text-gray-400 italic';
+
+                return (
+                    <div className="flex flex-col gap-1 text-left" aria-label={`DOI: ${identifierValue}. Title: ${title}`}>
+                        <span className={identifierClasses}>{identifierValue}</span>
                         <span className="text-sm leading-relaxed font-normal wrap-break-word text-gray-900 dark:text-gray-100">{title}</span>
-                        <span className="hidden text-sm whitespace-nowrap text-gray-600 md:inline dark:text-gray-300">{resourceType}</span>
                     </div>
                 );
             },
@@ -1323,10 +1327,15 @@ function ResourcesPage({
                     </td>
                     {resourceColumns.map((column) => (
                         <td key={column.key} className={`px-6 py-1.5 ${column.widthClass} ${column.cellClassName ?? ''}`}>
-                            {column.key === 'id_doi' ? (
+                            {column.key === 'id_resourcetype' ? (
                                 <div className="flex flex-col gap-2">
                                     <div className="h-4 w-10 rounded bg-gray-200 dark:bg-gray-700"></div>
-                                    <div className="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
+                                    <div className="h-4 w-24 rounded bg-gray-200 dark:bg-gray-700"></div>
+                                </div>
+                            ) : column.key === 'doi_title' ? (
+                                <div className="flex flex-col gap-2">
+                                    <div className="h-4 w-40 rounded bg-gray-200 dark:bg-gray-700"></div>
+                                    <div className="h-4 w-3/4 rounded bg-gray-200 dark:bg-gray-700"></div>
                                 </div>
                             ) : column.key === 'created_updated' ? (
                                 <div className="flex flex-col gap-2">
@@ -1460,7 +1469,7 @@ function ResourcesPage({
                                                         : 'none';
 
                                                     return (
-                                                <TableHead
+                                                        <TableHead
                                                             key={column.key}
                                                             className={`text-xs tracking-wider text-gray-500 uppercase dark:text-gray-300 ${column.widthClass}`}
                                                             aria-sort={column.sortOptions ? ariaSortValue : undefined}
@@ -1519,7 +1528,9 @@ function ResourcesPage({
                                                         key={deriveResourceRowKey(resource)}
                                                         className="hover:bg-gray-50 dark:hover:bg-gray-800"
                                                         ref={isLast ? lastResourceElementRef : null}
-                                                        data-state={resource.id !== undefined && selectedIds.has(resource.id) ? 'selected' : undefined}
+                                                        data-state={
+                                                            resource.id !== undefined && selectedIds.has(resource.id) ? 'selected' : undefined
+                                                        }
                                                     >
                                                         <TableCell className="w-12 min-w-12 align-middle">
                                                             {resource.id !== undefined && (
@@ -1565,7 +1576,11 @@ function ResourcesPage({
                                                                             size="icon"
                                                                             onClick={() => handleRegisterDoi(resource)}
                                                                             aria-label={`${shouldUseUpdateMetadataLabel(resource) ? 'Update metadata' : 'Register DOI'} for resource ${resourceLabel}`}
-                                                                            title={shouldUseUpdateMetadataLabel(resource) ? 'Update metadata' : 'Register DOI'}
+                                                                            title={
+                                                                                shouldUseUpdateMetadataLabel(resource)
+                                                                                    ? 'Update metadata'
+                                                                                    : 'Register DOI'
+                                                                            }
                                                                             data-testid="datacite-button"
                                                                         >
                                                                             <DataCiteIcon
@@ -1580,8 +1595,7 @@ function ResourcesPage({
                                                                         variant="ghost"
                                                                         size="icon"
                                                                         onClick={() =>
-                                                                            resource.id != null &&
-                                                                            setCitationManagerResourceId(resource.id)
+                                                                            resource.id != null && setCitationManagerResourceId(resource.id)
                                                                         }
                                                                         disabled={citationVocabulariesLoading}
                                                                         aria-label={`Manage citations for resource ${resourceLabel}`}
@@ -1633,11 +1647,17 @@ function ResourcesPage({
                                                                         type="button"
                                                                         variant="ghost"
                                                                         size="icon"
-                                                                        onClick={canDeleteResource(resource) ? () => handleRequestDelete(resource) : undefined}
+                                                                        onClick={
+                                                                            canDeleteResource(resource)
+                                                                                ? () => handleRequestDelete(resource)
+                                                                                : undefined
+                                                                        }
                                                                         disabled={!canDeleteResource(resource) || isDeletingResource}
                                                                         aria-label={`Delete resource ${resourceLabel}`}
                                                                         title={getDeleteButtonTitle(resource)}
-                                                                        className={!canDeleteResource(resource) ? 'cursor-not-allowed opacity-40' : undefined}
+                                                                        className={
+                                                                            !canDeleteResource(resource) ? 'cursor-not-allowed opacity-40' : undefined
+                                                                        }
                                                                     >
                                                                         <Trash2 aria-hidden="true" className="size-4" />
                                                                     </Button>
@@ -1715,11 +1735,7 @@ function ResourcesPage({
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <AlertDialogCancel disabled={isDeletingResource}>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                            variant="destructive"
-                            onClick={handleConfirmDelete}
-                            disabled={isDeletingResource}
-                        >
+                        <AlertDialogAction variant="destructive" onClick={handleConfirmDelete} disabled={isDeletingResource}>
                             {isDeletingResource ? 'Deleting...' : 'Delete Draft'}
                         </AlertDialogAction>
                     </AlertDialogFooter>

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -191,9 +191,7 @@ describe('ResourcesPage – extended', () => {
         });
 
         it('uses doi when id is missing', () => {
-            expect(
-                deriveResourceRowKey({ id: undefined as never, doi: '10.5880/test', year: 2024 } as never),
-            ).toBe('resource-doi-10.5880/test');
+            expect(deriveResourceRowKey({ id: undefined as never, doi: '10.5880/test', year: 2024 } as never)).toBe('resource-doi-10.5880/test');
         });
 
         it('falls back to metadata segments when both id and doi are missing', () => {
@@ -259,10 +257,59 @@ describe('ResourcesPage – extended', () => {
             await act(async () => {
                 fireEvent.click(idButton);
             });
-            expect(routerMock.visit).toHaveBeenCalledWith(
-                expect.stringContaining('sort_key=id'),
-                expect.any(Object),
-            );
+            expect(routerMock.visit).toHaveBeenCalledWith(expect.stringContaining('sort_key=id'), expect.any(Object));
+        });
+    });
+
+    // ── Issue 908 layout ──────────────────────────────────────────────
+    describe('Issue 908 resource overview layout', () => {
+        it('renders resource type below ID and DOI above title in the row cells', () => {
+            renderPage({
+                resources: [
+                    makeResource({
+                        id: 7,
+                        doi: '10.5880/compact-layout',
+                        title: 'Compact Layout Resource',
+                        resourcetypegeneral: 'Dataset',
+                    }),
+                ],
+            });
+
+            const table = screen.getByRole('table');
+            const dataRow = within(table).getAllByRole('row')[1];
+            const cells = within(dataRow).getAllByRole('cell');
+
+            expect(Array.from(cells[2].querySelectorAll('span')).map((span) => span.textContent)).toEqual(['#7', 'Dataset']);
+            expect(Array.from(cells[3].querySelectorAll('span')).map((span) => span.textContent)).toEqual([
+                '10.5880/compact-layout',
+                'Compact Layout Resource',
+            ]);
+        });
+
+        it('keeps the regrouped columns compact instead of restoring the old oversized title width', () => {
+            renderPage();
+
+            const headers = screen.getAllByRole('columnheader');
+            const idResourceTypeHeader = headers.find((header) => {
+                const text = header.textContent ?? '';
+                return text.includes('ID') && text.includes('Type');
+            });
+            const doiTitleHeader = headers.find((header) => {
+                const text = header.textContent ?? '';
+                return text.includes('DOI') && text.includes('Title');
+            });
+
+            expect(idResourceTypeHeader).toBeDefined();
+            expect(doiTitleHeader).toBeDefined();
+            if (!idResourceTypeHeader || !doiTitleHeader) {
+                throw new Error('Expected ID/Resource Type and DOI/Title headers to render');
+            }
+
+            expect(idResourceTypeHeader).toHaveClass('min-w-[9rem]');
+            expect(doiTitleHeader).toHaveClass('min-w-[18rem]');
+            expect(doiTitleHeader).toHaveClass('md:min-w-[24rem]');
+            expect(doiTitleHeader.className).not.toContain('lg:min-w-[36rem]');
+            expect(doiTitleHeader.className).not.toContain('xl:min-w-[44rem]');
         });
     });
 
@@ -429,9 +476,7 @@ describe('ResourcesPage – extended', () => {
     describe('DOI registration button', () => {
         it('shows DataCite button when resource has a landing page', () => {
             renderPage({
-                resources: [
-                    makeResource({ landingPage: { id: 1, is_published: false, public_url: 'https://example.com' } }),
-                ],
+                resources: [makeResource({ landingPage: { id: 1, is_published: false, public_url: 'https://example.com' } })],
             });
             expect(screen.getByTestId('datacite-button')).toBeInTheDocument();
         });

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -7,16 +7,11 @@ import ResourcesPage from '@/pages/resources';
 
 const routerMock = vi.hoisted(() => ({ get: vi.fn(), delete: vi.fn() }));
 const buildCurationQueryFromResourceMock = vi.hoisted(() => vi.fn());
-const editorRouteMock = vi.hoisted(
-    () =>
-        vi.fn(
-            ({ query }: { query?: Record<string, string> } = {}) => ({
-                url: query
-                    ? `/editor?${new URLSearchParams(query).toString()}`
-                    : '/editor',
-                method: 'get',
-            }),
-        ),
+const editorRouteMock = vi.hoisted(() =>
+    vi.fn(({ query }: { query?: Record<string, string> } = {}) => ({
+        url: query ? `/editor?${new URLSearchParams(query).toString()}` : '/editor',
+        method: 'get',
+    })),
 );
 
 vi.mock('@inertiajs/react', () => ({
@@ -105,18 +100,19 @@ describe('ResourcesPage', () => {
 
         const table = screen.getByRole('table');
         expect(table).toBeInTheDocument();
-        expect(within(table).getByText('Primary title')).toBeInTheDocument();
-        expect(within(table).getByRole('columnheader', { name: /id.*doi/i })).toBeInTheDocument();
-        
+        expect(within(table).getByRole('group', { name: /sort options for id and resource type/i })).toBeInTheDocument();
+        expect(within(table).getByRole('group', { name: /sort options for doi and title/i })).toBeInTheDocument();
+
         const dataRows = within(table).getAllByRole('row').slice(1);
-        expect(within(dataRows[0]).getByText('#1')).toBeInTheDocument();
-        // DOI is now shown as text, not as a link
-        expect(within(dataRows[0]).getByText('10.9999/example')).toBeInTheDocument();
-        
+        const cells = within(dataRows[0]).getAllByRole('cell');
+        const idResourceTypeCell = cells[2];
+        const doiTitleCell = cells[3];
+
+        expect(Array.from(idResourceTypeCell.querySelectorAll('span')).map((span) => span.textContent)).toEqual(['#1', 'Dataset']);
+        expect(Array.from(doiTitleCell.querySelectorAll('span')).map((span) => span.textContent)).toEqual(['10.9999/example', 'Primary title']);
+
         expect(screen.getByRole('columnheader', { name: /actions/i })).toBeInTheDocument();
-        expect(
-            screen.getByRole('button', { name: /open resource.*10\.9999\/example.*in.*editor/i }),
-        ).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /open resource.*10\.9999\/example.*in.*editor/i })).toBeInTheDocument();
         const deleteButton = screen.getByRole('button', { name: /delete resource.*10\.9999\/example/i });
         expect(deleteButton).toBeDisabled();
         expect(deleteButton).toHaveAttribute('title', 'Only draft resources can be deleted');
@@ -126,14 +122,14 @@ describe('ResourcesPage', () => {
         render(
             <ResourcesPage
                 resources={[]}
-                pagination={{ 
-                    current_page: 1, 
-                    last_page: 1, 
-                    per_page: 50, 
-                    total: 0, 
-                    from: 0, 
-                    to: 0, 
-                    has_more: false 
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 0,
+                    from: 0,
+                    to: 0,
+                    has_more: false,
                 }}
                 sort={{ key: 'id', direction: 'asc' }}
             />,


### PR DESCRIPTION
This pull request refactors the resources table in `resources.tsx` to improve clarity and usability by reorganizing columns and updating labels, as well as making style and code consistency improvements. The changes primarily affect how resource information is displayed, especially the separation of ID/Resource Type and DOI/Title into distinct columns. Minor formatting and code simplification adjustments are also included.

**Table structure and display improvements:**

- Split the previous "ID/DOI" and "Title/Resource Type" columns into two clearer columns: one for "ID/Resource Type" and another for "DOI/Title", with updated header labels and width classes for better readability and responsiveness. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L87-R102) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1063-R1074) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1074-L1132)
- Updated the rendering logic for these columns to display resource type and DOI more prominently and with improved accessibility labels.

**UI/UX and accessibility enhancements:**

- Adjusted skeleton loading placeholders to match the new column structure for a more accurate loading state.
- Improved aria-labels and class names for better accessibility and consistent styling. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1074-L1132) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1326-R1338)

**Code style and consistency:**

- Refactored conditional logic and callback formatting for better readability and maintainability throughout the file, including in permission checks and event handlers. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L295-R299) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L595-R597) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L773-R779) [[4]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L812-R826) [[5]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L850-R859) [[6]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1522-R1533) [[7]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1568-R1583) [[8]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1583-R1598) [[9]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1636-R1660) [[10]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1718-R1738)
- Consolidated and cleaned up import statements for improved code organization. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R1) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L12-R13)

**Test update:**

- Updated a test for `deriveResourceRowKey` to use a more concise format, reflecting the new expectations for resource row keys.