### PR TITLE
Feature: Resizable Columns in Resources List

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,13 +1248,13 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -10620,9 +10620,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.49",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
+      "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12304,9 +12304,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
-      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13406,18 +13406,58 @@
       "license": "MIT"
     },
     "node_modules/unplugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.2.0.tgz",
+      "integrity": "sha512-6nGlT7EHsS+tTcTdAkYFqXIUwDrMJyJvHFNYGSr4x2/2ySIcV4f5e1RAJUeDyfOJPR8TF0auE8l+82PLhKjqsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/unraw": {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -118,6 +118,10 @@
         ],
         "improvements": [
             {
+                "title": "Resizable Resources Table Columns",
+                "description": "The Resources table now lets curators manually adjust every visible metadata column except the selection checkbox. Column widths are saved in the browser, can be reset to defaults, and long values stay on one line with ellipsis plus hover tooltips for the full text. Resize handles support mouse dragging and keyboard controls on tablet and desktop screens."
+            },
+            {
                 "title": "Related Items Naming in the Editor",
                 "description": "The Data Editor now labels the former Citations form group as 'Related Items' to match the DataCite relatedItem element. The manager action, help tooltip, modal title, and user documentation now use Related Item Manager wording, while citation labels and formatted citation previews keep their standards-specific terminology."
             },

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1845,6 +1845,19 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                         </p>
                         <p className="text-sm text-muted-foreground">Limit: up to 25 resources per batch.</p>
 
+                        <h4>Resizable Columns</h4>
+                        <p>
+                            On tablet and desktop screens, drag the resize handle at the right edge of a column header to adjust the Resources
+                            table to your available screen width. Focus a handle with the keyboard and use Arrow Left or Arrow Right for fine
+                            adjustments, Shift plus Arrow Left or Arrow Right for larger steps, Home for the minimum width, and End for the
+                            maximum width. ERNIE saves your column widths in this browser, and the reset button above the table restores the
+                            defaults.
+                        </p>
+                        <p>
+                            Long values are shortened with an ellipsis when a column becomes narrow. Hover over a shortened value to see the
+                            complete text in a tooltip.
+                        </p>
+
                         <h4>Responsive Layout</h4>
                         <p>
                             On smaller screens, less critical sub-rows (Resource Type, Curator) and the

--- a/resources/js/pages/resources-column-widths.ts
+++ b/resources/js/pages/resources-column-widths.ts
@@ -1,0 +1,127 @@
+export type ResourceColumnKey = 'id_resourcetype' | 'doi_title' | 'author_year' | 'curator_status' | 'created_updated';
+
+interface ResourceColumnWidthDefinition {
+    defaultWidth: number;
+    minWidth: number;
+    maxWidth: number;
+}
+
+export type ResourceColumnWidths = Record<ResourceColumnKey, number>;
+
+export const RESIZABLE_TABLE_MIN_VIEWPORT_WIDTH = 768;
+export const COLUMN_RESIZE_STEP = 16;
+export const COLUMN_RESIZE_LARGE_STEP = 48;
+export const COLUMN_WIDTH_STORAGE_KEY = 'resources.column-widths';
+export const RESOURCE_COLUMN_WIDTH_DEFINITIONS: Record<ResourceColumnKey, ResourceColumnWidthDefinition> = {
+    id_resourcetype: { defaultWidth: 160, minWidth: 120, maxWidth: 280 },
+    doi_title: { defaultWidth: 384, minWidth: 220, maxWidth: 720 },
+    author_year: { defaultWidth: 208, minWidth: 140, maxWidth: 360 },
+    curator_status: { defaultWidth: 176, minWidth: 140, maxWidth: 320 },
+    created_updated: { defaultWidth: 160, minWidth: 128, maxWidth: 260 },
+};
+export const RESOURCE_COLUMN_RESIZE_LABELS: Record<ResourceColumnKey, string> = {
+    id_resourcetype: 'ID and Resource Type',
+    doi_title: 'DOI and Title',
+    author_year: 'Author and Year',
+    curator_status: 'Curator and Status',
+    created_updated: 'Created and Updated dates',
+};
+export const RESOURCE_COLUMN_KEYS = Object.keys(RESOURCE_COLUMN_WIDTH_DEFINITIONS) as ResourceColumnKey[];
+
+const buildDefaultColumnWidths = (): ResourceColumnWidths =>
+    RESOURCE_COLUMN_KEYS.reduce((widths, columnKey) => {
+        widths[columnKey] = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey].defaultWidth;
+        return widths;
+    }, {} as ResourceColumnWidths);
+
+export const DEFAULT_RESOURCE_COLUMN_WIDTHS = buildDefaultColumnWidths();
+
+export const clampColumnWidth = (columnKey: ResourceColumnKey, width: number): number => {
+    const definition = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey];
+
+    if (!Number.isFinite(width)) {
+        return definition.defaultWidth;
+    }
+
+    return Math.min(definition.maxWidth, Math.max(definition.minWidth, Math.round(width)));
+};
+
+export const normalizeResourceColumnWidths = (value: unknown): ResourceColumnWidths => {
+    const widths = buildDefaultColumnWidths();
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return widths;
+    }
+
+    const storedWidths = value as Partial<Record<ResourceColumnKey, unknown>>;
+
+    RESOURCE_COLUMN_KEYS.forEach((columnKey) => {
+        const storedWidth = storedWidths[columnKey];
+        if (typeof storedWidth === 'number') {
+            widths[columnKey] = clampColumnWidth(columnKey, storedWidth);
+        }
+    });
+
+    return widths;
+};
+
+export const parseStoredResourceColumnWidths = (storedValue: string | null): ResourceColumnWidths | null => {
+    if (!storedValue) {
+        return null;
+    }
+
+    try {
+        return normalizeResourceColumnWidths(JSON.parse(storedValue));
+    } catch {
+        return null;
+    }
+};
+
+export const readStoredResourceColumnWidths = (): ResourceColumnWidths => {
+    if (typeof window === 'undefined') {
+        return buildDefaultColumnWidths();
+    }
+
+    try {
+        return parseStoredResourceColumnWidths(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)) ?? buildDefaultColumnWidths();
+    } catch {
+        return buildDefaultColumnWidths();
+    }
+};
+
+export const persistResourceColumnWidths = (widths: ResourceColumnWidths): void => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify(normalizeResourceColumnWidths(widths)));
+    } catch {
+        // Ignore storage failures; resizing should remain usable for the session.
+    }
+};
+
+export const clearStoredResourceColumnWidths = (): void => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.removeItem(COLUMN_WIDTH_STORAGE_KEY);
+    } catch {
+        // Ignore storage failures; the in-memory reset still applies.
+    }
+};
+
+export const areResourceColumnWidthsDefault = (widths: ResourceColumnWidths): boolean =>
+    RESOURCE_COLUMN_KEYS.every((columnKey) => widths[columnKey] === DEFAULT_RESOURCE_COLUMN_WIDTHS[columnKey]);
+
+export const isResizableViewport = (): boolean => (typeof window === 'undefined' ? true : window.innerWidth >= RESIZABLE_TABLE_MIN_VIEWPORT_WIDTH);
+
+export const shouldIncludeColumnInLayout = (column: { key: ResourceColumnKey }, tableCanResize: boolean): boolean => {
+    if (column.key === 'created_updated' && !tableCanResize) {
+        return false;
+    }
+
+    return true;
+};

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -433,11 +433,15 @@ function OverflowTooltipText({ value, className, tooltipClassName, testId }: Ove
     );
 }
 
+interface ColumnResizeOptions {
+    persist?: boolean;
+}
+
 interface ColumnResizeHandleProps {
     columnKey: ResourceColumnKey;
     width: number;
     disabled: boolean;
-    onResize: (columnKey: ResourceColumnKey, width: number) => void;
+    onResize: (columnKey: ResourceColumnKey, width: number, options?: ColumnResizeOptions) => void;
 }
 
 function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResizeHandleProps) {
@@ -445,8 +449,10 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
     const label = RESOURCE_COLUMN_RESIZE_LABELS[columnKey];
 
     const resizeTo = useCallback(
-        (nextWidth: number) => {
-            onResize(columnKey, clampColumnWidth(columnKey, nextWidth));
+        (nextWidth: number, options?: ColumnResizeOptions) => {
+            const clampedWidth = clampColumnWidth(columnKey, nextWidth);
+            onResize(columnKey, clampedWidth, options);
+            return clampedWidth;
         },
         [columnKey, onResize],
     );
@@ -462,20 +468,26 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
 
             const startX = event.clientX;
             const startWidth = width;
+            let latestWidth = startWidth;
 
             const handlePointerMove = (moveEvent: PointerEvent) => {
                 moveEvent.preventDefault();
-                resizeTo(startWidth + moveEvent.clientX - startX);
+                latestWidth = resizeTo(startWidth + moveEvent.clientX - startX);
             };
 
-            const stopResize = () => {
+            function stopResize() {
                 window.removeEventListener('pointermove', handlePointerMove);
-                window.removeEventListener('pointerup', stopResize);
+                window.removeEventListener('pointerup', commitResize);
                 window.removeEventListener('pointercancel', stopResize);
-            };
+            }
+
+            function commitResize() {
+                resizeTo(latestWidth, { persist: true });
+                stopResize();
+            }
 
             window.addEventListener('pointermove', handlePointerMove);
-            window.addEventListener('pointerup', stopResize, { once: true });
+            window.addEventListener('pointerup', commitResize, { once: true });
             window.addEventListener('pointercancel', stopResize, { once: true });
         },
         [disabled, resizeTo, width],
@@ -502,7 +514,7 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
 
             event.preventDefault();
             event.stopPropagation();
-            resizeTo(nextWidth);
+            resizeTo(nextWidth, { persist: true });
         },
         [definition.maxWidth, definition.minWidth, resizeTo, width],
     );
@@ -1505,15 +1517,15 @@ function ResourcesPage({
         [handleEditSelectedResources, handleExportSelectedResources, handleRegisterDoi, handleSetupLandingPage, singleSelectedResource],
     );
 
-    const handleColumnResize = useCallback((columnKey: ResourceColumnKey, width: number) => {
+    const handleColumnResize = useCallback((columnKey: ResourceColumnKey, width: number, options: ColumnResizeOptions = {}) => {
         setColumnWidths((currentWidths) => {
             const nextWidth = clampColumnWidth(columnKey, width);
-            if (currentWidths[columnKey] === nextWidth) {
-                return currentWidths;
+            const nextWidths = currentWidths[columnKey] === nextWidth ? currentWidths : { ...currentWidths, [columnKey]: nextWidth };
+
+            if (options.persist) {
+                persistResourceColumnWidths(nextWidths);
             }
 
-            const nextWidths = { ...currentWidths, [columnKey]: nextWidth };
-            persistResourceColumnWidths(nextWidths);
             return nextWidths;
         });
     }, []);

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -334,6 +334,14 @@ interface ColumnResizeHandleProps {
 function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResizeHandleProps) {
     const definition = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey];
     const label = RESOURCE_COLUMN_RESIZE_LABELS[columnKey];
+    const resizeAbortControllerRef = useRef<AbortController | null>(null);
+
+    useEffect(() => {
+        return () => {
+            resizeAbortControllerRef.current?.abort();
+            resizeAbortControllerRef.current = null;
+        };
+    }, []);
 
     const resizeTo = useCallback(
         (nextWidth: number, options?: ColumnResizeOptions) => {
@@ -353,6 +361,10 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
             event.preventDefault();
             event.stopPropagation();
 
+            resizeAbortControllerRef.current?.abort();
+
+            const abortController = new AbortController();
+            resizeAbortControllerRef.current = abortController;
             const startX = event.clientX;
             const startWidth = width;
             const activePointerId = event.pointerId;
@@ -368,9 +380,11 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
             };
 
             function stopResize() {
-                window.removeEventListener('pointermove', handlePointerMove);
-                window.removeEventListener('pointerup', commitResize);
-                window.removeEventListener('pointercancel', cancelResize);
+                abortController.abort();
+
+                if (resizeAbortControllerRef.current === abortController) {
+                    resizeAbortControllerRef.current = null;
+                }
             }
 
             function commitResize(upEvent: PointerEvent) {
@@ -390,9 +404,9 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
                 stopResize();
             }
 
-            window.addEventListener('pointermove', handlePointerMove);
-            window.addEventListener('pointerup', commitResize);
-            window.addEventListener('pointercancel', cancelResize);
+            window.addEventListener('pointermove', handlePointerMove, { signal: abortController.signal });
+            window.addEventListener('pointerup', commitResize, { signal: abortController.signal });
+            window.addEventListener('pointercancel', cancelResize, { signal: abortController.signal });
         },
         [disabled, resizeTo, width],
     );

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -683,8 +683,8 @@ function ResourcesPage({
         return parseResourceFiltersFromUrl(window.location.search);
     });
     const [filterOptions, setFilterOptions] = useState<ResourceFilterOptions | null>(null);
-    const [columnWidths, setColumnWidths] = useState<ResourceColumnWidths>(() => readStoredResourceColumnWidths());
-    const [tableCanResize, setTableCanResize] = useState<boolean>(() => isResizableViewport());
+    const [columnWidths, setColumnWidths] = useState<ResourceColumnWidths>(DEFAULT_RESOURCE_COLUMN_WIDTHS);
+    const [tableCanResize, setTableCanResize] = useState<boolean>(true);
 
     const lastResourceElementRef = useRef<HTMLTableRowElement | null>(null);
     const observerRef = useRef<IntersectionObserver | null>(null);
@@ -696,6 +696,10 @@ function ResourcesPage({
     useEffect(() => {
         setPagination(initialPagination);
     }, [initialPagination]);
+
+    useEffect(() => {
+        setColumnWidths(readStoredResourceColumnWidths());
+    }, []);
 
     useEffect(() => {
         const handleViewportResize = () => {

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -390,7 +390,8 @@ function OverflowTooltipText({ value, className, tooltipClassName, testId }: Ove
 
     const measureOverflow = useCallback(() => {
         const element = textRef.current;
-        setIsOverflowing(Boolean(element && element.scrollWidth > element.clientWidth));
+        const nextIsOverflowing = Boolean(element && element.scrollWidth > element.clientWidth);
+        setIsOverflowing((currentIsOverflowing) => (currentIsOverflowing === nextIsOverflowing ? currentIsOverflowing : nextIsOverflowing));
     }, []);
 
     useEffect(() => {

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1955,7 +1955,7 @@ function ResourcesPage({
                                                         <TableHead
                                                             key={column.key}
                                                             className={cn(
-                                                                'relative overflow-hidden pr-6 text-xs tracking-wider text-gray-500 uppercase dark:text-gray-300',
+                                                                'relative pr-6 text-xs tracking-wider text-gray-500 uppercase dark:text-gray-300',
                                                                 column.visibilityClassName,
                                                             )}
                                                             aria-sort={column.sortOptions ? ariaSortValue : undefined}

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -2149,10 +2149,14 @@ export default ResourcesPage;
 
 export {
     clampColumnWidth,
+    clearStoredResourceColumnWidths,
     COLUMN_WIDTH_STORAGE_KEY,
     DEFAULT_RESOURCE_COLUMN_WIDTHS,
     deriveResourceRowKey,
+    isResizableViewport,
     normalizeResourceColumnWidths,
     OverflowTooltipText,
     parseStoredResourceColumnWidths,
+    persistResourceColumnWidths,
+    readStoredResourceColumnWidths,
 };

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -424,7 +424,7 @@ function OverflowTooltipText({ value, className, tooltipClassName, testId }: Ove
     }
 
     return (
-        <TooltipProvider>
+        <TooltipProvider delayDuration={0}>
             <Tooltip>
                 <TooltipTrigger asChild>{text}</TooltipTrigger>
                 <TooltipContent className={cn('max-w-sm text-left break-words normal-case', tooltipClassName)}>{value}</TooltipContent>
@@ -468,9 +468,14 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
 
             const startX = event.clientX;
             const startWidth = width;
+            const activePointerId = event.pointerId;
             let latestWidth = startWidth;
 
             const handlePointerMove = (moveEvent: PointerEvent) => {
+                if (moveEvent.pointerId !== activePointerId) {
+                    return;
+                }
+
                 moveEvent.preventDefault();
                 latestWidth = resizeTo(startWidth + moveEvent.clientX - startX);
             };
@@ -478,17 +483,29 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
             function stopResize() {
                 window.removeEventListener('pointermove', handlePointerMove);
                 window.removeEventListener('pointerup', commitResize);
-                window.removeEventListener('pointercancel', stopResize);
+                window.removeEventListener('pointercancel', cancelResize);
             }
 
-            function commitResize() {
+            function commitResize(upEvent: PointerEvent) {
+                if (upEvent.pointerId !== activePointerId) {
+                    return;
+                }
+
                 resizeTo(latestWidth, { persist: true });
                 stopResize();
             }
 
+            function cancelResize(cancelEvent: PointerEvent) {
+                if (cancelEvent.pointerId !== activePointerId) {
+                    return;
+                }
+
+                stopResize();
+            }
+
             window.addEventListener('pointermove', handlePointerMove);
-            window.addEventListener('pointerup', commitResize, { once: true });
-            window.addEventListener('pointercancel', stopResize, { once: true });
+            window.addEventListener('pointerup', commitResize);
+            window.addEventListener('pointercancel', cancelResize);
         },
         [disabled, resizeTo, width],
     );

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1,9 +1,9 @@
 // organize-imports-ignore
 import { Head, router, usePage } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
-import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
-import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowDown, ArrowUp, ArrowUpDown, GripVertical, RotateCcw } from 'lucide-react';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { CitationManagerModal } from '@/components/citations/CitationManagerModal';
@@ -30,10 +30,12 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { type ValidationError, ValidationErrorModal } from '@/components/ui/validation-error-modal';
 import { useCitationVocabularies } from '@/hooks/use-citation-vocabularies';
 import AppLayout from '@/layouts/app-layout';
 import { extractErrorMessageFromBlob, parseValidationErrorFromBlob } from '@/lib/blob-utils';
+import { cn } from '@/lib/utils';
 import { editor as editorRoute } from '@/routes';
 import { type BreadcrumbItem, type User as AuthUser } from '@/types';
 import {
@@ -70,18 +72,48 @@ interface SortOption {
     description: string;
 }
 
+type ResourceColumnKey = 'id_resourcetype' | 'doi_title' | 'author_year' | 'curator_status' | 'created_updated';
+
 interface ResourceColumn {
-    key: string;
+    key: ResourceColumnKey;
     label: ReactNode;
-    widthClass: string;
+    visibilityClassName?: string;
+    colClassName?: string;
     cellClassName?: string;
     render?: (resource: Resource) => React.ReactNode;
     sortOptions?: SortOption[];
     sortGroupLabel?: string;
 }
 
-const DOI_TITLE_COLUMN_WIDTH_CLASSES = 'min-w-[18rem] md:min-w-[24rem]';
-const DATE_COLUMN_CONTAINER_CLASSES = 'flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300';
+interface ResourceColumnWidthDefinition {
+    defaultWidth: number;
+    minWidth: number;
+    maxWidth: number;
+}
+
+type ResourceColumnWidths = Record<ResourceColumnKey, number>;
+
+const SELECT_COLUMN_WIDTH = 48;
+const RESIZABLE_TABLE_MIN_VIEWPORT_WIDTH = 768;
+const COLUMN_RESIZE_STEP = 16;
+const COLUMN_RESIZE_LARGE_STEP = 48;
+const COLUMN_WIDTH_STORAGE_KEY = 'resources.column-widths';
+const RESOURCE_COLUMN_WIDTH_DEFINITIONS: Record<ResourceColumnKey, ResourceColumnWidthDefinition> = {
+    id_resourcetype: { defaultWidth: 160, minWidth: 120, maxWidth: 280 },
+    doi_title: { defaultWidth: 384, minWidth: 220, maxWidth: 720 },
+    author_year: { defaultWidth: 208, minWidth: 140, maxWidth: 360 },
+    curator_status: { defaultWidth: 176, minWidth: 140, maxWidth: 320 },
+    created_updated: { defaultWidth: 160, minWidth: 128, maxWidth: 260 },
+};
+const RESOURCE_COLUMN_RESIZE_LABELS: Record<ResourceColumnKey, string> = {
+    id_resourcetype: 'ID and Resource Type',
+    doi_title: 'DOI and Title',
+    author_year: 'Author and Year',
+    curator_status: 'Curator and Status',
+    created_updated: 'Created and Updated dates',
+};
+const RESOURCE_COLUMN_KEYS = Object.keys(RESOURCE_COLUMN_WIDTH_DEFINITIONS) as ResourceColumnKey[];
+const DATE_COLUMN_CONTAINER_CLASSES = 'flex min-w-0 flex-col gap-1 text-left text-gray-600 dark:text-gray-300';
 const DATE_COLUMN_HEADER_LABEL = (
     <span className="flex flex-col leading-tight normal-case">
         <span>Created</span>
@@ -113,6 +145,104 @@ const DEFAULT_DIRECTION_BY_KEY: Record<ResourceSortKey, ResourceSortDirection> =
     publicstatus: 'asc',
     created_at: 'desc',
     updated_at: 'desc',
+};
+
+const buildDefaultColumnWidths = (): ResourceColumnWidths =>
+    RESOURCE_COLUMN_KEYS.reduce((widths, columnKey) => {
+        widths[columnKey] = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey].defaultWidth;
+        return widths;
+    }, {} as ResourceColumnWidths);
+
+const DEFAULT_RESOURCE_COLUMN_WIDTHS = buildDefaultColumnWidths();
+
+const clampColumnWidth = (columnKey: ResourceColumnKey, width: number): number => {
+    const definition = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey];
+
+    if (!Number.isFinite(width)) {
+        return definition.defaultWidth;
+    }
+
+    return Math.min(definition.maxWidth, Math.max(definition.minWidth, Math.round(width)));
+};
+
+const normalizeResourceColumnWidths = (value: unknown): ResourceColumnWidths => {
+    const widths = buildDefaultColumnWidths();
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return widths;
+    }
+
+    const storedWidths = value as Partial<Record<ResourceColumnKey, unknown>>;
+
+    RESOURCE_COLUMN_KEYS.forEach((columnKey) => {
+        const storedWidth = storedWidths[columnKey];
+        if (typeof storedWidth === 'number') {
+            widths[columnKey] = clampColumnWidth(columnKey, storedWidth);
+        }
+    });
+
+    return widths;
+};
+
+const parseStoredResourceColumnWidths = (storedValue: string | null): ResourceColumnWidths | null => {
+    if (!storedValue) {
+        return null;
+    }
+
+    try {
+        return normalizeResourceColumnWidths(JSON.parse(storedValue));
+    } catch {
+        return null;
+    }
+};
+
+const readStoredResourceColumnWidths = (): ResourceColumnWidths => {
+    if (typeof window === 'undefined') {
+        return buildDefaultColumnWidths();
+    }
+
+    try {
+        return parseStoredResourceColumnWidths(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)) ?? buildDefaultColumnWidths();
+    } catch {
+        return buildDefaultColumnWidths();
+    }
+};
+
+const persistResourceColumnWidths = (widths: ResourceColumnWidths): void => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify(normalizeResourceColumnWidths(widths)));
+    } catch {
+        // Ignore storage failures; resizing should remain usable for the session.
+    }
+};
+
+const clearStoredResourceColumnWidths = (): void => {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    try {
+        window.localStorage.removeItem(COLUMN_WIDTH_STORAGE_KEY);
+    } catch {
+        // Ignore storage failures; the in-memory reset still applies.
+    }
+};
+
+const areResourceColumnWidthsDefault = (widths: ResourceColumnWidths): boolean =>
+    RESOURCE_COLUMN_KEYS.every((columnKey) => widths[columnKey] === DEFAULT_RESOURCE_COLUMN_WIDTHS[columnKey]);
+
+const isResizableViewport = (): boolean => (typeof window === 'undefined' ? true : window.innerWidth >= RESIZABLE_TABLE_MIN_VIEWPORT_WIDTH);
+
+const shouldIncludeColumnInLayout = (column: ResourceColumn, tableCanResize: boolean): boolean => {
+    if (column.key === 'created_updated' && !tableCanResize) {
+        return false;
+    }
+
+    return true;
 };
 
 const getDefaultBatchDeleteErrorMessage = (selectedCount: number): string =>
@@ -247,6 +377,160 @@ const SortDirectionIndicator = ({ isActive, direction }: { isActive: boolean; di
     return <ArrowDown aria-hidden="true" className="size-3.5" />;
 };
 
+interface OverflowTooltipTextProps {
+    value: string;
+    className?: string;
+    tooltipClassName?: string;
+    testId?: string;
+}
+
+function OverflowTooltipText({ value, className, tooltipClassName, testId }: OverflowTooltipTextProps) {
+    const textRef = useRef<HTMLSpanElement | null>(null);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+
+    const measureOverflow = useCallback(() => {
+        const element = textRef.current;
+        setIsOverflowing(Boolean(element && element.scrollWidth > element.clientWidth));
+    }, []);
+
+    useEffect(() => {
+        measureOverflow();
+
+        const element = textRef.current;
+        if (!element || typeof ResizeObserver === 'undefined') {
+            return undefined;
+        }
+
+        const resizeObserver = new ResizeObserver(measureOverflow);
+        resizeObserver.observe(element);
+
+        return () => resizeObserver.disconnect();
+    }, [measureOverflow, value]);
+
+    const text = (
+        <span
+            ref={textRef}
+            className={cn('block min-w-0 truncate', className)}
+            data-overflowing={isOverflowing ? 'true' : 'false'}
+            data-testid={testId}
+        >
+            {value}
+        </span>
+    );
+
+    if (!isOverflowing) {
+        return text;
+    }
+
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>{text}</TooltipTrigger>
+                <TooltipContent className={cn('max-w-sm text-left break-words normal-case', tooltipClassName)}>{value}</TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+}
+
+interface ColumnResizeHandleProps {
+    columnKey: ResourceColumnKey;
+    width: number;
+    disabled: boolean;
+    onResize: (columnKey: ResourceColumnKey, width: number) => void;
+}
+
+function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResizeHandleProps) {
+    const definition = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey];
+    const label = RESOURCE_COLUMN_RESIZE_LABELS[columnKey];
+
+    const resizeTo = useCallback(
+        (nextWidth: number) => {
+            onResize(columnKey, clampColumnWidth(columnKey, nextWidth));
+        },
+        [columnKey, onResize],
+    );
+
+    const handlePointerDown = useCallback(
+        (event: ReactPointerEvent<HTMLButtonElement>) => {
+            if (disabled || event.button !== 0) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            const startX = event.clientX;
+            const startWidth = width;
+
+            const handlePointerMove = (moveEvent: PointerEvent) => {
+                moveEvent.preventDefault();
+                resizeTo(startWidth + moveEvent.clientX - startX);
+            };
+
+            const stopResize = () => {
+                window.removeEventListener('pointermove', handlePointerMove);
+                window.removeEventListener('pointerup', stopResize);
+                window.removeEventListener('pointercancel', stopResize);
+            };
+
+            window.addEventListener('pointermove', handlePointerMove);
+            window.addEventListener('pointerup', stopResize, { once: true });
+            window.addEventListener('pointercancel', stopResize, { once: true });
+        },
+        [disabled, resizeTo, width],
+    );
+
+    const handleKeyDown = useCallback(
+        (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+            let nextWidth: number | null = null;
+            const step = event.shiftKey ? COLUMN_RESIZE_LARGE_STEP : COLUMN_RESIZE_STEP;
+
+            if (event.key === 'ArrowLeft') {
+                nextWidth = width - step;
+            } else if (event.key === 'ArrowRight') {
+                nextWidth = width + step;
+            } else if (event.key === 'Home') {
+                nextWidth = definition.minWidth;
+            } else if (event.key === 'End') {
+                nextWidth = definition.maxWidth;
+            }
+
+            if (nextWidth === null) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            resizeTo(nextWidth);
+        },
+        [definition.maxWidth, definition.minWidth, resizeTo, width],
+    );
+
+    return (
+        <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={`Resize ${label} column`}
+            aria-valuemin={definition.minWidth}
+            aria-valuemax={definition.maxWidth}
+            aria-valuenow={width}
+            className="absolute inset-y-0 right-0 z-10 hidden h-full w-5 translate-x-1/2 cursor-col-resize rounded-none border-l border-border/80 bg-background/80 p-0 text-muted-foreground opacity-80 transition hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-0 md:flex"
+            disabled={disabled}
+            tabIndex={disabled ? -1 : 0}
+            title={`Resize ${label} column`}
+            data-testid={`resources-column-resize-${columnKey}`}
+            onPointerDown={handlePointerDown}
+            onKeyDown={handleKeyDown}
+        >
+            <GripVertical aria-hidden="true" className="size-3" />
+            <span className="sr-only">Resize {label} column</span>
+        </Button>
+    );
+}
+
 type DateDetails = { label: string; iso: string | null };
 
 const deriveResourceRowKey = (resource: Resource): string => {
@@ -369,6 +653,8 @@ function ResourcesPage({
         return parseResourceFiltersFromUrl(window.location.search);
     });
     const [filterOptions, setFilterOptions] = useState<ResourceFilterOptions | null>(null);
+    const [columnWidths, setColumnWidths] = useState<ResourceColumnWidths>(() => readStoredResourceColumnWidths());
+    const [tableCanResize, setTableCanResize] = useState<boolean>(() => isResizableViewport());
 
     const lastResourceElementRef = useRef<HTMLTableRowElement | null>(null);
     const observerRef = useRef<IntersectionObserver | null>(null);
@@ -380,6 +666,17 @@ function ResourcesPage({
     useEffect(() => {
         setPagination(initialPagination);
     }, [initialPagination]);
+
+    useEffect(() => {
+        const handleViewportResize = () => {
+            setTableCanResize(isResizableViewport());
+        };
+
+        handleViewportResize();
+        window.addEventListener('resize', handleViewportResize);
+
+        return () => window.removeEventListener('resize', handleViewportResize);
+    }, []);
 
     // Load more resources for infinite scrolling
     const loadMore = useCallback(async () => {
@@ -1207,14 +1504,32 @@ function ResourcesPage({
         [handleEditSelectedResources, handleExportSelectedResources, handleRegisterDoi, handleSetupLandingPage, singleSelectedResource],
     );
 
+    const handleColumnResize = useCallback((columnKey: ResourceColumnKey, width: number) => {
+        setColumnWidths((currentWidths) => {
+            const nextWidth = clampColumnWidth(columnKey, width);
+            if (currentWidths[columnKey] === nextWidth) {
+                return currentWidths;
+            }
+
+            const nextWidths = { ...currentWidths, [columnKey]: nextWidth };
+            persistResourceColumnWidths(nextWidths);
+            return nextWidths;
+        });
+    }, []);
+
+    const handleResetColumnWidths = useCallback(() => {
+        const defaultWidths = buildDefaultColumnWidths();
+        clearStoredResourceColumnWidths();
+        setColumnWidths(defaultWidths);
+    }, []);
+
     const sortedResources = resources;
 
     const resourceColumns: ResourceColumn[] = [
         {
             key: 'id_resourcetype',
             label: ID_RESOURCE_TYPE_COLUMN_HEADER_LABEL,
-            widthClass: 'min-w-[9rem]',
-            cellClassName: 'whitespace-normal align-middle',
+            cellClassName: 'align-middle',
             sortOptions: [
                 {
                     key: 'id',
@@ -1234,13 +1549,13 @@ function ResourcesPage({
                 const resourceType = resource.resourcetypegeneral ?? '-';
 
                 return (
-                    <div className="flex flex-col gap-1 text-left" aria-label={`Resource ID: ${idValue}. Resource Type: ${resourceType}`}>
+                    <div className="flex min-w-0 flex-col gap-1 text-left" aria-label={`Resource ID: ${idValue}. Resource Type: ${resourceType}`}>
                         <span
                             className={hasId ? 'text-sm font-semibold text-gray-900 dark:text-gray-100' : 'text-sm text-gray-500 dark:text-gray-300'}
                         >
                             {idValue}
                         </span>
-                        <span className="text-sm text-gray-600 dark:text-gray-300">{resourceType}</span>
+                        <OverflowTooltipText value={resourceType} className="text-sm text-gray-600 dark:text-gray-300" />
                     </div>
                 );
             },
@@ -1248,8 +1563,7 @@ function ResourcesPage({
         {
             key: 'doi_title',
             label: DOI_TITLE_COLUMN_HEADER_LABEL,
-            widthClass: DOI_TITLE_COLUMN_WIDTH_CLASSES,
-            cellClassName: 'whitespace-normal align-middle',
+            cellClassName: 'align-middle',
             sortOptions: [
                 {
                     key: 'doi',
@@ -1269,13 +1583,13 @@ function ResourcesPage({
                 // Lighter gray for "Not registered" text to de-emphasize missing DOI
                 // Dark mode uses lighter shade (400) for better readability on dark backgrounds
                 const identifierClasses = resource.doi
-                    ? 'text-sm wrap-break-word text-gray-600 dark:text-gray-300'
+                    ? 'text-sm text-gray-600 dark:text-gray-300'
                     : 'text-sm text-gray-500 dark:text-gray-400 italic';
 
                 return (
-                    <div className="flex flex-col gap-1 text-left" aria-label={`DOI: ${identifierValue}. Title: ${title}`}>
-                        <span className={identifierClasses}>{identifierValue}</span>
-                        <span className="text-sm leading-relaxed font-normal wrap-break-word text-gray-900 dark:text-gray-100">{title}</span>
+                    <div className="flex min-w-0 flex-col gap-1 text-left" aria-label={`DOI: ${identifierValue}. Title: ${title}`}>
+                        <OverflowTooltipText value={identifierValue} className={identifierClasses} />
+                        <OverflowTooltipText value={title} className="text-sm leading-relaxed font-normal text-gray-900 dark:text-gray-100" />
                     </div>
                 );
             },
@@ -1288,8 +1602,7 @@ function ResourcesPage({
                     <span>Year</span>
                 </span>
             ),
-            widthClass: 'min-w-[12rem]',
-            cellClassName: 'whitespace-normal align-middle',
+            cellClassName: 'align-middle',
             sortOptions: [
                 {
                     key: 'first_author',
@@ -1320,8 +1633,8 @@ function ResourcesPage({
                 const year = resource.year?.toString() ?? '-';
 
                 return (
-                    <div className="flex flex-col gap-1 text-left text-gray-600 dark:text-gray-300">
-                        <span className="text-sm">{authorName}</span>
+                    <div className="flex min-w-0 flex-col gap-1 text-left text-gray-600 dark:text-gray-300">
+                        <OverflowTooltipText value={authorName} className="text-sm" />
                         <span className="text-sm">{year}</span>
                     </div>
                 );
@@ -1335,8 +1648,7 @@ function ResourcesPage({
                     <span>Status</span>
                 </span>
             ),
-            widthClass: 'min-w-[10rem]',
-            cellClassName: 'whitespace-normal align-middle',
+            cellClassName: 'align-middle',
             sortOptions: [
                 {
                     key: 'curator',
@@ -1383,10 +1695,10 @@ function ResourcesPage({
                     : statusLabel;
 
                 return (
-                    <div className="flex flex-col gap-1 text-center text-gray-600 dark:text-gray-300">
-                        <span className="hidden text-sm lg:inline">{curator}</span>
+                    <div className="flex min-w-0 flex-col gap-1 text-center text-gray-600 dark:text-gray-300">
+                        <OverflowTooltipText value={curator} className="hidden text-sm lg:block" />
                         <span
-                            className={statusClasses}
+                            className={cn(statusClasses, 'max-w-full')}
                             onClick={isClickable ? () => handleStatusBadgeClick(resource, status) : undefined}
                             role={isClickable ? 'button' : undefined}
                             tabIndex={isClickable ? 0 : undefined}
@@ -1403,7 +1715,7 @@ function ResourcesPage({
                             aria-label={ariaLabel}
                             title={ariaLabel}
                         >
-                            <span>{statusLabel}</span>
+                            <span className="truncate">{statusLabel}</span>
                         </span>
                     </div>
                 );
@@ -1412,8 +1724,9 @@ function ResourcesPage({
         {
             key: 'created_updated',
             label: DATE_COLUMN_HEADER_LABEL,
-            widthClass: 'hidden min-w-[9rem] md:table-cell',
-            cellClassName: 'hidden whitespace-normal align-middle md:table-cell',
+            visibilityClassName: 'hidden md:table-cell',
+            colClassName: 'hidden md:table-column',
+            cellClassName: 'hidden align-middle md:table-cell',
             sortOptions: [
                 {
                     key: 'created_at',
@@ -1448,6 +1761,14 @@ function ResourcesPage({
         },
     ];
 
+    const columnWidthsAreDefault = useMemo(() => areResourceColumnWidthsDefault(columnWidths), [columnWidths]);
+    const resourcesTableWidth =
+        SELECT_COLUMN_WIDTH +
+        resourceColumns.reduce(
+            (totalWidth, column) => totalWidth + (shouldIncludeColumnInLayout(column, tableCanResize) ? columnWidths[column.key] : 0),
+            0,
+        );
+
     const LoadingSkeleton = () => (
         <>
             {[...Array(5)].map((_, index) => (
@@ -1456,7 +1777,7 @@ function ResourcesPage({
                         <div className="size-4 rounded bg-gray-200 dark:bg-gray-700" />
                     </td>
                     {resourceColumns.map((column) => (
-                        <td key={column.key} className={`px-6 py-1.5 ${column.widthClass} ${column.cellClassName ?? ''}`}>
+                        <td key={column.key} className={cn('overflow-hidden px-6 py-1.5', column.visibilityClassName, column.cellClassName)}>
                             {column.key === 'id_resourcetype' ? (
                                 <div className="flex flex-col gap-2">
                                     <div className="h-4 w-10 rounded bg-gray-200 dark:bg-gray-700"></div>
@@ -1565,12 +1886,38 @@ function ResourcesPage({
                                     <Badge variant="outline" className="text-xs">
                                         Sorted by: {getSortLabel(sortState.key)} {sortState.direction === 'asc' ? 'ascending' : 'descending'}
                                     </Badge>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        className="h-7 gap-1.5 text-xs"
+                                        onClick={handleResetColumnWidths}
+                                        disabled={columnWidthsAreDefault}
+                                        title="Reset resource table column widths"
+                                        data-testid="resources-reset-column-widths"
+                                    >
+                                        <RotateCcw aria-hidden="true" className="size-3.5" />
+                                        Reset column widths
+                                    </Button>
                                 </div>
                                 <div className="overflow-x-auto">
-                                    <Table data-testid="resources-table">
+                                    <Table className="table-fixed" data-testid="resources-table" style={{ width: `${resourcesTableWidth}px` }}>
                                         <caption className="sr-only">
                                             List of resources with metadata including title, type, DOI, contributors, language, and version
                                         </caption>
+                                        <colgroup>
+                                            <col data-testid="resources-column-select" style={{ width: SELECT_COLUMN_WIDTH }} />
+                                            {resourceColumns.map((column) => (
+                                                <col
+                                                    key={column.key}
+                                                    className={column.colClassName}
+                                                    data-testid={`resources-column-${column.key}`}
+                                                    style={{
+                                                        width: shouldIncludeColumnInLayout(column, tableCanResize) ? columnWidths[column.key] : 0,
+                                                    }}
+                                                />
+                                            ))}
+                                        </colgroup>
                                         <TableHeader className="bg-gray-50 dark:bg-gray-800">
                                             <TableRow>
                                                 <TableHead className="w-12 min-w-12">
@@ -1594,13 +1941,16 @@ function ResourcesPage({
                                                     return (
                                                         <TableHead
                                                             key={column.key}
-                                                            className={`text-xs tracking-wider text-gray-500 uppercase dark:text-gray-300 ${column.widthClass}`}
+                                                            className={cn(
+                                                                'relative overflow-hidden pr-6 text-xs tracking-wider text-gray-500 uppercase dark:text-gray-300',
+                                                                column.visibilityClassName,
+                                                            )}
                                                             aria-sort={column.sortOptions ? ariaSortValue : undefined}
                                                             scope="col"
                                                         >
                                                             {column.sortOptions ? (
                                                                 <div
-                                                                    className="flex flex-col gap-1"
+                                                                    className="flex min-w-0 flex-col gap-1 pr-1"
                                                                     role="group"
                                                                     aria-label={column.sortGroupLabel ?? 'Sorting options'}
                                                                 >
@@ -1615,13 +1965,13 @@ function ResourcesPage({
                                                                                 type="button"
                                                                                 variant={isActive ? 'secondary' : 'ghost'}
                                                                                 size="sm"
-                                                                                className="h-7 justify-start px-2 text-xs font-medium"
+                                                                                className="h-7 min-w-0 justify-start px-2 text-xs font-medium"
                                                                                 onClick={() => handleSortChange(option.key)}
                                                                                 aria-pressed={isActive}
                                                                                 aria-label={buttonLabel}
                                                                                 title={buttonLabel}
                                                                             >
-                                                                                <span>{option.label}</span>
+                                                                                <span className="truncate">{option.label}</span>
                                                                                 <SortDirectionIndicator
                                                                                     isActive={isActive}
                                                                                     direction={displayDirection}
@@ -1631,10 +1981,16 @@ function ResourcesPage({
                                                                     })}
                                                                 </div>
                                                             ) : (
-                                                                <div className="text-left text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-300">
+                                                                <div className="min-w-0 text-left text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-300">
                                                                     {column.label}
                                                                 </div>
                                                             )}
+                                                            <ColumnResizeHandle
+                                                                columnKey={column.key}
+                                                                width={columnWidths[column.key]}
+                                                                disabled={!tableCanResize}
+                                                                onResize={handleColumnResize}
+                                                            />
                                                         </TableHead>
                                                     );
                                                 })}
@@ -1668,7 +2024,11 @@ function ResourcesPage({
                                                         {resourceColumns.map((column) => (
                                                             <TableCell
                                                                 key={column.key}
-                                                                className={`text-sm text-gray-500 dark:text-gray-300 ${column.widthClass} ${column.cellClassName ?? ''}`}
+                                                                className={cn(
+                                                                    'overflow-hidden text-sm text-gray-500 dark:text-gray-300',
+                                                                    column.visibilityClassName,
+                                                                    column.cellClassName,
+                                                                )}
                                                             >
                                                                 {column.render
                                                                     ? column.render(resource)
@@ -1786,4 +2146,12 @@ function ResourcesPage({
 
 export default ResourcesPage;
 
-export { deriveResourceRowKey };
+export {
+    clampColumnWidth,
+    COLUMN_WIDTH_STORAGE_KEY,
+    DEFAULT_RESOURCE_COLUMN_WIDTHS,
+    deriveResourceRowKey,
+    normalizeResourceColumnWidths,
+    OverflowTooltipText,
+    parseStoredResourceColumnWidths,
+};

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -30,12 +30,28 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { type ValidationError, ValidationErrorModal } from '@/components/ui/validation-error-modal';
 import { useCitationVocabularies } from '@/hooks/use-citation-vocabularies';
 import AppLayout from '@/layouts/app-layout';
 import { extractErrorMessageFromBlob, parseValidationErrorFromBlob } from '@/lib/blob-utils';
 import { cn } from '@/lib/utils';
+import {
+    areResourceColumnWidthsDefault,
+    clampColumnWidth,
+    clearStoredResourceColumnWidths,
+    COLUMN_RESIZE_LARGE_STEP,
+    COLUMN_RESIZE_STEP,
+    DEFAULT_RESOURCE_COLUMN_WIDTHS,
+    isResizableViewport,
+    persistResourceColumnWidths,
+    readStoredResourceColumnWidths,
+    RESOURCE_COLUMN_RESIZE_LABELS,
+    RESOURCE_COLUMN_WIDTH_DEFINITIONS,
+    type ResourceColumnKey,
+    type ResourceColumnWidths,
+    shouldIncludeColumnInLayout,
+} from '@/pages/resources-column-widths';
 import { editor as editorRoute } from '@/routes';
 import { type BreadcrumbItem, type User as AuthUser } from '@/types';
 import {
@@ -72,8 +88,6 @@ interface SortOption {
     description: string;
 }
 
-type ResourceColumnKey = 'id_resourcetype' | 'doi_title' | 'author_year' | 'curator_status' | 'created_updated';
-
 interface ResourceColumn {
     key: ResourceColumnKey;
     label: ReactNode;
@@ -85,34 +99,7 @@ interface ResourceColumn {
     sortGroupLabel?: string;
 }
 
-interface ResourceColumnWidthDefinition {
-    defaultWidth: number;
-    minWidth: number;
-    maxWidth: number;
-}
-
-type ResourceColumnWidths = Record<ResourceColumnKey, number>;
-
 const SELECT_COLUMN_WIDTH = 48;
-const RESIZABLE_TABLE_MIN_VIEWPORT_WIDTH = 768;
-const COLUMN_RESIZE_STEP = 16;
-const COLUMN_RESIZE_LARGE_STEP = 48;
-const COLUMN_WIDTH_STORAGE_KEY = 'resources.column-widths';
-const RESOURCE_COLUMN_WIDTH_DEFINITIONS: Record<ResourceColumnKey, ResourceColumnWidthDefinition> = {
-    id_resourcetype: { defaultWidth: 160, minWidth: 120, maxWidth: 280 },
-    doi_title: { defaultWidth: 384, minWidth: 220, maxWidth: 720 },
-    author_year: { defaultWidth: 208, minWidth: 140, maxWidth: 360 },
-    curator_status: { defaultWidth: 176, minWidth: 140, maxWidth: 320 },
-    created_updated: { defaultWidth: 160, minWidth: 128, maxWidth: 260 },
-};
-const RESOURCE_COLUMN_RESIZE_LABELS: Record<ResourceColumnKey, string> = {
-    id_resourcetype: 'ID and Resource Type',
-    doi_title: 'DOI and Title',
-    author_year: 'Author and Year',
-    curator_status: 'Curator and Status',
-    created_updated: 'Created and Updated dates',
-};
-const RESOURCE_COLUMN_KEYS = Object.keys(RESOURCE_COLUMN_WIDTH_DEFINITIONS) as ResourceColumnKey[];
 const DATE_COLUMN_CONTAINER_CLASSES = 'flex min-w-0 flex-col gap-1 text-left text-gray-600 dark:text-gray-300';
 const DATE_COLUMN_HEADER_LABEL = (
     <span className="flex flex-col leading-tight normal-case">
@@ -145,104 +132,6 @@ const DEFAULT_DIRECTION_BY_KEY: Record<ResourceSortKey, ResourceSortDirection> =
     publicstatus: 'asc',
     created_at: 'desc',
     updated_at: 'desc',
-};
-
-const buildDefaultColumnWidths = (): ResourceColumnWidths =>
-    RESOURCE_COLUMN_KEYS.reduce((widths, columnKey) => {
-        widths[columnKey] = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey].defaultWidth;
-        return widths;
-    }, {} as ResourceColumnWidths);
-
-const DEFAULT_RESOURCE_COLUMN_WIDTHS = buildDefaultColumnWidths();
-
-const clampColumnWidth = (columnKey: ResourceColumnKey, width: number): number => {
-    const definition = RESOURCE_COLUMN_WIDTH_DEFINITIONS[columnKey];
-
-    if (!Number.isFinite(width)) {
-        return definition.defaultWidth;
-    }
-
-    return Math.min(definition.maxWidth, Math.max(definition.minWidth, Math.round(width)));
-};
-
-const normalizeResourceColumnWidths = (value: unknown): ResourceColumnWidths => {
-    const widths = buildDefaultColumnWidths();
-
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-        return widths;
-    }
-
-    const storedWidths = value as Partial<Record<ResourceColumnKey, unknown>>;
-
-    RESOURCE_COLUMN_KEYS.forEach((columnKey) => {
-        const storedWidth = storedWidths[columnKey];
-        if (typeof storedWidth === 'number') {
-            widths[columnKey] = clampColumnWidth(columnKey, storedWidth);
-        }
-    });
-
-    return widths;
-};
-
-const parseStoredResourceColumnWidths = (storedValue: string | null): ResourceColumnWidths | null => {
-    if (!storedValue) {
-        return null;
-    }
-
-    try {
-        return normalizeResourceColumnWidths(JSON.parse(storedValue));
-    } catch {
-        return null;
-    }
-};
-
-const readStoredResourceColumnWidths = (): ResourceColumnWidths => {
-    if (typeof window === 'undefined') {
-        return buildDefaultColumnWidths();
-    }
-
-    try {
-        return parseStoredResourceColumnWidths(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)) ?? buildDefaultColumnWidths();
-    } catch {
-        return buildDefaultColumnWidths();
-    }
-};
-
-const persistResourceColumnWidths = (widths: ResourceColumnWidths): void => {
-    if (typeof window === 'undefined') {
-        return;
-    }
-
-    try {
-        window.localStorage.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify(normalizeResourceColumnWidths(widths)));
-    } catch {
-        // Ignore storage failures; resizing should remain usable for the session.
-    }
-};
-
-const clearStoredResourceColumnWidths = (): void => {
-    if (typeof window === 'undefined') {
-        return;
-    }
-
-    try {
-        window.localStorage.removeItem(COLUMN_WIDTH_STORAGE_KEY);
-    } catch {
-        // Ignore storage failures; the in-memory reset still applies.
-    }
-};
-
-const areResourceColumnWidthsDefault = (widths: ResourceColumnWidths): boolean =>
-    RESOURCE_COLUMN_KEYS.every((columnKey) => widths[columnKey] === DEFAULT_RESOURCE_COLUMN_WIDTHS[columnKey]);
-
-const isResizableViewport = (): boolean => (typeof window === 'undefined' ? true : window.innerWidth >= RESIZABLE_TABLE_MIN_VIEWPORT_WIDTH);
-
-const shouldIncludeColumnInLayout = (column: ResourceColumn, tableCanResize: boolean): boolean => {
-    if (column.key === 'created_updated' && !tableCanResize) {
-        return false;
-    }
-
-    return true;
 };
 
 const getDefaultBatchDeleteErrorMessage = (selectedCount: number): string =>
@@ -424,12 +313,10 @@ function OverflowTooltipText({ value, className, tooltipClassName, testId }: Ove
     }
 
     return (
-        <TooltipProvider delayDuration={0}>
-            <Tooltip>
-                <TooltipTrigger asChild>{text}</TooltipTrigger>
-                <TooltipContent className={cn('max-w-sm text-left break-words normal-case', tooltipClassName)}>{value}</TooltipContent>
-            </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+            <TooltipTrigger asChild>{text}</TooltipTrigger>
+            <TooltipContent className={cn('max-w-sm text-left break-words normal-case', tooltipClassName)}>{value}</TooltipContent>
+        </Tooltip>
     );
 }
 
@@ -547,7 +434,7 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
             aria-valuemin={definition.minWidth}
             aria-valuemax={definition.maxWidth}
             aria-valuenow={width}
-            className="absolute inset-y-0 right-0 z-10 hidden h-full w-5 translate-x-1/2 cursor-col-resize rounded-none border-l border-border/80 bg-background/80 p-0 text-muted-foreground opacity-80 transition hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-0 md:flex"
+            className="absolute inset-y-0 right-0 z-10 hidden h-full w-5 translate-x-1/2 cursor-col-resize touch-none rounded-none border-l border-border/80 bg-background/80 p-0 text-muted-foreground opacity-80 transition hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-0 md:flex"
             disabled={disabled}
             tabIndex={disabled ? -1 : 0}
             title={`Resize ${label} column`}
@@ -1552,7 +1439,7 @@ function ResourcesPage({
     }, []);
 
     const handleResetColumnWidths = useCallback(() => {
-        const defaultWidths = buildDefaultColumnWidths();
+        const defaultWidths = { ...DEFAULT_RESOURCE_COLUMN_WIDTHS };
         clearStoredResourceColumnWidths();
         setColumnWidths(defaultWidths);
     }, []);
@@ -2180,16 +2067,4 @@ function ResourcesPage({
 
 export default ResourcesPage;
 
-export {
-    clampColumnWidth,
-    clearStoredResourceColumnWidths,
-    COLUMN_WIDTH_STORAGE_KEY,
-    DEFAULT_RESOURCE_COLUMN_WIDTHS,
-    deriveResourceRowKey,
-    isResizableViewport,
-    normalizeResourceColumnWidths,
-    OverflowTooltipText,
-    parseStoredResourceColumnWidths,
-    persistResourceColumnWidths,
-    readStoredResourceColumnWidths,
-};
+export { deriveResourceRowKey, OverflowTooltipText };

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -343,6 +343,19 @@ describe('ResourcesPage column resizing', () => {
         expect(storedWidths.doi_title).toBe(720);
     });
 
+    it('cleans up pointer listeners when unmounted during a drag', () => {
+        const { unmount } = renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 1 });
+
+        unmount();
+        fireEvent.pointerMove(window, { clientX: 900, pointerId: 1 });
+        fireEvent.pointerUp(window, { pointerId: 1 });
+
+        expect(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)).toBeNull();
+    });
+
     it('ignores unsupported resize interactions and clamps keyboard home to the minimum width', () => {
         renderResourcesPage();
 

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -219,6 +219,16 @@ describe('ResourcesPage column resizing', () => {
         expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
     });
 
+    it('keeps resize handles unclipped by their header cells', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        const headerCell = handle.closest('th');
+
+        expect(handle).toHaveClass('translate-x-1/2');
+        expect(headerCell).not.toHaveClass('overflow-hidden');
+    });
+
     it('resizes a column with the keyboard and persists the new width', () => {
         renderResourcesPage();
 

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -300,6 +300,30 @@ describe('ResourcesPage column resizing', () => {
         expect(storedWidths.doi_title).toBe(720);
     });
 
+    it('ignores resize events from inactive pointers', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 1 });
+        fireEvent.pointerMove(window, { clientX: 900, pointerId: 2 });
+        fireEvent.pointerCancel(window, { pointerId: 2 });
+
+        expect(handle).toHaveAttribute('aria-valuenow', `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}`);
+        expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
+
+        fireEvent.pointerMove(window, { clientX: 900, pointerId: 1 });
+        fireEvent.pointerUp(window, { pointerId: 2 });
+
+        expect(handle).toHaveAttribute('aria-valuenow', '720');
+        expect(getDoiTitleColumn()).toHaveStyle({ width: '720px' });
+        expect(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)).toBeNull();
+
+        fireEvent.pointerUp(window, { pointerId: 1 });
+
+        const storedWidths = JSON.parse(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY) ?? '{}') as Record<string, number>;
+        expect(storedWidths.doi_title).toBe(720);
+    });
+
     it('ignores unsupported resize interactions and clamps keyboard home to the minimum width', () => {
         renderResourcesPage();
 
@@ -383,9 +407,7 @@ describe('ResourcesPage column resizing', () => {
     });
 
     it('opens and closes DataCite import modals from the import buttons', async () => {
-        render(
-            <ResourcesPage resources={[resource]} pagination={pagination} sort={{ key: 'id', direction: 'asc' }} canImportFromDataCite />,
-        );
+        render(<ResourcesPage resources={[resource]} pagination={pagination} sort={{ key: 'id', direction: 'asc' }} canImportFromDataCite />);
 
         await userEvent.click(screen.getByRole('button', { name: /import all old resources/i }));
         expect(screen.getByTestId('datacite-import-modal')).toBeInTheDocument();
@@ -554,7 +576,7 @@ describe('OverflowTooltipText', () => {
         await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'true'));
         await userEvent.hover(text);
 
-        expect(await screen.findByRole('tooltip')).toHaveTextContent('A long title that overflows');
+        expect(screen.getByRole('tooltip')).toHaveTextContent('A long title that overflows');
     });
 
     it('measures overflow when ResizeObserver is unavailable', async () => {

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderToString } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const routerMock = vi.hoisted(() => ({ delete: vi.fn(), get: vi.fn(), reload: vi.fn(), visit: vi.fn() }));
@@ -242,12 +243,29 @@ describe('ResourcesPage column resizing', () => {
         expect(storedWidths.doi_title).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title + 16);
     });
 
-    it('hydrates persisted column widths from localStorage', () => {
+    it('renders SSR-safe default widths before client-side hydration', () => {
+        vi.stubGlobal('window', undefined);
+
+        try {
+            const html = renderToString(<ResourcesPage resources={[resource]} pagination={pagination} sort={{ key: 'id', direction: 'asc' }} />);
+
+            expect(html).toContain(`data-testid="resources-column-doi_title" style="width:${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px"`);
+            expect(html).toContain(
+                `data-testid="resources-column-created_updated" style="width:${DEFAULT_RESOURCE_COLUMN_WIDTHS.created_updated}px"`,
+            );
+            expect(html).toContain('data-testid="resources-column-resize-doi_title"');
+            expect(html).not.toContain('data-testid="resources-column-resize-doi_title" disabled=""');
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('hydrates persisted column widths from localStorage after mount', async () => {
         window.localStorage.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify({ doi_title: 512, author_year: 999 }));
 
         renderResourcesPage();
 
-        expect(getDoiTitleColumn()).toHaveStyle({ width: '512px' });
+        await waitFor(() => expect(getDoiTitleColumn()).toHaveStyle({ width: '512px' }));
         expect(screen.getByTestId('resources-column-author_year')).toHaveStyle({ width: '360px' });
     });
 
@@ -386,13 +404,14 @@ describe('ResourcesPage column resizing', () => {
         }
     });
 
-    it('disables resizing and removes the date column from layout on narrow viewports', () => {
+    it('hydrates narrow viewport resizing state after mount', async () => {
         setViewportWidth(700);
 
         renderResourcesPage();
 
         const handle = screen.getByTestId('resources-column-resize-doi_title');
-        expect(handle).toBeDisabled();
+
+        await waitFor(() => expect(handle).toBeDisabled());
         expect(handle).toHaveAttribute('tabindex', '-1');
         expect(screen.getByTestId('resources-column-created_updated')).toHaveStyle({ width: '0px' });
         expect(screen.getByTestId('resources-table')).toHaveStyle({ width: '976px' });

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -190,8 +190,7 @@ describe('resource column width helpers', () => {
     });
 
     it('treats storage helpers as SSR-safe no-ops without window', () => {
-        const originalWindow = globalThis.window;
-        Object.defineProperty(globalThis, 'window', { configurable: true, writable: true, value: undefined });
+        vi.stubGlobal('window', undefined);
 
         try {
             expect(readStoredResourceColumnWidths()).toEqual(DEFAULT_RESOURCE_COLUMN_WIDTHS);
@@ -199,7 +198,7 @@ describe('resource column width helpers', () => {
             expect(() => persistResourceColumnWidths(DEFAULT_RESOURCE_COLUMN_WIDTHS)).not.toThrow();
             expect(() => clearStoredResourceColumnWidths()).not.toThrow();
         } finally {
-            Object.defineProperty(globalThis, 'window', { configurable: true, writable: true, value: originalWindow });
+            vi.unstubAllGlobals();
         }
     });
 });
@@ -274,16 +273,21 @@ describe('ResourcesPage column resizing', () => {
         }
     });
 
-    it('resizes a column with pointer drag and clamps at the maximum width', () => {
+    it('resizes a column with pointer drag and persists only after pointerup', () => {
         renderResourcesPage();
 
         const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
         fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 1 });
         fireEvent.pointerMove(window, { clientX: 900, pointerId: 1 });
-        fireEvent.pointerUp(window, { pointerId: 1 });
 
         expect(handle).toHaveAttribute('aria-valuenow', '720');
         expect(getDoiTitleColumn()).toHaveStyle({ width: '720px' });
+        expect(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)).toBeNull();
+
+        fireEvent.pointerUp(window, { pointerId: 1 });
+
+        const storedWidths = JSON.parse(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY) ?? '{}') as Record<string, number>;
+        expect(storedWidths.doi_title).toBe(720);
     });
 
     it('ignores unsupported resize interactions and clamps keyboard home to the minimum width', () => {
@@ -447,7 +451,6 @@ describe('ResourcesPage column resizing', () => {
     });
 
     it('renders loading skeleton rows while the next resource page is loading', async () => {
-        const originalIntersectionObserver = globalThis.IntersectionObserver;
         const observerInstances: Array<{ disconnect: ReturnType<typeof vi.fn> }> = [];
 
         class IntersectingObserver implements IntersectionObserver {
@@ -471,11 +474,7 @@ describe('ResourcesPage column resizing', () => {
             }
         }
 
-        Object.defineProperty(globalThis, 'IntersectionObserver', {
-            configurable: true,
-            writable: true,
-            value: IntersectingObserver,
-        });
+        vi.stubGlobal('IntersectionObserver', IntersectingObserver);
 
         axiosGetMock.mockImplementation((url: string) => {
             if (url === '/resources/load-more') {
@@ -498,15 +497,7 @@ describe('ResourcesPage column resizing', () => {
 
             expect(observerInstances).toHaveLength(1);
         } finally {
-            if (originalIntersectionObserver) {
-                Object.defineProperty(globalThis, 'IntersectionObserver', {
-                    configurable: true,
-                    writable: true,
-                    value: originalIntersectionObserver,
-                });
-            } else {
-                Reflect.deleteProperty(globalThis, 'IntersectionObserver');
-            }
+            vi.unstubAllGlobals();
         }
     });
 });
@@ -557,8 +548,7 @@ describe('OverflowTooltipText', () => {
     });
 
     it('measures overflow when ResizeObserver is unavailable', async () => {
-        const originalResizeObserver = globalThis.ResizeObserver;
-        Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, writable: true, value: undefined });
+        vi.stubGlobal('ResizeObserver', undefined);
         Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 80 });
         Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 240 });
 
@@ -568,15 +558,7 @@ describe('OverflowTooltipText', () => {
             const text = screen.getByTestId('overflow-text');
             await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'true'));
         } finally {
-            if (originalResizeObserver) {
-                Object.defineProperty(globalThis, 'ResizeObserver', {
-                    configurable: true,
-                    writable: true,
-                    value: originalResizeObserver,
-                });
-            } else {
-                Reflect.deleteProperty(globalThis, 'ResizeObserver');
-            }
+            vi.unstubAllGlobals();
         }
     });
 });

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -1,0 +1,239 @@
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const routerMock = vi.hoisted(() => ({ delete: vi.fn(), get: vi.fn(), reload: vi.fn(), visit: vi.fn() }));
+const axiosGetMock = vi.hoisted(() => vi.fn());
+const mockUser = vi.hoisted(() => ({
+    id: 1,
+    name: 'Test User',
+    email: 'test@example.test',
+    font_size_preference: 'regular',
+    email_verified_at: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    role: 'group_leader',
+    can_manage_landing_pages: true,
+    can_register_production_doi: true,
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    router: routerMock,
+    usePage: () => ({ props: { auth: { user: mockUser } } }),
+}));
+
+vi.mock('axios', () => ({
+    default: { get: axiosGetMock },
+    get: axiosGetMock,
+    isAxiosError: (err: unknown) => Boolean(err && typeof err === 'object' && 'isAxiosError' in err),
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        error: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+    },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div data-testid="app-layout">{children}</div>,
+}));
+
+vi.mock('@/components/resources-filters', () => ({
+    ResourcesFilters: () => <div data-testid="resources-filters" />,
+}));
+
+vi.mock('@/components/landing-pages/modals/SetupLandingPageModal', () => ({ default: () => null }));
+vi.mock('@/components/resources/modals/ImportFromDataCiteModal', () => ({ default: () => null }));
+vi.mock('@/components/resources/modals/ImportSingleOldResourceModal', () => ({ default: () => null }));
+vi.mock('@/components/resources/modals/RegisterDoiModal', () => ({ default: () => null }));
+vi.mock('@/components/citations/CitationManagerModal', () => ({ CitationManagerModal: () => null }));
+vi.mock('@/components/ui/validation-error-modal', () => ({ ValidationErrorModal: () => null }));
+vi.mock('@/hooks/use-citation-vocabularies', () => ({
+    useCitationVocabularies: () => ({
+        vocabularies: { contributorTypes: [], relationTypes: [], resourceTypes: [] },
+        isLoading: false,
+    }),
+}));
+vi.mock('@/routes', () => ({
+    editor: vi.fn(() => ({ method: 'get', url: '/editor' })),
+}));
+vi.mock('@/utils/filter-parser', () => ({
+    parseResourceFiltersFromUrl: vi.fn().mockReturnValue({}),
+}));
+
+import ResourcesPage, {
+    clampColumnWidth,
+    COLUMN_WIDTH_STORAGE_KEY,
+    DEFAULT_RESOURCE_COLUMN_WIDTHS,
+    normalizeResourceColumnWidths,
+    OverflowTooltipText,
+    parseStoredResourceColumnWidths,
+} from '@/pages/resources';
+
+const resource = {
+    id: 1,
+    doi: '10.5880/test.2026.001',
+    year: 2026,
+    created_at: '2026-01-01T10:00:00Z',
+    updated_at: '2026-02-01T10:00:00Z',
+    curator: 'Column Curator',
+    publicstatus: 'published',
+    resourcetypegeneral: 'Dataset',
+    title: 'A very long resource title that should be truncated when the DOI title column is narrowed',
+    first_author: { familyName: 'Longlastname', givenName: 'Longfirstname' },
+    landingPage: { id: 1, is_published: true, public_url: 'https://example.test/resource' },
+};
+
+const pagination = {
+    current_page: 1,
+    last_page: 1,
+    per_page: 50,
+    total: 1,
+    from: 1,
+    to: 1,
+    has_more: false,
+};
+
+function renderResourcesPage() {
+    return render(<ResourcesPage resources={[resource]} pagination={pagination} sort={{ key: 'id', direction: 'asc' }} />);
+}
+
+function getDoiTitleColumn() {
+    return screen.getByTestId('resources-column-doi_title');
+}
+
+describe('resource column width helpers', () => {
+    it('clamps widths to each column boundary', () => {
+        expect(clampColumnWidth('doi_title', 100)).toBe(220);
+        expect(clampColumnWidth('doi_title', 900)).toBe(720);
+        expect(clampColumnWidth('doi_title', 333.6)).toBe(334);
+        expect(clampColumnWidth('doi_title', Number.NaN)).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title);
+    });
+
+    it('normalizes stored width objects and ignores unknown values', () => {
+        const widths = normalizeResourceColumnWidths({
+            doi_title: 999,
+            author_year: 120,
+            curator_status: 'wide',
+            unknown_column: 100,
+        });
+
+        expect(widths.doi_title).toBe(720);
+        expect(widths.author_year).toBe(140);
+        expect(widths.curator_status).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.curator_status);
+        expect(widths.created_updated).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.created_updated);
+    });
+
+    it('parses valid storage and rejects malformed storage', () => {
+        expect(parseStoredResourceColumnWidths('{bad json')).toBeNull();
+        expect(parseStoredResourceColumnWidths(null)).toBeNull();
+        expect(parseStoredResourceColumnWidths(JSON.stringify({ doi_title: 300 }))?.doi_title).toBe(300);
+    });
+});
+
+describe('ResourcesPage column resizing', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        axiosGetMock.mockResolvedValue({ data: {} });
+        window.localStorage.clear();
+        Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 });
+    });
+
+    it('renders visible resize handles and default colgroup widths', () => {
+        renderResourcesPage();
+
+        expect(screen.getByRole('separator', { name: /resize doi and title column/i })).toBeInTheDocument();
+        expect(screen.getByRole('separator', { name: /resize author and year column/i })).toBeInTheDocument();
+        expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
+    });
+
+    it('resizes a column with the keyboard and persists the new width', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        fireEvent.keyDown(handle, { key: 'ArrowRight' });
+
+        expect(handle).toHaveAttribute('aria-valuenow', String(DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title + 16));
+        expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title + 16}px` });
+
+        const storedWidths = JSON.parse(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY) ?? '{}') as Record<string, number>;
+        expect(storedWidths.doi_title).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title + 16);
+    });
+
+    it('resizes a column with pointer drag and clamps at the maximum width', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 1 });
+        fireEvent.pointerMove(window, { clientX: 900, pointerId: 1 });
+        fireEvent.pointerUp(window, { pointerId: 1 });
+
+        expect(handle).toHaveAttribute('aria-valuenow', '720');
+        expect(getDoiTitleColumn()).toHaveStyle({ width: '720px' });
+    });
+
+    it('resets persisted column widths back to defaults', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        fireEvent.keyDown(handle, { key: 'End' });
+        expect(getDoiTitleColumn()).toHaveStyle({ width: '720px' });
+        expect(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)).not.toBeNull();
+
+        fireEvent.click(screen.getByTestId('resources-reset-column-widths'));
+
+        expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
+        expect(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)).toBeNull();
+    });
+});
+
+describe('OverflowTooltipText', () => {
+    let clientWidthDescriptor: PropertyDescriptor | undefined;
+    let scrollWidthDescriptor: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+        clientWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+        scrollWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+    });
+
+    afterEach(() => {
+        if (clientWidthDescriptor) {
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', clientWidthDescriptor);
+        }
+
+        if (scrollWidthDescriptor) {
+            Object.defineProperty(HTMLElement.prototype, 'scrollWidth', scrollWidthDescriptor);
+        }
+    });
+
+    it('does not create a tooltip for text that fits', async () => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 200 });
+        Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 120 });
+
+        render(<OverflowTooltipText value="Short title" testId="overflow-text" />);
+
+        const text = screen.getByTestId('overflow-text');
+        await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'false'));
+        await userEvent.hover(text);
+
+        expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('shows a tooltip with full text when content overflows', async () => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 80 });
+        Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 240 });
+
+        render(<OverflowTooltipText value="A long title that overflows" testId="overflow-text" />);
+
+        const text = screen.getByTestId('overflow-text');
+        await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'true'));
+        await userEvent.hover(text);
+
+        expect(await screen.findByRole('tooltip')).toHaveTextContent('A long title that overflows');
+    });
+});

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -48,10 +48,44 @@ vi.mock('@/components/resources-filters', () => ({
 }));
 
 vi.mock('@/components/landing-pages/modals/SetupLandingPageModal', () => ({ default: () => null }));
-vi.mock('@/components/resources/modals/ImportFromDataCiteModal', () => ({ default: () => null }));
-vi.mock('@/components/resources/modals/ImportSingleOldResourceModal', () => ({ default: () => null }));
+vi.mock('@/components/resources/modals/ImportFromDataCiteModal', () => ({
+    default: ({ isOpen, onClose, onSuccess }: { isOpen: boolean; onClose: () => void; onSuccess: () => void }) =>
+        isOpen ? (
+            <div data-testid="datacite-import-modal">
+                <button type="button" onClick={onSuccess}>
+                    Import all success
+                </button>
+                <button type="button" onClick={onClose}>
+                    Close all resources import
+                </button>
+            </div>
+        ) : null,
+}));
+vi.mock('@/components/resources/modals/ImportSingleOldResourceModal', () => ({
+    default: ({ isOpen, onClose, onSuccess }: { isOpen: boolean; onClose: () => void; onSuccess: () => void }) =>
+        isOpen ? (
+            <div data-testid="single-resource-import-modal">
+                <button type="button" onClick={onSuccess}>
+                    Import single success
+                </button>
+                <button type="button" onClick={onClose}>
+                    Close single resource import
+                </button>
+            </div>
+        ) : null,
+}));
 vi.mock('@/components/resources/modals/RegisterDoiModal', () => ({ default: () => null }));
-vi.mock('@/components/citations/CitationManagerModal', () => ({ CitationManagerModal: () => null }));
+vi.mock('@/components/citations/CitationManagerModal', () => ({
+    CitationManagerModal: ({ open, onOpenChange, resourceId }: { open: boolean; onOpenChange: (open: boolean) => void; resourceId: number }) =>
+        open ? (
+            <div data-testid="citation-manager-modal">
+                Related items for {resourceId}
+                <button type="button" onClick={() => onOpenChange(false)}>
+                    Close citation manager
+                </button>
+            </div>
+        ) : null,
+}));
 vi.mock('@/components/ui/validation-error-modal', () => ({ ValidationErrorModal: () => null }));
 vi.mock('@/hooks/use-citation-vocabularies', () => ({
     useCitationVocabularies: () => ({
@@ -68,11 +102,15 @@ vi.mock('@/utils/filter-parser', () => ({
 
 import ResourcesPage, {
     clampColumnWidth,
+    clearStoredResourceColumnWidths,
     COLUMN_WIDTH_STORAGE_KEY,
     DEFAULT_RESOURCE_COLUMN_WIDTHS,
+    isResizableViewport,
     normalizeResourceColumnWidths,
     OverflowTooltipText,
     parseStoredResourceColumnWidths,
+    persistResourceColumnWidths,
+    readStoredResourceColumnWidths,
 } from '@/pages/resources';
 
 const resource = {
@@ -107,6 +145,15 @@ function getDoiTitleColumn() {
     return screen.getByTestId('resources-column-doi_title');
 }
 
+async function clickResourceAction(actionTestId: string) {
+    await userEvent.click(screen.getByTestId('resources-actions-menu-trigger'));
+    await userEvent.click(await screen.findByTestId(actionTestId));
+}
+
+function setViewportWidth(width: number) {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
+}
+
 describe('resource column width helpers', () => {
     it('clamps widths to each column boundary', () => {
         expect(clampColumnWidth('doi_title', 100)).toBe(220);
@@ -129,10 +176,31 @@ describe('resource column width helpers', () => {
         expect(widths.created_updated).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.created_updated);
     });
 
+    it('falls back to default widths for invalid stored shapes', () => {
+        expect(normalizeResourceColumnWidths(null)).toEqual(DEFAULT_RESOURCE_COLUMN_WIDTHS);
+        expect(normalizeResourceColumnWidths(['doi_title', 400])).toEqual(DEFAULT_RESOURCE_COLUMN_WIDTHS);
+        expect(normalizeResourceColumnWidths('wide')).toEqual(DEFAULT_RESOURCE_COLUMN_WIDTHS);
+    });
+
     it('parses valid storage and rejects malformed storage', () => {
         expect(parseStoredResourceColumnWidths('{bad json')).toBeNull();
         expect(parseStoredResourceColumnWidths(null)).toBeNull();
         expect(parseStoredResourceColumnWidths(JSON.stringify({ doi_title: 300 }))?.doi_title).toBe(300);
+        expect(parseStoredResourceColumnWidths(JSON.stringify([]))).toEqual(DEFAULT_RESOURCE_COLUMN_WIDTHS);
+    });
+
+    it('treats storage helpers as SSR-safe no-ops without window', () => {
+        const originalWindow = globalThis.window;
+        Object.defineProperty(globalThis, 'window', { configurable: true, writable: true, value: undefined });
+
+        try {
+            expect(readStoredResourceColumnWidths()).toEqual(DEFAULT_RESOURCE_COLUMN_WIDTHS);
+            expect(isResizableViewport()).toBe(true);
+            expect(() => persistResourceColumnWidths(DEFAULT_RESOURCE_COLUMN_WIDTHS)).not.toThrow();
+            expect(() => clearStoredResourceColumnWidths()).not.toThrow();
+        } finally {
+            Object.defineProperty(globalThis, 'window', { configurable: true, writable: true, value: originalWindow });
+        }
     });
 });
 
@@ -141,7 +209,7 @@ describe('ResourcesPage column resizing', () => {
         vi.clearAllMocks();
         axiosGetMock.mockResolvedValue({ data: {} });
         window.localStorage.clear();
-        Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1280 });
+        setViewportWidth(1280);
     });
 
     it('renders visible resize handles and default colgroup widths', () => {
@@ -165,6 +233,47 @@ describe('ResourcesPage column resizing', () => {
         expect(storedWidths.doi_title).toBe(DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title + 16);
     });
 
+    it('hydrates persisted column widths from localStorage', () => {
+        window.localStorage.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify({ doi_title: 512, author_year: 999 }));
+
+        renderResourcesPage();
+
+        expect(getDoiTitleColumn()).toHaveStyle({ width: '512px' });
+        expect(screen.getByTestId('resources-column-author_year')).toHaveStyle({ width: '360px' });
+    });
+
+    it('falls back to defaults when stored column widths cannot be read', () => {
+        const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('storage unavailable');
+        });
+
+        try {
+            renderResourcesPage();
+
+            expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
+        } finally {
+            getItemSpy.mockRestore();
+        }
+    });
+
+    it('keeps resized widths in memory when localStorage persistence fails', () => {
+        const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('storage unavailable');
+        });
+
+        try {
+            renderResourcesPage();
+
+            const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+            fireEvent.keyDown(handle, { key: 'ArrowRight' });
+
+            expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title + 16}px` });
+            expect(setItemSpy).toHaveBeenCalled();
+        } finally {
+            setItemSpy.mockRestore();
+        }
+    });
+
     it('resizes a column with pointer drag and clamps at the maximum width', () => {
         renderResourcesPage();
 
@@ -175,6 +284,35 @@ describe('ResourcesPage column resizing', () => {
 
         expect(handle).toHaveAttribute('aria-valuenow', '720');
         expect(getDoiTitleColumn()).toHaveStyle({ width: '720px' });
+    });
+
+    it('ignores unsupported resize interactions and clamps keyboard home to the minimum width', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+
+        fireEvent.pointerDown(handle, { button: 1, clientX: 100, pointerId: 1 });
+        fireEvent.pointerMove(window, { clientX: 900, pointerId: 1 });
+        fireEvent.keyDown(handle, { key: 'Escape' });
+
+        expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
+
+        fireEvent.keyDown(handle, { key: 'Home' });
+        fireEvent.keyDown(handle, { key: 'ArrowLeft', shiftKey: true });
+
+        expect(handle).toHaveAttribute('aria-valuenow', '220');
+        expect(getDoiTitleColumn()).toHaveStyle({ width: '220px' });
+    });
+
+    it('removes pointer listeners after pointer cancellation', () => {
+        renderResourcesPage();
+
+        const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
+        fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 1 });
+        fireEvent.pointerCancel(window, { pointerId: 1 });
+        fireEvent.pointerMove(window, { clientX: 900, pointerId: 1 });
+
+        expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
     });
 
     it('resets persisted column widths back to defaults', () => {
@@ -189,6 +327,187 @@ describe('ResourcesPage column resizing', () => {
 
         expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
         expect(window.localStorage.getItem(COLUMN_WIDTH_STORAGE_KEY)).toBeNull();
+    });
+
+    it('resets in-memory widths when localStorage removal fails', () => {
+        window.localStorage.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify({ doi_title: 720 }));
+        const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+            throw new Error('storage unavailable');
+        });
+
+        try {
+            renderResourcesPage();
+
+            expect(getDoiTitleColumn()).toHaveStyle({ width: '720px' });
+
+            fireEvent.click(screen.getByTestId('resources-reset-column-widths'));
+
+            expect(getDoiTitleColumn()).toHaveStyle({ width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px` });
+        } finally {
+            removeItemSpy.mockRestore();
+        }
+    });
+
+    it('disables resizing and removes the date column from layout on narrow viewports', () => {
+        setViewportWidth(700);
+
+        renderResourcesPage();
+
+        const handle = screen.getByTestId('resources-column-resize-doi_title');
+        expect(handle).toBeDisabled();
+        expect(handle).toHaveAttribute('tabindex', '-1');
+        expect(screen.getByTestId('resources-column-created_updated')).toHaveStyle({ width: '0px' });
+        expect(screen.getByTestId('resources-table')).toHaveStyle({ width: '976px' });
+
+        setViewportWidth(1280);
+        fireEvent.resize(window);
+
+        expect(handle).not.toBeDisabled();
+        expect(screen.getByTestId('resources-column-created_updated')).toHaveStyle({
+            width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.created_updated}px`,
+        });
+    });
+
+    it('opens and closes DataCite import modals from the import buttons', async () => {
+        render(
+            <ResourcesPage resources={[resource]} pagination={pagination} sort={{ key: 'id', direction: 'asc' }} canImportFromDataCite />,
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: /import all old resources/i }));
+        expect(screen.getByTestId('datacite-import-modal')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', { name: /import all success/i }));
+        expect(routerMock.reload).toHaveBeenCalledWith({ only: ['resources', 'pagination'] });
+
+        await userEvent.click(screen.getByRole('button', { name: /close all resources import/i }));
+        expect(screen.queryByTestId('datacite-import-modal')).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', { name: /import old single resource/i }));
+        expect(screen.getByTestId('single-resource-import-modal')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', { name: /import single success/i }));
+        expect(routerMock.reload).toHaveBeenCalledWith({ only: ['resources', 'pagination'] });
+
+        await userEvent.click(screen.getByRole('button', { name: /close single resource import/i }));
+        expect(screen.queryByTestId('single-resource-import-modal')).not.toBeInTheDocument();
+    });
+
+    it('opens and closes the citation manager from the selected resource action', async () => {
+        renderResourcesPage();
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        await clickResourceAction('resources-action-manage-related-items');
+
+        expect(screen.getByTestId('citation-manager-modal')).toHaveTextContent('Related items for 1');
+
+        await userEvent.click(screen.getByRole('button', { name: /close citation manager/i }));
+
+        expect(screen.queryByTestId('citation-manager-modal')).not.toBeInTheDocument();
+    });
+
+    it('supports family-only authors and keyboard activation on clickable status badges', async () => {
+        const originalClipboard = navigator.clipboard;
+        const originalOpen = window.open;
+        const writeTextMock = vi.fn().mockResolvedValue(undefined);
+        const openMock = vi.fn();
+
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            writable: true,
+            value: { writeText: writeTextMock },
+        });
+        Object.defineProperty(window, 'open', { configurable: true, writable: true, value: openMock });
+
+        try {
+            render(
+                <ResourcesPage
+                    resources={[{ ...resource, first_author: { familyName: 'Familyonly' } }]}
+                    pagination={pagination}
+                    sort={{ key: 'id', direction: 'asc' }}
+                />,
+            );
+
+            expect(screen.getByText('Familyonly')).toBeInTheDocument();
+
+            const statusBadge = screen.getByRole('button', { name: /published - click to open doi/i });
+            fireEvent.keyDown(statusBadge, { key: 'Enter' });
+            fireEvent.keyDown(statusBadge, { key: ' ' });
+            await userEvent.click(statusBadge);
+
+            await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(3));
+            expect(openMock).toHaveBeenCalledWith('https://doi.org/10.5880/test.2026.001', '_blank', 'noopener,noreferrer');
+        } finally {
+            if (originalClipboard) {
+                Object.defineProperty(navigator, 'clipboard', { configurable: true, writable: true, value: originalClipboard });
+            } else {
+                Reflect.deleteProperty(navigator, 'clipboard');
+            }
+            Object.defineProperty(window, 'open', { configurable: true, writable: true, value: originalOpen });
+        }
+    });
+
+    it('renders loading skeleton rows while the next resource page is loading', async () => {
+        const originalIntersectionObserver = globalThis.IntersectionObserver;
+        const observerInstances: Array<{ disconnect: ReturnType<typeof vi.fn> }> = [];
+
+        class IntersectingObserver implements IntersectionObserver {
+            readonly root = null;
+            readonly rootMargin = '100px';
+            readonly scrollMargin = '0px';
+            readonly thresholds = [0.1];
+
+            private readonly callback: IntersectionObserverCallback;
+            readonly disconnect = vi.fn();
+            readonly takeRecords = vi.fn((): IntersectionObserverEntry[] => []);
+            readonly unobserve = vi.fn();
+
+            constructor(callback: IntersectionObserverCallback) {
+                this.callback = callback;
+                observerInstances.push(this);
+            }
+
+            observe(target: Element) {
+                this.callback([{ isIntersecting: true, target } as IntersectionObserverEntry], this);
+            }
+        }
+
+        Object.defineProperty(globalThis, 'IntersectionObserver', {
+            configurable: true,
+            writable: true,
+            value: IntersectingObserver,
+        });
+
+        axiosGetMock.mockImplementation((url: string) => {
+            if (url === '/resources/load-more') {
+                return new Promise(() => undefined);
+            }
+
+            return Promise.resolve({ data: {} });
+        });
+
+        try {
+            render(
+                <ResourcesPage
+                    resources={[resource]}
+                    pagination={{ ...pagination, has_more: true, last_page: 2, total: 2 }}
+                    sort={{ key: 'id', direction: 'asc' }}
+                />,
+            );
+
+            await waitFor(() => expect(document.querySelectorAll('tr.animate-pulse')).toHaveLength(5));
+
+            expect(observerInstances).toHaveLength(1);
+        } finally {
+            if (originalIntersectionObserver) {
+                Object.defineProperty(globalThis, 'IntersectionObserver', {
+                    configurable: true,
+                    writable: true,
+                    value: originalIntersectionObserver,
+                });
+            } else {
+                Reflect.deleteProperty(globalThis, 'IntersectionObserver');
+            }
+        }
     });
 });
 
@@ -235,5 +554,29 @@ describe('OverflowTooltipText', () => {
         await userEvent.hover(text);
 
         expect(await screen.findByRole('tooltip')).toHaveTextContent('A long title that overflows');
+    });
+
+    it('measures overflow when ResizeObserver is unavailable', async () => {
+        const originalResizeObserver = globalThis.ResizeObserver;
+        Object.defineProperty(globalThis, 'ResizeObserver', { configurable: true, writable: true, value: undefined });
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 80 });
+        Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 240 });
+
+        try {
+            render(<OverflowTooltipText value="A long title without a resize observer" testId="overflow-text" />);
+
+            const text = screen.getByTestId('overflow-text');
+            await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'true'));
+        } finally {
+            if (originalResizeObserver) {
+                Object.defineProperty(globalThis, 'ResizeObserver', {
+                    configurable: true,
+                    writable: true,
+                    value: originalResizeObserver,
+                });
+            } else {
+                Reflect.deleteProperty(globalThis, 'ResizeObserver');
+            }
+        }
     });
 });

--- a/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-column-widths.test.tsx
@@ -101,18 +101,19 @@ vi.mock('@/utils/filter-parser', () => ({
     parseResourceFiltersFromUrl: vi.fn().mockReturnValue({}),
 }));
 
-import ResourcesPage, {
+import { TooltipProvider } from '@/components/ui/tooltip';
+import ResourcesPage, { OverflowTooltipText } from '@/pages/resources';
+import {
     clampColumnWidth,
     clearStoredResourceColumnWidths,
     COLUMN_WIDTH_STORAGE_KEY,
     DEFAULT_RESOURCE_COLUMN_WIDTHS,
     isResizableViewport,
     normalizeResourceColumnWidths,
-    OverflowTooltipText,
     parseStoredResourceColumnWidths,
     persistResourceColumnWidths,
     readStoredResourceColumnWidths,
-} from '@/pages/resources';
+} from '@/pages/resources-column-widths';
 
 const resource = {
     id: 1,
@@ -226,7 +227,7 @@ describe('ResourcesPage column resizing', () => {
         const handle = screen.getByRole('separator', { name: /resize doi and title column/i });
         const headerCell = handle.closest('th');
 
-        expect(handle).toHaveClass('translate-x-1/2');
+        expect(handle).toHaveClass('translate-x-1/2', 'touch-none');
         expect(headerCell).not.toHaveClass('overflow-hidden');
     });
 
@@ -554,6 +555,13 @@ describe('ResourcesPage column resizing', () => {
 });
 
 describe('OverflowTooltipText', () => {
+    const renderOverflowTooltipText = (value: string) =>
+        render(
+            <TooltipProvider delayDuration={0}>
+                <OverflowTooltipText value={value} testId="overflow-text" />
+            </TooltipProvider>,
+        );
+
     let clientWidthDescriptor: PropertyDescriptor | undefined;
     let scrollWidthDescriptor: PropertyDescriptor | undefined;
 
@@ -576,7 +584,7 @@ describe('OverflowTooltipText', () => {
         Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 200 });
         Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 120 });
 
-        render(<OverflowTooltipText value="Short title" testId="overflow-text" />);
+        renderOverflowTooltipText('Short title');
 
         const text = screen.getByTestId('overflow-text');
         await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'false'));
@@ -589,7 +597,7 @@ describe('OverflowTooltipText', () => {
         Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 80 });
         Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 240 });
 
-        render(<OverflowTooltipText value="A long title that overflows" testId="overflow-text" />);
+        renderOverflowTooltipText('A long title that overflows');
 
         const text = screen.getByTestId('overflow-text');
         await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'true'));
@@ -604,7 +612,7 @@ describe('OverflowTooltipText', () => {
         Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, get: () => 240 });
 
         try {
-            render(<OverflowTooltipText value="A long title without a resize observer" testId="overflow-text" />);
+            renderOverflowTooltipText('A long title without a resize observer');
 
             const text = screen.getByTestId('overflow-text');
             await waitFor(() => expect(text).toHaveAttribute('data-overflowing', 'true'));

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -84,7 +84,7 @@ vi.mock('@/hooks/use-citation-vocabularies', () => ({
     }),
 }));
 
-import ResourcesPage, { deriveResourceRowKey } from '@/pages/resources';
+import ResourcesPage, { DEFAULT_RESOURCE_COLUMN_WIDTHS, deriveResourceRowKey } from '@/pages/resources';
 
 interface TestResource {
     id: number;
@@ -299,19 +299,17 @@ describe('ResourcesPage - extended', () => {
             ]);
         });
 
-        it('keeps the regrouped columns compact', () => {
+        it('keeps the regrouped columns compact and resizable', () => {
             renderPage();
 
-            const headers = screen.getAllByRole('columnheader');
-            const idResourceTypeHeader = headers.find((header) => (header.textContent ?? '').includes('ID'));
-            const doiTitleHeader = headers.find((header) => (header.textContent ?? '').includes('DOI'));
-
-            expect(idResourceTypeHeader).toBeDefined();
-            expect(doiTitleHeader).toBeDefined();
-            expect(idResourceTypeHeader).toHaveClass('min-w-[9rem]');
-            expect(doiTitleHeader).toHaveClass('min-w-[18rem]');
-            expect(doiTitleHeader).toHaveClass('md:min-w-[24rem]');
-            expect(doiTitleHeader?.className).not.toContain('lg:min-w-[36rem]');
+            expect(screen.getByTestId('resources-column-id_resourcetype')).toHaveStyle({
+                width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.id_resourcetype}px`,
+            });
+            expect(screen.getByTestId('resources-column-doi_title')).toHaveStyle({
+                width: `${DEFAULT_RESOURCE_COLUMN_WIDTHS.doi_title}px`,
+            });
+            expect(screen.getByRole('separator', { name: /resize id and resource type column/i })).toBeInTheDocument();
+            expect(screen.getByRole('separator', { name: /resize doi and title column/i })).toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -84,7 +84,8 @@ vi.mock('@/hooks/use-citation-vocabularies', () => ({
     }),
 }));
 
-import ResourcesPage, { DEFAULT_RESOURCE_COLUMN_WIDTHS, deriveResourceRowKey } from '@/pages/resources';
+import ResourcesPage, { deriveResourceRowKey } from '@/pages/resources';
+import { DEFAULT_RESOURCE_COLUMN_WIDTHS } from '@/pages/resources-column-widths';
 
 interface TestResource {
     id: number;


### PR DESCRIPTION
This pull request introduces a major enhancement to the Resources table: users can now manually resize all visible metadata columns (except the selection checkbox) on tablet and desktop screens. Column widths are persisted in the browser, can be reset to defaults, and long values are truncated with tooltips for easy access to full content. The implementation includes both UI and accessibility improvements, as well as supporting logic for managing and persisting column widths.

Key changes include:

**Resizable Columns Functionality**
* Added a new module `resources-column-widths.ts` providing types, constants, and utility functions for managing resource column widths, including persistence to localStorage and layout logic.
* Updated `resources.tsx` to use the new resizing logic, including state management for column widths, handling viewport responsiveness, and providing reset functionality. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R587-R588) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R601-R615) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R1442-R1467)

**User Interface Enhancements**
* Implemented `ColumnResizeHandle` and keyboard/mouse controls for adjusting column widths, with accessible labels and focus management.
* Added `OverflowTooltipText` component to truncate long cell values with ellipsis and show full content in a tooltip on hover. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R269-R464) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1237-R1501) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1272-R1527)
* Adjusted table cell layouts and classes to support flexible widths and truncation. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L74-R103) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1237-R1501) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1272-R1527)

**Documentation and Change Log**
* Updated the changelog and user documentation to describe the new resizable columns feature and explain how to use it, including keyboard shortcuts and tooltips. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR120-R123) [[2]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR1848-R1860)

These changes significantly improve the usability and accessibility of the Resources table, especially for users working with large or variable-width data.