### PR TITLE
Feature: Discovery System for Crossref Funder ID Transformation

### DIFF
--- a/app/Console/Commands/GetRorIds.php
+++ b/app/Console/Commands/GetRorIds.php
@@ -19,12 +19,13 @@ use Throwable;
 #[Signature('get-ror-ids {--output= : Override the output file path}')]
 class GetRorIds extends Command
 {
-
     private const METADATA_URL = 'https://zenodo.org/api/records/';
 
     private const COMMUNITY = 'ror-data';
 
     private const OUTPUT_RELATIVE_PATH = 'ror/ror-affiliations.json';
+
+    private const FUNDREF_INDEX_RELATIVE_PATH = 'ror/ror-fundref-index.json';
 
     /**
      * Execute the console command.
@@ -113,11 +114,18 @@ class GetRorIds extends Command
         $targetPath = is_string($outputPath) && $outputPath !== ''
             ? $outputPath
             : storage_path('app/private/'.self::OUTPUT_RELATIVE_PATH);
+        $fundrefIndexPath = $this->fundrefIndexTargetPath($targetPath);
 
         $directory = dirname($targetPath);
 
         if (! File::exists($directory)) {
             File::makeDirectory($directory, 0o755, true);
+        }
+
+        $fundrefDirectory = dirname($fundrefIndexPath);
+
+        if (! File::exists($fundrefDirectory)) {
+            File::makeDirectory($fundrefDirectory, 0o755, true);
         }
 
         try {
@@ -129,6 +137,8 @@ class GetRorIds extends Command
             } else {
                 $saved = $this->convertDumpToSuggestions($temporaryPath, $targetPath);
             }
+
+            $fundrefSaved = $this->buildFundrefIndex($temporaryPath, $isZip, $fundrefIndexPath);
         } catch (Throwable $exception) {
             File::delete($temporaryPath);
             $this->error(sprintf('Failed to process ROR data dump: %s', $exception->getMessage()));
@@ -148,6 +158,7 @@ class GetRorIds extends Command
         $this->call('cache:clear-app', ['category' => 'ror']);
 
         $this->info(sprintf('Saved %d ROR affiliation entries to %s', $saved, $targetPath));
+        $this->info(sprintf('Saved %d ROR FundRef candidate entries to %s', $fundrefSaved, $fundrefIndexPath));
 
         return self::SUCCESS;
     }
@@ -238,7 +249,7 @@ class GetRorIds extends Command
         }
 
         $timestamp = Carbon::now()->toIso8601String();
-        fwrite($outputHandle, '{"lastUpdated":' . json_encode($timestamp, JSON_THROW_ON_ERROR) . ',"data":[');
+        fwrite($outputHandle, '{"lastUpdated":'.json_encode($timestamp, JSON_THROW_ON_ERROR).',"data":[');
 
         $first = true;
         $count = 0;
@@ -268,7 +279,7 @@ class GetRorIds extends Command
             }
         }
 
-        fwrite($outputHandle, '],"total":' . $count . '}');
+        fwrite($outputHandle, '],"total":'.$count.'}');
         fclose($outputHandle);
 
         return $count;
@@ -415,7 +426,7 @@ class GetRorIds extends Command
         }
 
         $timestamp = Carbon::now()->toIso8601String();
-        fwrite($outputHandle, '{"lastUpdated":' . json_encode($timestamp, JSON_THROW_ON_ERROR) . ',"data":[');
+        fwrite($outputHandle, '{"lastUpdated":'.json_encode($timestamp, JSON_THROW_ON_ERROR).',"data":[');
 
         $first = true;
         $count = 0;
@@ -514,10 +525,370 @@ class GetRorIds extends Command
             $count++;
         }
 
-        fwrite($outputHandle, '],"total":' . $count . '}');
+        fwrite($outputHandle, '],"total":'.$count.'}');
         fclose($outputHandle);
         gzclose($resource);
 
         return $count;
+    }
+
+    private function fundrefIndexTargetPath(string $affiliationTargetPath): string
+    {
+        $outputPath = $this->option('output');
+
+        if (is_string($outputPath) && $outputPath !== '') {
+            return dirname($affiliationTargetPath).DIRECTORY_SEPARATOR.'ror-fundref-index.json';
+        }
+
+        return storage_path('app/private/'.self::FUNDREF_INDEX_RELATIVE_PATH);
+    }
+
+    private function buildFundrefIndex(string $dumpPath, bool $isZip, string $targetPath): int
+    {
+        return $isZip
+            ? $this->buildFundrefIndexFromZip($dumpPath, $targetPath)
+            : $this->buildFundrefIndexFromGzip($dumpPath, $targetPath);
+    }
+
+    private function buildFundrefIndexFromZip(string $zipPath, string $targetPath): int
+    {
+        $zip = new \ZipArchive;
+
+        if ($zip->open($zipPath) !== true) {
+            throw new \RuntimeException('Unable to open the downloaded ROR data archive for FundRef indexing.');
+        }
+
+        $jsonFile = null;
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $filename = $zip->getNameIndex($i);
+
+            if (is_string($filename) && Str::endsWith($filename, '.json')) {
+                if (! Str::contains($filename, 'schema_v2')) {
+                    $jsonFile = $filename;
+
+                    break;
+                }
+
+                if ($jsonFile === null) {
+                    $jsonFile = $filename;
+                }
+            }
+        }
+
+        if ($jsonFile === null) {
+            $zip->close();
+
+            throw new \RuntimeException('No JSON file found in the ROR data archive for FundRef indexing.');
+        }
+
+        $jsonContent = $zip->getFromName($jsonFile);
+        $zip->close();
+
+        if ($jsonContent === false) {
+            throw new \RuntimeException(sprintf('Failed to extract %s from archive for FundRef indexing.', $jsonFile));
+        }
+
+        $tempJsonPath = (string) tempnam(sys_get_temp_dir(), 'ror-fundref-json-');
+        File::put($tempJsonPath, $jsonContent);
+
+        try {
+            return $this->buildFundrefIndexFromJsonFile($tempJsonPath, $targetPath);
+        } finally {
+            File::delete($tempJsonPath);
+        }
+    }
+
+    private function buildFundrefIndexFromJsonFile(string $sourcePath, string $targetPath): int
+    {
+        $jsonContent = file_get_contents($sourcePath);
+
+        if ($jsonContent === false) {
+            throw new \RuntimeException("Failed to read file: {$sourcePath}");
+        }
+
+        $organizations = json_decode($jsonContent, true, 512, JSON_THROW_ON_ERROR);
+        unset($jsonContent);
+
+        if (! is_array($organizations)) {
+            throw new \RuntimeException('Invalid JSON structure in ROR data file.');
+        }
+
+        $timestamp = Carbon::now()->toIso8601String();
+        $source = $this->fundrefIndexSource($timestamp);
+        $outputHandle = $this->openFundrefIndex($targetPath, $timestamp, $source);
+        $first = true;
+        $count = 0;
+
+        foreach ($organizations as $decoded) {
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            $candidate = $this->processFundrefCandidate($decoded, $source);
+
+            if ($candidate === null) {
+                continue;
+            }
+
+            $this->writeFundrefCandidate($outputHandle, $candidate, $first);
+            $count++;
+        }
+
+        $this->closeFundrefIndex($outputHandle, $count);
+
+        return $count;
+    }
+
+    private function buildFundrefIndexFromGzip(string $sourcePath, string $targetPath): int
+    {
+        $resource = gzopen($sourcePath, 'rb');
+
+        if ($resource === false) {
+            throw new \RuntimeException('Unable to open the downloaded ROR data archive for FundRef indexing.');
+        }
+
+        $timestamp = Carbon::now()->toIso8601String();
+        $source = $this->fundrefIndexSource($timestamp);
+        $outputHandle = $this->openFundrefIndex($targetPath, $timestamp, $source);
+        $first = true;
+        $count = 0;
+
+        while (! gzeof($resource)) {
+            $line = gzgets($resource);
+
+            if ($line === false) {
+                break;
+            }
+
+            $trimmed = trim($line);
+
+            if ($trimmed === '') {
+                continue;
+            }
+
+            try {
+                /** @var array<string, mixed> $decoded */
+                $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                $this->warn(sprintf('Skipping malformed JSON line during FundRef indexing: %s', $exception->getMessage()));
+
+                continue;
+            }
+
+            $candidate = $this->processFundrefCandidate($decoded, $source);
+
+            if ($candidate === null) {
+                continue;
+            }
+
+            $this->writeFundrefCandidate($outputHandle, $candidate, $first);
+            $count++;
+        }
+
+        $this->closeFundrefIndex($outputHandle, $count);
+        gzclose($resource);
+
+        return $count;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fundrefIndexSource(string $timestamp): array
+    {
+        return [
+            'source' => 'ror_fundref_index',
+            'source_file' => self::FUNDREF_INDEX_RELATIVE_PATH,
+            'source_generated_by' => 'get-ror-ids',
+            'source_generated_from' => 'ROR Zenodo data dump',
+            'source_retrieved_at' => $timestamp,
+            'matching_strategy' => 'exact_fundref_external_id',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $source
+     * @return resource
+     */
+    private function openFundrefIndex(string $targetPath, string $timestamp, array $source): mixed
+    {
+        $outputHandle = fopen($targetPath, 'wb');
+
+        if ($outputHandle === false) {
+            throw new \RuntimeException(sprintf('Unable to open FundRef index path [%s] for writing.', $targetPath));
+        }
+
+        fwrite($outputHandle, '{"lastUpdated":'.json_encode($timestamp, JSON_THROW_ON_ERROR).',"source":'.json_encode($source, JSON_THROW_ON_ERROR).',"data":[');
+
+        return $outputHandle;
+    }
+
+    /**
+     * @param  resource  $outputHandle
+     * @param  array<string, mixed>  $candidate
+     */
+    private function writeFundrefCandidate(mixed $outputHandle, array $candidate, bool &$first): void
+    {
+        $encoded = json_encode($candidate, JSON_THROW_ON_ERROR);
+
+        if (! $first) {
+            fwrite($outputHandle, ',');
+        } else {
+            $first = false;
+        }
+
+        fwrite($outputHandle, $encoded);
+    }
+
+    /**
+     * @param  resource  $outputHandle
+     */
+    private function closeFundrefIndex(mixed $outputHandle, int $count): void
+    {
+        fwrite($outputHandle, '],"total":'.$count.'}');
+        fclose($outputHandle);
+    }
+
+    /**
+     * @param  array<string, mixed>  $decoded
+     * @param  array<string, mixed>  $source
+     * @return array<string, mixed>|null
+     */
+    private function processFundrefCandidate(array $decoded, array $source): ?array
+    {
+        $organization = $this->processOrganization($decoded);
+
+        if ($organization === null) {
+            return null;
+        }
+
+        $rorId = $this->canonicalRorIdentifier($organization['rorId']);
+        $fundref = $this->extractFundrefExternalId($decoded);
+
+        if ($rorId === null || $fundref === null) {
+            return null;
+        }
+
+        $types = Arr::get($decoded, 'types', []);
+
+        if (! is_array($types)) {
+            $types = [];
+        }
+
+        return [
+            'ror_id' => $rorId,
+            'ror_display_name' => $organization['prefLabel'],
+            'ror_status' => $this->stringValue(Arr::get($decoded, 'status')) ?? 'active',
+            'ror_types' => array_values(array_filter(array_map('strval', $types))),
+            'ror_record_last_modified' => $this->stringValue(Arr::get($decoded, 'updated'))
+                ?? $this->stringValue(Arr::get($decoded, 'last_modified')),
+            'external_ids' => [
+                'fundref' => $fundref,
+            ],
+            'names' => $organization['otherLabel'],
+            'source' => $source,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $decoded
+     * @return array{all: list<string>, preferred: string|null}|null
+     */
+    private function extractFundrefExternalId(array $decoded): ?array
+    {
+        $externalIds = Arr::get($decoded, 'external_ids', []);
+
+        if (! is_array($externalIds)) {
+            return null;
+        }
+
+        if (array_is_list($externalIds)) {
+            foreach ($externalIds as $entry) {
+                if (! is_array($entry)) {
+                    continue;
+                }
+
+                if (mb_strtolower((string) Arr::get($entry, 'type')) === 'fundref') {
+                    return $this->normalizeFundrefExternalId($entry);
+                }
+            }
+        }
+
+        foreach ($externalIds as $key => $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            if (in_array(mb_strtolower((string) $key), ['fundref', 'fundref id'], true)) {
+                return $this->normalizeFundrefExternalId($entry);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @return array{all: list<string>, preferred: string|null}|null
+     */
+    private function normalizeFundrefExternalId(array $entry): ?array
+    {
+        $all = Arr::get($entry, 'all', []);
+
+        if (is_string($all) || is_numeric($all)) {
+            $all = [$all];
+        }
+
+        if (! is_array($all)) {
+            return null;
+        }
+
+        $values = array_values(array_unique(array_filter(
+            array_map(fn (mixed $value): ?string => $this->fundrefValue($value), $all),
+            fn (?string $value): bool => $value !== null,
+        )));
+
+        if ($values === []) {
+            return null;
+        }
+
+        $preferred = $this->fundrefValue(Arr::get($entry, 'preferred'));
+
+        return [
+            'all' => $values,
+            'preferred' => $preferred,
+        ];
+    }
+
+    private function fundrefValue(mixed $value): ?string
+    {
+        $value = $this->stringValue($value);
+
+        if ($value === null || ! preg_match('/^[0-9]+$/', $value)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function canonicalRorIdentifier(string $identifier): ?string
+    {
+        if (preg_match('#^(?:https?://)?(?:www\.)?ror\.org/([a-z0-9]{9})/?$#i', trim($identifier), $matches)) {
+            return 'https://ror.org/'.strtolower($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if ($value === null || is_array($value) || is_object($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
     }
 }

--- a/app/Console/Commands/GetRorIds.php
+++ b/app/Console/Commands/GetRorIds.php
@@ -135,20 +135,18 @@ class GetRorIds extends Command
             $fileKey = Arr::get($dataFile, 'key', '');
             $isZip = is_string($fileKey) && Str::endsWith($fileKey, '.zip');
 
-            if ($isZip) {
-                $saved = $this->processZipDump($temporaryPath, $temporaryTargetPath);
-            } else {
-                $saved = $this->convertDumpToSuggestions($temporaryPath, $temporaryTargetPath);
-            }
+            $counts = $isZip
+                ? $this->processZipDump($temporaryPath, $temporaryTargetPath, $temporaryFundrefIndexPath)
+                : $this->processGzipDump($temporaryPath, $temporaryTargetPath, $temporaryFundrefIndexPath);
 
+            $saved = $counts['affiliations'];
             if ($saved === 0) {
                 throw new \RuntimeException('No ROR affiliations were written.');
             }
 
-            $fundrefSaved = $this->buildFundrefIndex($temporaryPath, $isZip, $temporaryFundrefIndexPath);
+            $fundrefSaved = $counts['fundref'];
 
-            $this->replaceOutputFile($temporaryFundrefIndexPath, $fundrefIndexPath);
-            $this->replaceOutputFile($temporaryTargetPath, $targetPath);
+            $this->commitOutputFiles($temporaryTargetPath, $targetPath, $temporaryFundrefIndexPath, $fundrefIndexPath);
         } catch (Throwable $exception) {
             File::delete([$temporaryPath, $temporaryTargetPath, $temporaryFundrefIndexPath]);
             $this->error(sprintf('Failed to process ROR data dump: %s', $exception->getMessage()));
@@ -174,23 +172,105 @@ class GetRorIds extends Command
             .'.'.basename($targetPath).'.'.(string) Str::uuid().'.tmp';
     }
 
-    private function replaceOutputFile(string $temporaryPath, string $targetPath): void
-    {
-        if (! File::exists($temporaryPath)) {
-            throw new \RuntimeException("Temporary output file does not exist: {$temporaryPath}");
+    private function commitOutputFiles(
+        string $temporaryAffiliationsPath,
+        string $affiliationsPath,
+        string $temporaryFundrefIndexPath,
+        string $fundrefIndexPath,
+    ): void {
+        $this->assertMovableOutput($temporaryAffiliationsPath, 'Temporary affiliations file');
+        $this->assertMovableOutput($temporaryFundrefIndexPath, 'Temporary FundRef index file');
+        $this->assertCommitTarget($affiliationsPath, 'Affiliations target');
+        $this->assertCommitTarget($fundrefIndexPath, 'FundRef index target');
+
+        if ($affiliationsPath === $fundrefIndexPath) {
+            throw new \RuntimeException('Affiliations and FundRef index targets must be distinct file paths.');
         }
 
-        if (! @rename($temporaryPath, $targetPath)) {
-            throw new \RuntimeException("Failed to move temporary output file into place: {$targetPath}");
+        $affiliationsBackupPath = $this->temporaryOutputPath($affiliationsPath).'.bak';
+        $fundrefBackupPath = $this->temporaryOutputPath($fundrefIndexPath).'.bak';
+        $affiliationsBackedUp = false;
+        $fundrefBackedUp = false;
+        $affiliationsCommitted = false;
+        $fundrefCommitted = false;
+
+        try {
+            if (File::exists($affiliationsPath)) {
+                $this->moveOutputFile($affiliationsPath, $affiliationsBackupPath);
+                $affiliationsBackedUp = true;
+            }
+
+            if (File::exists($fundrefIndexPath)) {
+                $this->moveOutputFile($fundrefIndexPath, $fundrefBackupPath);
+                $fundrefBackedUp = true;
+            }
+
+            $this->moveOutputFile($temporaryAffiliationsPath, $affiliationsPath);
+            $affiliationsCommitted = true;
+
+            $this->moveOutputFile($temporaryFundrefIndexPath, $fundrefIndexPath);
+            $fundrefCommitted = true;
+
+            File::delete([$affiliationsBackupPath, $fundrefBackupPath]);
+        } catch (Throwable $exception) {
+            if ($affiliationsCommitted) {
+                File::delete($affiliationsPath);
+            }
+
+            if ($fundrefCommitted) {
+                File::delete($fundrefIndexPath);
+            }
+
+            if ($affiliationsBackedUp && File::exists($affiliationsBackupPath)) {
+                $this->moveOutputFile($affiliationsBackupPath, $affiliationsPath);
+            }
+
+            if ($fundrefBackedUp && File::exists($fundrefBackupPath)) {
+                $this->moveOutputFile($fundrefBackupPath, $fundrefIndexPath);
+            }
+
+            throw $exception;
+        } finally {
+            File::delete([$affiliationsBackupPath, $fundrefBackupPath]);
         }
     }
 
-    private function processZipDump(string $zipPath, string $targetPath): int
+    private function assertMovableOutput(string $path, string $label): void
+    {
+        if (! File::exists($path) || File::isDirectory($path)) {
+            throw new \RuntimeException("{$label} does not exist or is not a file: {$path}");
+        }
+    }
+
+    private function assertCommitTarget(string $path, string $label): void
+    {
+        if (File::isDirectory($path)) {
+            throw new \RuntimeException("{$label} is a directory, expected a file path: {$path}");
+        }
+    }
+
+    private function moveOutputFile(string $sourcePath, string $targetPath): void
+    {
+        $this->assertMovableOutput($sourcePath, 'Output source');
+
+        if (File::isDirectory($targetPath)) {
+            throw new \RuntimeException("Output target is a directory, expected a file path: {$targetPath}");
+        }
+
+        if (! @rename($sourcePath, $targetPath)) {
+            throw new \RuntimeException("Failed to move output file into place: {$targetPath}");
+        }
+    }
+
+    /**
+     * @return array{affiliations: int, fundref: int}
+     */
+    private function processZipDump(string $zipPath, string $affiliationsTargetPath, string $fundrefIndexTargetPath): array
     {
         $tempJsonPath = $this->extractZipJsonToTemporaryFile($zipPath, 'ror-json-');
 
         try {
-            return $this->convertJsonToSuggestions($tempJsonPath, $targetPath);
+            return $this->processJsonDumpToOutputs($tempJsonPath, $affiliationsTargetPath, $fundrefIndexTargetPath);
         } finally {
             File::delete($tempJsonPath);
         }
@@ -260,7 +340,10 @@ class GetRorIds extends Command
         return $jsonFile;
     }
 
-    private function convertJsonToSuggestions(string $sourcePath, string $targetPath): int
+    /**
+     * @return array{affiliations: int, fundref: int}
+     */
+    private function processJsonDumpToOutputs(string $sourcePath, string $affiliationsTargetPath, string $fundrefIndexTargetPath): array
     {
         $this->info('Loading JSON data into memory...');
         $jsonContent = file_get_contents($sourcePath);
@@ -272,7 +355,6 @@ class GetRorIds extends Command
         $this->info('Parsing JSON...');
         $organizations = json_decode($jsonContent, true, 512, JSON_THROW_ON_ERROR);
 
-        // Free memory
         unset($jsonContent);
 
         if (! is_array($organizations)) {
@@ -281,47 +363,62 @@ class GetRorIds extends Command
 
         $this->info(sprintf('Found %d organizations, processing...', count($organizations)));
 
-        $outputHandle = fopen($targetPath, 'wb');
-
-        if ($outputHandle === false) {
-            throw new \RuntimeException(sprintf('Unable to open output path [%s] for writing.', $targetPath));
-        }
-
         $timestamp = Carbon::now()->toIso8601String();
-        fwrite($outputHandle, '{"lastUpdated":'.json_encode($timestamp, JSON_THROW_ON_ERROR).',"data":[');
+        $source = $this->fundrefIndexSource($timestamp);
+        $affiliationsHandle = $this->openAffiliationSuggestions($affiliationsTargetPath, $timestamp);
+        $fundrefHandle = null;
+        $firstAffiliation = true;
+        $firstFundref = true;
+        $affiliationCount = 0;
+        $fundrefCount = 0;
 
-        $first = true;
-        $count = 0;
+        try {
+            $fundrefHandle = $this->openFundrefIndex($fundrefIndexTargetPath, $timestamp, $source);
 
-        foreach ($organizations as $decoded) {
-            if (! is_array($decoded)) {
-                continue;
+            foreach ($organizations as $decoded) {
+                if (! is_array($decoded)) {
+                    continue;
+                }
+
+                $entry = $this->processOrganization($decoded);
+
+                if ($entry === null) {
+                    continue;
+                }
+
+                $this->writeAffiliationSuggestion($affiliationsHandle, $entry, $firstAffiliation);
+                $affiliationCount++;
+
+                if ($affiliationCount % 10000 === 0) {
+                    $this->info(sprintf('Processed %d organizations...', $affiliationCount));
+                }
+
+                $candidate = $this->processFundrefCandidate($decoded, $source, $entry);
+
+                if ($candidate !== null) {
+                    $this->writeFundrefCandidate($fundrefHandle, $candidate, $firstFundref);
+                    $fundrefCount++;
+                }
             }
 
-            $entry = $this->processOrganization($decoded);
+            $this->closeAffiliationSuggestions($affiliationsHandle, $affiliationCount);
+            $affiliationsHandle = null;
+            $this->closeFundrefIndex($fundrefHandle, $fundrefCount);
+            $fundrefHandle = null;
+        } finally {
+            if (is_resource($affiliationsHandle)) {
+                fclose($affiliationsHandle);
+            }
 
-            if ($entry !== null) {
-                $encoded = json_encode($entry, JSON_THROW_ON_ERROR);
-
-                if (! $first) {
-                    fwrite($outputHandle, ',');
-                } else {
-                    $first = false;
-                }
-
-                fwrite($outputHandle, $encoded);
-                $count++;
-
-                if ($count % 10000 === 0) {
-                    $this->info(sprintf('Processed %d organizations...', $count));
-                }
+            if (is_resource($fundrefHandle)) {
+                fclose($fundrefHandle);
             }
         }
 
-        fwrite($outputHandle, '],"total":'.$count.'}');
-        fclose($outputHandle);
-
-        return $count;
+        return [
+            'affiliations' => $affiliationCount,
+            'fundref' => $fundrefCount,
+        ];
     }
 
     /**
@@ -448,7 +545,10 @@ class GetRorIds extends Command
         ];
     }
 
-    private function convertDumpToSuggestions(string $sourcePath, string $targetPath): int
+    /**
+     * @return array{affiliations: int, fundref: int}
+     */
+    private function processGzipDump(string $sourcePath, string $affiliationsTargetPath, string $fundrefIndexTargetPath): array
     {
         $resource = gzopen($sourcePath, 'rb');
 
@@ -456,119 +556,122 @@ class GetRorIds extends Command
             throw new \RuntimeException('Unable to open the downloaded ROR data archive.');
         }
 
-        $outputHandle = fopen($targetPath, 'wb');
-
-        if ($outputHandle === false) {
-            gzclose($resource);
-
-            throw new \RuntimeException(sprintf('Unable to open output path [%s] for writing.', $targetPath));
-        }
-
         $timestamp = Carbon::now()->toIso8601String();
-        fwrite($outputHandle, '{"lastUpdated":'.json_encode($timestamp, JSON_THROW_ON_ERROR).',"data":[');
+        $source = $this->fundrefIndexSource($timestamp);
+        $affiliationsHandle = $this->openAffiliationSuggestions($affiliationsTargetPath, $timestamp);
+        $fundrefHandle = null;
+        $firstAffiliation = true;
+        $firstFundref = true;
+        $affiliationCount = 0;
+        $fundrefCount = 0;
 
-        $first = true;
-        $count = 0;
+        try {
+            $fundrefHandle = $this->openFundrefIndex($fundrefIndexTargetPath, $timestamp, $source);
 
-        while (! gzeof($resource)) {
-            $line = gzgets($resource);
+            while (! gzeof($resource)) {
+                $line = gzgets($resource);
 
-            if ($line === false) {
-                break;
-            }
+                if ($line === false) {
+                    break;
+                }
 
-            $trimmed = trim($line);
+                $trimmed = trim($line);
 
-            if ($trimmed === '') {
-                continue;
-            }
-
-            try {
-                /** @var array<string, mixed> $decoded */
-                $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
-            } catch (JsonException $exception) {
-                $this->warn(sprintf('Skipping malformed JSON line: %s', $exception->getMessage()));
-
-                continue;
-            }
-
-            $preferredName = Arr::get($decoded, 'name');
-            $identifier = Arr::get($decoded, 'id');
-
-            if (! is_string($preferredName) || ! is_string($identifier) || $preferredName === '' || $identifier === '') {
-                continue;
-            }
-
-            $aliases = Arr::get($decoded, 'aliases', []);
-
-            if (! is_array($aliases)) {
-                $aliases = [];
-            }
-
-            $aliases = array_values(array_filter(
-                array_map('strval', $aliases),
-                fn (string $alias) => $alias !== ''
-            ));
-
-            $acronyms = Arr::get($decoded, 'acronyms', []);
-
-            if (! is_array($acronyms)) {
-                $acronyms = [];
-            }
-
-            $acronyms = array_values(array_filter(
-                array_map('strval', $acronyms),
-                fn (string $acronym) => $acronym !== ''
-            ));
-
-            $rawLabels = Arr::get($decoded, 'labels', []);
-
-            if (! is_array($rawLabels)) {
-                $rawLabels = [];
-            }
-
-            $labelNames = [];
-
-            foreach ($rawLabels as $label) {
-                if (! is_array($label)) {
+                if ($trimmed === '') {
                     continue;
                 }
 
-                $labelValue = Arr::get($label, 'label');
+                try {
+                    $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+                } catch (JsonException $exception) {
+                    $this->warn(sprintf('Skipping malformed JSON line: %s', $exception->getMessage()));
 
-                if (is_string($labelValue) && $labelValue !== '') {
-                    $labelNames[] = $labelValue;
+                    continue;
+                }
+
+                if (! is_array($decoded)) {
+                    continue;
+                }
+
+                $entry = $this->processOrganization($decoded);
+
+                if ($entry === null) {
+                    continue;
+                }
+
+                $this->writeAffiliationSuggestion($affiliationsHandle, $entry, $firstAffiliation);
+                $affiliationCount++;
+
+                $candidate = $this->processFundrefCandidate($decoded, $source, $entry);
+
+                if ($candidate !== null) {
+                    $this->writeFundrefCandidate($fundrefHandle, $candidate, $firstFundref);
+                    $fundrefCount++;
                 }
             }
 
-            $combinedTerms = array_merge([$preferredName], $aliases, $acronyms, $labelNames);
-            $searchTerms = array_values(array_unique($combinedTerms));
-
-            $entry = [
-                'value' => $preferredName,
-                'rorId' => $identifier,
-                'country' => Arr::get($decoded, 'country.country_name'),
-                'countryCode' => Arr::get($decoded, 'country.country_code'),
-                'searchTerms' => $searchTerms,
-            ];
-
-            $encoded = json_encode($entry, JSON_THROW_ON_ERROR);
-
-            if (! $first) {
-                fwrite($outputHandle, ',');
-            } else {
-                $first = false;
+            $this->closeAffiliationSuggestions($affiliationsHandle, $affiliationCount);
+            $affiliationsHandle = null;
+            $this->closeFundrefIndex($fundrefHandle, $fundrefCount);
+            $fundrefHandle = null;
+        } finally {
+            if (is_resource($affiliationsHandle)) {
+                fclose($affiliationsHandle);
             }
 
-            fwrite($outputHandle, $encoded);
-            $count++;
+            if (is_resource($fundrefHandle)) {
+                fclose($fundrefHandle);
+            }
+
+            gzclose($resource);
         }
 
+        return [
+            'affiliations' => $affiliationCount,
+            'fundref' => $fundrefCount,
+        ];
+    }
+
+    /**
+     * @return resource
+     */
+    private function openAffiliationSuggestions(string $targetPath, string $timestamp): mixed
+    {
+        $outputHandle = fopen($targetPath, 'wb');
+
+        if ($outputHandle === false) {
+            throw new \RuntimeException(sprintf('Unable to open output path [%s] for writing.', $targetPath));
+        }
+
+        fwrite($outputHandle, '{"lastUpdated":'.json_encode($timestamp, JSON_THROW_ON_ERROR).',"data":[');
+
+        return $outputHandle;
+    }
+
+    /**
+     * @param  resource  $outputHandle
+     * @param  array<string, mixed>  $entry
+     */
+    private function writeAffiliationSuggestion(mixed $outputHandle, array $entry, bool &$first): void
+    {
+        $encoded = json_encode($entry, JSON_THROW_ON_ERROR);
+
+        if (! $first) {
+            fwrite($outputHandle, ',');
+        } else {
+            $first = false;
+        }
+
+        fwrite($outputHandle, $encoded);
+    }
+
+    /**
+     * @param  resource  $outputHandle
+     */
+    private function closeAffiliationSuggestions(mixed $outputHandle, int $count): void
+    {
         fwrite($outputHandle, '],"total":'.$count.'}');
         fclose($outputHandle);
-        gzclose($resource);
-
-        return $count;
     }
 
     private function fundrefIndexTargetPath(string $affiliationTargetPath): string
@@ -580,117 +683,6 @@ class GetRorIds extends Command
         }
 
         return storage_path('app/private/'.self::FUNDREF_INDEX_RELATIVE_PATH);
-    }
-
-    private function buildFundrefIndex(string $dumpPath, bool $isZip, string $targetPath): int
-    {
-        return $isZip
-            ? $this->buildFundrefIndexFromZip($dumpPath, $targetPath)
-            : $this->buildFundrefIndexFromGzip($dumpPath, $targetPath);
-    }
-
-    private function buildFundrefIndexFromZip(string $zipPath, string $targetPath): int
-    {
-        $tempJsonPath = $this->extractZipJsonToTemporaryFile($zipPath, 'ror-fundref-json-');
-
-        try {
-            return $this->buildFundrefIndexFromJsonFile($tempJsonPath, $targetPath);
-        } finally {
-            File::delete($tempJsonPath);
-        }
-    }
-
-    private function buildFundrefIndexFromJsonFile(string $sourcePath, string $targetPath): int
-    {
-        $jsonContent = file_get_contents($sourcePath);
-
-        if ($jsonContent === false) {
-            throw new \RuntimeException("Failed to read file: {$sourcePath}");
-        }
-
-        $organizations = json_decode($jsonContent, true, 512, JSON_THROW_ON_ERROR);
-        unset($jsonContent);
-
-        if (! is_array($organizations)) {
-            throw new \RuntimeException('Invalid JSON structure in ROR data file.');
-        }
-
-        $timestamp = Carbon::now()->toIso8601String();
-        $source = $this->fundrefIndexSource($timestamp);
-        $outputHandle = $this->openFundrefIndex($targetPath, $timestamp, $source);
-        $first = true;
-        $count = 0;
-
-        foreach ($organizations as $decoded) {
-            if (! is_array($decoded)) {
-                continue;
-            }
-
-            $candidate = $this->processFundrefCandidate($decoded, $source);
-
-            if ($candidate === null) {
-                continue;
-            }
-
-            $this->writeFundrefCandidate($outputHandle, $candidate, $first);
-            $count++;
-        }
-
-        $this->closeFundrefIndex($outputHandle, $count);
-
-        return $count;
-    }
-
-    private function buildFundrefIndexFromGzip(string $sourcePath, string $targetPath): int
-    {
-        $resource = gzopen($sourcePath, 'rb');
-
-        if ($resource === false) {
-            throw new \RuntimeException('Unable to open the downloaded ROR data archive for FundRef indexing.');
-        }
-
-        $timestamp = Carbon::now()->toIso8601String();
-        $source = $this->fundrefIndexSource($timestamp);
-        $outputHandle = $this->openFundrefIndex($targetPath, $timestamp, $source);
-        $first = true;
-        $count = 0;
-
-        while (! gzeof($resource)) {
-            $line = gzgets($resource);
-
-            if ($line === false) {
-                break;
-            }
-
-            $trimmed = trim($line);
-
-            if ($trimmed === '') {
-                continue;
-            }
-
-            try {
-                /** @var array<string, mixed> $decoded */
-                $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
-            } catch (JsonException $exception) {
-                $this->warn(sprintf('Skipping malformed JSON line during FundRef indexing: %s', $exception->getMessage()));
-
-                continue;
-            }
-
-            $candidate = $this->processFundrefCandidate($decoded, $source);
-
-            if ($candidate === null) {
-                continue;
-            }
-
-            $this->writeFundrefCandidate($outputHandle, $candidate, $first);
-            $count++;
-        }
-
-        $this->closeFundrefIndex($outputHandle, $count);
-        gzclose($resource);
-
-        return $count;
     }
 
     /**
@@ -754,16 +746,16 @@ class GetRorIds extends Command
     /**
      * @param  array<string, mixed>  $decoded
      * @param  array<string, mixed>  $source
+     * @param  array{prefLabel: string, rorId: string, otherLabel: array<int, string>}|null  $organization
      * @return array<string, mixed>|null
      */
-    private function processFundrefCandidate(array $decoded, array $source): ?array
+    private function processFundrefCandidate(array $decoded, array $source, ?array $organization = null): ?array
     {
-        $organization = $this->processOrganization($decoded);
+        $organization ??= $this->processOrganization($decoded);
 
         if ($organization === null) {
             return null;
         }
-
         $rorId = $this->canonicalRorIdentifier($organization['rorId']);
         $fundref = $this->extractFundrefExternalId($decoded);
 

--- a/app/Console/Commands/GetRorIds.php
+++ b/app/Console/Commands/GetRorIds.php
@@ -128,31 +128,35 @@ class GetRorIds extends Command
             File::makeDirectory($fundrefDirectory, 0o755, true);
         }
 
+        $temporaryTargetPath = $this->temporaryOutputPath($targetPath);
+        $temporaryFundrefIndexPath = $this->temporaryOutputPath($fundrefIndexPath);
+
         try {
             $fileKey = Arr::get($dataFile, 'key', '');
             $isZip = is_string($fileKey) && Str::endsWith($fileKey, '.zip');
 
             if ($isZip) {
-                $saved = $this->processZipDump($temporaryPath, $targetPath);
+                $saved = $this->processZipDump($temporaryPath, $temporaryTargetPath);
             } else {
-                $saved = $this->convertDumpToSuggestions($temporaryPath, $targetPath);
+                $saved = $this->convertDumpToSuggestions($temporaryPath, $temporaryTargetPath);
             }
 
-            $fundrefSaved = $this->buildFundrefIndex($temporaryPath, $isZip, $fundrefIndexPath);
+            if ($saved === 0) {
+                throw new \RuntimeException('No ROR affiliations were written.');
+            }
+
+            $fundrefSaved = $this->buildFundrefIndex($temporaryPath, $isZip, $temporaryFundrefIndexPath);
+
+            $this->replaceOutputFile($temporaryFundrefIndexPath, $fundrefIndexPath);
+            $this->replaceOutputFile($temporaryTargetPath, $targetPath);
         } catch (Throwable $exception) {
-            File::delete($temporaryPath);
+            File::delete([$temporaryPath, $temporaryTargetPath, $temporaryFundrefIndexPath]);
             $this->error(sprintf('Failed to process ROR data dump: %s', $exception->getMessage()));
 
             return self::FAILURE;
         }
 
         File::delete($temporaryPath);
-
-        if ($saved === 0) {
-            $this->warn('No ROR affiliations were written.');
-
-            return self::FAILURE;
-        }
 
         // Invalidate ROR caches after successful update
         $this->call('cache:clear-app', ['category' => 'ror']);
@@ -163,7 +167,36 @@ class GetRorIds extends Command
         return self::SUCCESS;
     }
 
+    private function temporaryOutputPath(string $targetPath): string
+    {
+        return dirname($targetPath)
+            .DIRECTORY_SEPARATOR
+            .'.'.basename($targetPath).'.'.(string) Str::uuid().'.tmp';
+    }
+
+    private function replaceOutputFile(string $temporaryPath, string $targetPath): void
+    {
+        if (! File::exists($temporaryPath)) {
+            throw new \RuntimeException("Temporary output file does not exist: {$temporaryPath}");
+        }
+
+        if (! @rename($temporaryPath, $targetPath)) {
+            throw new \RuntimeException("Failed to move temporary output file into place: {$targetPath}");
+        }
+    }
+
     private function processZipDump(string $zipPath, string $targetPath): int
+    {
+        $tempJsonPath = $this->extractZipJsonToTemporaryFile($zipPath, 'ror-json-');
+
+        try {
+            return $this->convertJsonToSuggestions($tempJsonPath, $targetPath);
+        } finally {
+            File::delete($tempJsonPath);
+        }
+    }
+
+    private function extractZipJsonToTemporaryFile(string $zipPath, string $temporaryPrefix): string
     {
         $zip = new \ZipArchive;
 
@@ -171,54 +204,60 @@ class GetRorIds extends Command
             throw new \RuntimeException('Unable to open the downloaded ROR data archive.');
         }
 
-        // Find the JSON file in the ZIP (prefer schema v1 for smaller size)
+        try {
+            $jsonFile = $this->findJsonFileInZip($zip);
+
+            if ($jsonFile === null) {
+                throw new \RuntimeException('No JSON file found in the ROR data archive.');
+            }
+
+            $this->info(sprintf('Processing %s from archive...', $jsonFile));
+
+            $source = $zip->getStream($jsonFile);
+
+            if ($source === false) {
+                throw new \RuntimeException(sprintf('Failed to stream %s from archive.', $jsonFile));
+            }
+
+            $tempJsonPath = (string) tempnam(sys_get_temp_dir(), $temporaryPrefix);
+            $target = fopen($tempJsonPath, 'wb');
+
+            if ($target === false) {
+                fclose($source);
+
+                throw new \RuntimeException(sprintf('Failed to open temporary JSON path for %s.', $jsonFile));
+            }
+
+            try {
+                stream_copy_to_stream($source, $target);
+            } finally {
+                fclose($source);
+                fclose($target);
+            }
+
+            return $tempJsonPath;
+        } finally {
+            $zip->close();
+        }
+    }
+
+    private function findJsonFileInZip(\ZipArchive $zip): ?string
+    {
         $jsonFile = null;
 
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $filename = $zip->getNameIndex($i);
 
             if (is_string($filename) && Str::endsWith($filename, '.json')) {
-                // Prefer schema v1 files (without _schema_v2 suffix) for smaller footprint
                 if (! Str::contains($filename, 'schema_v2')) {
-                    $jsonFile = $filename;
-
-                    break;
+                    return $filename;
                 }
 
-                // Fallback to v2 files
-                if ($jsonFile === null) {
-                    $jsonFile = $filename;
-                }
+                $jsonFile ??= $filename;
             }
         }
 
-        if ($jsonFile === null) {
-            $zip->close();
-
-            throw new \RuntimeException('No JSON file found in the ROR data archive.');
-        }
-
-        $this->info(sprintf('Processing %s from archive…', $jsonFile));
-
-        // Extract JSON content
-        $jsonContent = $zip->getFromName($jsonFile);
-        $zip->close();
-
-        if ($jsonContent === false) {
-            throw new \RuntimeException(sprintf('Failed to extract %s from archive.', $jsonFile));
-        }
-
-        // Create temporary file for JSON content
-        $tempJsonPath = (string) tempnam(sys_get_temp_dir(), 'ror-json-');
-        File::put($tempJsonPath, $jsonContent);
-
-        try {
-            $count = $this->convertJsonToSuggestions($tempJsonPath, $targetPath);
-        } finally {
-            File::delete($tempJsonPath);
-        }
-
-        return $count;
+        return $jsonFile;
     }
 
     private function convertJsonToSuggestions(string $sourcePath, string $targetPath): int
@@ -552,45 +591,7 @@ class GetRorIds extends Command
 
     private function buildFundrefIndexFromZip(string $zipPath, string $targetPath): int
     {
-        $zip = new \ZipArchive;
-
-        if ($zip->open($zipPath) !== true) {
-            throw new \RuntimeException('Unable to open the downloaded ROR data archive for FundRef indexing.');
-        }
-
-        $jsonFile = null;
-
-        for ($i = 0; $i < $zip->numFiles; $i++) {
-            $filename = $zip->getNameIndex($i);
-
-            if (is_string($filename) && Str::endsWith($filename, '.json')) {
-                if (! Str::contains($filename, 'schema_v2')) {
-                    $jsonFile = $filename;
-
-                    break;
-                }
-
-                if ($jsonFile === null) {
-                    $jsonFile = $filename;
-                }
-            }
-        }
-
-        if ($jsonFile === null) {
-            $zip->close();
-
-            throw new \RuntimeException('No JSON file found in the ROR data archive for FundRef indexing.');
-        }
-
-        $jsonContent = $zip->getFromName($jsonFile);
-        $zip->close();
-
-        if ($jsonContent === false) {
-            throw new \RuntimeException(sprintf('Failed to extract %s from archive for FundRef indexing.', $jsonFile));
-        }
-
-        $tempJsonPath = (string) tempnam(sys_get_temp_dir(), 'ror-fundref-json-');
-        File::put($tempJsonPath, $jsonContent);
+        $tempJsonPath = $this->extractZipJsonToTemporaryFile($zipPath, 'ror-fundref-json-');
 
         try {
             return $this->buildFundrefIndexFromJsonFile($tempJsonPath, $targetPath);

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorAcceptanceService.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorAcceptanceService.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+use App\Models\AssistantSuggestion;
+use App\Models\FunderIdentifierType;
+use App\Models\FundingReference;
+use App\Services\DataCiteSyncService;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Applies accepted Crossref Funder ID to ROR suggestions.
+ */
+final readonly class CrossrefFunderRorAcceptanceService
+{
+    public function __construct(
+        private DataCiteSyncService $dataCiteSyncService,
+        private CrossrefFunderRorIdentifierNormalizer $normalizer = new CrossrefFunderRorIdentifierNormalizer,
+    ) {}
+
+    /**
+     * @return array{success: bool, message: string}
+     */
+    public function accept(AssistantSuggestion $suggestion): array
+    {
+        $validation = $this->validatedPayload($suggestion);
+
+        if ($validation['success'] === false) {
+            return $validation;
+        }
+
+        /** @var array{ror_id: string, normalized_crossref_funder_id: string} $payload */
+        $payload = $validation['payload'];
+
+        $result = DB::transaction(function () use ($suggestion, $payload): array {
+            $fundingReference = FundingReference::query()
+                ->with('resource')
+                ->whereKey($suggestion->target_id)
+                ->where('resource_id', $suggestion->resource_id)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $fundingReference instanceof FundingReference) {
+                return [
+                    'success' => false,
+                    'message' => 'The funding reference for this Crossref-to-ROR suggestion no longer exists.',
+                ];
+            }
+
+            if (! $this->isCrossrefFunderType($fundingReference)) {
+                return [
+                    'success' => false,
+                    'message' => 'This funding reference is no longer typed as a Crossref Funder ID.',
+                ];
+            }
+
+            $current = $this->normalizer->normalizeCrossrefFunderId(
+                $fundingReference->funder_identifier,
+                allowBareSuffix: true,
+            );
+
+            if ($current === null || $current['normalized'] !== $payload['normalized_crossref_funder_id']) {
+                return [
+                    'success' => false,
+                    'message' => 'This funding reference changed since the suggestion was created. Please refresh the assistant list.',
+                ];
+            }
+
+            $rorType = $this->rorFunderIdentifierType();
+
+            if (! $rorType instanceof FunderIdentifierType) {
+                return [
+                    'success' => false,
+                    'message' => 'The local ROR funder identifier type is missing.',
+                ];
+            }
+
+            $fundingReference->update([
+                'funder_identifier' => $payload['ror_id'],
+                'funder_identifier_type_id' => $rorType->id,
+                'scheme_uri' => CrossrefFunderRorIdentifierNormalizer::ROR_SCHEME_URI,
+            ]);
+
+            AssistantSuggestion::query()
+                ->where('assistant_id', CrossrefFunderRorDiscoveryService::ASSISTANT_ID)
+                ->where('target_type', CrossrefFunderRorDiscoveryService::TARGET_TYPE)
+                ->where('target_id', $fundingReference->id)
+                ->where('id', '!=', $suggestion->id)
+                ->delete();
+
+            return [
+                'success' => true,
+                'message' => 'Funding reference identifier normalized to ROR.',
+                'funding_reference' => $fundingReference->fresh('resource'),
+            ];
+        });
+
+        if ($result['success'] !== true || ! ($result['funding_reference'] ?? null) instanceof FundingReference) {
+            return [
+                'success' => (bool) $result['success'],
+                'message' => (string) $result['message'],
+            ];
+        }
+
+        $fundingReference = $result['funding_reference'];
+        $syncResult = $this->dataCiteSyncService->syncIfRegistered($fundingReference->resource);
+
+        if ($syncResult->hasFailed()) {
+            return [
+                'success' => true,
+                'message' => 'Funding reference identifier normalized to ROR. DataCite sync was attempted but did not complete: '.$syncResult->errorMessage,
+            ];
+        }
+
+        return [
+            'success' => true,
+            'message' => 'Funding reference identifier normalized to ROR.',
+        ];
+    }
+
+    /**
+     * @return array{success: false, message: string}|array{success: true, payload: array{ror_id: string, normalized_crossref_funder_id: string}}
+     */
+    private function validatedPayload(AssistantSuggestion $suggestion): array
+    {
+        if ($suggestion->target_type !== CrossrefFunderRorDiscoveryService::TARGET_TYPE) {
+            return [
+                'success' => false,
+                'message' => 'This Crossref-to-ROR suggestion targets an unsupported entity type.',
+            ];
+        }
+
+        $metadata = $suggestion->metadata ?? [];
+        $current = is_array($metadata['current'] ?? null) ? $metadata['current'] : [];
+        $proposed = is_array($metadata['proposed'] ?? null) ? $metadata['proposed'] : [];
+
+        $rorId = $this->normalizer->canonicalRorIdentifier($proposed['funder_identifier'] ?? null);
+        $normalizedCrossrefFunderId = $this->normalizer->filledString($current['normalized_crossref_funder_id'] ?? null);
+        $proposedType = $this->normalizer->filledString($proposed['funder_identifier_type'] ?? null);
+        $schemeUri = $this->normalizer->filledString($proposed['scheme_uri'] ?? null);
+
+        if ($rorId === null || $normalizedCrossrefFunderId === null) {
+            return [
+                'success' => false,
+                'message' => 'This suggestion does not contain complete Crossref-to-ROR metadata.',
+            ];
+        }
+
+        if ($rorId !== $suggestion->suggested_value) {
+            return [
+                'success' => false,
+                'message' => 'The suggestion value and proposed ROR identifier do not match.',
+            ];
+        }
+
+        if ($proposedType !== 'ROR' || $schemeUri !== CrossrefFunderRorIdentifierNormalizer::ROR_SCHEME_URI) {
+            return [
+                'success' => false,
+                'message' => 'Only ROR funder identifier suggestions can be accepted by this assistant.',
+            ];
+        }
+
+        return [
+            'success' => true,
+            'payload' => [
+                'ror_id' => $rorId,
+                'normalized_crossref_funder_id' => $normalizedCrossrefFunderId,
+            ],
+        ];
+    }
+
+    private function isCrossrefFunderType(FundingReference $fundingReference): bool
+    {
+        $type = $fundingReference->funderIdentifierType;
+
+        return $type instanceof FunderIdentifierType
+            && ($type->name === 'Crossref Funder ID' || $type->slug === 'Crossref Funder ID');
+    }
+
+    private function rorFunderIdentifierType(): ?FunderIdentifierType
+    {
+        return FunderIdentifierType::query()
+            ->where('name', 'ROR')
+            ->orWhere('slug', 'ROR')
+            ->first();
+    }
+}

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorDiscoveryService.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorDiscoveryService.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+use Closure;
+use Illuminate\Support\Arr;
+
+/**
+ * Coordinates Crossref Funder ID to ROR discovery for funding references.
+ */
+final readonly class CrossrefFunderRorDiscoveryService
+{
+    public const string ASSISTANT_ID = 'crossref-funder-ror-suggestion';
+
+    public const string TARGET_TYPE = 'funding_reference';
+
+    public function __construct(
+        private CrossrefFunderRorMatchInputProvider $inputProvider,
+        private ?object $mappingSource = null,
+        private CrossrefFunderRorIdentifierNormalizer $normalizer = new CrossrefFunderRorIdentifierNormalizer,
+    ) {}
+
+    /**
+     * @param  Closure(int, string, int, string, string, float|null, array<string, mixed>|null): bool  $storeSuggestion
+     * @param  Closure(string): void  $onProgress
+     */
+    public function discover(Closure $storeSuggestion, Closure $onProgress): int
+    {
+        $inputs = $this->inputProvider->pendingInputs();
+        $inputCount = $inputs->count();
+
+        $onProgress("Checking {$inputCount} Crossref Funder ID funding reference(s) against the local ROR FundRef index.");
+
+        if ($inputCount === 0) {
+            $onProgress('No eligible Crossref Funder ID funding references found.');
+
+            return 0;
+        }
+
+        $stored = 0;
+        $suppressed = 0;
+
+        foreach ($inputs as $input) {
+            $result = $this->match($input);
+
+            if ($result['status'] !== 'matched') {
+                $suppressed++;
+                $onProgress(sprintf(
+                    'Suppressed funding_reference %d: %s.',
+                    $input->targetId,
+                    implode(', ', $result['reasons']),
+                ));
+
+                continue;
+            }
+
+            /** @var array<string, mixed> $metadata */
+            $metadata = $result['metadata'];
+            $rorId = (string) $metadata['proposed']['funder_identifier'];
+            $label = sprintf('%s -> %s', (string) $metadata['proposed']['ror_display_name'], $rorId);
+
+            $wasStored = $storeSuggestion(
+                $input->resourceId,
+                self::TARGET_TYPE,
+                $input->targetId,
+                $rorId,
+                $label,
+                1.0,
+                $metadata,
+            );
+
+            if ($wasStored) {
+                $stored++;
+            }
+        }
+
+        $onProgress("Stored {$stored} Crossref-to-ROR suggestion(s); suppressed {$suppressed} mapping(s).");
+
+        return $stored;
+    }
+
+    /**
+     * @return array{status: 'matched', metadata: array<string, mixed>}|array{status: 'suppressed', reasons: list<string>}
+     */
+    private function match(CrossrefFunderRorMatchInput $input): array
+    {
+        $candidates = $this->candidatesFor($input->normalizedCrossrefFunderId);
+
+        if ($candidates === []) {
+            return [
+                'status' => 'suppressed',
+                'reasons' => ['no_exact_ror_fundref_match'],
+            ];
+        }
+
+        $eligible = [];
+        $suppressionReasons = [];
+
+        foreach ($candidates as $candidate) {
+            $evaluation = $this->evaluateCandidate($candidate, $input);
+
+            if ($evaluation['eligible']) {
+                $eligible[] = $evaluation['candidate'];
+
+                continue;
+            }
+
+            foreach ($evaluation['reasons'] as $reason) {
+                $suppressionReasons[$reason] = true;
+            }
+        }
+
+        if (count($eligible) > 1) {
+            return [
+                'status' => 'suppressed',
+                'reasons' => ['multiple_active_ror_matches'],
+            ];
+        }
+
+        if ($eligible === []) {
+            $reasons = array_keys($suppressionReasons);
+
+            return [
+                'status' => 'suppressed',
+                'reasons' => $reasons !== [] ? $reasons : ['no_exact_ror_fundref_match'],
+            ];
+        }
+
+        return [
+            'status' => 'matched',
+            'metadata' => $this->metadata($input, $eligible[0]),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function candidatesFor(string $normalizedFundrefId): array
+    {
+        $source = $this->mappingSource ?? app(CrossrefFunderRorFundrefIndexMappingSource::class);
+
+        foreach (['candidatesForCrossrefFunderId', 'candidatesForFundref', 'lookup'] as $method) {
+            if (method_exists($source, $method)) {
+                $candidates = $source->{$method}($normalizedFundrefId);
+
+                if (! is_array($candidates)) {
+                    return [];
+                }
+
+                return array_values(array_filter($candidates, fn (mixed $candidate): bool => is_array($candidate)));
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array{eligible: true, candidate: array<string, mixed>, reasons: list<string>}|array{eligible: false, reasons: list<string>}
+     */
+    private function evaluateCandidate(array $candidate, CrossrefFunderRorMatchInput $input): array
+    {
+        $reasons = [];
+        $matchedExternalId = $this->matchedExternalId($candidate, $input->normalizedCrossrefFunderId);
+
+        if ($matchedExternalId === null) {
+            $reasons[] = 'no_exact_ror_fundref_match';
+        }
+
+        $rorId = $this->normalizer->canonicalRorIdentifier($candidate['ror_id'] ?? $candidate['id'] ?? null);
+
+        if ($rorId === null) {
+            $reasons[] = 'ror_candidate_missing_valid_id';
+        }
+
+        $status = $this->stringValue($candidate['ror_status'] ?? $candidate['status'] ?? null) ?? '';
+
+        if ($status !== 'active') {
+            $reasons[] = 'only_inactive_or_withdrawn_ror_matches';
+        }
+
+        $types = $this->stringList($candidate['ror_types'] ?? $candidate['types'] ?? []);
+
+        if (! in_array('funder', $types, true)) {
+            $reasons[] = 'ror_candidate_not_funder_type';
+        }
+
+        $source = is_array($candidate['source'] ?? null) ? $candidate['source'] : [];
+
+        if ($source === [] || $this->stringValue($source['source_retrieved_at'] ?? null) === null) {
+            $reasons[] = 'ror_candidate_missing_provenance';
+        }
+
+        if ($reasons !== []) {
+            return [
+                'eligible' => false,
+                'reasons' => array_values(array_unique($reasons)),
+            ];
+        }
+
+        $candidate['ror_id'] = $rorId;
+        $candidate['ror_status'] = $status;
+        $candidate['ror_types'] = $types;
+        $candidate['ror_display_name'] = $this->displayName($candidate);
+        $candidate['matched_external_id'] = $matchedExternalId;
+        $candidate['source'] = $source;
+
+        return [
+            'eligible' => true,
+            'candidate' => $candidate,
+            'reasons' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array{type: string, value: string, matched_in: string, preferred: string|null}|null
+     */
+    private function matchedExternalId(array $candidate, string $fundrefId): ?array
+    {
+        $fundref = Arr::get($candidate, 'external_ids.fundref');
+
+        if (! is_array($fundref)) {
+            return null;
+        }
+
+        $all = $fundref['all'] ?? [];
+
+        if (! is_array($all)) {
+            return null;
+        }
+
+        $values = array_map(fn (mixed $value): string => trim((string) $value), $all);
+
+        if (! in_array($fundrefId, $values, true)) {
+            return null;
+        }
+
+        return [
+            'type' => 'fundref',
+            'value' => $fundrefId,
+            'matched_in' => 'external_ids[type=fundref].all',
+            'preferred' => $this->stringValue($fundref['preferred'] ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function metadata(CrossrefFunderRorMatchInput $input, array $candidate): array
+    {
+        $warnings = $this->warnings($input, $candidate);
+
+        return [
+            'contract_version' => '1.0',
+            'issue' => 784,
+            'current' => $input->currentPayload(),
+            'proposed' => [
+                'funder_identifier' => $candidate['ror_id'],
+                'funder_identifier_type' => 'ROR',
+                'scheme_uri' => CrossrefFunderRorIdentifierNormalizer::ROR_SCHEME_URI,
+                'ror_id' => $candidate['ror_id'],
+                'ror_display_name' => $candidate['ror_display_name'],
+                'ror_status' => $candidate['ror_status'],
+                'ror_types' => $candidate['ror_types'],
+                'ror_record_last_modified' => $this->stringValue($candidate['ror_record_last_modified'] ?? null),
+                'matched_external_id' => $candidate['matched_external_id'],
+            ],
+            'provenance' => $candidate['source'],
+            'confidence' => [
+                'level' => 'high',
+                'score' => 1.0,
+                'evidence' => [
+                    'exact_fundref_external_id_match',
+                    'single_active_ror_candidate',
+                    'candidate_has_valid_ror_id',
+                    'source_snapshot_recorded',
+                ],
+            ],
+            'ambiguity' => [
+                'status' => $warnings === [] ? 'none' : 'warning',
+                'candidate_count' => 1,
+                'notes' => [],
+                'warnings' => $warnings,
+            ],
+            'acceptance' => [
+                'updates' => [
+                    'funder_identifier' => $candidate['ror_id'],
+                    'funder_identifier_type' => 'ROR',
+                    'scheme_uri' => CrossrefFunderRorIdentifierNormalizer::ROR_SCHEME_URI,
+                ],
+                'preserve' => [
+                    'funder_name',
+                    'award_number',
+                    'award_uri',
+                    'award_title',
+                ],
+                'preconditions' => [
+                    'target funding reference still exists',
+                    'target still has Crossref Funder ID type',
+                    'target normalized Crossref Funder ID still matches current.normalized_crossref_funder_id',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function warnings(CrossrefFunderRorMatchInput $input, array $candidate): array
+    {
+        $warnings = [];
+        $localName = mb_strtolower(trim($input->funderName));
+        $rorNames = array_map('mb_strtolower', $this->candidateNames($candidate));
+
+        if ($localName !== '' && ! in_array($localName, $rorNames, true)) {
+            $warnings[] = 'local_name_not_found_in_ror_names';
+        }
+
+        if ($localName !== '' && $localName !== mb_strtolower((string) $candidate['ror_display_name'])) {
+            $warnings[] = 'ror_display_name_differs_from_local_name';
+        }
+
+        return array_values(array_unique($warnings));
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function candidateNames(array $candidate): array
+    {
+        $names = [$this->displayName($candidate)];
+
+        foreach (['names', 'aliases', 'labels'] as $key) {
+            if (! is_array($candidate[$key] ?? null)) {
+                continue;
+            }
+
+            foreach ($candidate[$key] as $entry) {
+                if (is_string($entry) && trim($entry) !== '') {
+                    $names[] = trim($entry);
+
+                    continue;
+                }
+
+                if (is_array($entry)) {
+                    $value = $this->stringValue($entry['value'] ?? $entry['label'] ?? null);
+
+                    if ($value !== null) {
+                        $names[] = $value;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function displayName(array $candidate): string
+    {
+        return $this->stringValue($candidate['ror_display_name'] ?? $candidate['display_name'] ?? $candidate['name'] ?? null)
+            ?? 'Unknown ROR organization';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(fn (mixed $item): ?string => $this->stringValue($item), $value),
+            fn (?string $item): bool => $item !== null,
+        ));
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if ($value === null || is_array($value) || is_object($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorDiscoveryService.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorDiscoveryService.php
@@ -16,11 +16,15 @@ final readonly class CrossrefFunderRorDiscoveryService
 
     public const string TARGET_TYPE = 'funding_reference';
 
+    private CrossrefFunderRorMappingSource $mappingSource;
+
     public function __construct(
         private CrossrefFunderRorMatchInputProvider $inputProvider,
-        private ?CrossrefFunderRorMappingSource $mappingSource = null,
+        ?CrossrefFunderRorMappingSource $mappingSource = null,
         private CrossrefFunderRorIdentifierNormalizer $normalizer = new CrossrefFunderRorIdentifierNormalizer,
-    ) {}
+    ) {
+        $this->mappingSource = $mappingSource ?? app(CrossrefFunderRorFundrefIndexMappingSource::class);
+    }
 
     /**
      * @param  Closure(int, string, int, string, string, float|null, array<string, mixed>|null): bool  $storeSuggestion
@@ -139,9 +143,7 @@ final readonly class CrossrefFunderRorDiscoveryService
      */
     private function candidatesFor(string $normalizedFundrefId): array
     {
-        $source = $this->mappingSource ?? app(CrossrefFunderRorFundrefIndexMappingSource::class);
-
-        return $source->candidatesForCrossrefFunderId($normalizedFundrefId);
+        return $this->mappingSource->candidatesForCrossrefFunderId($normalizedFundrefId);
     }
 
     /**

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorDiscoveryService.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorDiscoveryService.php
@@ -18,7 +18,7 @@ final readonly class CrossrefFunderRorDiscoveryService
 
     public function __construct(
         private CrossrefFunderRorMatchInputProvider $inputProvider,
-        private ?object $mappingSource = null,
+        private ?CrossrefFunderRorMappingSource $mappingSource = null,
         private CrossrefFunderRorIdentifierNormalizer $normalizer = new CrossrefFunderRorIdentifierNormalizer,
     ) {}
 
@@ -141,19 +141,7 @@ final readonly class CrossrefFunderRorDiscoveryService
     {
         $source = $this->mappingSource ?? app(CrossrefFunderRorFundrefIndexMappingSource::class);
 
-        foreach (['candidatesForCrossrefFunderId', 'candidatesForFundref', 'lookup'] as $method) {
-            if (method_exists($source, $method)) {
-                $candidates = $source->{$method}($normalizedFundrefId);
-
-                if (! is_array($candidates)) {
-                    return [];
-                }
-
-                return array_values(array_filter($candidates, fn (mixed $candidate): bool => is_array($candidate)));
-            }
-        }
-
-        return [];
+        return $source->candidatesForCrossrefFunderId($normalizedFundrefId);
     }
 
     /**

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorFundrefIndexMappingSource.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorFundrefIndexMappingSource.php
@@ -11,7 +11,7 @@ use JsonException;
 /**
  * Reads exact FundRef-to-ROR candidates from the locally generated ROR index.
  */
-final class CrossrefFunderRorFundrefIndexMappingSource
+final class CrossrefFunderRorFundrefIndexMappingSource implements CrossrefFunderRorMappingSource
 {
     public const string INDEX_PATH = 'ror/ror-fundref-index.json';
 

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorFundrefIndexMappingSource.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorFundrefIndexMappingSource.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+use JsonException;
+
+/**
+ * Reads exact FundRef-to-ROR candidates from the locally generated ROR index.
+ */
+final class CrossrefFunderRorFundrefIndexMappingSource
+{
+    public const string INDEX_PATH = 'ror/ror-fundref-index.json';
+
+    /** @var array<array-key, list<array<string, mixed>>>|null */
+    private ?array $index = null;
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function candidatesForCrossrefFunderId(string $normalizedFundrefId): array
+    {
+        $this->ensureLoaded();
+
+        return $this->index[$normalizedFundrefId] ?? [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function candidatesForFundref(string $normalizedFundrefId): array
+    {
+        return $this->candidatesForCrossrefFunderId($normalizedFundrefId);
+    }
+
+    private function ensureLoaded(): void
+    {
+        if ($this->index !== null) {
+            return;
+        }
+
+        $this->index = [];
+        $disk = Storage::disk('local');
+
+        if (! $disk->exists(self::INDEX_PATH)) {
+            return;
+        }
+
+        $contents = $disk->get(self::INDEX_PATH);
+
+        if (! is_string($contents) || trim($contents) === '') {
+            return;
+        }
+
+        try {
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return;
+        }
+
+        if (! is_array($decoded)) {
+            return;
+        }
+
+        $entries = isset($decoded['data']) && is_array($decoded['data'])
+            ? $decoded['data']
+            : $decoded;
+
+        $fallbackSource = is_array($decoded['source'] ?? null) ? $decoded['source'] : [];
+
+        foreach ($entries as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $this->addEntry($entry, $fallbackSource);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @param  array<string, mixed>  $fallbackSource
+     */
+    private function addEntry(array $entry, array $fallbackSource): void
+    {
+        $fundref = $this->stringValue($entry['fundref'] ?? $entry['fundref_id'] ?? null);
+
+        if ($fundref !== null && is_array($entry['candidates'] ?? null)) {
+            foreach ($entry['candidates'] as $candidate) {
+                if (is_array($candidate)) {
+                    $this->appendCandidate($fundref, $this->withSource($candidate, $fallbackSource));
+                }
+            }
+
+            return;
+        }
+
+        foreach ($this->fundrefValues($entry) as $candidateFundref) {
+            $this->appendCandidate($candidateFundref, $this->withSource($entry, $fallbackSource));
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @param  array<string, mixed>  $fallbackSource
+     * @return array<string, mixed>
+     */
+    private function withSource(array $candidate, array $fallbackSource): array
+    {
+        if (! is_array($candidate['source'] ?? null) && $fallbackSource !== []) {
+            $candidate['source'] = $fallbackSource;
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return list<string>
+     */
+    private function fundrefValues(array $candidate): array
+    {
+        $values = Arr::get($candidate, 'external_ids.fundref.all');
+
+        if (is_array($values)) {
+            return array_values(array_filter(
+                array_map(fn (mixed $value): ?string => $this->stringValue($value), $values),
+                fn (?string $value): bool => $value !== null,
+            ));
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function appendCandidate(string $fundref, array $candidate): void
+    {
+        if (! preg_match('/^[0-9]+$/', $fundref)) {
+            return;
+        }
+
+        if ($this->index === null) {
+            $this->index = [];
+        }
+
+        $candidates = $this->index[$fundref] ?? [];
+        $candidates[] = $candidate;
+        $this->index[$fundref] = $candidates;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if ($value === null || is_array($value) || is_object($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorIdentifierNormalizer.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorIdentifierNormalizer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+final class CrossrefFunderRorIdentifierNormalizer
+{
+    public const string CROSSREF_SCHEME_URI = 'https://doi.org/10.13039/';
+
+    public const string ROR_SCHEME_URI = 'https://ror.org/';
+
+    /**
+     * @return array{identifier: string, normalized: string, canonical: string}|null
+     */
+    public function normalizeCrossrefFunderId(?string $identifier, bool $allowBareSuffix = false): ?array
+    {
+        $value = $this->filledString($identifier);
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (str_starts_with($value, '<') && str_ends_with($value, '>')) {
+            $value = trim(substr($value, 1, -1));
+        }
+
+        if ($value === '' || preg_match('/[\s?#]/', $value)) {
+            return null;
+        }
+
+        $doiBody = null;
+
+        if (preg_match('#^(?:https?://)?(?:dx\.)?doi\.org/(10\.13039/[0-9]+)$#i', $value, $matches)) {
+            $doiBody = $matches[1];
+        } elseif (preg_match('#^doi:(10\.13039/[0-9]+)$#i', $value, $matches)) {
+            $doiBody = $matches[1];
+        } elseif (preg_match('#^(10\.13039/[0-9]+)$#i', $value, $matches)) {
+            $doiBody = $matches[1];
+        } elseif ($allowBareSuffix && preg_match('/^[0-9]+$/', $value)) {
+            $doiBody = '10.13039/'.$value;
+        }
+
+        if ($doiBody === null || ! str_starts_with(strtolower($doiBody), '10.13039/')) {
+            return null;
+        }
+
+        $suffix = substr($doiBody, strlen('10.13039/'));
+
+        if ($suffix === '' || ! preg_match('/^[0-9]+$/', $suffix)) {
+            return null;
+        }
+
+        return [
+            'identifier' => self::CROSSREF_SCHEME_URI.$suffix,
+            'normalized' => $suffix,
+            'canonical' => self::CROSSREF_SCHEME_URI.$suffix,
+        ];
+    }
+
+    public function canonicalRorIdentifier(?string $identifier): ?string
+    {
+        $value = $this->filledString($identifier);
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (preg_match('#^(?:https?://)?(?:www\.)?ror\.org/([a-z0-9]{9})/?$#i', $value, $matches)) {
+            return self::ROR_SCHEME_URI.strtolower($matches[1]);
+        }
+
+        if (preg_match('/^[a-z0-9]{9}$/i', $value)) {
+            return self::ROR_SCHEME_URI.strtolower($value);
+        }
+
+        return null;
+    }
+
+    public function filledString(mixed $value): ?string
+    {
+        if ($value === null || is_array($value) || is_object($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorMappingSource.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorMappingSource.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+interface CrossrefFunderRorMappingSource
+{
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function candidatesForCrossrefFunderId(string $normalizedFundrefId): array;
+}

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorMatchInput.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorMatchInput.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+/**
+ * One funding reference that can be checked for Crossref Funder ID to ROR normalization.
+ */
+final readonly class CrossrefFunderRorMatchInput
+{
+    public function __construct(
+        public int $resourceId,
+        public string $targetType,
+        public int $targetId,
+        public string $funderName,
+        public string $funderIdentifier,
+        public string $funderIdentifierType,
+        public ?string $schemeUri,
+        public string $normalizedCrossrefFunderId,
+        public string $canonicalCrossrefFunderIdentifier,
+        public ?string $awardNumber = null,
+        public ?string $awardUri = null,
+        public ?string $awardTitle = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function currentPayload(): array
+    {
+        return array_filter([
+            'funding_reference_id' => $this->targetId,
+            'resource_id' => $this->resourceId,
+            'funder_name' => $this->funderName,
+            'funder_identifier' => $this->funderIdentifier,
+            'funder_identifier_type' => $this->funderIdentifierType,
+            'scheme_uri' => $this->schemeUri,
+            'normalized_crossref_funder_id' => $this->normalizedCrossrefFunderId,
+            'canonical_crossref_funder_identifier' => $this->canonicalCrossrefFunderIdentifier,
+            'award_number' => $this->awardNumber,
+            'award_uri' => $this->awardUri,
+            'award_title' => $this->awardTitle,
+        ], fn (mixed $value): bool => $value !== null && $value !== '');
+    }
+}

--- a/app/Services/CrossrefFunderRor/CrossrefFunderRorMatchInputProvider.php
+++ b/app/Services/CrossrefFunderRor/CrossrefFunderRorMatchInputProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CrossrefFunderRor;
+
+use App\Models\FundingReference;
+use Illuminate\Support\Collection;
+
+/**
+ * Reads funding references that are eligible for Crossref Funder ID to ROR normalization.
+ */
+class CrossrefFunderRorMatchInputProvider
+{
+    private const string TARGET_TYPE = 'funding_reference';
+
+    public function __construct(
+        private readonly CrossrefFunderRorIdentifierNormalizer $normalizer = new CrossrefFunderRorIdentifierNormalizer,
+    ) {}
+
+    /**
+     * @return Collection<int, CrossrefFunderRorMatchInput>
+     */
+    public function pendingInputs(): Collection
+    {
+        $rows = FundingReference::query()
+            ->with('funderIdentifierType')
+            ->whereNotNull('funder_identifier')
+            ->where('funder_identifier', '!=', '')
+            ->whereHas('resource')
+            ->whereHas('funderIdentifierType', function ($query): void {
+                $query->where('name', 'Crossref Funder ID')
+                    ->orWhere('slug', 'Crossref Funder ID');
+            })
+            ->orderBy('id')
+            ->get();
+
+        return $rows
+            ->map(fn (FundingReference $fundingReference): ?CrossrefFunderRorMatchInput => $this->toInput($fundingReference))
+            ->filter()
+            ->values();
+    }
+
+    private function toInput(FundingReference $fundingReference): ?CrossrefFunderRorMatchInput
+    {
+        $normalized = $this->normalizer->normalizeCrossrefFunderId(
+            $fundingReference->funder_identifier,
+            allowBareSuffix: true,
+        );
+
+        if ($normalized === null) {
+            return null;
+        }
+
+        $type = $fundingReference->funderIdentifierType;
+
+        if ($type === null) {
+            return null;
+        }
+
+        return new CrossrefFunderRorMatchInput(
+            resourceId: $fundingReference->resource_id,
+            targetType: self::TARGET_TYPE,
+            targetId: $fundingReference->id,
+            funderName: trim($fundingReference->funder_name),
+            funderIdentifier: $normalized['identifier'],
+            funderIdentifierType: $type->name,
+            schemeUri: $this->normalizer->filledString($fundingReference->scheme_uri),
+            normalizedCrossrefFunderId: $normalized['normalized'],
+            canonicalCrossrefFunderIdentifier: $normalized['canonical'],
+            awardNumber: $this->normalizer->filledString($fundingReference->award_number),
+            awardUri: $this->normalizer->filledString($fundingReference->award_uri),
+            awardTitle: $this->normalizer->filledString($fundingReference->award_title),
+        );
+    }
+}

--- a/modules/assistants/CrossrefFunderRorSuggestion/Assistant.php
+++ b/modules/assistants/CrossrefFunderRorSuggestion/Assistant.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Assistants\CrossrefFunderRorSuggestion;
+
+use App\Models\AssistantSuggestion;
+use App\Services\Assistance\GenericTableAssistant;
+use App\Services\CrossrefFunderRor\CrossrefFunderRorAcceptanceService;
+use App\Services\CrossrefFunderRor\CrossrefFunderRorDiscoveryService;
+use Closure;
+
+final class Assistant extends GenericTableAssistant
+{
+    public function __construct(
+        private readonly CrossrefFunderRorDiscoveryService $discoveryService,
+        private readonly CrossrefFunderRorAcceptanceService $acceptanceService,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function getManifestPath(): string
+    {
+        return __DIR__.'/manifest.json';
+    }
+
+    /**
+     * @param  Closure(string): void  $onProgress
+     */
+    #[\Override]
+    protected function discover(Closure $onProgress): int
+    {
+        return $this->discoveryService->discover(
+            storeSuggestion: fn (
+                int $resourceId,
+                string $targetType,
+                int $targetId,
+                string $suggestedValue,
+                string $suggestedLabel,
+                ?float $similarityScore,
+                ?array $metadata,
+            ): bool => $this->storeSuggestion(
+                resourceId: $resourceId,
+                targetType: $targetType,
+                targetId: $targetId,
+                suggestedValue: $suggestedValue,
+                suggestedLabel: $suggestedLabel,
+                similarityScore: $similarityScore,
+                metadata: $metadata,
+            ),
+            onProgress: $onProgress,
+        );
+    }
+
+    /** @return array{success: bool, message: string} */
+    #[\Override]
+    protected function applyAccepted(AssistantSuggestion $suggestion): array
+    {
+        return $this->acceptanceService->accept($suggestion);
+    }
+}

--- a/modules/assistants/CrossrefFunderRorSuggestion/manifest.json
+++ b/modules/assistants/CrossrefFunderRorSuggestion/manifest.json
@@ -1,0 +1,24 @@
+{
+    "id": "crossref-funder-ror-suggestion",
+    "name": "Crossref Funder ROR Suggestions",
+    "description": "Proposes ROR replacements for legacy Crossref Funder IDs on funding references.",
+    "icon": "BadgeCheck",
+    "version": "1.0.0",
+    "assistant_class": "Modules\\Assistants\\CrossrefFunderRorSuggestion\\Assistant",
+    "route_prefix": "crossref-funder-rors",
+    "lock_key": "crossref_funder_ror_discovery_running",
+    "cache_key_prefix": "crossref_funder_ror_discovery",
+    "sort_order": 45,
+    "status_labels": {
+        "checking": "Starting Crossref Funder ID to ROR discovery...",
+        "completed_with_results": "Crossref Funder ID to ROR discovery completed: {count} new suggestion(s) found.",
+        "completed_empty": "Crossref Funder ID to ROR discovery completed: No new suggestions found.",
+        "failed": "Crossref Funder ID to ROR discovery failed: {error}",
+        "already_running": "A Crossref Funder ID to ROR discovery job is already running."
+    },
+    "empty_state": {
+        "title": "No pending Crossref Funder ID suggestions",
+        "description": "No funding references currently have a safe Crossref Funder ID to ROR mapping."
+    },
+    "card_component": null
+}

--- a/tests/pest/Feature/Commands/GetRorIdsCommandTest.php
+++ b/tests/pest/Feature/Commands/GetRorIdsCommandTest.php
@@ -23,6 +23,51 @@ function getRorIdsCommandZipData(array $organizations): string
     return $zipData;
 }
 
+function getRorIdsCommandGzipData(array $organizations): string
+{
+    $jsonLines = implode("\n", array_map(
+        fn (array $organization): string => json_encode($organization, JSON_THROW_ON_ERROR),
+        $organizations,
+    ));
+    $tempGzipPath = tempnam(sys_get_temp_dir(), 'ror-test-gzip-');
+    $gzip = gzopen($tempGzipPath, 'wb');
+
+    if ($gzip === false) {
+        throw new RuntimeException('Failed to open test GZIP data.');
+    }
+
+    gzwrite($gzip, $jsonLines);
+    gzclose($gzip);
+
+    $gzipData = file_get_contents($tempGzipPath);
+    unlink($tempGzipPath);
+
+    if ($gzipData === false) {
+        throw new RuntimeException('Failed to read test GZIP data.');
+    }
+
+    return $gzipData;
+}
+
+function getRorIdsCommandGzipMetadata(): array
+{
+    return [
+        'hits' => [
+            'hits' => [
+                [
+                    'files' => [
+                        [
+                            'key' => 'v1.0-2024-01-01-ror-data.jsonl.gz',
+                            'links' => [
+                                'self' => 'https://example.org/ror-data-latest.jsonl.gz',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+}
 function getRorIdsCommandMetadata(): array
 {
     return [
@@ -134,6 +179,59 @@ it('fetches and stores ROR affiliation suggestions and FundRef index entries', f
     File::delete([$outputPath, $fundrefIndexPath]);
 });
 
+it('fetches gzipped JSONL ROR data and stores both derived outputs', function () {
+    $organizations = [
+        [
+            'id' => 'https://ror.org/018mejw64',
+            'name' => 'Deutsche Forschungsgemeinschaft',
+            'aliases' => ['German Research Foundation'],
+            'acronyms' => ['DFG'],
+            'labels' => [
+                ['label' => 'Deutsche Forschungsgemeinschaft'],
+            ],
+            'status' => 'active',
+            'types' => ['funder', 'nonprofit'],
+            'external_ids' => [
+                'FundRef' => [
+                    'preferred' => '501100001659',
+                    'all' => ['501100001659'],
+                ],
+            ],
+        ],
+    ];
+
+    Http::fake([
+        'https://zenodo.org/api/records*' => Http::response(getRorIdsCommandGzipMetadata(), 200),
+        'https://example.org/ror-data-latest.jsonl.gz' => Http::response(getRorIdsCommandGzipData($organizations), 200),
+    ]);
+
+    $outputPath = storage_path('app/testing/'.Str::random(8).'-ror-affiliations.json');
+    $fundrefIndexPath = dirname($outputPath).DIRECTORY_SEPARATOR.'ror-fundref-index.json';
+    File::ensureDirectoryExists(dirname($outputPath));
+
+    $this->artisan('get-ror-ids', ['--output' => $outputPath])
+        ->assertExitCode(0);
+
+    $decoded = json_decode(File::get($outputPath), true, 512, JSON_THROW_ON_ERROR);
+    $fundrefIndex = json_decode(File::get($fundrefIndexPath), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($decoded['data'])->toBe([
+        [
+            'prefLabel' => 'Deutsche Forschungsgemeinschaft',
+            'rorId' => 'https://ror.org/018mejw64',
+            'otherLabel' => [
+                'Deutsche Forschungsgemeinschaft',
+                'German Research Foundation',
+                'DFG',
+            ],
+        ],
+    ])
+        ->and($fundrefIndex['total'])->toBe(1)
+        ->and($fundrefIndex['data'][0]['ror_id'])->toBe('https://ror.org/018mejw64')
+        ->and($fundrefIndex['data'][0]['external_ids']['fundref']['all'])->toBe(['501100001659']);
+
+    File::delete([$outputPath, $fundrefIndexPath]);
+});
 it('does not replace affiliations when the FundRef index cannot be moved into place', function () {
     $organizations = [
         [
@@ -171,6 +269,42 @@ it('does not replace affiliations when the FundRef index cannot be moved into pl
     File::deleteDirectory($fundrefIndexPath);
 });
 
+it('does not replace the FundRef index when affiliations cannot be moved into place', function () {
+    $organizations = [
+        [
+            'id' => 'https://ror.org/018mejw64',
+            'name' => 'Deutsche Forschungsgemeinschaft',
+            'status' => 'active',
+            'types' => ['funder'],
+            'external_ids' => [
+                'FundRef' => [
+                    'preferred' => '501100001659',
+                    'all' => ['501100001659'],
+                ],
+            ],
+        ],
+    ];
+
+    Http::fake([
+        'https://zenodo.org/api/records*' => Http::response(getRorIdsCommandMetadata(), 200),
+        'https://example.org/ror-data-latest.zip' => Http::response(getRorIdsCommandZipData($organizations), 200),
+    ]);
+
+    $outputPath = storage_path('app/testing/'.Str::random(8).'-ror-affiliations.json');
+    $fundrefIndexPath = dirname($outputPath).DIRECTORY_SEPARATOR.'ror-fundref-index.json';
+    File::ensureDirectoryExists(dirname($outputPath));
+    File::makeDirectory($outputPath);
+    File::put($fundrefIndexPath, 'old fundref index');
+
+    $this->artisan('get-ror-ids', ['--output' => $outputPath])
+        ->expectsOutputToContain('Failed to process ROR data dump')
+        ->assertExitCode(1);
+
+    expect(File::get($fundrefIndexPath))->toBe('old fundref index');
+
+    File::deleteDirectory($outputPath);
+    File::delete($fundrefIndexPath);
+});
 it('fails when the metadata request is unsuccessful', function () {
     Http::fake([
         'https://zenodo.org/api/records*' => Http::response([], 503),

--- a/tests/pest/Feature/Commands/GetRorIdsCommandTest.php
+++ b/tests/pest/Feature/Commands/GetRorIdsCommandTest.php
@@ -4,35 +4,8 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 
-it('fetches and stores ROR affiliation suggestions', function () {
-    $organizations = [
-        [
-            'id' => 'https://ror.org/123456789',
-            'name' => 'Example University',
-            'aliases' => ['University of Examples'],
-            'acronyms' => ['EU'],
-            'labels' => [
-                ['label' => 'Beispiel Universität'],
-            ],
-            'country' => [
-                'country_name' => 'Germany',
-                'country_code' => 'DE',
-            ],
-        ],
-        [
-            'id' => 'https://ror.org/987654321',
-            'name' => 'Sample Institute',
-            'aliases' => [],
-            'acronyms' => [],
-            'labels' => [],
-            'country' => [
-                'country_name' => 'Switzerland',
-                'country_code' => 'CH',
-            ],
-        ],
-    ];
-
-    // Create a ZIP file with JSON content
+function getRorIdsCommandZipData(array $organizations): string
+{
     $jsonContent = json_encode($organizations, JSON_THROW_ON_ERROR);
     $tempZipPath = tempnam(sys_get_temp_dir(), 'ror-test-');
     $zip = new ZipArchive;
@@ -43,7 +16,16 @@ it('fetches and stores ROR affiliation suggestions', function () {
     $zipData = file_get_contents($tempZipPath);
     unlink($tempZipPath);
 
-    $metadata = [
+    if ($zipData === false) {
+        throw new RuntimeException('Failed to read test ZIP data.');
+    }
+
+    return $zipData;
+}
+
+function getRorIdsCommandMetadata(): array
+{
+    return [
         'hits' => [
             'hits' => [
                 [
@@ -59,43 +41,134 @@ it('fetches and stores ROR affiliation suggestions', function () {
             ],
         ],
     ];
+}
+
+it('fetches and stores ROR affiliation suggestions and FundRef index entries', function () {
+    $organizations = [
+        [
+            'id' => 'https://ror.org/018mejw64',
+            'name' => 'Deutsche Forschungsgemeinschaft',
+            'aliases' => ['German Research Foundation'],
+            'acronyms' => ['DFG'],
+            'labels' => [
+                ['label' => 'Deutsche Forschungsgemeinschaft'],
+            ],
+            'status' => 'active',
+            'types' => ['funder', 'nonprofit'],
+            'external_ids' => [
+                'FundRef' => [
+                    'preferred' => '501100001659',
+                    'all' => ['501100001659'],
+                ],
+            ],
+            'country' => [
+                'country_name' => 'Germany',
+                'country_code' => 'DE',
+            ],
+        ],
+        [
+            'id' => 'https://ror.org/04z8jg394',
+            'name' => 'GFZ Helmholtz Centre for Geosciences',
+            'aliases' => [],
+            'acronyms' => [],
+            'labels' => [],
+            'status' => 'active',
+            'types' => ['facility', 'funder'],
+            'external_ids' => [
+                'FundRef' => [
+                    'preferred' => '501100010956',
+                    'all' => ['501100010956'],
+                ],
+            ],
+            'country' => [
+                'country_name' => 'Germany',
+                'country_code' => 'DE',
+            ],
+        ],
+    ];
 
     Http::fake([
-        'https://zenodo.org/api/records*' => Http::response($metadata, 200),
-        'https://example.org/ror-data-latest.zip' => Http::response($zipData, 200),
+        'https://zenodo.org/api/records*' => Http::response(getRorIdsCommandMetadata(), 200),
+        'https://example.org/ror-data-latest.zip' => Http::response(getRorIdsCommandZipData($organizations), 200),
     ]);
 
     $outputPath = storage_path('app/testing/'.Str::random(8).'-ror-affiliations.json');
+    $fundrefIndexPath = dirname($outputPath).DIRECTORY_SEPARATOR.'ror-fundref-index.json';
     File::ensureDirectoryExists(dirname($outputPath));
 
     $this->artisan('get-ror-ids', ['--output' => $outputPath])
         ->assertExitCode(0);
 
-    expect(File::exists($outputPath))->toBeTrue();
+    expect(File::exists($outputPath))->toBeTrue()
+        ->and(File::exists($fundrefIndexPath))->toBeTrue();
 
     $decoded = json_decode(File::get($outputPath), true, 512, JSON_THROW_ON_ERROR);
+    $fundrefIndex = json_decode(File::get($fundrefIndexPath), true, 512, JSON_THROW_ON_ERROR);
 
-    expect($decoded)->toHaveKeys(['lastUpdated', 'data', 'total']);
-    expect($decoded['total'])->toBe(2);
-    expect($decoded['data'])->toBe([
+    expect($decoded)->toHaveKeys(['lastUpdated', 'data', 'total'])
+        ->and($decoded['total'])->toBe(2)
+        ->and($decoded['data'])->toBe([
+            [
+                'prefLabel' => 'Deutsche Forschungsgemeinschaft',
+                'rorId' => 'https://ror.org/018mejw64',
+                'otherLabel' => [
+                    'Deutsche Forschungsgemeinschaft',
+                    'German Research Foundation',
+                    'DFG',
+                ],
+            ],
+            [
+                'prefLabel' => 'GFZ Helmholtz Centre for Geosciences',
+                'rorId' => 'https://ror.org/04z8jg394',
+                'otherLabel' => ['GFZ Helmholtz Centre for Geosciences'],
+            ],
+        ])
+        ->and($fundrefIndex)->toHaveKeys(['lastUpdated', 'source', 'data', 'total'])
+        ->and($fundrefIndex['total'])->toBe(2)
+        ->and($fundrefIndex['data'][0]['ror_id'])->toBe('https://ror.org/018mejw64')
+        ->and($fundrefIndex['data'][0]['external_ids']['fundref']['all'])->toBe(['501100001659'])
+        ->and($fundrefIndex['data'][1]['ror_id'])->toBe('https://ror.org/04z8jg394')
+        ->and($fundrefIndex['data'][1]['external_ids']['fundref']['all'])->toBe(['501100010956'])
+        ->and($fundrefIndex['source']['source_file'])->toBe('ror/ror-fundref-index.json');
+
+    File::delete([$outputPath, $fundrefIndexPath]);
+});
+
+it('does not replace affiliations when the FundRef index cannot be moved into place', function () {
+    $organizations = [
         [
-            'prefLabel' => 'Example University',
-            'rorId' => 'https://ror.org/123456789',
-            'otherLabel' => [
-                'Example University',
-                'University of Examples',
-                'EU',
-                'Beispiel Universität',
+            'id' => 'https://ror.org/018mejw64',
+            'name' => 'Deutsche Forschungsgemeinschaft',
+            'status' => 'active',
+            'types' => ['funder'],
+            'external_ids' => [
+                'FundRef' => [
+                    'preferred' => '501100001659',
+                    'all' => ['501100001659'],
+                ],
             ],
         ],
-        [
-            'prefLabel' => 'Sample Institute',
-            'rorId' => 'https://ror.org/987654321',
-            'otherLabel' => ['Sample Institute'],
-        ],
+    ];
+
+    Http::fake([
+        'https://zenodo.org/api/records*' => Http::response(getRorIdsCommandMetadata(), 200),
+        'https://example.org/ror-data-latest.zip' => Http::response(getRorIdsCommandZipData($organizations), 200),
     ]);
 
+    $outputPath = storage_path('app/testing/'.Str::random(8).'-ror-affiliations.json');
+    $fundrefIndexPath = dirname($outputPath).DIRECTORY_SEPARATOR.'ror-fundref-index.json';
+    File::ensureDirectoryExists(dirname($outputPath));
+    File::put($outputPath, 'old affiliations');
+    File::makeDirectory($fundrefIndexPath);
+
+    $this->artisan('get-ror-ids', ['--output' => $outputPath])
+        ->expectsOutputToContain('Failed to process ROR data dump')
+        ->assertExitCode(1);
+
+    expect(File::get($outputPath))->toBe('old affiliations');
+
     File::delete($outputPath);
+    File::deleteDirectory($fundrefIndexPath);
 });
 
 it('fails when the metadata request is unsuccessful', function () {

--- a/tests/pest/Feature/Services/CrossrefFunderRorDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/CrossrefFunderRorDiscoveryServiceTest.php
@@ -6,13 +6,14 @@ use App\Models\FunderIdentifierType;
 use App\Models\FundingReference;
 use App\Models\Resource;
 use App\Services\CrossrefFunderRor\CrossrefFunderRorDiscoveryService;
+use App\Services\CrossrefFunderRor\CrossrefFunderRorMappingSource;
 use App\Services\CrossrefFunderRor\CrossrefFunderRorMatchInputProvider;
 use Database\Seeders\FunderIdentifierTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-final class CrossrefFunderRorInMemoryMappingSource
+final class CrossrefFunderRorInMemoryMappingSource implements CrossrefFunderRorMappingSource
 {
     /** @var list<string> */
     public array $requestedFundrefIds = [];
@@ -33,15 +34,7 @@ final class CrossrefFunderRorInMemoryMappingSource
     /**
      * @return list<array<string, mixed>>
      */
-    public function candidatesForFundref(string $normalizedFundrefId): array
-    {
-        return $this->lookup($normalizedFundrefId);
-    }
-
-    /**
-     * @return list<array<string, mixed>>
-     */
-    public function lookup(string $normalizedFundrefId): array
+    private function lookup(string $normalizedFundrefId): array
     {
         $this->requestedFundrefIds[] = $normalizedFundrefId;
 

--- a/tests/pest/Feature/Services/CrossrefFunderRorDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/CrossrefFunderRorDiscoveryServiceTest.php
@@ -1,0 +1,477 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\FunderIdentifierType;
+use App\Models\FundingReference;
+use App\Models\Resource;
+use App\Services\CrossrefFunderRor\CrossrefFunderRorDiscoveryService;
+use App\Services\CrossrefFunderRor\CrossrefFunderRorMatchInputProvider;
+use Database\Seeders\FunderIdentifierTypeSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+final class CrossrefFunderRorInMemoryMappingSource
+{
+    /** @var list<string> */
+    public array $requestedFundrefIds = [];
+
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $candidatesByFundref
+     */
+    public function __construct(private readonly array $candidatesByFundref) {}
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function candidatesForCrossrefFunderId(string $normalizedFundrefId): array
+    {
+        return $this->lookup($normalizedFundrefId);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function candidatesForFundref(string $normalizedFundrefId): array
+    {
+        return $this->lookup($normalizedFundrefId);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function lookup(string $normalizedFundrefId): array
+    {
+        $this->requestedFundrefIds[] = $normalizedFundrefId;
+
+        return $this->candidatesByFundref[$normalizedFundrefId] ?? [];
+    }
+}
+
+function crossrefFunderRorType(string $name): FunderIdentifierType
+{
+    return FunderIdentifierType::where('name', $name)->firstOrFail();
+}
+
+function crossrefFunderRorFundingReference(
+    Resource $resource,
+    string $funderName,
+    ?string $identifier,
+    FunderIdentifierType $type,
+    ?string $schemeUri = 'https://doi.org/10.13039/',
+    array $overrides = [],
+): FundingReference {
+    return FundingReference::create(array_replace([
+        'resource_id' => $resource->id,
+        'funder_name' => $funderName,
+        'funder_identifier' => $identifier,
+        'funder_identifier_type_id' => $type->id,
+        'scheme_uri' => $schemeUri,
+        'award_number' => 'EXAMPLE-1',
+        'award_uri' => 'https://example.test/award/1',
+        'award_title' => 'Existing award metadata must be preserved',
+    ], $overrides));
+}
+
+function crossrefFunderRorCandidate(array $overrides = []): array
+{
+    return array_replace_recursive([
+        'ror_id' => 'https://ror.org/018mejw64',
+        'ror_display_name' => 'Deutsche Forschungsgemeinschaft',
+        'ror_status' => 'active',
+        'ror_types' => ['funder', 'nonprofit'],
+        'ror_record_last_modified' => '2026-06-01',
+        'external_ids' => [
+            'fundref' => [
+                'all' => ['501100001659'],
+                'preferred' => '501100001659',
+            ],
+        ],
+        'source' => [
+            'source' => 'ror_fundref_index',
+            'source_file' => 'ror/ror-fundref-index.json',
+            'source_generated_by' => 'get-ror-ids',
+            'source_generated_from' => 'ROR Zenodo data dump',
+            'source_retrieved_at' => '2026-06-24T00:00:00Z',
+            'matching_strategy' => 'exact_fundref_external_id',
+        ],
+    ], $overrides);
+}
+
+it('reads only eligible Crossref Funder ID funding references as normalized inputs', function (): void {
+    $this->seed(FunderIdentifierTypeSeeder::class);
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.001')->create();
+    $crossrefType = crossrefFunderRorType('Crossref Funder ID');
+    $rorType = crossrefFunderRorType('ROR');
+    $otherType = crossrefFunderRorType('Other');
+
+    $dfg = crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Deutsche Forschungsgemeinschaft',
+        identifier: ' https://doi.org/10.13039/501100001659 ',
+        type: $crossrefType,
+    );
+
+    $gfz = crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'GFZ Helmholtz Centre for Geosciences',
+        identifier: 'doi:10.13039/501100010956',
+        type: $crossrefType,
+    );
+
+    $europeanCommission = crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'European Commission',
+        identifier: '501100000780',
+        type: $crossrefType,
+        schemeUri: null,
+    );
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Already ROR-normalized DFG',
+        identifier: 'https://ror.org/018mejw64',
+        type: $rorType,
+        schemeUri: 'https://ror.org/',
+    );
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Crossref-shaped value with unsupported local type',
+        identifier: 'https://doi.org/10.13039/501100004238',
+        type: $otherType,
+    );
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Missing identifier',
+        identifier: null,
+        type: $crossrefType,
+    );
+
+    $inputs = (new CrossrefFunderRorMatchInputProvider)->pendingInputs();
+
+    expect($inputs)->toHaveCount(3)
+        ->and($inputs->pluck('targetId')->all())->toEqualCanonicalizing([
+            $dfg->id,
+            $gfz->id,
+            $europeanCommission->id,
+        ]);
+
+    $dfgInput = $inputs->first(fn (object $input): bool => $input->targetId === $dfg->id);
+    $gfzInput = $inputs->first(fn (object $input): bool => $input->targetId === $gfz->id);
+    $ecInput = $inputs->first(fn (object $input): bool => $input->targetId === $europeanCommission->id);
+
+    expect($dfgInput->targetType)->toBe('funding_reference')
+        ->and($dfgInput->resourceId)->toBe($resource->id)
+        ->and($dfgInput->funderName)->toBe('Deutsche Forschungsgemeinschaft')
+        ->and($dfgInput->funderIdentifier)->toBe('https://doi.org/10.13039/501100001659')
+        ->and($dfgInput->funderIdentifierType)->toBe('Crossref Funder ID')
+        ->and($dfgInput->normalizedCrossrefFunderId)->toBe('501100001659')
+        ->and($dfgInput->canonicalCrossrefFunderIdentifier)->toBe('https://doi.org/10.13039/501100001659')
+        ->and($gfzInput->normalizedCrossrefFunderId)->toBe('501100010956')
+        ->and($gfzInput->canonicalCrossrefFunderIdentifier)->toBe('https://doi.org/10.13039/501100010956')
+        ->and($ecInput->normalizedCrossrefFunderId)->toBe('501100000780')
+        ->and($ecInput->canonicalCrossrefFunderIdentifier)->toBe('https://doi.org/10.13039/501100000780');
+});
+
+it('stores high-confidence suggestions for exact active ROR fundref mappings', function (): void {
+    $this->seed(FunderIdentifierTypeSeeder::class);
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.002')->create();
+    $crossrefType = crossrefFunderRorType('Crossref Funder ID');
+
+    $dfg = crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Deutsche Forschungsgemeinschaft',
+        identifier: 'https://doi.org/10.13039/501100001659',
+        type: $crossrefType,
+        overrides: [
+            'award_number' => 'DFG-EXAMPLE',
+            'award_uri' => 'https://gepris.dfg.de/gepris/OCTOPUS',
+            'award_title' => 'A real funding reference keeps its award metadata',
+        ],
+    );
+
+    $gfz = crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'GFZ Helmholtz Centre for Geosciences',
+        identifier: 'https://doi.org/10.13039/501100010956',
+        type: $crossrefType,
+    );
+
+    $mappingSource = new CrossrefFunderRorInMemoryMappingSource([
+        '501100001659' => [
+            crossrefFunderRorCandidate(),
+        ],
+        '501100010956' => [
+            crossrefFunderRorCandidate([
+                'ror_id' => 'https://ror.org/04z8jg394',
+                'ror_display_name' => 'GFZ Helmholtz Centre for Geosciences',
+                'ror_types' => ['facility', 'funder'],
+                'external_ids' => [
+                    'fundref' => [
+                        'all' => ['501100010956'],
+                        'preferred' => '501100010956',
+                    ],
+                ],
+            ]),
+        ],
+    ]);
+
+    $service = new CrossrefFunderRorDiscoveryService(
+        inputProvider: new CrossrefFunderRorMatchInputProvider,
+        mappingSource: $mappingSource,
+    );
+
+    $storedSuggestions = [];
+    $progressMessages = [];
+
+    $count = $service->discover(
+        storeSuggestion: function (
+            int $resourceId,
+            string $targetType,
+            int $targetId,
+            string $suggestedValue,
+            string $suggestedLabel,
+            ?float $similarityScore,
+            ?array $metadata,
+        ) use (&$storedSuggestions): bool {
+            $storedSuggestions[] = compact(
+                'resourceId',
+                'targetType',
+                'targetId',
+                'suggestedValue',
+                'suggestedLabel',
+                'similarityScore',
+                'metadata',
+            );
+
+            return true;
+        },
+        onProgress: function (string $message) use (&$progressMessages): void {
+            $progressMessages[] = $message;
+        },
+    );
+
+    expect($count)->toBe(2)
+        ->and($storedSuggestions)->toHaveCount(2)
+        ->and($mappingSource->requestedFundrefIds)->toEqualCanonicalizing([
+            '501100001659',
+            '501100010956',
+        ]);
+
+    $dfgSuggestion = collect($storedSuggestions)->first(fn (array $suggestion): bool => $suggestion['targetId'] === $dfg->id);
+    $gfzSuggestion = collect($storedSuggestions)->first(fn (array $suggestion): bool => $suggestion['targetId'] === $gfz->id);
+
+    expect($dfgSuggestion)->not->toBeNull()
+        ->and($dfgSuggestion['resourceId'])->toBe($resource->id)
+        ->and($dfgSuggestion['targetType'])->toBe('funding_reference')
+        ->and($dfgSuggestion['suggestedValue'])->toBe('https://ror.org/018mejw64')
+        ->and($dfgSuggestion['suggestedLabel'])->toContain('Deutsche Forschungsgemeinschaft')
+        ->and($dfgSuggestion['similarityScore'])->toBe(1.0)
+        ->and($dfgSuggestion['metadata']['contract_version'])->toBe('1.0')
+        ->and($dfgSuggestion['metadata']['current']['funding_reference_id'])->toBe($dfg->id)
+        ->and($dfgSuggestion['metadata']['current']['funder_name'])->toBe('Deutsche Forschungsgemeinschaft')
+        ->and($dfgSuggestion['metadata']['current']['funder_identifier'])->toBe('https://doi.org/10.13039/501100001659')
+        ->and($dfgSuggestion['metadata']['current']['funder_identifier_type'])->toBe('Crossref Funder ID')
+        ->and($dfgSuggestion['metadata']['current']['normalized_crossref_funder_id'])->toBe('501100001659')
+        ->and($dfgSuggestion['metadata']['current']['canonical_crossref_funder_identifier'])->toBe('https://doi.org/10.13039/501100001659')
+        ->and($dfgSuggestion['metadata']['current']['award_number'])->toBe('DFG-EXAMPLE')
+        ->and($dfgSuggestion['metadata']['proposed']['funder_identifier'])->toBe('https://ror.org/018mejw64')
+        ->and($dfgSuggestion['metadata']['proposed']['funder_identifier_type'])->toBe('ROR')
+        ->and($dfgSuggestion['metadata']['proposed']['scheme_uri'])->toBe('https://ror.org/')
+        ->and($dfgSuggestion['metadata']['proposed']['matched_external_id'])->toBe([
+            'type' => 'fundref',
+            'value' => '501100001659',
+            'matched_in' => 'external_ids[type=fundref].all',
+            'preferred' => '501100001659',
+        ])
+        ->and($dfgSuggestion['metadata']['provenance']['source'])->toBe('ror_fundref_index')
+        ->and($dfgSuggestion['metadata']['provenance']['matching_strategy'])->toBe('exact_fundref_external_id')
+        ->and($dfgSuggestion['metadata']['confidence']['level'])->toBe('high')
+        ->and($dfgSuggestion['metadata']['confidence']['score'])->toBe(1.0)
+        ->and($dfgSuggestion['metadata']['confidence']['evidence'])->toContain('exact_fundref_external_id_match')
+        ->and($dfgSuggestion['metadata']['ambiguity'])->toMatchArray([
+            'status' => 'none',
+            'candidate_count' => 1,
+            'notes' => [],
+            'warnings' => [],
+        ])
+        ->and($dfgSuggestion['metadata']['acceptance']['updates'])->toBe([
+            'funder_identifier' => 'https://ror.org/018mejw64',
+            'funder_identifier_type' => 'ROR',
+            'scheme_uri' => 'https://ror.org/',
+        ])
+        ->and($dfgSuggestion['metadata']['acceptance']['preserve'])->toEqualCanonicalizing([
+            'funder_name',
+            'award_number',
+            'award_uri',
+            'award_title',
+        ])
+        ->and($gfzSuggestion['suggestedValue'])->toBe('https://ror.org/04z8jg394')
+        ->and($gfzSuggestion['metadata']['proposed']['matched_external_id']['matched_in'])->toBe('external_ids[type=fundref].all')
+        ->and($progressMessages)->not->toBeEmpty();
+});
+
+it('suppresses valid Crossref Funder IDs when no exact ROR fundref mapping exists', function (): void {
+    $this->seed(FunderIdentifierTypeSeeder::class);
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.003')->create();
+    $crossrefType = crossrefFunderRorType('Crossref Funder ID');
+    $rorType = crossrefFunderRorType('ROR');
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'University of Potsdam',
+        identifier: 'https://doi.org/10.13039/501100004238',
+        type: $crossrefType,
+    );
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Already normalized DFG',
+        identifier: 'https://ror.org/018mejw64',
+        type: $rorType,
+        schemeUri: 'https://ror.org/',
+    );
+
+    $mappingSource = new CrossrefFunderRorInMemoryMappingSource([]);
+    $service = new CrossrefFunderRorDiscoveryService(
+        inputProvider: new CrossrefFunderRorMatchInputProvider,
+        mappingSource: $mappingSource,
+    );
+
+    $storedSuggestions = [];
+
+    $count = $service->discover(
+        storeSuggestion: function () use (&$storedSuggestions): bool {
+            $storedSuggestions[] = true;
+
+            return true;
+        },
+        onProgress: fn (string $message): null => null,
+    );
+
+    expect($count)->toBe(0)
+        ->and($storedSuggestions)->toBeEmpty()
+        ->and($mappingSource->requestedFundrefIds)->toBe(['501100004238']);
+});
+
+it('suppresses ambiguous mappings when the same FundRef ID has multiple active ROR candidates', function (): void {
+    $this->seed(FunderIdentifierTypeSeeder::class);
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.004')->create();
+    $crossrefType = crossrefFunderRorType('Crossref Funder ID');
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'Deutsche Forschungsgemeinschaft',
+        identifier: 'https://doi.org/10.13039/501100001659',
+        type: $crossrefType,
+    );
+
+    $mappingSource = new CrossrefFunderRorInMemoryMappingSource([
+        '501100001659' => [
+            crossrefFunderRorCandidate(),
+            crossrefFunderRorCandidate([
+                'ror_id' => 'https://ror.org/04z8jg394',
+                'ror_display_name' => 'GFZ Helmholtz Centre for Geosciences',
+                'ror_types' => ['facility', 'funder'],
+            ]),
+        ],
+    ]);
+
+    $service = new CrossrefFunderRorDiscoveryService(
+        inputProvider: new CrossrefFunderRorMatchInputProvider,
+        mappingSource: $mappingSource,
+    );
+
+    $storedSuggestions = [];
+    $progressMessages = [];
+
+    $count = $service->discover(
+        storeSuggestion: function () use (&$storedSuggestions): bool {
+            $storedSuggestions[] = true;
+
+            return true;
+        },
+        onProgress: function (string $message) use (&$progressMessages): void {
+            $progressMessages[] = $message;
+        },
+    );
+
+    expect($count)->toBe(0)
+        ->and($storedSuggestions)->toBeEmpty()
+        ->and($mappingSource->requestedFundrefIds)->toBe(['501100001659'])
+        ->and(implode("\n", $progressMessages))->toContain('multiple_active_ror_matches');
+});
+
+it('suppresses exact mappings when all ROR candidates are inactive or not funder records', function (): void {
+    $this->seed(FunderIdentifierTypeSeeder::class);
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.005')->create();
+    $crossrefType = crossrefFunderRorType('Crossref Funder ID');
+
+    crossrefFunderRorFundingReference(
+        resource: $resource,
+        funderName: 'European Commission',
+        identifier: 'https://doi.org/10.13039/501100000780',
+        type: $crossrefType,
+    );
+
+    $mappingSource = new CrossrefFunderRorInMemoryMappingSource([
+        '501100000780' => [
+            crossrefFunderRorCandidate([
+                'ror_id' => 'https://ror.org/00k4n6c32',
+                'ror_display_name' => 'European Commission',
+                'ror_status' => 'inactive',
+                'ror_types' => ['funder', 'government'],
+                'external_ids' => [
+                    'fundref' => [
+                        'all' => ['501100000780'],
+                        'preferred' => '501100000780',
+                    ],
+                ],
+            ]),
+            crossrefFunderRorCandidate([
+                'ror_id' => 'https://ror.org/03yrm5c26',
+                'ror_display_name' => 'California Digital Library',
+                'ror_status' => 'active',
+                'ror_types' => ['archive'],
+                'external_ids' => [
+                    'fundref' => [
+                        'all' => ['501100000780'],
+                        'preferred' => '501100000780',
+                    ],
+                ],
+            ]),
+        ],
+    ]);
+
+    $service = new CrossrefFunderRorDiscoveryService(
+        inputProvider: new CrossrefFunderRorMatchInputProvider,
+        mappingSource: $mappingSource,
+    );
+
+    $storedSuggestions = [];
+    $progressMessages = [];
+
+    $count = $service->discover(
+        storeSuggestion: function () use (&$storedSuggestions): bool {
+            $storedSuggestions[] = true;
+
+            return true;
+        },
+        onProgress: function (string $message) use (&$progressMessages): void {
+            $progressMessages[] = $message;
+        },
+    );
+
+    expect($count)->toBe(0)
+        ->and($storedSuggestions)->toBeEmpty()
+        ->and(implode("\n", $progressMessages))->toContain('only_inactive_or_withdrawn_ror_matches')
+        ->and(implode("\n", $progressMessages))->toContain('ror_candidate_not_funder_type');
+});

--- a/tests/pest/Feature/Services/CrossrefFunderRorSuggestionAssistantTest.php
+++ b/tests/pest/Feature/Services/CrossrefFunderRorSuggestionAssistantTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AssistantSuggestion;
+use App\Models\FunderIdentifierType;
+use App\Models\FundingReference;
+use App\Models\Resource;
+use App\Services\CrossrefFunderRor\CrossrefFunderRorDiscoveryService;
+use Database\Seeders\FunderIdentifierTypeSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Assistants\CrossrefFunderRorSuggestion\Assistant;
+
+uses(RefreshDatabase::class);
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function crossrefFunderRorAcceptanceMetadata(FundingReference $fundingReference, array $overrides = []): array
+{
+    return array_replace_recursive([
+        'contract_version' => '1.0',
+        'issue' => 784,
+        'current' => [
+            'funding_reference_id' => $fundingReference->id,
+            'resource_id' => $fundingReference->resource_id,
+            'funder_name' => $fundingReference->funder_name,
+            'funder_identifier' => 'https://doi.org/10.13039/501100001659',
+            'funder_identifier_type' => 'Crossref Funder ID',
+            'scheme_uri' => 'https://doi.org/10.13039/',
+            'normalized_crossref_funder_id' => '501100001659',
+            'canonical_crossref_funder_identifier' => 'https://doi.org/10.13039/501100001659',
+            'award_number' => $fundingReference->award_number,
+            'award_uri' => $fundingReference->award_uri,
+            'award_title' => $fundingReference->award_title,
+        ],
+        'proposed' => [
+            'funder_identifier' => 'https://ror.org/018mejw64',
+            'funder_identifier_type' => 'ROR',
+            'scheme_uri' => 'https://ror.org/',
+            'ror_id' => 'https://ror.org/018mejw64',
+            'ror_display_name' => 'Deutsche Forschungsgemeinschaft',
+            'ror_status' => 'active',
+            'ror_types' => ['funder', 'nonprofit'],
+            'matched_external_id' => [
+                'type' => 'fundref',
+                'value' => '501100001659',
+                'matched_in' => 'external_ids[type=fundref].all',
+                'preferred' => '501100001659',
+            ],
+        ],
+        'provenance' => [
+            'source' => 'ror_fundref_index',
+            'source_file' => 'ror/ror-fundref-index.json',
+            'source_retrieved_at' => '2026-06-24T00:00:00Z',
+            'matching_strategy' => 'exact_fundref_external_id',
+        ],
+        'confidence' => [
+            'level' => 'high',
+            'score' => 1.0,
+            'evidence' => ['exact_fundref_external_id_match'],
+        ],
+        'ambiguity' => [
+            'status' => 'none',
+            'candidate_count' => 1,
+            'notes' => [],
+            'warnings' => [],
+        ],
+    ], $overrides);
+}
+
+/**
+ * @param  array<string, mixed>  $metadata
+ */
+function crossrefFunderRorAcceptanceSuggestion(Resource $resource, FundingReference $fundingReference, array $metadata = []): AssistantSuggestion
+{
+    return AssistantSuggestion::create([
+        'assistant_id' => CrossrefFunderRorDiscoveryService::ASSISTANT_ID,
+        'resource_id' => $resource->id,
+        'target_type' => CrossrefFunderRorDiscoveryService::TARGET_TYPE,
+        'target_id' => $fundingReference->id,
+        'suggested_value' => 'https://ror.org/018mejw64',
+        'suggested_label' => 'Deutsche Forschungsgemeinschaft -> https://ror.org/018mejw64',
+        'similarity_score' => 1.0,
+        'metadata' => crossrefFunderRorAcceptanceMetadata($fundingReference, $metadata),
+        'discovered_at' => now(),
+    ]);
+}
+
+it('accepts a Crossref-to-ROR suggestion by updating only identifier fields', function (): void {
+    (new FunderIdentifierTypeSeeder)->run();
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.006')->create();
+    $crossrefType = FunderIdentifierType::where('name', 'Crossref Funder ID')->firstOrFail();
+
+    $fundingReference = FundingReference::create([
+        'resource_id' => $resource->id,
+        'funder_name' => 'Deutsche Forschungsgemeinschaft',
+        'funder_identifier' => 'https://doi.org/10.13039/501100001659',
+        'funder_identifier_type_id' => $crossrefType->id,
+        'scheme_uri' => 'https://doi.org/10.13039/',
+        'award_number' => 'DFG-EXAMPLE',
+        'award_uri' => 'https://gepris.dfg.de/gepris/OCTOPUS',
+        'award_title' => 'Existing award metadata must remain untouched',
+    ]);
+
+    $suggestion = crossrefFunderRorAcceptanceSuggestion($resource, $fundingReference);
+
+    $result = app(Assistant::class)->acceptSuggestion($suggestion->id);
+    $fundingReference->refresh();
+
+    $rorType = FunderIdentifierType::where('name', 'ROR')->firstOrFail();
+
+    expect($result['success'])->toBeTrue()
+        ->and(AssistantSuggestion::find($suggestion->id))->toBeNull()
+        ->and($fundingReference->funder_identifier)->toBe('https://ror.org/018mejw64')
+        ->and($fundingReference->funder_identifier_type_id)->toBe($rorType->id)
+        ->and($fundingReference->scheme_uri)->toBe('https://ror.org/')
+        ->and($fundingReference->funder_name)->toBe('Deutsche Forschungsgemeinschaft')
+        ->and($fundingReference->award_number)->toBe('DFG-EXAMPLE')
+        ->and($fundingReference->award_uri)->toBe('https://gepris.dfg.de/gepris/OCTOPUS')
+        ->and($fundingReference->award_title)->toBe('Existing award metadata must remain untouched');
+});
+
+it('does not accept stale Crossref-to-ROR suggestions when the current FundRef ID changed', function (): void {
+    (new FunderIdentifierTypeSeeder)->run();
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.007')->create();
+    $crossrefType = FunderIdentifierType::where('name', 'Crossref Funder ID')->firstOrFail();
+
+    $fundingReference = FundingReference::create([
+        'resource_id' => $resource->id,
+        'funder_name' => 'Deutsche Forschungsgemeinschaft',
+        'funder_identifier' => 'https://doi.org/10.13039/501100010956',
+        'funder_identifier_type_id' => $crossrefType->id,
+        'scheme_uri' => 'https://doi.org/10.13039/',
+    ]);
+
+    $suggestion = crossrefFunderRorAcceptanceSuggestion($resource, $fundingReference);
+
+    $result = app(Assistant::class)->acceptSuggestion($suggestion->id);
+    $fundingReference->refresh();
+
+    expect($result['success'])->toBeFalse()
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
+        ->and($fundingReference->funder_identifier)->toBe('https://doi.org/10.13039/501100010956')
+        ->and($fundingReference->funder_identifier_type_id)->toBe($crossrefType->id)
+        ->and($fundingReference->scheme_uri)->toBe('https://doi.org/10.13039/');
+});


### PR DESCRIPTION
This pull request introduces a new Crossref Funder ID to ROR mapping and acceptance feature. It adds a discovery service that suggests ROR identifiers for funding references with Crossref Funder IDs, an acceptance service to apply accepted suggestions, and a mapping source that loads local FundRef-to-ROR candidate data. The services ensure only valid, unambiguous, and provenance-backed ROR matches are suggested and accepted.

**Crossref Funder ID to ROR Suggestion and Acceptance**

* `CrossrefFunderRorDiscoveryService`:
  - Implements logic to discover and suggest ROR identifiers for funding references with Crossref Funder IDs, ensuring only single, active, funder-type ROR matches with provenance are considered. Suppressed suggestions are logged with reasons.
  - Provides a contract for storing suggestions and reporting progress, with detailed metadata and acceptance preconditions in the suggestion payload.

* `CrossrefFunderRorAcceptanceService`:
  - Validates and applies accepted ROR suggestions to funding references, updating the identifier and type, removing other suggestions, and triggering DataCite sync if needed. Handles validation failures with descriptive messages.

**Mapping Source Integration**

* `CrossrefFunderRorFundrefIndexMappingSource`:
  - Loads and parses a local JSON index of FundRef-to-ROR candidates, supporting robust fallback and provenance handling. Provides candidate lookups for normalized FundRef IDs.