### PR TITLE
Feature: Support second Prefix for GEOFON resources and import Line Geometry

### DIFF
--- a/app/Http/Controllers/DataCiteImportController.php
+++ b/app/Http/Controllers/DataCiteImportController.php
@@ -7,7 +7,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StartSingleOldResourceImportRequest;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Models\Resource;
-use App\Services\LegacyResourceLookupService;
+use App\Services\DoiImportEligibilityService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -54,21 +54,21 @@ class DataCiteImportController extends Controller
     /**
      * Start a new single-resource import job.
      *
-     * Validates that the DOI belongs to a GFZ legacy resource before dispatching
-     * the background job.
+     * Validates that the DOI uses a configured GFZ DataCite prefix or belongs to
+     * a GFZ legacy resource before dispatching the background job.
      */
     public function startSingle(
         StartSingleOldResourceImportRequest $request,
-        LegacyResourceLookupService $legacyResourceLookupService
+        DoiImportEligibilityService $doiImportEligibilityService
     ): JsonResponse {
         $this->authorize('importFromDataCite', Resource::class);
 
         $doi = $request->getDoi();
 
         try {
-            $exists = $legacyResourceLookupService->existsByDoi($doi);
+            $exists = $doiImportEligibilityService->canImport($doi);
         } catch (\Throwable $exception) {
-            Log::warning('Legacy DOI lookup failed before single DataCite import', [
+            Log::warning('DOI eligibility lookup failed before single DataCite import', [
                 'doi' => $doi,
                 'error' => $exception->getMessage(),
             ]);
@@ -80,7 +80,7 @@ class DataCiteImportController extends Controller
 
         if (! $exists) {
             throw \Illuminate\Validation\ValidationException::withMessages([
-                'doi' => 'Only GFZ legacy resources can be imported with this action.',
+                'doi' => 'Only DOIs with a configured GFZ DataCite prefix or GFZ legacy resources can be imported with this action.',
             ]);
         }
 
@@ -185,3 +185,5 @@ class DataCiteImportController extends Controller
         ], now()->addHours(24));
     }
 }
+
+

--- a/app/Http/Controllers/DataCiteImportController.php
+++ b/app/Http/Controllers/DataCiteImportController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StartSingleOldResourceImportRequest;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Models\Resource;
+use App\Models\User;
 use App\Services\DoiImportEligibilityService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
@@ -14,6 +15,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Controller for DataCite import operations.
@@ -37,7 +39,7 @@ class DataCiteImportController extends Controller
 
         $importId = Str::uuid()->toString();
 
-        /** @var \App\Models\User $user */
+        /** @var User $user */
         $user = $request->user();
 
         $this->initializeProgress(importId: $importId, total: 0);
@@ -79,14 +81,14 @@ class DataCiteImportController extends Controller
         }
 
         if (! $exists) {
-            throw \Illuminate\Validation\ValidationException::withMessages([
+            throw ValidationException::withMessages([
                 'doi' => 'Only DOIs with a configured GFZ DataCite prefix or GFZ legacy resources can be imported with this action.',
             ]);
         }
 
         $importId = Str::uuid()->toString();
 
-        /** @var \App\Models\User $user */
+        /** @var User $user */
         $user = $request->user();
 
         $this->initializeProgress(importId: $importId, total: 1);
@@ -185,5 +187,3 @@ class DataCiteImportController extends Controller
         ], now()->addHours(24));
     }
 }
-
-

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -205,7 +205,7 @@ class StoreDraftResourceRequest extends FormRequest
     }
 
     /**
-     * Input normalization â€“ reuses the same logic as StoreResourceRequest.
+     * Input normalization - reuses the same logic as StoreResourceRequest.
      */
     protected function prepareForValidation(): void
     {
@@ -1035,7 +1035,7 @@ class StoreDraftResourceRequest extends FormRequest
     }
 
     /**
-     * After-validation hooks â€” structural checks with minimal mandatory field enforcement.
+     * After-validation hooks - structural checks with minimal mandatory field enforcement.
      *
      * Unlike StoreResourceRequest, this does NOT require:
      * - At least one Abstract description
@@ -1146,7 +1146,7 @@ class StoreDraftResourceRequest extends FormRequest
     }
 
     /**
-     * Normalize a DOI input value: trim, strip URL prefix, lowercase â€” or return null.
+     * Normalize a DOI input value: trim, strip URL prefix, lowercase, or return null.
      */
     private function normalizeDoiInput(mixed $input): mixed
     {
@@ -1220,4 +1220,3 @@ class StoreDraftResourceRequest extends FormRequest
         return true;
     }
 }
-

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -1046,7 +1046,7 @@ class StoreDraftResourceRequest extends FormRequest
      * - Main Title must exist (at least one)
      * - Person authors must have lastName if provided
      * - Contributors must have proper structure if provided
-     * - Polygon coverages must have at least 3 points
+     * - Polygon and line coverages must have the required minimum number of points
      *
      * @return array<int, callable(Validator): void>
      */
@@ -1114,7 +1114,7 @@ class StoreDraftResourceRequest extends FormRequest
                     );
                 }
             },
-            // Validate polygon coverages have at least 3 points
+            // Validate polygon and line coverages have the required minimum number of points
             function (Validator $validator): void {
                 $coverages = $this->input('spatialTemporalCoverages', []);
 

--- a/app/Http/Requests/StoreDraftResourceRequest.php
+++ b/app/Http/Requests/StoreDraftResourceRequest.php
@@ -205,7 +205,7 @@ class StoreDraftResourceRequest extends FormRequest
     }
 
     /**
-     * Input normalization – reuses the same logic as StoreResourceRequest.
+     * Input normalization â€“ reuses the same logic as StoreResourceRequest.
      */
     protected function prepareForValidation(): void
     {
@@ -1035,7 +1035,7 @@ class StoreDraftResourceRequest extends FormRequest
     }
 
     /**
-     * After-validation hooks — structural checks with minimal mandatory field enforcement.
+     * After-validation hooks â€” structural checks with minimal mandatory field enforcement.
      *
      * Unlike StoreResourceRequest, this does NOT require:
      * - At least one Abstract description
@@ -1129,13 +1129,14 @@ class StoreDraftResourceRequest extends FormRequest
 
                     $type = $coverage['type'] ?? 'point';
 
-                    if ($type === 'polygon') {
+                    if ($type === 'polygon' || $type === 'line') {
                         $polygonPoints = $coverage['polygonPoints'] ?? [];
+                        $minimumPoints = $type === 'polygon' ? 3 : 2;
 
-                        if (! is_array($polygonPoints) || count($polygonPoints) < 3) {
+                        if (! is_array($polygonPoints) || count($polygonPoints) < $minimumPoints) {
                             $validator->errors()->add(
                                 "spatialTemporalCoverages.$index.polygonPoints",
-                                '[Spatial & Temporal Coverage] Coverage #'.($index + 1).' polygon must have at least 3 points.',
+                                '[Spatial & Temporal Coverage] Coverage #'.($index + 1).' '.$type.' must have at least '.$minimumPoints.' points.',
                             );
                         }
                     }
@@ -1145,7 +1146,7 @@ class StoreDraftResourceRequest extends FormRequest
     }
 
     /**
-     * Normalize a DOI input value: trim, strip URL prefix, lowercase — or return null.
+     * Normalize a DOI input value: trim, strip URL prefix, lowercase â€” or return null.
      */
     private function normalizeDoiInput(mixed $input): mixed
     {
@@ -1219,3 +1220,4 @@ class StoreDraftResourceRequest extends FormRequest
         return true;
     }
 }
+

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -1421,7 +1421,7 @@ class StoreResourceRequest extends FormRequest
                 }
             },
             function (Validator $validator): void {
-                // Validate polygon coverages have at least 3 points
+                // Validate polygon and line coverages have the required minimum number of points
                 $coverages = $this->input('spatialTemporalCoverages', []);
 
                 if (! is_array($coverages)) {

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -179,7 +179,7 @@ class StoreResourceRequest extends FormRequest
             // Related Item Manager: inline <relatedItem> metadata (DataCite 4.7).
             'relatedItems' => ['nullable', 'array'],
             // Canonical DataCite `resourceTypeGeneral` enum (PascalCase, no
-            // spaces — e.g. `JournalArticle`); kept in sync with
+            // spaces â€” e.g. `JournalArticle`); kept in sync with
             // `StoreRelatedItemRequest` and the vocabularies endpoint via
             // `ResourceType::slugToDataciteResourceTypeGeneral()` (and the
             // matching instance helper `dataciteResourceTypeGeneral()`).
@@ -1033,7 +1033,7 @@ class StoreResourceRequest extends FormRequest
     }
 
     /**
-     * Normalize a DOI input value: trim, strip URL prefix, lowercase — or return null.
+     * Normalize a DOI input value: trim, strip URL prefix, lowercase â€” or return null.
      *
      * Reuses the normalization logic from DoiSuggestionService to ensure consistent
      * DOI handling across the entire system (validation, storage, duplicate checks).
@@ -1373,7 +1373,7 @@ class StoreResourceRequest extends FormRequest
 
                     $roles = $contributor['roles'] ?? [];
 
-                    // Skip roles-empty check — already enforced by 'contributors.*.roles' => ['required', 'array', 'min:1'] in rules()
+                    // Skip roles-empty check â€” already enforced by 'contributors.*.roles' => ['required', 'array', 'min:1'] in rules()
 
                     // Require email when Contact Person role is assigned to a person contributor
                     if ($type === 'person' && is_array($roles) && $contactPersonNames !== []) {
@@ -1435,13 +1435,14 @@ class StoreResourceRequest extends FormRequest
 
                     $type = $coverage['type'] ?? 'point';
 
-                    if ($type === 'polygon') {
+                    if ($type === 'polygon' || $type === 'line') {
                         $polygonPoints = $coverage['polygonPoints'] ?? [];
+                        $minimumPoints = $type === 'polygon' ? 3 : 2;
 
-                        if (! is_array($polygonPoints) || count($polygonPoints) < 3) {
+                        if (! is_array($polygonPoints) || count($polygonPoints) < $minimumPoints) {
                             $validator->errors()->add(
                                 "spatialTemporalCoverages.$index.polygonPoints",
-                                '[Spatial & Temporal Coverage] Coverage #'.($index + 1).' polygon must have at least 3 points.',
+                                '[Spatial & Temporal Coverage] Coverage #'.($index + 1).' '.$type.' must have at least '.$minimumPoints.' points.',
                             );
                         }
                     }
@@ -1461,3 +1462,4 @@ class StoreResourceRequest extends FormRequest
         return null;
     }
 }
+

--- a/app/Http/Requests/StoreResourceRequest.php
+++ b/app/Http/Requests/StoreResourceRequest.php
@@ -179,7 +179,7 @@ class StoreResourceRequest extends FormRequest
             // Related Item Manager: inline <relatedItem> metadata (DataCite 4.7).
             'relatedItems' => ['nullable', 'array'],
             // Canonical DataCite `resourceTypeGeneral` enum (PascalCase, no
-            // spaces â€” e.g. `JournalArticle`); kept in sync with
+            // spaces -- e.g. `JournalArticle`); kept in sync with
             // `StoreRelatedItemRequest` and the vocabularies endpoint via
             // `ResourceType::slugToDataciteResourceTypeGeneral()` (and the
             // matching instance helper `dataciteResourceTypeGeneral()`).
@@ -1033,7 +1033,7 @@ class StoreResourceRequest extends FormRequest
     }
 
     /**
-     * Normalize a DOI input value: trim, strip URL prefix, lowercase â€” or return null.
+     * Normalize a DOI input value: trim, strip URL prefix, lowercase, or return null.
      *
      * Reuses the normalization logic from DoiSuggestionService to ensure consistent
      * DOI handling across the entire system (validation, storage, duplicate checks).
@@ -1373,7 +1373,7 @@ class StoreResourceRequest extends FormRequest
 
                     $roles = $contributor['roles'] ?? [];
 
-                    // Skip roles-empty check â€” already enforced by 'contributors.*.roles' => ['required', 'array', 'min:1'] in rules()
+                    // Skip roles-empty check -- already enforced by 'contributors.*.roles' => ['required', 'array', 'min:1'] in rules()
 
                     // Require email when Contact Person role is assigned to a person contributor
                     if ($type === 'person' && is_array($roles) && $contactPersonNames !== []) {
@@ -1462,4 +1462,3 @@ class StoreResourceRequest extends FormRequest
         return null;
     }
 }
-

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -646,6 +646,7 @@ class ImportFromDataCiteJob implements ShouldQueue
     {
         return ['changed' => false];
     }
+
     /**
      * @return array{changed: bool, metaworks_unavailable: bool}
      */
@@ -886,4 +887,3 @@ class ImportFromDataCiteJob implements ShouldQueue
         return $this->singleDoi;
     }
 }
-

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -7,6 +7,7 @@ namespace App\Jobs;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteImportService;
+use App\Services\DataCiteLandingPageImportService;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
@@ -505,14 +506,17 @@ class ImportFromDataCiteJob implements ShouldQueue
             if ($existingResource !== null) {
                 Log::debug('Skipping existing DOI', ['doi' => $doi]);
 
-                $legacyDownloadSync = $shouldLookupMetaworks
-                    ? $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService)
-                    : $this->emptyLegacyDownloadSyncResult();
+                $dataCiteLandingPageSync = $this->syncDataCiteLandingPage($existingResource, $doiRecord);
+                $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
+
+                if ($shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
+                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
+                }
 
                 return [
                     'status' => 'skipped',
                     'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
-                    'enriched' => $legacyDownloadSync['changed'],
+                    'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
                 ];
             }
 
@@ -539,14 +543,19 @@ class ImportFromDataCiteJob implements ShouldQueue
                 Log::debug('Skipping existing DOI', ['doi' => $doi]);
 
                 $existingResource = Resource::where('doi', $doi)->first();
-                $legacyDownloadSync = $existingResource !== null && $shouldLookupMetaworks
-                    ? $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService)
-                    : $this->emptyLegacyDownloadSyncResult();
+                $dataCiteLandingPageSync = $existingResource !== null
+                    ? $this->syncDataCiteLandingPage($existingResource, $preparedDoiRecord)
+                    : $this->emptyDataCiteLandingPageSyncResult();
+                $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
+
+                if ($existingResource !== null && $shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
+                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
+                }
 
                 return [
                     'status' => 'skipped',
                     'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
-                    'enriched' => $legacyDownloadSync['changed'],
+                    'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
                 ];
             }
 
@@ -554,6 +563,8 @@ class ImportFromDataCiteJob implements ShouldQueue
             $importedResource = $result['resource'];
 
             $this->enrichImportedResourceFromLegacyDatabases($importedResource, $doi);
+
+            $this->syncDataCiteLandingPage($importedResource, $preparedDoiRecord);
 
             $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
@@ -583,14 +594,19 @@ class ImportFromDataCiteJob implements ShouldQueue
                 Log::debug('Skipping DOI due to concurrent insert (race condition)', ['doi' => $doi]);
 
                 $existingResource = Resource::where('doi', $doi)->first();
-                $legacyDownloadSync = $existingResource !== null && $shouldLookupMetaworks
-                    ? $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService)
-                    : $this->emptyLegacyDownloadSyncResult();
+                $dataCiteLandingPageSync = $existingResource !== null
+                    ? $this->syncDataCiteLandingPage($existingResource, $doiRecord)
+                    : $this->emptyDataCiteLandingPageSyncResult();
+                $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
+
+                if ($existingResource !== null && $shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
+                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
+                }
 
                 return [
                     'status' => 'skipped',
                     'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
-                    'enriched' => $legacyDownloadSync['changed'],
+                    'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
                 ];
             }
 
@@ -598,6 +614,38 @@ class ImportFromDataCiteJob implements ShouldQueue
         }
     }
 
+    /**
+     * @param  array<string, mixed>  $doiRecord
+     * @return array{changed: bool}
+     */
+    private function syncDataCiteLandingPage(Resource $resource, array $doiRecord): array
+    {
+        $attributes = is_array($doiRecord['attributes'] ?? null)
+            ? $doiRecord['attributes']
+            : $doiRecord;
+
+        try {
+            $result = app(DataCiteLandingPageImportService::class)->createExternalForResource($resource, $attributes);
+
+            return ['changed' => $result['changed']];
+        } catch (\Throwable $exception) {
+            Log::warning('Failed to import external DataCite landing page URL', [
+                'doi' => $resource->doi,
+                'resource_id' => $resource->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return $this->emptyDataCiteLandingPageSyncResult();
+        }
+    }
+
+    /**
+     * @return array{changed: bool}
+     */
+    private function emptyDataCiteLandingPageSyncResult(): array
+    {
+        return ['changed' => false];
+    }
     /**
      * @return array{changed: bool, metaworks_unavailable: bool}
      */
@@ -838,3 +886,4 @@ class ImportFromDataCiteJob implements ShouldQueue
         return $this->singleDoi;
     }
 }
+

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Services\Legacy\LegacyCoverageGeometryParser;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 /**
  * @property int $id
@@ -454,7 +456,7 @@ class OldDataset extends Model
 
     /**
      * Normalize a name for fuzzy matching by removing punctuation and extra whitespace.
-     * Converts names like "Läuchli, Charlotte" to "lauchli charlotte" for comparison.
+     * Converts names like "LÃ¤uchli, Charlotte" to "lauchli charlotte" for comparison.
      * Removes diacritics, punctuation (commas, periods, hyphens), and normalizes whitespace.
      *
      * @param  string|null  $name  The name to normalize
@@ -469,7 +471,7 @@ class OldDataset extends Model
         // Convert to lowercase
         $normalized = mb_strtolower($name, 'UTF-8');
 
-        // Transliterate to ASCII (e.g., ä -> a, ü -> u)
+        // Transliterate to ASCII (e.g., Ã¤ -> a, Ã¼ -> u)
         $normalized = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalized) ?: $normalized;
 
         // Remove common punctuation (commas, periods, hyphens)
@@ -630,7 +632,7 @@ class OldDataset extends Model
                 }
 
                 // Strategy 3: Check if normalized names contain each other (partial match)
-                // This handles cases like "Läuchli, Charlotte" vs "Läuchli Charlotte"
+                // This handles cases like "LÃ¤uchli, Charlotte" vs "LÃ¤uchli Charlotte"
                 if (! $matched && $agentNormalizedWords && $contactInfo['normalizedWords']) {
                     if ($agentNormalizedWords === $contactInfo['normalizedWords']) {
                         $matched = true;
@@ -767,10 +769,10 @@ class OldDataset extends Model
             $hasCommaSeparatedName = ! empty($agent->name) && str_contains($agent->name, ',');
 
             // Decision logic (in priority order):
-            // 1. If has HostingInstitution/Distributor/ResearchGroup/Sponsor → ALWAYS Institution
-            // 2. If name contains comma → Person (format: "Lastname, Firstname")
-            // 3. If has firstname OR lastname → Person
-            // 4. Default → Institution
+            // 1. If has HostingInstitution/Distributor/ResearchGroup/Sponsor â†’ ALWAYS Institution
+            // 2. If name contains comma â†’ Person (format: "Lastname, Firstname")
+            // 3. If has firstname OR lastname â†’ Person
+            // 4. Default â†’ Institution
 
             if ($hasInstitutionOnlyRole) {
                 $isPerson = false;
@@ -990,12 +992,13 @@ class OldDataset extends Model
      *
      * The old database stores:
      * - Spatial data: minlat, maxlat, minlon, maxlon (as floats)
+     * - Optional line geometry: wkt (often a bare `lon lat lon lat ...` coordinate chain)
      * - Temporal data: start, end (as strings), dateformat (format pattern), startutc, endutc (as datetime)
      * - Description: text field
      *
      * This method converts to the new ERNIE format with separate date/time fields and timezone.
      *
-     * @return array<int, array{id: string, latMin: string, latMax: string, lonMin: string, lonMax: string, startDate: string, endDate: string, startTime: string, endTime: string, timezone: string, description: string}>
+     * @return array<int, array<string, mixed>>
      */
     public function getCoverages(): array
     {
@@ -1004,20 +1007,65 @@ class OldDataset extends Model
         }
 
         $db = DB::connection($this->connection);
+        $geometryParser = app(LegacyCoverageGeometryParser::class);
 
         // Get all coverage entries for this resource
         $coverages = $db->table('coverage')
             ->where('resource_id', $this->id)
             ->get();
 
-        return $coverages->map(function ($coverage, $index) {
+        return $coverages->map(function ($coverage, $index) use ($geometryParser) {
+            // Parse temporal data from the old format
+            $temporal = $this->parseTemporalCoverage(
+                $coverage->start,
+                $coverage->end,
+                $coverage->dateformat
+            );
+
+            $baseCoverage = [
+                // Generate unique ID for frontend (use index since old DB doesn't have unique IDs per entry)
+                'id' => 'coverage-'.($index + 1),
+
+                // Temporal coverage (dates and times)
+                'startDate' => $temporal['startDate'],
+                'endDate' => $temporal['endDate'],
+                'startTime' => $temporal['startTime'],
+                'endTime' => $temporal['endTime'],
+                'timezone' => $temporal['timezone'],
+
+                // Description
+                'description' => $coverage->description ?? '',
+            ];
+
+            $rawWkt = isset($coverage->wkt) ? trim((string) $coverage->wkt) : '';
+
+            if ($rawWkt !== '') {
+                $linePoints = $geometryParser->parseLine($rawWkt);
+
+                if ($linePoints !== null) {
+                    return array_merge($baseCoverage, [
+                        'type' => 'line',
+                        'latMin' => '',
+                        'latMax' => '',
+                        'lonMin' => '',
+                        'lonMax' => '',
+                        'polygonPoints' => $linePoints,
+                    ]);
+                }
+
+                Log::warning('Legacy coverage WKT could not be parsed as a line', [
+                    'resource_id' => $this->id,
+                    'coverage_id' => $coverage->id ?? null,
+                ]);
+            }
+
             // Convert coordinates to strings with max 6 decimal places
             $latMin = $coverage->minlat !== null ? number_format((float) $coverage->minlat, 6, '.', '') : '';
             $lonMin = $coverage->minlon !== null ? number_format((float) $coverage->minlon, 6, '.', '') : '';
 
-            // Check if this is a point (min = max for both coordinates) or a rectangle
-            // In the old database, points were stored with identical min and max values
-            // In ERNIE, we represent points by leaving max coordinates empty for better UX and DataCite compliance
+            // Check if this is a point (min = max for both coordinates) or a rectangle.
+            // In the old database, points were stored with identical min and max values.
+            // In ERNIE, we represent points by leaving max coordinates empty for better UX and DataCite compliance.
             $isPoint = ($coverage->minlat === $coverage->maxlat && $coverage->minlon === $coverage->maxlon);
 
             if ($isPoint) {
@@ -1032,18 +1080,8 @@ class OldDataset extends Model
                 $type = 'box';
             }
 
-            // Parse temporal data from the old format
-            $temporal = $this->parseTemporalCoverage(
-                $coverage->start,
-                $coverage->end,
-                $coverage->dateformat
-            );
-
-            return [
-                // Generate unique ID for frontend (use index since old DB doesn't have unique IDs per entry)
-                'id' => 'coverage-'.($index + 1),
-
-                // Coverage type (point, box, or polygon - old DB only has point and box)
+            return array_merge($baseCoverage, [
+                // Coverage type (point, box, or line)
                 'type' => $type,
 
                 // Spatial coverage (coordinates)
@@ -1051,17 +1089,7 @@ class OldDataset extends Model
                 'latMax' => $latMax,
                 'lonMin' => $lonMin,
                 'lonMax' => $lonMax,
-
-                // Temporal coverage (dates and times)
-                'startDate' => $temporal['startDate'],
-                'endDate' => $temporal['endDate'],
-                'startTime' => $temporal['startTime'],
-                'endTime' => $temporal['endTime'],
-                'timezone' => $temporal['timezone'],
-
-                // Description
-                'description' => $coverage->description ?? '',
-            ];
+            ]);
         })->toArray();
     }
 
@@ -1246,3 +1274,5 @@ class OldDataset extends Model
         })->toArray();
     }
 }
+
+

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use App\Services\Legacy\LegacyCoverageGeometryParser;
+use App\Services\Legacy\LegacyCoverageGeometryParserService;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -1007,7 +1007,7 @@ class OldDataset extends Model
         }
 
         $db = DB::connection($this->connection);
-        $geometryParser = app(LegacyCoverageGeometryParser::class);
+        $geometryParser = app(LegacyCoverageGeometryParserService::class);
 
         // Get all coverage entries for this resource
         $coverages = $db->table('coverage')

--- a/app/Models/OldDataset.php
+++ b/app/Models/OldDataset.php
@@ -456,7 +456,7 @@ class OldDataset extends Model
 
     /**
      * Normalize a name for fuzzy matching by removing punctuation and extra whitespace.
-     * Converts names like "LÃ¤uchli, Charlotte" to "lauchli charlotte" for comparison.
+     * Converts names like "Lauchli, Charlotte" to "lauchli charlotte" for comparison.
      * Removes diacritics, punctuation (commas, periods, hyphens), and normalizes whitespace.
      *
      * @param  string|null  $name  The name to normalize
@@ -471,7 +471,7 @@ class OldDataset extends Model
         // Convert to lowercase
         $normalized = mb_strtolower($name, 'UTF-8');
 
-        // Transliterate to ASCII (e.g., Ã¤ -> a, Ã¼ -> u)
+        // Transliterate to ASCII (e.g., umlaut variants -> plain ASCII)
         $normalized = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $normalized) ?: $normalized;
 
         // Remove common punctuation (commas, periods, hyphens)
@@ -632,7 +632,7 @@ class OldDataset extends Model
                 }
 
                 // Strategy 3: Check if normalized names contain each other (partial match)
-                // This handles cases like "LÃ¤uchli, Charlotte" vs "LÃ¤uchli Charlotte"
+                // This handles cases like "Lauchli, Charlotte" vs "Lauchli Charlotte"
                 if (! $matched && $agentNormalizedWords && $contactInfo['normalizedWords']) {
                     if ($agentNormalizedWords === $contactInfo['normalizedWords']) {
                         $matched = true;
@@ -769,10 +769,10 @@ class OldDataset extends Model
             $hasCommaSeparatedName = ! empty($agent->name) && str_contains($agent->name, ',');
 
             // Decision logic (in priority order):
-            // 1. If has HostingInstitution/Distributor/ResearchGroup/Sponsor â†’ ALWAYS Institution
-            // 2. If name contains comma â†’ Person (format: "Lastname, Firstname")
-            // 3. If has firstname OR lastname â†’ Person
-            // 4. Default â†’ Institution
+            // 1. If has HostingInstitution/Distributor/ResearchGroup/Sponsor -> ALWAYS Institution
+            // 2. If name contains comma -> Person (format: "Lastname, Firstname")
+            // 3. If has firstname OR lastname -> Person
+            // 4. Default -> Institution
 
             if ($hasInstitutionOnlyRole) {
                 $isPerson = false;
@@ -1274,5 +1274,3 @@ class OldDataset extends Model
         })->toArray();
     }
 }
-
-

--- a/app/Services/DataCiteLandingPageImportService.php
+++ b/app/Services/DataCiteLandingPageImportService.php
@@ -68,7 +68,6 @@ class DataCiteLandingPageImportService
                 'published_at' => $isFindable ? now() : null,
             ]);
 
-            $landingPage->setRelation('resource', $resource);
             $landingPage->save();
 
             return $this->result(changed: true, created: true, landingPage: $landingPage->fresh(['externalDomain']) ?? $landingPage);

--- a/app/Services/DataCiteLandingPageImportService.php
+++ b/app/Services/DataCiteLandingPageImportService.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CacheKey;
+use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
+use App\Models\Resource;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class DataCiteLandingPageImportService
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{changed: bool, created: bool, landing_page: LandingPage|null}
+     */
+    public function createExternalForResource(Resource $resource, array $attributes): array
+    {
+        if (! $resource->exists) {
+            return $this->result();
+        }
+
+        $url = isset($attributes['url']) ? trim((string) $attributes['url']) : '';
+
+        if ($url === '') {
+            return $this->result();
+        }
+
+        $parts = $this->parseExternalUrl($url);
+
+        if ($parts === null) {
+            Log::warning('Skipping invalid DataCite landing page URL during import', [
+                'resource_id' => $resource->id,
+                'doi' => $resource->doi,
+                'url' => mb_substr($url, 0, 512),
+            ]);
+
+            return $this->result();
+        }
+
+        $result = DB::transaction(function () use ($resource, $attributes, $parts): array {
+            $existingLandingPage = LandingPage::query()
+                ->where('resource_id', $resource->id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existingLandingPage !== null) {
+                return $this->result(landingPage: $existingLandingPage);
+            }
+
+            $domain = LandingPageDomain::query()->firstOrCreate([
+                'domain' => $parts['domain'],
+            ]);
+
+            $isFindable = strtolower(trim((string) ($attributes['state'] ?? ''))) === 'findable';
+
+            $landingPage = new LandingPage([
+                'resource_id' => $resource->id,
+                'template' => 'external',
+                'external_domain_id' => $domain->id,
+                'external_path' => $parts['path'],
+                'ftp_url' => null,
+                'downloads_unavailable' => false,
+                'is_published' => $isFindable,
+                'published_at' => $isFindable ? now() : null,
+            ]);
+
+            $landingPage->setRelation('resource', $resource);
+            $landingPage->save();
+
+            return $this->result(changed: true, created: true, landingPage: $landingPage->fresh(['externalDomain']) ?? $landingPage);
+        });
+
+        if ($result['changed']) {
+            CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->forget();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{domain: string, path: string}|null
+     */
+    public function parseExternalUrl(string $url): ?array
+    {
+        $trimmed = trim($url);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        $parts = parse_url($trimmed);
+
+        if ($parts === false) {
+            return null;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return null;
+        }
+
+        $port = isset($parts['port']) ? ':'.(int) $parts['port'] : '';
+        $domain = "{$scheme}://{$host}{$port}/";
+        $path = ltrim((string) ($parts['path'] ?? ''), '/');
+
+        if (isset($parts['query']) && $parts['query'] !== '') {
+            $path .= '?'.$parts['query'];
+        }
+
+        if (isset($parts['fragment']) && $parts['fragment'] !== '') {
+            $path .= '#'.$parts['fragment'];
+        }
+
+        if (mb_strlen($domain) > 768 || mb_strlen($path) > 2048) {
+            return null;
+        }
+
+        return [
+            'domain' => $domain,
+            'path' => $path,
+        ];
+    }
+
+    /**
+     * @return array{changed: bool, created: bool, landing_page: LandingPage|null}
+     */
+    private function result(bool $changed = false, bool $created = false, ?LandingPage $landingPage = null): array
+    {
+        return [
+            'changed' => $changed,
+            'created' => $created,
+            'landing_page' => $landingPage,
+        ];
+    }
+}

--- a/app/Services/DoiImportEligibilityService.php
+++ b/app/Services/DoiImportEligibilityService.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+class DoiImportEligibilityService
+{
+    public function __construct(
+        private readonly LegacyResourceLookupService $legacyResourceLookupService,
+        private readonly DoiSuggestionService $doiSuggestionService,
+    ) {}
+
+    /**
+     * @throws \Throwable when the SUMARIOPMD fallback lookup is unavailable
+     */
+    public function canImport(string $doi): bool
+    {
+        $normalisedDoi = $this->normaliseDoi($doi);
+
+        if ($this->hasConfiguredDataCitePrefix($normalisedDoi)) {
+            return true;
+        }
+
+        return $this->legacyResourceLookupService->existsByDoi($normalisedDoi);
+    }
+
+    public function hasConfiguredDataCitePrefix(string $doi): bool
+    {
+        $prefix = $this->extractPrefix($this->normaliseDoi($doi));
+
+        if ($prefix === null) {
+            return false;
+        }
+
+        return in_array($prefix, $this->configuredProductionPrefixes(), true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function configuredProductionPrefixes(): array
+    {
+        $prefixes = config('datacite.production.prefixes', []);
+
+        if (! is_array($prefixes)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(
+            array_map(
+                static fn (mixed $prefix): string => strtolower(trim((string) $prefix)),
+                $prefixes,
+            ),
+            static fn (string $prefix): bool => $prefix !== '',
+        )));
+    }
+
+    private function normaliseDoi(string $doi): string
+    {
+        $normalised = $this->doiSuggestionService->normalizeDoi($doi);
+
+        return $normalised !== '' ? $normalised : strtolower(trim($doi));
+    }
+
+    private function extractPrefix(string $doi): ?string
+    {
+        $slashPosition = strpos($doi, '/');
+
+        if ($slashPosition === false || $slashPosition === 0) {
+            return null;
+        }
+
+        return strtolower(substr($doi, 0, $slashPosition));
+    }
+}

--- a/app/Services/Legacy/LegacyCoverageGeometryParser.php
+++ b/app/Services/Legacy/LegacyCoverageGeometryParser.php
@@ -33,7 +33,7 @@ class LegacyCoverageGeometryParser
             return null;
         }
 
-        $normalised = str_replace([",", "\r", "\n", "\t"], ' ', $payload);
+        $normalised = str_replace([',', "\r", "\n", "\t"], ' ', $payload);
         $tokens = preg_split('/\s+/', trim($normalised));
 
         if (! is_array($tokens) || count($tokens) < 4 || count($tokens) % 2 !== 0) {

--- a/app/Services/Legacy/LegacyCoverageGeometryParser.php
+++ b/app/Services/Legacy/LegacyCoverageGeometryParser.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Legacy;
+
+class LegacyCoverageGeometryParser
+{
+    /**
+     * Parse legacy coverage geometry into ERNIE line points.
+     *
+     * Legacy SUMARIOPMD records mostly store lines as bare coordinate chains
+     * (`lon lat lon lat ...`) rather than standards-compliant WKT. This parser
+     * accepts those chains, comma-separated variants, and LINESTRING WKT.
+     *
+     * @return list<array{lat: float, lon: float}>|null
+     */
+    public function parseLine(mixed $geometry): ?array
+    {
+        if (! is_string($geometry) && ! is_numeric($geometry)) {
+            return null;
+        }
+
+        $value = trim((string) $geometry);
+
+        if ($value === '') {
+            return null;
+        }
+
+        $payload = $this->extractCoordinatePayload($value);
+
+        if ($payload === null) {
+            return null;
+        }
+
+        $normalised = str_replace([",", "\r", "\n", "\t"], ' ', $payload);
+        $tokens = preg_split('/\s+/', trim($normalised));
+
+        if (! is_array($tokens) || count($tokens) < 4 || count($tokens) % 2 !== 0) {
+            return null;
+        }
+
+        $points = [];
+
+        for ($index = 0; $index < count($tokens); $index += 2) {
+            $lon = $tokens[$index];
+            $lat = $tokens[$index + 1];
+
+            if (! is_numeric($lon) || ! is_numeric($lat)) {
+                return null;
+            }
+
+            $lonFloat = (float) $lon;
+            $latFloat = (float) $lat;
+
+            if ($lonFloat < -180.0 || $lonFloat > 180.0 || $latFloat < -90.0 || $latFloat > 90.0) {
+                return null;
+            }
+
+            $points[] = [
+                'lat' => $latFloat,
+                'lon' => $lonFloat,
+            ];
+        }
+
+        return count($points) >= 2 ? $points : null;
+    }
+
+    private function extractCoordinatePayload(string $value): ?string
+    {
+        $trimmed = trim($value);
+
+        if (preg_match('/^LINESTRING\s*\((.*)\)$/is', $trimmed, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        if (preg_match('/^MULTILINESTRING\s*\(\s*\((.*)\)\s*\)$/is', $trimmed, $matches) === 1) {
+            return trim((string) preg_replace('/\)\s*,\s*\(/', ' ', $matches[1]));
+        }
+
+        if (preg_match('/[A-Za-z]/', $trimmed) === 1) {
+            return null;
+        }
+
+        return $trimmed;
+    }
+}

--- a/app/Services/Legacy/LegacyCoverageGeometryParserService.php
+++ b/app/Services/Legacy/LegacyCoverageGeometryParserService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Legacy;
 
-class LegacyCoverageGeometryParser
+class LegacyCoverageGeometryParserService
 {
     /**
      * Parse legacy coverage geometry into ERNIE line points.

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -79,6 +79,10 @@ class LegacyLandingPageImportService
                 );
             }
 
+            if ($landingPage->isExternal()) {
+                return $this->syncResult(landingPage: $landingPage);
+            }
+
             $landingPage->loadMissing('links');
 
             $ftpUrlAdded = false;
@@ -240,3 +244,4 @@ class LegacyLandingPageImportService
         ];
     }
 }
+

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -244,4 +244,3 @@ class LegacyLandingPageImportService
         ];
     }
 }
-

--- a/app/Services/LegacyResourceLookupService.php
+++ b/app/Services/LegacyResourceLookupService.php
@@ -11,7 +11,8 @@ class LegacyResourceLookupService
     public function existsByDoi(string $doi): bool
     {
         return OldDataset::query()
-            ->where('identifier', $doi)
+            ->whereRaw('LOWER(identifier) = ?', [strtolower(trim($doi))])
             ->exists();
     }
 }
+

--- a/app/Services/LegacyResourceLookupService.php
+++ b/app/Services/LegacyResourceLookupService.php
@@ -15,4 +15,3 @@ class LegacyResourceLookupService
             ->exists();
     }
 }
-

--- a/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
+++ b/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
@@ -1,4 +1,4 @@
-﻿import { router } from '@inertiajs/react';
+import { router } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
 import { AlertCircle, CheckCircle2, Download, Search, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';

--- a/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
+++ b/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
@@ -1,4 +1,4 @@
-import { router } from '@inertiajs/react';
+﻿import { router } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
 import { AlertCircle, CheckCircle2, Download, Search, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -228,7 +228,7 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
                         Import old single Resource
                     </DialogTitle>
                     <DialogDescription>
-                        {modalState === 'confirm' && 'Enter a single GFZ legacy DOI to import it from DataCite into ERNIE.'}
+                        {modalState === 'confirm' && 'Enter a GFZ DataCite or SUMARIO legacy DOI to import it into ERNIE.'}
                         {modalState === 'running' && `Importing ${submittedDoi ?? 'resource'}...`}
                         {modalState === 'completed' &&
                             (wasEnriched
@@ -247,7 +247,7 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
                                 <Search className="size-4" />
                                 <AlertTitle>Accepted DOI formats</AlertTitle>
                                 <AlertDescription>
-                                    Enter either a bare DOI such as <span className="font-mono">10.5880/GFZ.OJSJ.2026.001</span> or a DOI URL such as{' '}
+                                    Enter either a bare DOI such as <span className="font-mono">10.14470/RV968923</span> or a DOI URL such as{' '}
                                     <span className="font-mono">https://doi.org/10.5880/GFZ.OJSJ.2026.001</span>.
                                 </AlertDescription>
                             </Alert>
@@ -263,12 +263,12 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
                                             setFieldError(null);
                                         }
                                     }}
-                                    placeholder="10.5880/GFZ.OJSJ.2026.001"
+                                    placeholder="10.14470/RV968923"
                                     autoComplete="off"
                                     aria-invalid={fieldError ? true : undefined}
                                 />
                                 <p className="text-xs text-muted-foreground">
-                                    The DOI must exist in the GFZ legacy database before the import can start.
+                                    The DOI must use a configured GFZ DataCite prefix or exist in the legacy SUMARIO database.
                                 </p>
                                 {fieldError && <p className="text-sm text-destructive">{fieldError}</p>}
                             </div>
@@ -357,3 +357,4 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
         </Dialog>
     );
 }
+

--- a/tests/pest/Feature/DataCite/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCite/DataCiteImportControllerTest.php
@@ -8,8 +8,13 @@ use App\Models\User;
 use App\Services\LegacyResourceLookupService;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 
 covers(DataCiteImportController::class);
+
+beforeEach(function (): void {
+    Config::set('datacite.production.prefixes', ['10.5880', '10.14470']);
+});
 
 describe('POST /datacite/import/start', function (): void {
     test('admin can start import', function (): void {
@@ -34,11 +39,66 @@ describe('POST /datacite/import/start', function (): void {
 });
 
 describe('POST /datacite/import/start-single', function (): void {
-    test('admin can start single import for a legacy DOI URL', function (): void {
+    test('admin can start single import for a configured DataCite DOI URL', function (): void {
         Bus::fake();
         $admin = User::factory()->admin()->create();
 
-        $lookupService = new class extends LegacyResourceLookupService
+        $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
+        {
+            #[\Override]
+            public function existsByDoi(string $doi): bool
+            {
+                throw new RuntimeException('Legacy lookup should not be used for configured DataCite prefixes.');
+            }
+        });
+
+        $response = $this->actingAs($admin)
+            ->postJson('/datacite/import/start-single', [
+                'doi' => 'https://doi.org/10.5880/GFZ.OJSJ.2026.001',
+            ])
+            ->assertOk()
+            ->assertJsonStructure(['import_id', 'message']);
+
+        $importId = $response->json('import_id');
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status['status'])->toBe('pending')
+            ->and($status['total'])->toBe(1);
+
+        Bus::assertDispatched(ImportFromDataCiteJob::class, function (ImportFromDataCiteJob $job): bool {
+            return $job->getSingleDoi() === '10.5880/gfz.ojsj.2026.001';
+        });
+    });
+
+    test('admin can start single import for the GEOFON 10.14470 prefix without a legacy row', function (): void {
+        Bus::fake();
+        $admin = User::factory()->admin()->create();
+
+        $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
+        {
+            #[\Override]
+            public function existsByDoi(string $doi): bool
+            {
+                throw new RuntimeException('Legacy lookup should not be used for configured DataCite prefixes.');
+            }
+        });
+
+        $this->actingAs($admin)
+            ->postJson('/datacite/import/start-single', [
+                'doi' => '10.14470/RV968923',
+            ])
+            ->assertOk();
+
+        Bus::assertDispatched(ImportFromDataCiteJob::class, function (ImportFromDataCiteJob $job): bool {
+            return $job->getSingleDoi() === '10.14470/rv968923';
+        });
+    });
+
+    test('admin can start single import for an unconfigured DOI with a legacy fallback row', function (): void {
+        Bus::fake();
+        $admin = User::factory()->admin()->create();
+
+        $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
             public array $receivedDois = [];
 
@@ -49,27 +109,16 @@ describe('POST /datacite/import/start-single', function (): void {
 
                 return true;
             }
-        };
+        });
 
-        $this->app->instance(LegacyResourceLookupService::class, $lookupService);
-
-        $response = $this->actingAs($admin)
+        $this->actingAs($admin)
             ->postJson('/datacite/import/start-single', [
-                'doi' => 'https://doi.org/10.5880/GFZ.OJSJ.2026.001',
+                'doi' => '10.9999/legacy.only',
             ])
-            ->assertOk()
-            ->assertJsonStructure(['import_id', 'message']);
-
-        expect($lookupService->receivedDois)->toBe(['10.5880/gfz.ojsj.2026.001']);
-
-        $importId = $response->json('import_id');
-        $status = Cache::get("datacite_import:{$importId}");
-
-        expect($status['status'])->toBe('pending')
-            ->and($status['total'])->toBe(1);
+            ->assertOk();
 
         Bus::assertDispatched(ImportFromDataCiteJob::class, function (ImportFromDataCiteJob $job): bool {
-            return $job->getSingleDoi() === '10.5880/gfz.ojsj.2026.001';
+            return $job->getSingleDoi() === '10.9999/legacy.only';
         });
     });
 
@@ -87,49 +136,46 @@ describe('POST /datacite/import/start-single', function (): void {
         Bus::assertNothingDispatched();
     });
 
-    test('returns validation error when DOI is not a GFZ legacy resource', function (): void {
+    test('returns validation error when DOI has no configured prefix and no legacy fallback row', function (): void {
         Bus::fake();
         $admin = User::factory()->admin()->create();
 
-        $lookupService = new class extends LegacyResourceLookupService
+        $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
             #[\Override]
             public function existsByDoi(string $doi): bool
             {
                 return false;
             }
-        };
-
-        $this->app->instance(LegacyResourceLookupService::class, $lookupService);
+        });
 
         $this->actingAs($admin)
             ->postJson('/datacite/import/start-single', [
-                'doi' => '10.5880/gfz.ojsj.2026.001',
+                'doi' => '10.9999/missing',
             ])
             ->assertUnprocessable()
-            ->assertJsonValidationErrors(['doi']);
+            ->assertJsonValidationErrors(['doi'])
+            ->assertJsonPath('errors.doi.0', 'Only DOIs with a configured GFZ DataCite prefix or GFZ legacy resources can be imported with this action.');
 
         Bus::assertNothingDispatched();
     });
 
-    test('returns service unavailable when legacy lookup fails', function (): void {
+    test('returns service unavailable when legacy fallback lookup fails', function (): void {
         Bus::fake();
         $admin = User::factory()->admin()->create();
 
-        $lookupService = new class extends LegacyResourceLookupService
+        $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
             #[\Override]
             public function existsByDoi(string $doi): bool
             {
                 throw new RuntimeException('Legacy DB unavailable');
             }
-        };
-
-        $this->app->instance(LegacyResourceLookupService::class, $lookupService);
+        });
 
         $this->actingAs($admin)
             ->postJson('/datacite/import/start-single', [
-                'doi' => '10.5880/gfz.ojsj.2026.001',
+                'doi' => '10.9999/legacy.lookup.unavailable',
             ])
             ->assertStatus(503)
             ->assertJsonPath('message', 'The legacy resource database is currently unavailable. Please try again later.');

--- a/tests/pest/Feature/DataCite/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCite/DataCiteImportControllerTest.php
@@ -9,6 +9,7 @@ use App\Services\LegacyResourceLookupService;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 
 covers(DataCiteImportController::class);
 
@@ -45,7 +46,7 @@ describe('POST /datacite/import/start-single', function (): void {
 
         $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
-            #[\Override]
+            #[Override]
             public function existsByDoi(string $doi): bool
             {
                 throw new RuntimeException('Legacy lookup should not be used for configured DataCite prefixes.');
@@ -76,7 +77,7 @@ describe('POST /datacite/import/start-single', function (): void {
 
         $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
-            #[\Override]
+            #[Override]
             public function existsByDoi(string $doi): bool
             {
                 throw new RuntimeException('Legacy lookup should not be used for configured DataCite prefixes.');
@@ -102,7 +103,7 @@ describe('POST /datacite/import/start-single', function (): void {
         {
             public array $receivedDois = [];
 
-            #[\Override]
+            #[Override]
             public function existsByDoi(string $doi): bool
             {
                 $this->receivedDois[] = $doi;
@@ -142,7 +143,7 @@ describe('POST /datacite/import/start-single', function (): void {
 
         $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
-            #[\Override]
+            #[Override]
             public function existsByDoi(string $doi): bool
             {
                 return false;
@@ -166,7 +167,7 @@ describe('POST /datacite/import/start-single', function (): void {
 
         $this->app->instance(LegacyResourceLookupService::class, new class extends LegacyResourceLookupService
         {
-            #[\Override]
+            #[Override]
             public function existsByDoi(string $doi): bool
             {
                 throw new RuntimeException('Legacy DB unavailable');
@@ -187,7 +188,7 @@ describe('POST /datacite/import/start-single', function (): void {
 describe('GET /datacite/import/{importId}/status', function (): void {
     test('returns status for existing import', function (): void {
         $admin = User::factory()->admin()->create();
-        $importId = \Illuminate\Support\Str::uuid()->toString();
+        $importId = Str::uuid()->toString();
 
         Cache::put("datacite_import:{$importId}", [
             'status' => 'running',
@@ -211,7 +212,7 @@ describe('GET /datacite/import/{importId}/status', function (): void {
 
     test('returns 404 for unknown import', function (): void {
         $admin = User::factory()->admin()->create();
-        $importId = \Illuminate\Support\Str::uuid()->toString();
+        $importId = Str::uuid()->toString();
 
         $this->actingAs($admin)
             ->getJson("/datacite/import/{$importId}/status")

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -4,6 +4,7 @@ use App\Enums\CacheKey;
 use App\Enums\UserRole;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
 use App\Models\LandingPageFile;
 use App\Models\LandingPageLink;
 use App\Models\Resource;
@@ -1551,4 +1552,3 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($status['error'])->toBe('Queue crashed');
     });
 });
-

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -1243,6 +1243,97 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/10.5880.skip.backfill')
             ->and($landingPage->is_published)->toBeTrue();
     });
+
+    it('creates an external landing page from DataCite url before metaworks lookup', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.14470/rv968923',
+                    'attributes' => [
+                        'doi' => '10.14470/rv968923',
+                        'url' => 'https://geofon.gfz.de/waveform/archive/network.php?ncode=_EIFELLNX',
+                        'state' => 'findable',
+                        'titles' => [['title' => 'GEOFON Network']],
+                        'publicationYear' => 2024,
+                        'types' => ['resourceTypeGeneral' => 'Dataset'],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.14470/rv968923']));
+
+        $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $metaworksService->shouldNotReceive('lookupFileEntries');
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $metaworksService);
+
+        $resource = Resource::where('doi', '10.14470/rv968923')->firstOrFail();
+        $landingPage = $resource->fresh(['landingPage.externalDomain'])->landingPage;
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->template)->toBe('external')
+            ->and($landingPage->is_published)->toBeTrue()
+            ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->externalDomain->domain)->toBe('https://geofon.gfz.de/')
+            ->and($landingPage->external_path)->toBe('waveform/archive/network.php?ncode=_EIFELLNX')
+            ->and(LandingPageDomain::where('domain', 'https://geofon.gfz.de/')->exists())->toBeTrue();
+    });
+
+    it('backfills an external DataCite landing page for skipped existing resources', function () {
+        $resource = Resource::factory()->create(['doi' => '10.14470/skip.external']);
+
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.14470/skip.external',
+                    'attributes' => [
+                        'doi' => '10.14470/skip.external',
+                        'url' => 'https://geofon.gfz.de/waveform/archive/network.php?ncode=SKIP',
+                        'state' => 'findable',
+                    ],
+                ];
+            })());
+
+        $this->transformer->shouldReceive('transform')->never();
+
+        $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $metaworksService->shouldNotReceive('lookupFileEntries');
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['imported'])->toBe(0)
+            ->and($status['skipped'])->toBe(1)
+            ->and($status['enriched'])->toBe(1)
+            ->and($status['enriched_dois'])->toBe(['10.14470/skip.external']);
+
+        $landingPage = $resource->fresh(['landingPage.externalDomain'])->landingPage;
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->template)->toBe('external')
+            ->and($landingPage->external_url)->toBe('https://geofon.gfz.de/waveform/archive/network.php?ncode=SKIP');
+    });
     it('continues import gracefully when metaworks lookup fails', function () {
         $this->importService
             ->shouldReceive('getTotalDoiCount')
@@ -1460,3 +1551,4 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($status['error'])->toBe('Queue crashed');
     });
 });
+

--- a/tests/pest/Feature/Resources/PolygonValidationTest.php
+++ b/tests/pest/Feature/Resources/PolygonValidationTest.php
@@ -489,4 +489,58 @@ describe('Polygon Validation', function () {
 
         expect($geoLocation->place)->toBe('Berlin, Germany');
     });
+    test('rejects line coverage with fewer than two points', function () {
+        $user = User::factory()->create();
+        $resourceTypeId = seedLookupTables();
+
+        $payload = createBasePayload($resourceTypeId, [
+            'spatialTemporalCoverages' => [
+                [
+                    'type' => 'line',
+                    'polygonPoints' => [
+                        ['lon' => 10.0, 'lat' => 50.0],
+                    ],
+                    'description' => 'Incomplete line',
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['spatialTemporalCoverages.0.polygonPoints']);
+    });
+
+    test('stores line coverage with two points', function () {
+        $user = User::factory()->create();
+        $resourceTypeId = seedLookupTables();
+
+        $payload = createBasePayload($resourceTypeId, [
+            'spatialTemporalCoverages' => [
+                [
+                    'type' => 'line',
+                    'polygonPoints' => [
+                        ['lon' => 10.0, 'lat' => 50.0],
+                        ['lon' => 11.0, 'lat' => 51.0],
+                    ],
+                    'description' => 'Two-point line',
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertStatus(201);
+
+        $resource = Resource::query()->latest('id')->firstOrFail();
+        $geoLocation = $resource->geoLocations->first();
+
+        expect($geoLocation->geo_type)->toBe('line')
+            ->and($geoLocation->polygon_points)->toHaveCount(2)
+            ->and($geoLocation->polygon_points[0]['longitude'])->toBe(10.0)
+            ->and($geoLocation->polygon_points[1]['latitude'])->toBe(51.0);
+    });
 });
+

--- a/tests/pest/Feature/Resources/PolygonValidationTest.php
+++ b/tests/pest/Feature/Resources/PolygonValidationTest.php
@@ -539,8 +539,8 @@ describe('Polygon Validation', function () {
 
         expect($geoLocation->geo_type)->toBe('line')
             ->and($geoLocation->polygon_points)->toHaveCount(2)
-            ->and($geoLocation->polygon_points[0]['longitude'])->toBe(10.0)
-            ->and($geoLocation->polygon_points[1]['latitude'])->toBe(51.0);
+            ->and($geoLocation->polygon_points[0]['longitude'])->toEqual(10.0)
+            ->and($geoLocation->polygon_points[1]['latitude'])->toEqual(51.0);
     });
 });
 

--- a/tests/pest/Feature/Resources/PolygonValidationTest.php
+++ b/tests/pest/Feature/Resources/PolygonValidationTest.php
@@ -543,4 +543,3 @@ describe('Polygon Validation', function () {
             ->and($geoLocation->polygon_points[1]['latitude'])->toEqual(51.0);
     });
 });
-

--- a/tests/pest/Unit/Models/OldDatasetCoverageTest.php
+++ b/tests/pest/Unit/Models/OldDatasetCoverageTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\OldDataset;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    Config::set('database.connections.metaworks', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+
+    DB::purge('metaworks');
+
+    Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+        $table->id();
+        $table->string('identifier')->nullable();
+    });
+
+    Schema::connection('metaworks')->create('coverage', function (Blueprint $table): void {
+        $table->id();
+        $table->float('minlat')->nullable();
+        $table->float('maxlat')->nullable();
+        $table->float('minlon')->nullable();
+        $table->float('maxlon')->nullable();
+        $table->text('wkt')->nullable();
+        $table->string('start')->nullable();
+        $table->string('end')->nullable();
+        $table->string('dateformat')->nullable();
+        $table->text('description')->nullable();
+        $table->unsignedBigInteger('resource_id');
+    });
+
+    DB::connection('metaworks')->table('resource')->insert([
+        'id' => 1,
+        'identifier' => '10.5880/legacy.coverage.001',
+    ]);
+});
+
+afterEach(function (): void {
+    Schema::connection('metaworks')->dropIfExists('coverage');
+    Schema::connection('metaworks')->dropIfExists('resource');
+    DB::disconnect('metaworks');
+});
+
+it('imports legacy coverage wkt coordinate chains as lines', function (): void {
+    DB::connection('metaworks')->table('coverage')->insert([
+        'resource_id' => 1,
+        'minlat' => 49.2,
+        'maxlat' => 49.4,
+        'minlon' => 8.1,
+        'maxlon' => 8.3,
+        'wkt' => '8.1 49.2 8.3 49.4',
+        'start' => '2024-01-01',
+        'end' => '2024-01-31',
+        'dateformat' => 'Y-m-d',
+        'description' => 'Legacy profile line',
+    ]);
+
+    $coverages = OldDataset::findOrFail(1)->getCoverages();
+
+    expect($coverages)->toHaveCount(1)
+        ->and($coverages[0])->toMatchArray([
+            'type' => 'line',
+            'latMin' => '',
+            'latMax' => '',
+            'lonMin' => '',
+            'lonMax' => '',
+            'description' => 'Legacy profile line',
+            'polygonPoints' => [
+                ['lat' => 49.2, 'lon' => 8.1],
+                ['lat' => 49.4, 'lon' => 8.3],
+            ],
+        ]);
+});
+
+it('falls back to legacy boxes when wkt cannot be parsed as a line', function (): void {
+    DB::connection('metaworks')->table('coverage')->insert([
+        'resource_id' => 1,
+        'minlat' => 49.2,
+        'maxlat' => 49.4,
+        'minlon' => 8.1,
+        'maxlon' => 8.3,
+        'wkt' => '13.O57855 49.2 8.3 49.4',
+        'description' => 'Fallback box',
+    ]);
+
+    $coverages = OldDataset::findOrFail(1)->getCoverages();
+
+    expect($coverages)->toHaveCount(1)
+        ->and($coverages[0])->toMatchArray([
+            'type' => 'box',
+            'latMin' => '49.200000',
+            'latMax' => '49.400000',
+            'lonMin' => '8.100000',
+            'lonMax' => '8.300000',
+            'description' => 'Fallback box',
+        ])
+        ->and($coverages[0])->not->toHaveKey('polygonPoints');
+});
+
+it('keeps point coverage behaviour when no wkt exists', function (): void {
+    DB::connection('metaworks')->table('coverage')->insert([
+        'resource_id' => 1,
+        'minlat' => 49.2,
+        'maxlat' => 49.2,
+        'minlon' => 8.1,
+        'maxlon' => 8.1,
+        'wkt' => null,
+        'description' => 'Legacy point',
+    ]);
+
+    $coverages = OldDataset::findOrFail(1)->getCoverages();
+
+    expect($coverages)->toHaveCount(1)
+        ->and($coverages[0])->toMatchArray([
+            'type' => 'point',
+            'latMin' => '49.200000',
+            'latMax' => '',
+            'lonMin' => '8.100000',
+            'lonMax' => '',
+        ]);
+});

--- a/tests/pest/Unit/Services/DataCiteLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteLandingPageImportServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
+use App\Models\Resource;
+use App\Services\DataCiteLandingPageImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('parses external DataCite URLs into domain and path', function (): void {
+    $parts = (new DataCiteLandingPageImportService)->parseExternalUrl(
+        'https://geofon.gfz.de/waveform/archive/network.php?ncode=_EIFELLNX'
+    );
+
+    expect($parts)->toBe([
+        'domain' => 'https://geofon.gfz.de/',
+        'path' => 'waveform/archive/network.php?ncode=_EIFELLNX',
+    ]);
+});
+
+it('creates a published external landing page for findable DataCite records', function (): void {
+    $resource = Resource::factory()->create(['doi' => '10.14470/rv968923']);
+
+    $result = (new DataCiteLandingPageImportService)->createExternalForResource($resource, [
+        'url' => 'https://geofon.gfz.de/waveform/archive/network.php?ncode=_EIFELLNX',
+        'state' => 'findable',
+    ]);
+
+    $landingPage = $resource->fresh(['landingPage.externalDomain'])->landingPage;
+
+    expect($result['changed'])->toBeTrue()
+        ->and($result['created'])->toBeTrue()
+        ->and($landingPage)->not->toBeNull()
+        ->and($landingPage->template)->toBe('external')
+        ->and($landingPage->ftp_url)->toBeNull()
+        ->and($landingPage->is_published)->toBeTrue()
+        ->and($landingPage->published_at)->not->toBeNull()
+        ->and($landingPage->externalDomain->domain)->toBe('https://geofon.gfz.de/')
+        ->and($landingPage->external_path)->toBe('waveform/archive/network.php?ncode=_EIFELLNX')
+        ->and($landingPage->public_url)->toBe('https://geofon.gfz.de/waveform/archive/network.php?ncode=_EIFELLNX');
+});
+
+it('creates a draft external landing page for non-findable DataCite records', function (): void {
+    $resource = Resource::factory()->create(['doi' => '10.14470/draft']);
+
+    (new DataCiteLandingPageImportService)->createExternalForResource($resource, [
+        'url' => 'https://geofon.gfz.de/waveform/archive/network.php?ncode=DRAFT',
+        'state' => 'draft',
+    ]);
+
+    $landingPage = $resource->fresh(['landingPage.externalDomain'])->landingPage;
+
+    expect($landingPage)->not->toBeNull()
+        ->and($landingPage->is_published)->toBeFalse()
+        ->and($landingPage->published_at)->toBeNull()
+        ->and($landingPage->external_url)->toBe('https://geofon.gfz.de/waveform/archive/network.php?ncode=DRAFT');
+});
+
+it('does not overwrite an existing landing page', function (): void {
+    $resource = Resource::factory()->create(['doi' => '10.14470/existing']);
+    $existing = LandingPage::factory()->draft()->create([
+        'resource_id' => $resource->id,
+        'ftp_url' => 'https://datapub.gfz.de/existing.zip',
+    ]);
+
+    $result = (new DataCiteLandingPageImportService)->createExternalForResource($resource, [
+        'url' => 'https://geofon.gfz.de/waveform/archive/network.php?ncode=EXISTING',
+        'state' => 'findable',
+    ]);
+
+    expect($result['changed'])->toBeFalse()
+        ->and(LandingPage::where('resource_id', $resource->id)->count())->toBe(1)
+        ->and($existing->fresh()->template)->toBe('default_gfz')
+        ->and($existing->fresh()->ftp_url)->toBe('https://datapub.gfz.de/existing.zip');
+});
+
+it('ignores empty and non-http DataCite URLs', function (?string $url): void {
+    $resource = Resource::factory()->create();
+
+    $result = (new DataCiteLandingPageImportService)->createExternalForResource($resource, [
+        'url' => $url,
+        'state' => 'findable',
+    ]);
+
+    expect($result['changed'])->toBeFalse()
+        ->and(LandingPage::where('resource_id', $resource->id)->exists())->toBeFalse()
+        ->and(LandingPageDomain::count())->toBe(0);
+})->with([
+    'empty' => [''],
+    'null' => [null],
+    'ftp' => ['ftp://geofon.gfz.de/network'],
+    'relative' => ['/waveform/archive/network.php?ncode=_EIFELLNX'],
+]);

--- a/tests/pest/Unit/Services/DoiImportEligibilityServiceTest.php
+++ b/tests/pest/Unit/Services/DoiImportEligibilityServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DoiImportEligibilityService;
+use App\Services\DoiSuggestionService;
+use App\Services\LegacyResourceLookupService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    Config::set('datacite.production.prefixes', ['10.5880', '10.14470']);
+    Config::set('database.connections.metaworks', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+
+    DB::purge('metaworks');
+
+    Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+        $table->id();
+        $table->string('identifier')->nullable();
+    });
+
+    $this->service = new DoiImportEligibilityService(
+        new LegacyResourceLookupService,
+        app(DoiSuggestionService::class),
+    );
+});
+
+afterEach(function (): void {
+    Schema::connection('metaworks')->dropIfExists('resource');
+    DB::disconnect('metaworks');
+});
+
+it('allows configured DataCite production prefixes without a legacy row', function (): void {
+    expect($this->service->canImport('10.14470/RV968923'))->toBeTrue();
+});
+
+it('allows DOI resolver URLs with configured prefixes', function (): void {
+    expect($this->service->canImport('https://doi.org/10.14470/RV968923'))->toBeTrue();
+});
+
+it('falls back to SUMARIOPMD legacy lookup for unconfigured prefixes', function (): void {
+    DB::connection('metaworks')->table('resource')->insert([
+        'identifier' => '10.9999/legacy.only',
+    ]);
+
+    expect($this->service->canImport('10.9999/legacy.only'))->toBeTrue();
+});
+
+it('rejects unconfigured prefixes without a legacy row', function (): void {
+    expect($this->service->canImport('10.9999/missing'))->toBeFalse();
+});

--- a/tests/pest/Unit/Services/LegacyCoverageGeometryParserServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyCoverageGeometryParserServiceTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use App\Services\Legacy\LegacyCoverageGeometryParser;
+use App\Services\Legacy\LegacyCoverageGeometryParserService;
 
 it('parses whitespace separated legacy line coordinate chains', function (): void {
-    $points = (new LegacyCoverageGeometryParser)->parseLine('8.1 49.2 8.3 49.4');
+    $points = (new LegacyCoverageGeometryParserService)->parseLine('8.1 49.2 8.3 49.4');
 
     expect($points)->toBe([
         ['lat' => 49.2, 'lon' => 8.1],
@@ -14,7 +14,7 @@ it('parses whitespace separated legacy line coordinate chains', function (): voi
 });
 
 it('parses comma separated legacy line coordinate chains', function (): void {
-    $points = (new LegacyCoverageGeometryParser)->parseLine('8.1, 49.2, 8.3, 49.4');
+    $points = (new LegacyCoverageGeometryParserService)->parseLine('8.1, 49.2, 8.3, 49.4');
 
     expect($points)->toBe([
         ['lat' => 49.2, 'lon' => 8.1],
@@ -23,7 +23,7 @@ it('parses comma separated legacy line coordinate chains', function (): void {
 });
 
 it('parses LINESTRING WKT values', function (): void {
-    $points = (new LegacyCoverageGeometryParser)->parseLine('LINESTRING (8.1 49.2, 8.3 49.4)');
+    $points = (new LegacyCoverageGeometryParserService)->parseLine('LINESTRING (8.1 49.2, 8.3 49.4)');
 
     expect($points)->toBe([
         ['lat' => 49.2, 'lon' => 8.1],
@@ -32,7 +32,7 @@ it('parses LINESTRING WKT values', function (): void {
 });
 
 it('returns null for unsupported or malformed geometry', function (string $geometry): void {
-    expect((new LegacyCoverageGeometryParser)->parseLine($geometry))->toBeNull();
+    expect((new LegacyCoverageGeometryParserService)->parseLine($geometry))->toBeNull();
 })->with([
     'odd coordinate count' => ['8.1 49.2 8.3'],
     'ocr typo in numeric token' => ['13.O57855 49.2 8.3 49.4'],

--- a/tests/pest/Unit/Services/LegacyCoverageGeometryParserTest.php
+++ b/tests/pest/Unit/Services/LegacyCoverageGeometryParserTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Legacy\LegacyCoverageGeometryParser;
+
+it('parses whitespace separated legacy line coordinate chains', function (): void {
+    $points = (new LegacyCoverageGeometryParser)->parseLine('8.1 49.2 8.3 49.4');
+
+    expect($points)->toBe([
+        ['lat' => 49.2, 'lon' => 8.1],
+        ['lat' => 49.4, 'lon' => 8.3],
+    ]);
+});
+
+it('parses comma separated legacy line coordinate chains', function (): void {
+    $points = (new LegacyCoverageGeometryParser)->parseLine('8.1, 49.2, 8.3, 49.4');
+
+    expect($points)->toBe([
+        ['lat' => 49.2, 'lon' => 8.1],
+        ['lat' => 49.4, 'lon' => 8.3],
+    ]);
+});
+
+it('parses LINESTRING WKT values', function (): void {
+    $points = (new LegacyCoverageGeometryParser)->parseLine('LINESTRING (8.1 49.2, 8.3 49.4)');
+
+    expect($points)->toBe([
+        ['lat' => 49.2, 'lon' => 8.1],
+        ['lat' => 49.4, 'lon' => 8.3],
+    ]);
+});
+
+it('returns null for unsupported or malformed geometry', function (string $geometry): void {
+    expect((new LegacyCoverageGeometryParser)->parseLine($geometry))->toBeNull();
+})->with([
+    'odd coordinate count' => ['8.1 49.2 8.3'],
+    'ocr typo in numeric token' => ['13.O57855 49.2 8.3 49.4'],
+    'unsupported WKT type' => ['POLYGON ((8.1 49.2, 8.3 49.4, 8.1 49.2))'],
+    'out of range latitude' => ['8.1 149.2 8.3 49.4'],
+]);

--- a/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\CacheKey;
 use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
 use App\Models\LandingPageFile;
 use App\Models\LandingPageLink;
 use App\Models\Resource;

--- a/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
@@ -168,4 +168,33 @@ describe('LegacyLandingPageImportService', function () {
                 'Download 3',
             ]);
     });
+    it('does not add legacy download URLs to external landing pages', function () {
+        $resource = Resource::factory()->create(['doi' => '10.14470/external.sync']);
+        $domain = LandingPageDomain::factory()->withDomain('https://geofon.gfz.de/')->create();
+        $landingPage = LandingPage::factory()->external()->published()->create([
+            'resource_id' => $resource->id,
+            'external_domain_id' => $domain->id,
+            'external_path' => 'waveform/archive/network.php?ncode=SYNC',
+            'ftp_url' => null,
+        ]);
+
+        $result = (new LegacyLandingPageImportService)->syncMissingFileEntries(
+            resource: $resource,
+            fileEntries: [
+                ['url' => 'https://datapub.gfz.de/legacy-file.zip', 'label' => 'Legacy file', 'visible' => 'public'],
+            ],
+            isPublished: true,
+        );
+
+        $landingPage = $landingPage->fresh(['links']);
+
+        expect($result['changed'])->toBeFalse()
+            ->and($result['created'])->toBeFalse()
+            ->and($result['ftp_url_added'])->toBeFalse()
+            ->and($result['links_added'])->toBe(0)
+            ->and($landingPage->template)->toBe('external')
+            ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->links)->toHaveCount(0);
+    });
 });
+

--- a/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
@@ -198,4 +198,3 @@ describe('LegacyLandingPageImportService', function () {
             ->and($landingPage->links)->toHaveCount(0);
     });
 });
-

--- a/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
@@ -52,4 +52,3 @@ describe('LegacyResourceLookupService', function () {
         expect($this->service->existsByDoi('10.14470/rv968923'))->toBeTrue();
     });
 });
-

--- a/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
@@ -44,4 +44,12 @@ describe('LegacyResourceLookupService', function () {
     it('returns false when the DOI does not exist in the legacy resource table', function () {
         expect($this->service->existsByDoi('10.5880/gfz.ojsj.2026.999'))->toBeFalse();
     });
+    it('matches DOI identifiers case-insensitively', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'identifier' => '10.14470/RV968923',
+        ]);
+
+        expect($this->service->existsByDoi('10.14470/rv968923'))->toBeTrue();
+    });
 });
+

--- a/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
@@ -1,4 +1,4 @@
-﻿import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';

--- a/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportSingleOldResourceModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+﻿import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
@@ -49,6 +49,13 @@ describe('ImportSingleOldResourceModal', () => {
         expect(screen.getByText('Import old single Resource')).toBeInTheDocument();
     });
 
+
+    it('shows 10.14470 as an accepted example prefix', () => {
+        render(<ImportSingleOldResourceModal isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />);
+
+        expect(screen.getByText('10.14470/RV968923')).toBeInTheDocument();
+        expect(screen.getByText(/configured GFZ DataCite prefix/i)).toBeInTheDocument();
+    });
     it('shows a client-side validation error for an invalid DOI', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
@@ -103,7 +110,7 @@ describe('ImportSingleOldResourceModal', () => {
                 status: 422,
                 data: {
                     errors: {
-                        doi: ['Only GFZ legacy resources can be imported with this action.'],
+                        doi: ['Only DOIs with a configured GFZ DataCite prefix or GFZ legacy resources can be imported with this action.'],
                     },
                 },
             },
@@ -115,7 +122,7 @@ describe('ImportSingleOldResourceModal', () => {
         await user.type(screen.getByLabelText('DOI'), '10.5880/gfz.ojsj.2026.001');
         await user.click(screen.getByRole('button', { name: /start import/i }));
 
-        expect(await screen.findByText('Only GFZ legacy resources can be imported with this action.')).toBeInTheDocument();
+        expect(await screen.findByText('Only DOIs with a configured GFZ DataCite prefix or GFZ legacy resources can be imported with this action.')).toBeInTheDocument();
     });
 
     it('shows an already-imported state when the single DOI is skipped', async () => {
@@ -241,3 +248,4 @@ describe('ImportSingleOldResourceModal', () => {
         });
     });
 });
+


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the import, validation, and enrichment logic for DataCite DOIs and resource coverages. The main changes include stricter eligibility checks for DOI imports, enhanced validation for spatial coverages, and improved enrichment of resources with DataCite landing page URLs.

**DOI Import and Eligibility Improvements:**

- The single-resource DataCite import now uses a new `DoiImportEligibilityService` to allow import of DOIs with a configured GFZ DataCite prefix or legacy resources, providing more flexible and accurate eligibility checks. Error messages and logging have been updated accordingly. (`app/Http/Controllers/DataCiteImportController.php`) [[1]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6L10-R18) [[2]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6L57-R73) [[3]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6L82-R91)
- The background import job now attempts to enrich resources with DataCite landing page URLs using the new `DataCiteLandingPageImportService`, both for newly imported and already existing resources. This is handled robustly with error logging and a clear indication of whether enrichment occurred. (`app/Jobs/ImportFromDataCiteJob.php`) [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L508-R519) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L542-R558) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R567-R568) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L586-R649)

**Validation Enhancements for Resource Coverages:**

- Validation logic for both draft and published resources now enforces that "polygon" coverages must have at least 3 points and "line" coverages at least 2 points, with improved error messages and comments. (`app/Http/Requests/StoreDraftResourceRequest.php`, `app/Http/Requests/StoreResourceRequest.php`) [[1]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L1049-R1049) [[2]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L1117-R1117) [[3]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L1132-R1139) [[4]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48L1424-R1424) [[5]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48L1438-R1445)

**Code Quality and Documentation:**

- Several docblocks and comments were clarified for consistency, including normalization logic and error messages. (`app/Http/Requests/StoreResourceRequest.php`, `app/Http/Requests/StoreDraftResourceRequest.php`) [[1]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L208-R208) [[2]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L1038-R1038) [[3]](diffhunk://#diff-e110643799af357383644a5bbd030c28fe4a3cceb7b60162aa4dbcdc31abba75L1148-R1149) [[4]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48L182-R182) [[5]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48L1036-R1036) [[6]](diffhunk://#diff-798b350caad8232f0b9f279c2ac14711cd72da5612f67f5aad474ae726ad9b48L1376-R1376)
- Minor improvements to name normalization and comments in the legacy dataset model for better clarity and accuracy. (`app/Models/OldDataset.php`) [[1]](diffhunk://#diff-8c93c3df47ab824fe7841f40c203c0e7fa795151cba9461161edfbf0ab43f7faL457-R459) [[2]](diffhunk://#diff-8c93c3df47ab824fe7841f40c203c0e7fa795151cba9461161edfbf0ab43f7faL472-R474) [[3]](diffhunk://#diff-8c93c3df47ab824fe7841f40c203c0e7fa795151cba9461161edfbf0ab43f7faL633-R635)

These changes collectively improve the reliability of DataCite imports, ensure more accurate validation of resource metadata, and enhance the maintainability of the codebase.