### PR TITLE
Feature: Improvement of the Quick Action Bar in the Resources List with

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -220,9 +220,19 @@ class ResourceController extends Controller
             foreach ($ids as $id) {
                 $resource = $resources->get($id);
 
-                if (! $resource instanceof Resource || ! ($request->user()?->can('delete', $resource) ?? false)) {
+                if (! $resource instanceof Resource) {
                     throw ValidationException::withMessages([
-                        'ids' => ['Published resources cannot be deleted.'],
+                        'ids' => ['Some selected resources could not be found.'],
+                    ]);
+                }
+
+                if (! ($request->user()?->can('delete', $resource) ?? false)) {
+                    $message = $resource->publicStatus() === 'published'
+                        ? 'Published resources cannot be deleted.'
+                        : 'You do not have permission to delete the selected resources.';
+
+                    throw ValidationException::withMessages([
+                        'ids' => [$message],
                     ]);
                 }
             }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -165,10 +165,10 @@ class ResourceController extends Controller
     }
 
     /**
-     * Delete a draft resource.
+     * Delete a resource that has not been published yet.
      *
-     * Authorization is enforced by DestroyResourceRequest::authorize() (delegates
-     * to ResourcePolicy::delete – curator / group leader / admin on draft resources only).
+     * Authorization is enforced by DestroyResourceRequest::authorize() and
+     * ResourcePolicy::delete() for admin, group leader, and curator users.
      */
     public function destroy(DestroyResourceRequest $request, Resource $resource): RedirectResponse
     {
@@ -176,14 +176,14 @@ class ResourceController extends Controller
 
         return redirect()
             ->route('resources')
-            ->with('success', 'Draft deleted successfully.');
+            ->with('success', 'Resource deleted successfully.');
     }
 
     /**
-     * Delete selected draft resources.
+     * Delete selected resources that have not been published yet.
      *
-     * Every resource is checked through ResourcePolicy::delete so batch deletion
-     * cannot bypass DOI, landing page, or draft-status safeguards.
+     * Every submitted resource is checked through ResourcePolicy::delete so
+     * batch deletion cannot bypass published-resource safeguards.
      *
      * @throws ValidationException
      */
@@ -222,7 +222,7 @@ class ResourceController extends Controller
 
                 if (! $resource instanceof Resource || ! ($request->user()?->can('delete', $resource) ?? false)) {
                     throw ValidationException::withMessages([
-                        'ids' => ['Only draft resources without a DOI and without a landing page can be deleted.'],
+                        'ids' => ['Published resources cannot be deleted.'],
                     ]);
                 }
             }
@@ -238,8 +238,8 @@ class ResourceController extends Controller
 
         $count = count($ids);
         $message = $count === 1
-            ? 'Draft deleted successfully.'
-            : "{$count} drafts deleted successfully.";
+            ? 'Resource deleted successfully.'
+            : "{$count} resources deleted successfully.";
 
         return redirect()
             ->route('resources')

--- a/app/Policies/ResourcePolicy.php
+++ b/app/Policies/ResourcePolicy.php
@@ -50,31 +50,23 @@ class ResourcePolicy
      */
     public function delete(User $user, Resource $resource): bool
     {
-        $canDeleteDrafts = $user->role === UserRole::ADMIN
+        $canDeleteResources = $user->role === UserRole::ADMIN
             || $user->role === UserRole::GROUP_LEADER
             || $user->role === UserRole::CURATOR;
 
-        if (! $canDeleteDrafts) {
-            return false;
-        }
-
-        if (filled($resource->doi)) {
-            return false;
-        }
-
-        $resource->loadMissing('landingPage');
-        if ($resource->landingPage !== null) {
+        if (! $canDeleteResources) {
             return false;
         }
 
         $resource->loadMissing([
+            'landingPage',
             'titles.titleType',
             'creators',
             'rights',
             'descriptions.descriptionType',
         ]);
 
-        return $resource->publicStatus() === 'draft';
+        return $resource->publicStatus() !== 'published';
     }
 
     /**

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -45,11 +45,11 @@
             },
             {
                 "title": "Bulk Actions on Resources Page",
-                "description": "Curators can now select multiple resources via checkboxes and trigger bulk actions: register/update DOIs at DataCite (up to 25 at once) and export selected resources as a single ZIP archive in DataCite JSON, DataCite XML, or DataCite JSON-LD format (up to 100 at once). DOI registration actions are hidden for users without DOI registration permission. Resource actions are now accessed from the selection toolbar menu after selecting one or more rows."
+                "description": "Curators can now select one or more resources via checkboxes and work from a clearer selection toolbar. Edit and Set up landing page are quick actions directly in the toolbar, while exports, DOI registration, metadata updates, related items, and deletion remain grouped in the Actions menu. Bulk DataCite registration/update supports up to 25 selected resources, and bulk export downloads selected resources as a single ZIP archive in DataCite JSON, DataCite XML, or DataCite JSON-LD format for up to 100 resources. If the browser blocks editor tabs, ERNIE shows fallback links for the affected resources."
             },
             {
-                "title": "Batch Draft Deletion on Resources Page",
-                "description": "Admins, Group Leaders, and Curators can now delete selected draft resources directly from the Resources bulk action menu. The action is limited to draft resources without a DOI and without any landing page, and the confirmation dialog reports how many drafts will be deleted before the request is submitted. Registered resources and resources with configured landing pages remain protected from batch deletion."
+                "title": "Batch Resource Deletion on Resources Page",
+                "description": "Admins, Group Leaders, and Curators can delete selected non-published resources from the Resources Actions menu. Draft, curation, and preview resources are grouped in the confirmation dialog and can be selected independently; preview resources include a warning that their preview landing pages will be removed. Published resources are shown as protected and are never submitted for deletion."
             },
             {
                 "title": "Landing Page Template Management",

--- a/resources/js/components/resources/bulk-actions-toolbar.tsx
+++ b/resources/js/components/resources/bulk-actions-toolbar.tsx
@@ -89,11 +89,37 @@ const ACTION_DEFINITIONS: ActionDefinition[] = [
 ];
 
 const DEFAULT_UNAVAILABLE_ACTION_REASON = 'This action is not available for the current selection.';
+const QUICK_ACTION_KEYS = ['edit', 'setup-landing-page'] satisfies ResourcesActionKey[];
+
+const getActionDefinition = (key: ResourcesActionKey): ActionDefinition => {
+    const definition = ACTION_DEFINITIONS.find((actionDefinition) => actionDefinition.key === key);
+
+    if (!definition) {
+        throw new Error(`Unknown resource action: ${key}`);
+    }
+
+    return definition;
+};
 
 export function ResourcesBulkActionsToolbar({ selectedCount, actions, onAction, onUnavailableAction }: ResourcesBulkActionsToolbarProps) {
     const hasSelection = selectedCount > 0;
     const actionMenuTitle = hasSelection ? 'Actions' : 'Select rows to enable resource actions';
-    const visibleActions = ACTION_DEFINITIONS.filter((definition) => actions[definition.key]?.visible !== false);
+    const visibleQuickActions = QUICK_ACTION_KEYS.map(getActionDefinition).filter((definition) => actions[definition.key]?.visible !== false);
+    const visibleMenuActions = ACTION_DEFINITIONS.filter(
+        (definition) => !QUICK_ACTION_KEYS.includes(definition.key) && actions[definition.key]?.visible !== false,
+    );
+
+    const executeAction = (definition: ActionDefinition): void => {
+        const state = actions[definition.key];
+        const unavailableReason = state.reason ?? DEFAULT_UNAVAILABLE_ACTION_REASON;
+
+        if (!state.available) {
+            onUnavailableAction(unavailableReason);
+            return;
+        }
+
+        onAction(definition.key);
+    };
 
     return (
         <div
@@ -106,71 +132,91 @@ export function ResourcesBulkActionsToolbar({ selectedCount, actions, onAction, 
                     : 'Select rows to enable resource actions'}
             </span>
 
-            {hasSelection ? (
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+                {visibleQuickActions.map((definition) => {
+                    const state = actions[definition.key];
+                    const isUnavailable = !state.available;
+                    const isLoading = state.loading === true;
+                    const unavailableReason = state.reason ?? DEFAULT_UNAVAILABLE_ACTION_REASON;
+
+                    return (
                         <Button
+                            key={definition.key}
                             type="button"
                             size="sm"
                             variant="outline"
-                            className="w-full justify-between sm:w-auto"
-                            title={actionMenuTitle}
-                            data-testid="resources-actions-menu-trigger"
+                            className={cn('w-full justify-center gap-2 sm:w-auto', isUnavailable && hasSelection && !isLoading && 'opacity-70')}
+                            disabled={!hasSelection || isLoading}
+                            title={!hasSelection ? actionMenuTitle : isUnavailable ? unavailableReason : definition.label}
+                            data-testid={`resources-action-${definition.key}`}
+                            data-unavailable={isUnavailable && hasSelection && !isLoading ? 'true' : undefined}
+                            onClick={() => executeAction(definition)}
                         >
-                            <span>Actions</span>
-                            <ChevronDown aria-hidden="true" className="size-4" />
+                            {definition.icon}
+                            <span className="truncate">{isLoading ? 'Working...' : definition.label}</span>
                         </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-64">
-                        {visibleActions.map((definition) => {
-                            const state = actions[definition.key];
-                            const isUnavailable = !state.available;
-                            const isLoading = state.loading === true;
-                            const unavailableReason = state.reason ?? DEFAULT_UNAVAILABLE_ACTION_REASON;
+                    );
+                })}
 
-                            return (
-                                <DropdownMenuItem
-                                    key={definition.key}
-                                    disabled={isLoading}
-                                    aria-disabled={isLoading || undefined}
-                                    data-unavailable={isUnavailable && !isLoading ? 'true' : undefined}
-                                    title={isUnavailable ? unavailableReason : definition.label}
-                                    data-testid={`resources-action-${definition.key}`}
-                                    variant={definition.variant ?? 'default'}
-                                    className={cn(
-                                        'items-start gap-2',
-                                        isUnavailable && !isLoading && 'cursor-help opacity-60 focus:bg-background focus:text-foreground',
-                                    )}
-                                    onSelect={() => {
-                                        if (isUnavailable) {
-                                            onUnavailableAction(unavailableReason);
-                                            return;
-                                        }
+                {hasSelection ? (
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="w-full justify-between sm:w-auto"
+                                title={actionMenuTitle}
+                                data-testid="resources-actions-menu-trigger"
+                            >
+                                <span>Actions</span>
+                                <ChevronDown aria-hidden="true" className="size-4" />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-64">
+                            {visibleMenuActions.map((definition) => {
+                                const state = actions[definition.key];
+                                const isUnavailable = !state.available;
+                                const isLoading = state.loading === true;
+                                const unavailableReason = state.reason ?? DEFAULT_UNAVAILABLE_ACTION_REASON;
 
-                                        onAction(definition.key);
-                                    }}
-                                >
-                                    {definition.icon}
-                                    <span className="min-w-0 flex-1 truncate">{isLoading ? 'Working...' : definition.label}</span>
-                                </DropdownMenuItem>
-                            );
-                        })}
-                    </DropdownMenuContent>
-                </DropdownMenu>
-            ) : (
-                <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    className="w-full justify-between sm:w-auto"
-                    disabled
-                    title={actionMenuTitle}
-                    data-testid="resources-actions-menu-trigger"
-                >
-                    <span>Actions</span>
-                    <ChevronDown aria-hidden="true" className="size-4" />
-                </Button>
-            )}
+                                return (
+                                    <DropdownMenuItem
+                                        key={definition.key}
+                                        disabled={isLoading}
+                                        aria-disabled={isLoading || undefined}
+                                        data-unavailable={isUnavailable && !isLoading ? 'true' : undefined}
+                                        title={isUnavailable ? unavailableReason : definition.label}
+                                        data-testid={`resources-action-${definition.key}`}
+                                        variant={definition.variant ?? 'default'}
+                                        className={cn(
+                                            'items-start gap-2',
+                                            isUnavailable && !isLoading && 'cursor-help opacity-60 focus:bg-background focus:text-foreground',
+                                        )}
+                                        onSelect={() => executeAction(definition)}
+                                    >
+                                        {definition.icon}
+                                        <span className="min-w-0 flex-1 truncate">{isLoading ? 'Working...' : definition.label}</span>
+                                    </DropdownMenuItem>
+                                );
+                            })}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                ) : (
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="w-full justify-between sm:w-auto"
+                        disabled
+                        title={actionMenuTitle}
+                        data-testid="resources-actions-menu-trigger"
+                    >
+                        <span>Actions</span>
+                        <ChevronDown aria-hidden="true" className="size-4" />
+                    </Button>
+                )}
+            </div>
         </div>
     );
 }

--- a/resources/js/components/resources/bulk-actions-toolbar.tsx
+++ b/resources/js/components/resources/bulk-actions-toolbar.tsx
@@ -90,6 +90,7 @@ const ACTION_DEFINITIONS: ActionDefinition[] = [
 
 const DEFAULT_UNAVAILABLE_ACTION_REASON = 'This action is not available for the current selection.';
 const QUICK_ACTION_KEYS = ['edit', 'setup-landing-page'] satisfies ResourcesActionKey[];
+const QUICK_ACTION_KEY_SET = new Set<ResourcesActionKey>(QUICK_ACTION_KEYS);
 
 const getActionDefinition = (key: ResourcesActionKey): ActionDefinition => {
     const definition = ACTION_DEFINITIONS.find((actionDefinition) => actionDefinition.key === key);
@@ -106,7 +107,7 @@ export function ResourcesBulkActionsToolbar({ selectedCount, actions, onAction, 
     const actionMenuTitle = hasSelection ? 'Actions' : 'Select rows to enable resource actions';
     const visibleQuickActions = QUICK_ACTION_KEYS.map(getActionDefinition).filter((definition) => actions[definition.key]?.visible !== false);
     const visibleMenuActions = ACTION_DEFINITIONS.filter(
-        (definition) => !QUICK_ACTION_KEYS.includes(definition.key) && actions[definition.key]?.visible !== false,
+        (definition) => !QUICK_ACTION_KEY_SET.has(definition.key) && actions[definition.key]?.visible !== false,
     );
 
     const executeAction = (definition: ActionDefinition): void => {

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1534,7 +1534,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 </p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={2} title="Create Landing Page">
-                                <p>Click the landing page icon button to generate a draft.</p>
+                                <p>Select the resource and click the <strong>Set up landing page</strong> quick action in the bulk toolbar to open the setup modal.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={3} title="Preview">
                                 <p>Review how the landing page will appear before publishing.</p>
@@ -1564,7 +1564,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <WorkflowSteps>
                             <WorkflowSteps.Step number={1} title="Open Landing Page Setup">
-                                <p>Click the landing page icon for your resource and open the setup modal.</p>
+                                <p>Select the resource on <code>/resources</code> and click <strong>Set up landing page</strong> in the bulk toolbar to open the setup modal.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={2} title="Add Links">
                                 <p>
@@ -1833,9 +1833,21 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             selected.
                         </p>
 
+                        <h4>Quick Resource Actions</h4>
+                        <p>
+                            <strong>Edit</strong> and <strong>Set up landing page</strong> appear as quick actions directly in the selection toolbar.
+                            Edit opens every selected resource in the Data Editor. If the browser blocks one or more editor tabs, ERNIE shows a
+                            fallback dialog with direct editor links. Set up landing page stays visible as a quick action and reports the standard
+                            single-record message when more than one row is selected.
+                        </p>
+                        <p>
+                            The remaining actions stay in the <strong>Actions</strong> menu so exports, DOI registration, metadata updates, related
+                            items, and deletion remain grouped together.
+                        </p>
+
                         <h4>Bulk Export (all roles)</h4>
                         <p>
-                            Click <strong>Export Selected</strong> to download a single ZIP archive containing
+                            Open the <strong>Actions</strong> menu and choose the desired export command to download a single ZIP archive containing
                             the metadata of every selected resource in your chosen format:
                         </p>
                         <ul className="list-inside list-disc space-y-1">
@@ -1851,15 +1863,30 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <h4>Bulk Register / Update DOI (Curator and above)</h4>
                         <p>
-                            Click <strong>Register Selected</strong> to push every selected resource to DataCite
-                            in one batch. The bulk flow <strong>only updates resources that already have a
-                            DOI</strong>; the button is disabled when the selection contains any DOI-less resource
-                            so you never accidentally mint a DOI without picking a prefix. To mint a new DOI,
-                            open the resource in the editor and use the single-resource register action there.
-                            Resources without a landing page or that are physical samples (IGSNs) are skipped
-                            and reported in the response toast.
+                            Open the <strong>Actions</strong> menu and choose <strong>Register DOI</strong> or <strong>Update metadata</strong> to
+                            push selected resources to DataCite in one batch. The bulk flow <strong>only updates resources that already have a DOI</strong>;
+                            the action is unavailable when the selection contains any DOI-less resource so you never accidentally mint a DOI without
+                            picking a prefix. To mint a new DOI, open the resource in the editor and use the single-resource register action there.
+                            Resources without a landing page or that are physical samples (IGSNs) are skipped and reported in the response toast.
                         </p>
                         <p className="text-sm text-muted-foreground">Limit: up to 25 resources per batch.</p>
+
+                        {roleHierarchy[userRole] >= roleHierarchy.curator && (
+                            <>
+                                <h4>Delete Selected Resources (Curator and above)</h4>
+                                <p>
+                                    Use <strong>Delete</strong> from the <strong>Actions</strong> menu to remove selected resources that have not been
+                                    published. DOI and landing page data no longer block deletion by themselves: draft, curation, and preview resources
+                                    can be deleted as long as their public status is not published.
+                                </p>
+                                <p>
+                                    The confirmation dialog groups the current selection into draft, curation, preview, and published resources. You can
+                                    choose which deletable groups to submit. Preview resources show an additional warning because their preview landing
+                                    pages will be removed with the resource. Published resources are listed as protected and are never sent to the delete
+                                    endpoint.
+                                </p>
+                            </>
+                        )}
 
                         <h4>Resizable Columns</h4>
                         <p>

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1063,8 +1063,8 @@ function ResourcesPage({
     );
     const selectedDeletableDeleteCount = selectedDeletableDeleteResourceIds.length;
     const publishedDeleteCount = selectedDeleteGroups.published.length;
-    const hasPreviewDeleteSelection = selectedDeleteGroups.review.length > 0;
-    const hasAnyDeletableDeleteSelection = DELETABLE_DELETE_STATUSES.some((status) => selectedDeleteGroups[status].length > 0);
+    const hasPreviewDeleteSelection = selectedDeleteStatuses.review && selectedDeleteGroups.review.length > 0;
+    const hasAnyDeletableDeleteSelection = selectedDeletableDeleteCount > 0;
 
     const handleOpenDeleteDialog = useCallback(() => {
         setSelectedDeleteStatuses({
@@ -2094,7 +2094,7 @@ function ResourcesPage({
                     <div className="space-y-2">
                         {blockedEditorTabs.map((tab) => (
                             <Button key={tab.id} asChild variant="outline" className="w-full justify-between gap-2">
-                                <a href={tab.url} target="_blank" rel="noreferrer">
+                                <a href={tab.url} target="_blank" rel="noopener noreferrer">
                                     <span className="truncate">{tab.label}</span>
                                     <ExternalLink aria-hidden="true" className="size-4 shrink-0" />
                                 </a>

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -1,7 +1,7 @@
 // organize-imports-ignore
 import { Head, router, usePage } from '@inertiajs/react';
 import axios, { isAxiosError } from 'axios';
-import { ArrowDown, ArrowUp, ArrowUpDown, GripVertical, RotateCcw } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink, GripVertical, RotateCcw } from 'lucide-react';
 import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -29,6 +29,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { type ValidationError, ValidationErrorModal } from '@/components/ui/validation-error-modal';
@@ -135,7 +136,7 @@ const DEFAULT_DIRECTION_BY_KEY: Record<ResourceSortKey, ResourceSortDirection> =
 };
 
 const getDefaultBatchDeleteErrorMessage = (selectedCount: number): string =>
-    selectedCount === 1 ? 'Failed to delete draft resource.' : 'Failed to delete draft resources.';
+    selectedCount === 1 ? 'Failed to delete resource.' : 'Failed to delete resources.';
 
 const normalizeValidationMessage = (value: unknown): string | null => {
     if (typeof value === 'string' && value.trim() !== '') {
@@ -168,12 +169,60 @@ const resolveBatchDeleteErrorMessage = (errors: Record<string, unknown> | undefi
     return normalizeValidationMessage(Object.values(errors)[0]) ?? fallbackMessage;
 };
 type ResourceExportAction = Extract<ResourcesActionKey, 'export-datacite-json' | 'export-datacite-xml' | 'export-jsonld'>;
+type ResourceDeleteStatus = 'draft' | 'curation' | 'review' | 'published';
+type DeletableResourceDeleteStatus = Exclude<ResourceDeleteStatus, 'published'>;
+
+interface BlockedEditorTab {
+    id: number;
+    label: string;
+    url: string;
+}
 
 const BATCH_EXPORT_FORMAT_BY_ACTION: Record<ResourceExportAction, 'datacite-json' | 'datacite-xml' | 'jsonld'> = {
     'export-datacite-json': 'datacite-json',
     'export-datacite-xml': 'datacite-xml',
     'export-jsonld': 'jsonld',
 };
+
+const DELETABLE_DELETE_STATUSES: DeletableResourceDeleteStatus[] = ['draft', 'curation', 'review'];
+const DELETE_STATUS_LABELS: Record<ResourceDeleteStatus, string> = {
+    draft: 'draft',
+    curation: 'curation',
+    review: 'preview',
+    published: 'published',
+};
+const DELETE_STATUS_DESCRIPTIONS: Record<DeletableResourceDeleteStatus, string> = {
+    draft: 'Draft resources will be removed from ERNIE.',
+    curation: 'Curation resources will be removed from ERNIE.',
+    review: 'Preview pages for these resources will also be deleted.',
+};
+
+const createDefaultDeleteStatusSelection = (): Record<DeletableResourceDeleteStatus, boolean> => ({
+    draft: true,
+    curation: true,
+    review: true,
+});
+
+const normalizeDeleteStatus = (resource: Resource): ResourceDeleteStatus => {
+    if (resource.publicstatus === 'published') {
+        return 'published';
+    }
+
+    if (resource.publicstatus === 'review') {
+        return 'review';
+    }
+
+    if (resource.publicstatus === 'curation') {
+        return 'curation';
+    }
+
+    return 'draft';
+};
+
+const formatDeleteStatusCount = (status: ResourceDeleteStatus, count: number): string =>
+    `${count} ${DELETE_STATUS_LABELS[status]} ${count === 1 ? 'resource' : 'resources'}`;
+
+const getResourceActionLabel = (resource: Resource): string => resource.title ?? resource.doi ?? `Resource #${resource.id}`;
 
 const getFilenameFromContentDisposition = (contentDisposition: string | undefined, fallback: string): string => {
     const filenameMatch = contentDisposition?.match(/filename="?([^"]+)"?/);
@@ -564,7 +613,7 @@ function ResourcesPage({
     const { auth } = usePage<{ auth: { user: AuthUser } }>().props;
     const canManageLandingPages = auth.user?.can_manage_landing_pages ?? false;
     const canRegisterDoi = auth.user?.can_register_production_doi ?? false;
-    const canDeleteDraftResources = auth.user?.role === 'admin' || auth.user?.role === 'group_leader' || auth.user?.role === 'curator';
+    const canDeleteResources = auth.user?.role === 'admin' || auth.user?.role === 'group_leader' || auth.user?.role === 'curator';
 
     const [resources, setResources] = useState<Resource[]>(initialResources);
     const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
@@ -980,6 +1029,9 @@ function ResourcesPage({
     const [isUpdateMetadataDialogOpen, setIsUpdateMetadataDialogOpen] = useState(false);
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
     const [isDeletingResource, setIsDeletingResource] = useState(false);
+    const [selectedDeleteStatuses, setSelectedDeleteStatuses] =
+        useState<Record<DeletableResourceDeleteStatus, boolean>>(createDefaultDeleteStatusSelection);
+    const [blockedEditorTabs, setBlockedEditorTabs] = useState<BlockedEditorTab[]>([]);
     const isDeletingResourceRef = useRef(false);
     const { vocabularies: citationVocabularies, isLoading: citationVocabulariesLoading } = useCitationVocabularies();
 
@@ -987,33 +1039,41 @@ function ResourcesPage({
         return typeof resource.doi === 'string' && resource.doi.trim().length > 0;
     }, []);
 
-    const getDeleteUnavailableReason = useCallback(
-        (resource: Resource): string | null => {
-            if (!canDeleteDraftResources) {
-                return 'You do not have permission to delete draft resources.';
-            }
+    const selectedDeleteGroups = useMemo((): Record<ResourceDeleteStatus, Resource[]> => {
+        const groups: Record<ResourceDeleteStatus, Resource[]> = {
+            draft: [],
+            curation: [],
+            review: [],
+            published: [],
+        };
 
-            if (resource.publicstatus !== 'draft') {
-                return 'Only draft resources can be deleted.';
-            }
+        selectedResources.forEach((resource) => {
+            groups[normalizeDeleteStatus(resource)].push(resource);
+        });
 
-            if (hasPersistentIdentifier(resource)) {
-                return 'Resources with persistent identifiers cannot be deleted.';
-            }
+        return groups;
+    }, [selectedResources]);
 
-            if (resource.landingPage) {
-                return 'Resources with landing pages cannot be deleted from this list. Remove the landing page first.';
-            }
-
-            return null;
-        },
-        [canDeleteDraftResources, hasPersistentIdentifier],
+    const selectedDeletableDeleteResourceIds = useMemo(
+        () =>
+            DELETABLE_DELETE_STATUSES.flatMap((status) =>
+                selectedDeleteStatuses[status] ? selectedDeleteGroups[status].map((resource) => resource.id) : [],
+            ),
+        [selectedDeleteGroups, selectedDeleteStatuses],
     );
+    const selectedDeletableDeleteCount = selectedDeletableDeleteResourceIds.length;
+    const publishedDeleteCount = selectedDeleteGroups.published.length;
+    const hasPreviewDeleteSelection = selectedDeleteGroups.review.length > 0;
+    const hasAnyDeletableDeleteSelection = DELETABLE_DELETE_STATUSES.some((status) => selectedDeleteGroups[status].length > 0);
 
-    const canDeleteResource = useCallback(
-        (resource: Resource): boolean => getDeleteUnavailableReason(resource) === null,
-        [getDeleteUnavailableReason],
-    );
+    const handleOpenDeleteDialog = useCallback(() => {
+        setSelectedDeleteStatuses({
+            draft: selectedDeleteGroups.draft.length > 0,
+            curation: selectedDeleteGroups.curation.length > 0,
+            review: selectedDeleteGroups.review.length > 0,
+        });
+        setIsDeleteDialogOpen(true);
+    }, [selectedDeleteGroups]);
 
     const handleUpdateMetadataDialogOpenChange = useCallback(
         (open: boolean) => {
@@ -1046,33 +1106,24 @@ function ResourcesPage({
         (event: ReactMouseEvent<HTMLButtonElement>) => {
             event.preventDefault();
 
-            if (isDeletingResourceRef.current || selectedResourceIds.length === 0) {
+            if (isDeletingResourceRef.current || selectedDeletableDeleteResourceIds.length === 0) {
                 return;
             }
 
-            const blockedResource = selectedResources.find((resource) => !canDeleteResource(resource));
-            if (blockedResource) {
-                toast.error(getDeleteUnavailableReason(blockedResource) ?? 'The selected resources cannot be deleted.');
-                return;
-            }
-
+            const deleteCount = selectedDeletableDeleteResourceIds.length;
             isDeletingResourceRef.current = true;
             setIsDeletingResource(true);
 
             router.delete('/resources/batch', {
-                data: { ids: selectedResourceIds },
+                data: { ids: selectedDeletableDeleteResourceIds },
                 preserveScroll: true,
                 onSuccess: () => {
                     setSelectedIds(new Set());
                     setIsDeleteDialogOpen(false);
-                    toast.success(
-                        selectedResourceIds.length === 1
-                            ? 'Draft deleted successfully.'
-                            : `${selectedResourceIds.length} drafts deleted successfully.`,
-                    );
+                    toast.success(deleteCount === 1 ? 'Resource deleted successfully.' : `${deleteCount} resources deleted successfully.`);
                 },
                 onError: (errors) => {
-                    toast.error(resolveBatchDeleteErrorMessage(errors, getDefaultBatchDeleteErrorMessage(selectedResourceIds.length)));
+                    toast.error(resolveBatchDeleteErrorMessage(errors, getDefaultBatchDeleteErrorMessage(deleteCount)));
                 },
                 onFinish: () => {
                     isDeletingResourceRef.current = false;
@@ -1080,7 +1131,7 @@ function ResourcesPage({
                 },
             });
         },
-        [canDeleteResource, getDeleteUnavailableReason, selectedResourceIds, selectedResources],
+        [selectedDeletableDeleteResourceIds],
     );
     const handleExportDataCiteJson = useCallback(async (resource: Resource) => {
         if (!resource.id) {
@@ -1246,17 +1297,22 @@ function ResourcesPage({
             return;
         }
 
-        let blockedPopups = 0;
+        const blockedTabs: BlockedEditorTab[] = [];
         selectedResources.forEach((resource) => {
             const url = editorRoute({ query: { resourceId: resource.id } }).url;
             const opened = window.open(url, '_blank', 'noopener,noreferrer');
             if (opened === null) {
-                blockedPopups += 1;
+                blockedTabs.push({
+                    id: resource.id,
+                    label: getResourceActionLabel(resource),
+                    url,
+                });
             }
         });
 
-        if (blockedPopups > 0) {
-            toast.warning('Your browser blocked one or more editor tabs. Please allow pop-ups for ERNIE and try again.');
+        if (blockedTabs.length > 0) {
+            setBlockedEditorTabs(blockedTabs);
+            toast.warning('Your browser blocked one or more editor tabs. Use the fallback links to continue editing.');
         }
     }, [selectedResources]);
 
@@ -1319,7 +1375,6 @@ function ResourcesPage({
 
     const selectedWithoutLandingPageCount = selectedResources.filter((resource) => !resource.landingPage).length;
     const selectedWithoutDoiCount = selectedResources.filter((resource) => !hasPersistentIdentifier(resource)).length;
-    const firstDeleteBlockedResource = selectedResources.find((resource) => !canDeleteResource(resource));
 
     const noSelectionReason = 'Select one or more resources first.';
     const singleRecordReason = 'This action can only be performed on a single record.';
@@ -1386,14 +1441,9 @@ function ResourcesPage({
             loading: isBulkRegistering,
         },
         delete: {
-            visible: canDeleteDraftResources,
-            available: selectedCount > 0 && firstDeleteBlockedResource === undefined,
-            reason:
-                selectedCount === 0
-                    ? noSelectionReason
-                    : firstDeleteBlockedResource
-                      ? (getDeleteUnavailableReason(firstDeleteBlockedResource) ?? 'The selected resources cannot be deleted.')
-                      : undefined,
+            visible: canDeleteResources,
+            available: selectedCount > 0,
+            reason: selectedCount === 0 ? noSelectionReason : undefined,
             loading: isDeletingResource,
         },
     };
@@ -1432,11 +1482,18 @@ function ResourcesPage({
                     setIsUpdateMetadataDialogOpen(true);
                     break;
                 case 'delete':
-                    setIsDeleteDialogOpen(true);
+                    handleOpenDeleteDialog();
                     break;
             }
         },
-        [handleEditSelectedResources, handleExportSelectedResources, handleRegisterDoi, handleSetupLandingPage, singleSelectedResource],
+        [
+            handleEditSelectedResources,
+            handleExportSelectedResources,
+            handleOpenDeleteDialog,
+            handleRegisterDoi,
+            handleSetupLandingPage,
+            singleSelectedResource,
+        ],
     );
 
     const handleColumnResize = useCallback((columnKey: ResourceColumnKey, width: number, options: ColumnResizeOptions = {}) => {
@@ -2019,6 +2076,38 @@ function ResourcesPage({
                 onSuccess={handleImportSuccess}
             />
 
+            <Dialog
+                open={blockedEditorTabs.length > 0}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setBlockedEditorTabs([]);
+                    }
+                }}
+            >
+                <DialogContent data-testid="blocked-editor-tabs-dialog">
+                    <DialogHeader>
+                        <DialogTitle>Open blocked editor tabs</DialogTitle>
+                        <DialogDescription>
+                            Your browser blocked one or more editor tabs. Open the resources below, or allow pop-ups for ERNIE and try again.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-2">
+                        {blockedEditorTabs.map((tab) => (
+                            <Button key={tab.id} asChild variant="outline" className="w-full justify-between gap-2">
+                                <a href={tab.url} target="_blank" rel="noreferrer">
+                                    <span className="truncate">{tab.label}</span>
+                                    <ExternalLink aria-hidden="true" className="size-4 shrink-0" />
+                                </a>
+                            </Button>
+                        ))}
+                    </div>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button type="button">Done</Button>
+                        </DialogClose>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
             <AlertDialog open={isUpdateMetadataDialogOpen} onOpenChange={handleUpdateMetadataDialogOpenChange}>
                 <AlertDialogContent>
                     <AlertDialogHeader>
@@ -2037,18 +2126,88 @@ function ResourcesPage({
             </AlertDialog>
 
             <AlertDialog open={isDeleteDialogOpen} onOpenChange={handleDeleteDialogOpenChange}>
-                <AlertDialogContent>
+                <AlertDialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
                     <AlertDialogHeader>
-                        <AlertDialogTitle>Delete {selectedCount === 1 ? 'draft resource' : 'draft resources'}?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            This will permanently remove {selectedCount} {selectedCount === 1 ? 'draft resource' : 'draft resources'} from ERNIE. Only
-                            draft resources without a DOI and without a landing page can be deleted.
-                        </AlertDialogDescription>
+                        <AlertDialogTitle>Delete selected resources?</AlertDialogTitle>
+                        <AlertDialogDescription>Choose which selected resource groups should be permanently removed.</AlertDialogDescription>
                     </AlertDialogHeader>
+
+                    <div className="space-y-4 text-sm" data-testid="resources-delete-confirmation-groups">
+                        {publishedDeleteCount > 0 && (
+                            <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-destructive">
+                                You have selected {selectedCount} {selectedCount === 1 ? 'resource' : 'resources'} for deletion. Of these,{' '}
+                                {publishedDeleteCount} {publishedDeleteCount === 1 ? 'resource cannot' : 'resources cannot'} be deleted because{' '}
+                                {publishedDeleteCount === 1 ? 'it is' : 'they are'} already registered.
+                            </div>
+                        )}
+
+                        {hasPreviewDeleteSelection && (
+                            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+                                If you confirm deletion for preview resources, their preview pages will be deleted. Please ensure users are informed
+                                that these links will no longer be available.
+                            </div>
+                        )}
+
+                        <div className="space-y-2">
+                            {DELETABLE_DELETE_STATUSES.map((status) => {
+                                const count = selectedDeleteGroups[status].length;
+
+                                if (count === 0) {
+                                    return null;
+                                }
+
+                                const checkboxId = `resources-delete-group-${status}`;
+
+                                return (
+                                    <div key={status} className="rounded-md border p-3" data-testid={`resources-delete-group-${status}`}>
+                                        <div className="flex items-start gap-3">
+                                            <Checkbox
+                                                id={checkboxId}
+                                                checked={selectedDeleteStatuses[status]}
+                                                onCheckedChange={(value) =>
+                                                    setSelectedDeleteStatuses((current) => ({ ...current, [status]: value === true }))
+                                                }
+                                                disabled={isDeletingResource}
+                                                data-testid={`resources-delete-group-${status}-checkbox`}
+                                            />
+                                            <label htmlFor={checkboxId} className="grid gap-1 leading-none">
+                                                <span className="font-medium">Delete {formatDeleteStatusCount(status, count)}</span>
+                                                <span className="text-muted-foreground">{DELETE_STATUS_DESCRIPTIONS[status]}</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+
+                            {publishedDeleteCount > 0 && (
+                                <div className="rounded-md border border-muted bg-muted/40 p-3" data-testid="resources-delete-group-published">
+                                    <p className="font-medium">{formatDeleteStatusCount('published', publishedDeleteCount)} cannot be deleted.</p>
+                                    <p className="mt-1 text-muted-foreground">Published resources are already registered and must remain in ERNIE.</p>
+                                </div>
+                            )}
+                        </div>
+
+                        {!hasAnyDeletableDeleteSelection && <p className="text-muted-foreground">No selected resources can be deleted.</p>}
+
+                        {hasAnyDeletableDeleteSelection && (
+                            <p className="text-muted-foreground">
+                                This action cannot be undone. If you wish to back up the data, download and save it as an XML file before deleting it.
+                            </p>
+                        )}
+                    </div>
+
                     <AlertDialogFooter>
                         <AlertDialogCancel disabled={isDeletingResource}>Cancel</AlertDialogCancel>
-                        <AlertDialogAction variant="destructive" onClick={handleConfirmDelete} disabled={isDeletingResource}>
-                            {isDeletingResource ? 'Deleting...' : `Delete ${selectedCount === 1 ? 'Draft' : 'Drafts'}`}
+                        <AlertDialogAction
+                            variant="destructive"
+                            onClick={handleConfirmDelete}
+                            disabled={isDeletingResource || selectedDeletableDeleteCount === 0}
+                        >
+                            {isDeletingResource
+                                ? 'Deleting...'
+                                : selectedDeletableDeleteCount === 1
+                                  ? 'Delete Resource'
+                                  : `Delete ${selectedDeletableDeleteCount} Resources`}
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/tests/pest/Feature/Policies/ResourcePolicyTest.php
+++ b/tests/pest/Feature/Policies/ResourcePolicyTest.php
@@ -72,6 +72,41 @@ function createNonDraftResourceForPolicy(): Resource
     ]);
 }
 
+function createReviewResourceForPolicy(string $doi = '10.5880/test.review.policy'): Resource
+{
+    $resource = createNonDraftResourceForPolicy();
+    $resource->update(['doi' => $doi]);
+
+    LandingPage::factory()->withDoi($doi)->draft()->create([
+        'resource_id' => $resource->id,
+    ]);
+
+    return $resource->fresh([
+        'titles.titleType',
+        'creators',
+        'rights',
+        'descriptions.descriptionType',
+        'landingPage',
+    ]);
+}
+
+function createPublishedResourceForPolicy(string $doi = '10.5880/test.published.policy'): Resource
+{
+    $resource = createNonDraftResourceForPolicy();
+    $resource->update(['doi' => $doi]);
+
+    LandingPage::factory()->withDoi($doi)->published()->create([
+        'resource_id' => $resource->id,
+    ]);
+
+    return $resource->fresh([
+        'titles.titleType',
+        'creators',
+        'rights',
+        'descriptions.descriptionType',
+        'landingPage',
+    ]);
+}
 describe('ResourcePolicy', function () {
     beforeEach(function () {
         $this->policy = new ResourcePolicy;
@@ -169,7 +204,7 @@ describe('ResourcePolicy', function () {
     });
 
     describe('delete', function () {
-        it('short-circuits before loading relations for users who cannot delete drafts', function () {
+        it('short-circuits before loading relations for users who cannot delete resources', function () {
             $user = User::factory()->create(['role' => UserRole::BEGINNER]);
 
             /** @var Resource&MockInterface $resource */
@@ -180,36 +215,21 @@ describe('ResourcePolicy', function () {
             expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
-        it('loads relations only after the role check passes', function () {
+        it('loads status relations only after the role check passes', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
 
             /** @var Resource&MockInterface $resource */
             $resource = Mockery::mock(Resource::class);
-            $resource->shouldReceive('getAttribute')->with('doi')->once()->andReturn(null);
-            $resource->shouldReceive('loadMissing')->once()->with('landingPage')->ordered()->andReturnSelf();
-            $resource->shouldReceive('getAttribute')->with('landingPage')->once()->ordered()->andReturn(null);
             $resource->shouldReceive('loadMissing')->once()->with([
+                'landingPage',
                 'titles.titleType',
                 'creators',
                 'rights',
                 'descriptions.descriptionType',
-            ])->ordered()->andReturnSelf();
+            ])->andReturnSelf();
             $resource->shouldReceive('publicStatus')->once()->andReturn('draft');
 
             expect($this->policy->delete($user, $resource))->toBeTrue();
-        });
-
-        it('short-circuits before loading completeness relations when the resource has a landing page', function () {
-            $user = User::factory()->create(['role' => UserRole::ADMIN]);
-
-            /** @var Resource&MockInterface $resource */
-            $resource = Mockery::mock(Resource::class);
-            $resource->shouldReceive('getAttribute')->with('doi')->once()->andReturn(null);
-            $resource->shouldReceive('loadMissing')->once()->with('landingPage')->andReturnSelf();
-            $resource->shouldReceive('getAttribute')->with('landingPage')->once()->andReturn(new LandingPage);
-            $resource->shouldNotReceive('publicStatus');
-
-            expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
         it('allows admin to delete a draft resource', function () {
@@ -217,17 +237,17 @@ describe('ResourcePolicy', function () {
             expect($this->policy->delete($user, $this->resource))->toBeTrue();
         });
 
-        it('denies admin from deleting a draft resource with a persistent identifier', function () {
+        it('allows admin to delete a draft resource with a persistent identifier', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
             $resource = Resource::factory()->create([
                 'doi' => '10.5880/test.2026.001',
             ]);
 
             expect($resource->publicStatus())->toBe('draft');
-            expect($this->policy->delete($user, $resource))->toBeFalse();
+            expect($this->policy->delete($user, $resource))->toBeTrue();
         });
 
-        it('denies admin from deleting a draft resource with a landing page', function () {
+        it('allows admin to delete a draft resource with a landing page', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
             LandingPage::factory()->withoutDoi()->draft()->create([
                 'resource_id' => $this->resource->id,
@@ -236,40 +256,44 @@ describe('ResourcePolicy', function () {
             $this->resource->refresh();
 
             expect($this->resource->publicStatus())->toBe('draft');
-            expect($this->policy->delete($user, $this->resource))->toBeFalse();
+            expect($this->policy->delete($user, $this->resource))->toBeTrue();
         });
 
-        it('allows group leader to delete a draft resource', function () {
+        it('allows group leader to delete a curation resource', function () {
             $user = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
-            expect($this->policy->delete($user, $this->resource))->toBeTrue();
+            $resource = createNonDraftResourceForPolicy();
+
+            expect($resource->publicStatus())->toBe('curation');
+            expect($this->policy->delete($user, $resource))->toBeTrue();
         });
 
-        it('allows curator to delete a draft resource', function () {
+        it('allows curator to delete a review resource', function () {
             $user = User::factory()->create(['role' => UserRole::CURATOR]);
-            expect($this->policy->delete($user, $this->resource))->toBeTrue();
+            $resource = createReviewResourceForPolicy();
+
+            expect($resource->publicStatus())->toBe('review');
+            expect($this->policy->delete($user, $resource))->toBeTrue();
         });
 
-        it('denies admin from deleting a non-draft resource', function () {
+        it('denies admin from deleting a published resource', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);
-            $resource = createNonDraftResourceForPolicy();
+            $resource = createPublishedResourceForPolicy();
 
-            expect($resource->publicStatus())->not->toBe('draft');
+            expect($resource->publicStatus())->toBe('published');
             expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
-        it('denies group leader from deleting a non-draft resource', function () {
+        it('denies group leader from deleting a published resource', function () {
             $user = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
-            $resource = createNonDraftResourceForPolicy();
+            $resource = createPublishedResourceForPolicy();
 
-            expect($resource->publicStatus())->not->toBe('draft');
             expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
-        it('denies curator from deleting a non-draft resource', function () {
+        it('denies curator from deleting a published resource', function () {
             $user = User::factory()->create(['role' => UserRole::CURATOR]);
-            $resource = createNonDraftResourceForPolicy();
+            $resource = createPublishedResourceForPolicy();
 
-            expect($resource->publicStatus())->not->toBe('draft');
             expect($this->policy->delete($user, $resource))->toBeFalse();
         });
 
@@ -278,7 +302,6 @@ describe('ResourcePolicy', function () {
             expect($this->policy->delete($user, $this->resource))->toBeFalse();
         });
     });
-
     describe('importFromDataCite', function () {
         it('allows admin to import from DataCite', function () {
             $user = User::factory()->create(['role' => UserRole::ADMIN]);

--- a/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
+++ b/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
@@ -300,7 +300,7 @@ it('rejects beginners from batch deleting resources', function (): void {
         ])
         ->assertRedirect(route('resources'))
         ->assertSessionHasErrors([
-            'ids' => 'Published resources cannot be deleted.',
+            'ids' => 'You do not have permission to delete the selected resources.',
         ]);
 
     expect(Resource::find($resource->id))->not->toBeNull();

--- a/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
+++ b/tests/pest/Feature/Resources/DestroyResourceRequestTest.php
@@ -17,11 +17,12 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
 
-function createNonDraftResource(): Resource
+function createCompleteResourceForDeletion(array $attributes = []): Resource
 {
-    $resource = Resource::factory()->create([
+    $resource = Resource::factory()->create(array_merge([
         'doi' => null,
-    ]);
+        'publication_year' => 2026,
+    ], $attributes));
 
     $titleType = TitleType::firstOrCreate([
         'slug' => 'MainTitle',
@@ -74,40 +75,55 @@ function createNonDraftResource(): Resource
     ]);
 }
 
+function createReviewResourceForDeletion(string $doi = '10.5880/test.review.001'): Resource
+{
+    $resource = createCompleteResourceForDeletion(['doi' => $doi]);
+
+    LandingPage::factory()->withDoi($doi)->draft()->create([
+        'resource_id' => $resource->id,
+    ]);
+
+    return $resource->fresh([
+        'titles.titleType',
+        'creators',
+        'rights',
+        'descriptions.descriptionType',
+        'landingPage',
+    ]);
+}
+
+function createPublishedResourceForDeletion(string $doi = '10.5880/test.published.001'): Resource
+{
+    $resource = createCompleteResourceForDeletion(['doi' => $doi]);
+
+    LandingPage::factory()->withDoi($doi)->published()->create([
+        'resource_id' => $resource->id,
+    ]);
+
+    return $resource->fresh([
+        'titles.titleType',
+        'creators',
+        'rights',
+        'descriptions.descriptionType',
+        'landingPage',
+    ]);
+}
+
 it('allows admins to delete draft resources', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $resource = Resource::factory()->create([
-        'doi' => null,
-    ]);
+    $resource = Resource::factory()->create(['doi' => null]);
 
     $this->actingAs($admin)
         ->delete(route('resources.destroy', $resource))
         ->assertRedirect(route('resources'))
-        ->assertSessionHas('success', 'Draft deleted successfully.');
+        ->assertSessionHas('success', 'Resource deleted successfully.');
 
     expect(Resource::find($resource->id))->toBeNull();
 });
 
-it('forbids admins from deleting draft resources with persistent identifiers', function (): void {
-    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $resource = Resource::factory()->create([
-        'doi' => '10.5880/test.2026.002',
-    ]);
-
-    expect($resource->publicStatus())->toBe('draft');
-
-    $this->actingAs($admin)
-        ->delete(route('resources.destroy', $resource))
-        ->assertStatus(403);
-
-    expect(Resource::find($resource->id))->not->toBeNull();
-});
-
 it('allows group leaders to delete draft resources', function (): void {
     $leader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
-    $resource = Resource::factory()->create([
-        'doi' => null,
-    ]);
+    $resource = Resource::factory()->create(['doi' => null]);
 
     $this->actingAs($leader)
         ->delete(route('resources.destroy', $resource))
@@ -118,9 +134,7 @@ it('allows group leaders to delete draft resources', function (): void {
 
 it('allows curators to delete draft resources', function (): void {
     $curator = User::factory()->create(['role' => UserRole::CURATOR]);
-    $resource = Resource::factory()->create([
-        'doi' => null,
-    ]);
+    $resource = Resource::factory()->create(['doi' => null]);
 
     $this->actingAs($curator)
         ->delete(route('resources.destroy', $resource))
@@ -129,39 +143,55 @@ it('allows curators to delete draft resources', function (): void {
     expect(Resource::find($resource->id))->toBeNull();
 });
 
-it('forbids admins from deleting non-draft resources', function (): void {
+it('allows admins to delete curation resources', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $resource = createNonDraftResource();
+    $resource = createCompleteResourceForDeletion();
 
-    expect($resource->publicStatus())->not->toBe('draft');
+    expect($resource->publicStatus())->toBe('curation');
 
     $this->actingAs($admin)
         ->delete(route('resources.destroy', $resource))
-        ->assertStatus(403);
+        ->assertRedirect(route('resources'));
 
-    expect(Resource::find($resource->id))->not->toBeNull();
+    expect(Resource::find($resource->id))->toBeNull();
 });
 
-it('forbids group leaders from deleting non-draft resources', function (): void {
-    $leader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
-    $resource = createNonDraftResource();
+it('allows admins to delete draft resources with persistent identifiers', function (): void {
+    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+    $resource = Resource::factory()->create(['doi' => '10.5880/test.2026.002']);
 
-    expect($resource->publicStatus())->not->toBe('draft');
+    expect($resource->publicStatus())->toBe('draft');
 
-    $this->actingAs($leader)
+    $this->actingAs($admin)
         ->delete(route('resources.destroy', $resource))
-        ->assertStatus(403);
+        ->assertRedirect(route('resources'));
 
-    expect(Resource::find($resource->id))->not->toBeNull();
+    expect(Resource::find($resource->id))->toBeNull();
 });
 
-it('forbids curators from deleting non-draft resources', function (): void {
-    $curator = User::factory()->create(['role' => UserRole::CURATOR]);
-    $resource = createNonDraftResource();
+it('allows admins to delete review resources and cascades their landing pages', function (): void {
+    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+    $resource = createReviewResourceForDeletion();
+    $landingPageId = $resource->landingPage?->id;
 
-    expect($resource->publicStatus())->not->toBe('draft');
+    expect($resource->publicStatus())->toBe('review')
+        ->and($landingPageId)->toBeInt();
 
-    $this->actingAs($curator)
+    $this->actingAs($admin)
+        ->delete(route('resources.destroy', $resource))
+        ->assertRedirect(route('resources'));
+
+    expect(Resource::find($resource->id))->toBeNull()
+        ->and(LandingPage::find($landingPageId))->toBeNull();
+});
+
+it('forbids admins from deleting published resources', function (): void {
+    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
+    $resource = createPublishedResourceForDeletion();
+
+    expect($resource->publicStatus())->toBe('published');
+
+    $this->actingAs($admin)
         ->delete(route('resources.destroy', $resource))
         ->assertStatus(403);
 
@@ -176,41 +206,28 @@ it('rejects guests from deleting resources', function (): void {
 
     expect(Resource::find($resource->id))->not->toBeNull();
 });
-it('forbids admins from deleting draft resources with landing pages', function (): void {
+
+it('allows admins to batch delete non-published resources', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $resource = Resource::factory()->create([
-        'doi' => null,
-    ]);
-    LandingPage::factory()->withoutDoi()->draft()->create([
-        'resource_id' => $resource->id,
-    ]);
-
-    expect($resource->fresh()->publicStatus())->toBe('draft');
-
-    $this->actingAs($admin)
-        ->delete(route('resources.destroy', $resource))
-        ->assertStatus(403);
-
-    expect(Resource::find($resource->id))->not->toBeNull();
-});
-
-it('allows admins to batch delete draft resources without identifiers or landing pages', function (): void {
-    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $first = Resource::factory()->create(['doi' => null]);
-    $second = Resource::factory()->create(['doi' => null]);
+    $draft = Resource::factory()->create(['doi' => null]);
+    $curation = createCompleteResourceForDeletion(['doi' => null]);
+    $review = createReviewResourceForDeletion('10.5880/test.review.batch');
+    $landingPageId = $review->landingPage?->id;
 
     $this->actingAs($admin)
         ->delete(route('resources.batch-destroy'), [
-            'ids' => [$first->id, $second->id],
+            'ids' => [$draft->id, $curation->id, $review->id],
         ])
         ->assertRedirect(route('resources'))
-        ->assertSessionHas('success', '2 drafts deleted successfully.');
+        ->assertSessionHas('success', '3 resources deleted successfully.');
 
-    expect(Resource::find($first->id))->toBeNull()
-        ->and(Resource::find($second->id))->toBeNull();
+    expect(Resource::find($draft->id))->toBeNull()
+        ->and(Resource::find($curation->id))->toBeNull()
+        ->and(Resource::find($review->id))->toBeNull()
+        ->and(LandingPage::find($landingPageId))->toBeNull();
 });
 
-it('allows admins to batch delete a single draft resource from duplicate selections', function (): void {
+it('allows admins to batch delete a single resource from duplicate selections', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
     $resource = Resource::factory()->create(['doi' => null]);
 
@@ -219,7 +236,7 @@ it('allows admins to batch delete a single draft resource from duplicate selecti
             'ids' => [$resource->id, $resource->id],
         ])
         ->assertRedirect(route('resources'))
-        ->assertSessionHas('success', 'Draft deleted successfully.');
+        ->assertSessionHas('success', 'Resource deleted successfully.');
 
     expect(Resource::find($resource->id))->toBeNull();
 });
@@ -233,7 +250,7 @@ it('normalizes duplicate batch delete ids before applying the maximum batch size
             'ids' => array_fill(0, DestroyResourcesRequest::MAX_BATCH_SIZE + 1, (string) $resource->id),
         ])
         ->assertRedirect(route('resources'))
-        ->assertSessionHas('success', 'Draft deleted successfully.');
+        ->assertSessionHas('success', 'Resource deleted successfully.');
 
     expect(Resource::find($resource->id))->toBeNull();
 });
@@ -253,44 +270,26 @@ it('preserves malformed batch delete ids while deduplicating valid integer ids',
     expect(Resource::find($resource->id))->not->toBeNull();
 });
 
-it('rejects batch deletion when any selected draft has a landing page', function (): void {
+it('rejects batch deletion when any submitted resource is published', function (): void {
     $admin = User::factory()->create(['role' => UserRole::ADMIN]);
     $safeDraft = Resource::factory()->create(['doi' => null]);
-    $draftWithLandingPage = Resource::factory()->create(['doi' => null]);
-    LandingPage::factory()->withoutDoi()->draft()->create([
-        'resource_id' => $draftWithLandingPage->id,
-    ]);
+    $published = createPublishedResourceForDeletion('10.5880/test.published.batch');
 
     $this->actingAs($admin)
         ->from(route('resources'))
         ->delete(route('resources.batch-destroy'), [
-            'ids' => [$safeDraft->id, $draftWithLandingPage->id],
+            'ids' => [$safeDraft->id, $published->id],
         ])
         ->assertRedirect(route('resources'))
-        ->assertSessionHasErrors('ids');
+        ->assertSessionHasErrors([
+            'ids' => 'Published resources cannot be deleted.',
+        ]);
 
     expect(Resource::find($safeDraft->id))->not->toBeNull()
-        ->and(Resource::find($draftWithLandingPage->id))->not->toBeNull();
+        ->and(Resource::find($published->id))->not->toBeNull();
 });
 
-it('rejects batch deletion when any selected draft has a persistent identifier', function (): void {
-    $admin = User::factory()->create(['role' => UserRole::ADMIN]);
-    $safeDraft = Resource::factory()->create(['doi' => null]);
-    $registeredDraft = Resource::factory()->create(['doi' => '10.5880/test.2026.batch']);
-
-    $this->actingAs($admin)
-        ->from(route('resources'))
-        ->delete(route('resources.batch-destroy'), [
-            'ids' => [$safeDraft->id, $registeredDraft->id],
-        ])
-        ->assertRedirect(route('resources'))
-        ->assertSessionHasErrors('ids');
-
-    expect(Resource::find($safeDraft->id))->not->toBeNull()
-        ->and(Resource::find($registeredDraft->id))->not->toBeNull();
-});
-
-it('rejects beginners from batch deleting draft resources', function (): void {
+it('rejects beginners from batch deleting resources', function (): void {
     $beginner = User::factory()->create(['role' => UserRole::BEGINNER]);
     $resource = Resource::factory()->create(['doi' => null]);
 
@@ -300,7 +299,9 @@ it('rejects beginners from batch deleting draft resources', function (): void {
             'ids' => [$resource->id],
         ])
         ->assertRedirect(route('resources'))
-        ->assertSessionHasErrors('ids');
+        ->assertSessionHasErrors([
+            'ids' => 'Published resources cannot be deleted.',
+        ]);
 
     expect(Resource::find($resource->id))->not->toBeNull();
 });

--- a/tests/playwright/workflows/11-landing-page-preview.spec.ts
+++ b/tests/playwright/workflows/11-landing-page-preview.spec.ts
@@ -97,9 +97,11 @@ test.describe('Landing Page Preview (Setup Modal)', () => {
         await expect(firstResourceRow).toBeVisible();
         await firstResourceRow.getByRole('checkbox').click();
         await expect(page.getByText(/^1 resource selected$/)).toBeVisible();
-        await page.getByTestId('resources-actions-menu-trigger').click();
-
         const setupLandingPageButton = page.getByTestId('resources-action-setup-landing-page');
+        if (!(await setupLandingPageButton.isVisible().catch(() => false))) {
+            await page.getByTestId('resources-actions-menu-trigger').click();
+        }
+
         await expect(setupLandingPageButton).toBeVisible();
         await expect(setupLandingPageButton).toBeEnabled();
         await setupLandingPageButton.click();

--- a/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
+++ b/tests/vitest/components/resources/__tests__/bulk-actions-toolbar.test.tsx
@@ -25,8 +25,7 @@ const openActionsMenu = async () => {
     await userEvent.click(screen.getByTestId('resources-actions-menu-trigger'));
 };
 
-const clickAction = async (testId: string) => {
-    await openActionsMenu();
+const clickQuickAction = async (testId: string) => {
     await userEvent.click(screen.getByTestId(testId));
 };
 
@@ -79,7 +78,7 @@ describe('ResourcesBulkActionsToolbar', () => {
         expect(screen.getByTestId('resources-action-register-doi')).toBeInTheDocument();
         expect(screen.getByTestId('resources-action-update-metadata')).toBeInTheDocument();
         expect(screen.getByTestId('resources-action-delete')).toBeInTheDocument();
-        expect(screen.getByTestId('resources-action-setup-landing-page')).toHaveAttribute('data-variant', 'default');
+        expect(screen.getByTestId('resources-action-setup-landing-page')).toHaveAttribute('data-variant', 'outline');
         expect(screen.getByTestId('resources-action-update-metadata')).toHaveAttribute('data-variant', 'default');
         expect(screen.getByTestId('resources-action-delete')).toHaveAttribute('data-variant', 'destructive');
     });
@@ -111,7 +110,7 @@ describe('ResourcesBulkActionsToolbar', () => {
             <ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} actions={makeActions({ edit: { available: true } })} onAction={onAction} />,
         );
 
-        await clickAction('resources-action-edit');
+        await clickQuickAction('resources-action-edit');
 
         expect(onAction).toHaveBeenCalledTimes(1);
         expect(onAction).toHaveBeenCalledWith('edit');
@@ -119,8 +118,6 @@ describe('ResourcesBulkActionsToolbar', () => {
 
     it('uses the action label as the title for available actions', async () => {
         render(<ResourcesBulkActionsToolbar {...baseProps} selectedCount={1} actions={makeActions({ edit: { available: true } })} />);
-
-        await openActionsMenu();
 
         const item = screen.getByTestId('resources-action-edit');
         expect(item).toHaveAttribute('title', 'Edit');
@@ -143,8 +140,6 @@ describe('ResourcesBulkActionsToolbar', () => {
                 onUnavailableAction={onUnavailableAction}
             />,
         );
-
-        await openActionsMenu();
 
         const item = screen.getByTestId('resources-action-setup-landing-page');
         expect(item).toHaveAttribute('data-unavailable', 'true');

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -342,6 +342,46 @@ describe('Docs page', () => {
         expect(screen.getByText('Creating Landing Pages')).toBeInTheDocument();
     });
 
+    it('documents resource quick actions and grouped delete behavior for curators', async () => {
+        const { user } = renderDocsPage('curator');
+
+        await openDatasetsTab(user);
+
+        expect(screen.getByText('Quick Resource Actions')).toBeInTheDocument();
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return text.includes('Edit and Set up landing page appear as quick actions directly in the selection toolbar.');
+            }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('Delete Selected Resources (Curator and above)')).toBeInTheDocument();
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return text.includes('Published resources are listed as protected and are never sent to the delete endpoint.');
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it('hides resource delete documentation for beginners', async () => {
+        const { user } = renderDocsPage('beginner');
+
+        await openDatasetsTab(user);
+
+        expect(screen.getByText('Quick Resource Actions')).toBeInTheDocument();
+        expect(screen.queryByText('Delete Selected Resources (Curator and above)')).not.toBeInTheDocument();
+    });
+
     it('shows landing page templates for group leaders', async () => {
         const groupLeaderPage = renderDocsPage('group_leader');
         await openDatasetsTab(groupLeaderPage.user);

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -339,6 +339,7 @@ describe('ResourcesPage - bulk selection', () => {
         expect(toastMock.warning).toHaveBeenCalledWith(expect.stringContaining('fallback links'));
         expect(screen.getByTestId('blocked-editor-tabs-dialog')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('href', '/editor?resourceId=1');
+        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('keeps single-resource actions visible but reports a useful error for multi-selection', async () => {
@@ -559,6 +560,27 @@ describe('ResourcesPage - bulk selection', () => {
         await userEvent.click(screen.getByRole('button', { name: /delete 2 resources/i }));
 
         expect(routerMock.delete).toHaveBeenCalledWith('/resources/batch', expect.objectContaining({ data: { ids: [10, 11] } }));
+    });
+
+    it('hides delete warnings and disables confirmation when all deletable groups are unchecked', async () => {
+        render(
+            <ResourcesPage
+                {...buildProps([buildResource({ id: 12, doi: '10.9999/review', title: 'Preview A', publicstatus: 'review', landingPage })])}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-12'));
+        await clickResourceAction('resources-action-delete');
+
+        expect(screen.getByText(/preview pages will be deleted/i)).toBeInTheDocument();
+        expect(screen.getByText(/this action cannot be undone/i)).toBeInTheDocument();
+
+        await userEvent.click(screen.getByTestId('resources-delete-group-review-checkbox'));
+
+        expect(screen.queryByText(/preview pages will be deleted/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/this action cannot be undone/i)).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /delete 0 resources/i })).toBeDisabled();
+        expect(routerMock.delete).not.toHaveBeenCalled();
     });
 
     it('explains published-only selections without submitting deletion', async () => {

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -161,8 +161,13 @@ const openResourceActionsMenu = async () => {
     await userEvent.click(screen.getByTestId('resources-actions-menu-trigger'));
 };
 
+const QUICK_RESOURCE_ACTION_TEST_IDS = new Set(['resources-action-edit', 'resources-action-setup-landing-page']);
+
 const clickResourceAction = async (testId: string) => {
-    await openResourceActionsMenu();
+    if (!QUICK_RESOURCE_ACTION_TEST_IDS.has(testId)) {
+        await openResourceActionsMenu();
+    }
+
     await userEvent.click(screen.getByTestId(testId));
 };
 describe('ResourcesPage - bulk selection', () => {
@@ -308,14 +313,32 @@ describe('ResourcesPage - bulk selection', () => {
         expect(openMock).toHaveBeenCalledWith('/editor?resourceId=2', '_blank', 'noopener,noreferrer');
     });
 
-    it('warns when an editor tab is blocked', async () => {
+    it('keeps quick edit and setup actions outside the action menu', async () => {
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+
+        expect(screen.getByTestId('resources-action-edit')).toBeInTheDocument();
+        expect(screen.getByTestId('resources-action-setup-landing-page')).toBeInTheDocument();
+
+        await openResourceActionsMenu();
+        const menu = screen.getByRole('menu');
+
+        expect(within(menu).queryByTestId('resources-action-edit')).not.toBeInTheDocument();
+        expect(within(menu).queryByTestId('resources-action-setup-landing-page')).not.toBeInTheDocument();
+        expect(within(menu).getByTestId('resources-action-manage-related-items')).toBeInTheDocument();
+    });
+
+    it('shows fallback editor links when an editor tab is blocked', async () => {
         openMock.mockReturnValueOnce(null);
         render(<ResourcesPage {...buildProps()} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
-        await clickResourceAction('resources-action-edit');
+        await userEvent.click(screen.getByTestId('resources-action-edit'));
 
-        expect(toastMock.warning).toHaveBeenCalledWith(expect.stringContaining('blocked'));
+        expect(toastMock.warning).toHaveBeenCalledWith(expect.stringContaining('fallback links'));
+        expect(screen.getByTestId('blocked-editor-tabs-dialog')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('href', '/editor?resourceId=1');
     });
 
     it('keeps single-resource actions visible but reports a useful error for multi-selection', async () => {
@@ -472,9 +495,9 @@ describe('ResourcesPage - bulk selection', () => {
         await clickResourceAction('resources-action-delete');
 
         expect(screen.getByRole('alertdialog')).toBeInTheDocument();
-        expect(screen.getByText(/only draft resources without a doi and without a landing page can be deleted/i)).toBeInTheDocument();
+        expect(screen.getByText(/delete 2 draft resources/i)).toBeInTheDocument();
 
-        await userEvent.click(screen.getByRole('button', { name: /delete drafts/i }));
+        await userEvent.click(screen.getByRole('button', { name: /delete 2 resources/i }));
 
         expect(routerMock.delete).toHaveBeenCalledWith(
             '/resources/batch',
@@ -497,17 +520,71 @@ describe('ResourcesPage - bulk selection', () => {
             deleteOptions.onFinish();
         });
 
+        expect(toastMock.success).toHaveBeenCalledWith('2 resources deleted successfully.');
         expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
     });
 
-    it('uses a singular delete confirmation label for one selected draft', async () => {
+    it('uses a singular delete confirmation label for one selected resource', async () => {
         render(<ResourcesPage {...buildProps([buildResource({ id: 10, doi: null, title: 'Draft A', publicstatus: 'draft', landingPage: null })])} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-10'));
         await clickResourceAction('resources-action-delete');
 
-        expect(screen.getByRole('button', { name: /^delete draft$/i })).toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: /^delete drafts$/i })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^delete resource$/i })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^delete resources$/i })).not.toBeInTheDocument();
+    });
+
+    it('shows grouped delete choices and submits only checked deletable groups', async () => {
+        render(
+            <ResourcesPage
+                {...buildProps([
+                    buildResource({ id: 10, doi: null, title: 'Draft A', publicstatus: 'draft', landingPage: null }),
+                    buildResource({ id: 11, doi: null, title: 'Curation A', publicstatus: 'curation', landingPage: null }),
+                    buildResource({ id: 12, doi: '10.9999/review', title: 'Preview A', publicstatus: 'review', landingPage }),
+                    buildResource({ id: 13, doi: '10.9999/published', title: 'Published A', publicstatus: 'published', landingPage }),
+                ])}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('resources-select-all'));
+        await clickResourceAction('resources-action-delete');
+
+        expect(screen.getByText(/delete 1 draft resource/i)).toBeInTheDocument();
+        expect(screen.getByText(/delete 1 curation resource/i)).toBeInTheDocument();
+        expect(screen.getByText(/delete 1 preview resource/i)).toBeInTheDocument();
+        expect(screen.getByTestId('resources-delete-group-published')).toHaveTextContent('1 published resource cannot be deleted');
+        expect(screen.getByText(/preview pages will be deleted/i)).toBeInTheDocument();
+
+        await userEvent.click(screen.getByTestId('resources-delete-group-review-checkbox'));
+        await userEvent.click(screen.getByRole('button', { name: /delete 2 resources/i }));
+
+        expect(routerMock.delete).toHaveBeenCalledWith('/resources/batch', expect.objectContaining({ data: { ids: [10, 11] } }));
+    });
+
+    it('explains published-only selections without submitting deletion', async () => {
+        render(<ResourcesPage {...buildProps([buildResource({ id: 13, publicstatus: 'published', title: 'Published A', landingPage })])} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-13'));
+        await clickResourceAction('resources-action-delete');
+
+        expect(screen.getByText(/no selected resources can be deleted/i)).toBeInTheDocument();
+        expect(screen.getByTestId('resources-delete-group-published')).toHaveTextContent('1 published resource cannot be deleted');
+        expect(screen.getByRole('button', { name: /delete 0 resources/i })).toBeDisabled();
+        expect(routerMock.delete).not.toHaveBeenCalled();
+    });
+
+    it('allows deleting draft resources that already have a landing page', async () => {
+        render(
+            <ResourcesPage
+                {...buildProps([buildResource({ id: 20, doi: null, title: 'Draft with Landing Page', publicstatus: 'draft', landingPage })])}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-20'));
+        await clickResourceAction('resources-action-delete');
+        await userEvent.click(screen.getByRole('button', { name: /^delete resource$/i }));
+
+        expect(routerMock.delete).toHaveBeenCalledWith('/resources/batch', expect.objectContaining({ data: { ids: [20] }, preserveScroll: true }));
     });
 
     it('shows the batch delete ids validation message returned by Inertia', async () => {
@@ -515,7 +592,7 @@ describe('ResourcesPage - bulk selection', () => {
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-10'));
         await clickResourceAction('resources-action-delete');
-        await userEvent.click(screen.getByRole('button', { name: /^delete draft$/i }));
+        await userEvent.click(screen.getByRole('button', { name: /^delete resource$/i }));
 
         const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
             onError: (errors?: Record<string, unknown>) => void;
@@ -523,11 +600,11 @@ describe('ResourcesPage - bulk selection', () => {
         };
 
         await act(async () => {
-            deleteOptions.onError({ ids: 'Only draft resources without landing pages can be deleted.' });
+            deleteOptions.onError({ ids: 'Published resources cannot be deleted.' });
             deleteOptions.onFinish();
         });
 
-        expect(toastMock.error).toHaveBeenCalledWith('Only draft resources without landing pages can be deleted.');
+        expect(toastMock.error).toHaveBeenCalledWith('Published resources cannot be deleted.');
     });
 
     it('shows item-level batch delete validation messages returned by Inertia', async () => {
@@ -535,7 +612,7 @@ describe('ResourcesPage - bulk selection', () => {
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-10'));
         await clickResourceAction('resources-action-delete');
-        await userEvent.click(screen.getByRole('button', { name: /^delete draft$/i }));
+        await userEvent.click(screen.getByRole('button', { name: /^delete resource$/i }));
 
         const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
             onError: (errors?: Record<string, unknown>) => void;
@@ -543,11 +620,11 @@ describe('ResourcesPage - bulk selection', () => {
         };
 
         await act(async () => {
-            deleteOptions.onError({ 'ids.0': ['The selected draft can no longer be deleted.'] });
+            deleteOptions.onError({ 'ids.0': ['The selected resource can no longer be deleted.'] });
             deleteOptions.onFinish();
         });
 
-        expect(toastMock.error).toHaveBeenCalledWith('The selected draft can no longer be deleted.');
+        expect(toastMock.error).toHaveBeenCalledWith('The selected resource can no longer be deleted.');
     });
 
     it('shows the first available batch delete validation message for non-id errors', async () => {
@@ -555,7 +632,7 @@ describe('ResourcesPage - bulk selection', () => {
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-10'));
         await clickResourceAction('resources-action-delete');
-        await userEvent.click(screen.getByRole('button', { name: /^delete draft$/i }));
+        await userEvent.click(screen.getByRole('button', { name: /^delete resource$/i }));
 
         const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
             onError: (errors?: Record<string, unknown>) => void;
@@ -563,18 +640,19 @@ describe('ResourcesPage - bulk selection', () => {
         };
 
         await act(async () => {
-            deleteOptions.onError({ general: 'The selected drafts cannot be deleted right now.' });
+            deleteOptions.onError({ general: 'The selected resources cannot be deleted right now.' });
             deleteOptions.onFinish();
         });
 
-        expect(toastMock.error).toHaveBeenCalledWith('The selected drafts cannot be deleted right now.');
+        expect(toastMock.error).toHaveBeenCalledWith('The selected resources cannot be deleted right now.');
     });
+
     it('falls back to a generic batch delete error when no validation message is available', async () => {
         render(<ResourcesPage {...buildProps([buildResource({ id: 10, doi: null, title: 'Draft A', publicstatus: 'draft', landingPage: null })])} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-10'));
         await clickResourceAction('resources-action-delete');
-        await userEvent.click(screen.getByRole('button', { name: /^delete draft$/i }));
+        await userEvent.click(screen.getByRole('button', { name: /^delete resource$/i }));
 
         const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
             onError: (errors?: Record<string, unknown>) => void;
@@ -586,10 +664,10 @@ describe('ResourcesPage - bulk selection', () => {
             deleteOptions.onFinish();
         });
 
-        expect(toastMock.error).toHaveBeenCalledWith('Failed to delete draft resource.');
+        expect(toastMock.error).toHaveBeenCalledWith('Failed to delete resource.');
     });
 
-    it('uses a plural generic batch delete error for multiple selected drafts', async () => {
+    it('uses a plural generic batch delete error for multiple selected resources', async () => {
         render(
             <ResourcesPage
                 {...buildProps([
@@ -602,7 +680,7 @@ describe('ResourcesPage - bulk selection', () => {
         fireEvent.click(screen.getByTestId('resources-row-checkbox-10'));
         fireEvent.click(screen.getByTestId('resources-row-checkbox-11'));
         await clickResourceAction('resources-action-delete');
-        await userEvent.click(screen.getByRole('button', { name: /^delete drafts$/i }));
+        await userEvent.click(screen.getByRole('button', { name: /^delete 2 resources$/i }));
 
         const deleteOptions = routerMock.delete.mock.calls.at(-1)?.[1] as {
             onError: (errors?: Record<string, unknown>) => void;
@@ -614,23 +692,8 @@ describe('ResourcesPage - bulk selection', () => {
             deleteOptions.onFinish();
         });
 
-        expect(toastMock.error).toHaveBeenCalledWith('Failed to delete draft resources.');
+        expect(toastMock.error).toHaveBeenCalledWith('Failed to delete resources.');
     });
-
-    it('blocks delete when a selected draft already has a landing page', async () => {
-        render(
-            <ResourcesPage
-                {...buildProps([buildResource({ id: 20, doi: null, title: 'Draft with Landing Page', publicstatus: 'draft', landingPage })])}
-            />,
-        );
-
-        fireEvent.click(screen.getByTestId('resources-row-checkbox-20'));
-        await clickResourceAction('resources-action-delete');
-
-        expect(toastMock.error).toHaveBeenCalledWith('Resources with landing pages cannot be deleted from this list. Remove the landing page first.');
-        expect(routerMock.delete).not.toHaveBeenCalled();
-    });
-
     it('reports partial metadata update responses returned as multi-status errors', async () => {
         axiosPostMock.mockRejectedValueOnce(
             Object.assign(new Error('partial success'), {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -138,30 +138,6 @@ function makePagination(overrides = {}) {
 
 const defaultSort = { key: 'updated_at' as const, direction: 'desc' as const };
 
-const createLocalStorageMock = (): Storage => {
-    let store: Record<string, string> = {};
-
-    return {
-        clear: vi.fn(() => {
-            store = {};
-        }),
-        getItem: vi.fn((key: string) => store[key] ?? null),
-        key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
-        removeItem: vi.fn((key: string) => {
-            delete store[key];
-        }),
-        setItem: vi.fn((key: string, value: string) => {
-            store[key] = String(value);
-        }),
-        get length() {
-            return Object.keys(store).length;
-        },
-    } as Storage;
-};
-
-const localStorageMock = createLocalStorageMock();
-Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
-Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, configurable: true });
 function renderPage(propsOverrides: Record<string, unknown> = {}) {
     const props = {
         resources: [makeResource()],
@@ -207,7 +183,7 @@ describe('ResourcesPage - extended', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        localStorage.clear();
+        window.localStorage.clear();
         axiosGetMock.mockResolvedValue({ data: {} });
         Object.assign(mockUser, {
             role: 'group_leader',

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -138,6 +138,30 @@ function makePagination(overrides = {}) {
 
 const defaultSort = { key: 'updated_at' as const, direction: 'desc' as const };
 
+const createLocalStorageMock = (): Storage => {
+    let store: Record<string, string> = {};
+
+    return {
+        clear: vi.fn(() => {
+            store = {};
+        }),
+        getItem: vi.fn((key: string) => store[key] ?? null),
+        key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+        removeItem: vi.fn((key: string) => {
+            delete store[key];
+        }),
+        setItem: vi.fn((key: string, value: string) => {
+            store[key] = String(value);
+        }),
+        get length() {
+            return Object.keys(store).length;
+        },
+    } as Storage;
+};
+
+const localStorageMock = createLocalStorageMock();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, configurable: true });
 function renderPage(propsOverrides: Record<string, unknown> = {}) {
     const props = {
         resources: [makeResource()],
@@ -159,8 +183,13 @@ const openResourceActionsMenu = async () => {
     await userEvent.click(screen.getByTestId('resources-actions-menu-trigger'));
 };
 
+const QUICK_RESOURCE_ACTION_TEST_IDS = new Set(['resources-action-edit', 'resources-action-setup-landing-page']);
+
 const clickResourceAction = async (testId: string) => {
-    await openResourceActionsMenu();
+    if (!QUICK_RESOURCE_ACTION_TEST_IDS.has(testId)) {
+        await openResourceActionsMenu();
+    }
+
     await userEvent.click(screen.getByTestId(testId));
 };
 
@@ -427,7 +456,7 @@ describe('ResourcesPage - extended', () => {
             expect(screen.getByTestId('resources-action-export-jsonld')).toBeInTheDocument();
         });
 
-        it('enables delete only for selected drafts without DOI and without landing page', async () => {
+        it('enables delete for selected non-published resources', async () => {
             renderPage({ resources: [makeResource({ id: 5, doi: null, publicstatus: 'draft', landingPage: null })] });
 
             fireEvent.click(screen.getByTestId('resources-row-checkbox-5'));
@@ -439,13 +468,14 @@ describe('ResourcesPage - extended', () => {
             expect(screen.getByRole('alertdialog')).toBeInTheDocument();
         });
 
-        it('keeps delete unavailable for draft resources with persistent identifiers', async () => {
-            renderPage({ resources: [makeResource({ id: 5, publicstatus: 'draft', landingPage: null })] });
+        it('keeps published resources out of the submitted delete request', async () => {
+            renderPage({ resources: [makeResource({ id: 5, publicstatus: 'published', landingPage })] });
 
             fireEvent.click(screen.getByTestId('resources-row-checkbox-5'));
             await clickResourceAction('resources-action-delete');
 
-            expect(toastMock.error).toHaveBeenCalledWith('Resources with persistent identifiers cannot be deleted.');
+            expect(screen.getByText(/no selected resources can be deleted/i)).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /delete 0 resources/i })).toBeDisabled();
             expect(routerMock.delete).not.toHaveBeenCalled();
         });
 
@@ -454,12 +484,12 @@ describe('ResourcesPage - extended', () => {
 
             fireEvent.click(screen.getByTestId('resources-row-checkbox-5'));
             await clickResourceAction('resources-action-delete');
-            await userEvent.click(screen.getByRole('button', { name: /^delete draft$/i }));
+            await userEvent.click(screen.getByRole('button', { name: /^delete resource$/i }));
 
             expect(routerMock.delete).toHaveBeenCalledWith('/resources/batch', expect.objectContaining({ data: { ids: [5] }, preserveScroll: true }));
         });
 
-        it('hides delete action when the user lacks draft-delete permission', async () => {
+        it('hides delete action when the user lacks delete permission', async () => {
             mockUser.role = 'beginner';
             renderPage({ resources: [makeResource({ id: 5, doi: null, publicstatus: 'draft', landingPage: null })] });
             fireEvent.click(screen.getByTestId('resources-row-checkbox-5'));

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -81,8 +81,13 @@ const openResourceActionsMenu = async () => {
     await userEvent.click(screen.getByTestId('resources-actions-menu-trigger'));
 };
 
+const QUICK_RESOURCE_ACTION_TEST_IDS = new Set(['resources-action-edit', 'resources-action-setup-landing-page']);
+
 const clickResourceAction = async (testId: string) => {
-    await openResourceActionsMenu();
+    if (!QUICK_RESOURCE_ACTION_TEST_IDS.has(testId)) {
+        await openResourceActionsMenu();
+    }
+
     await userEvent.click(screen.getByTestId(testId));
 };
 


### PR DESCRIPTION
This pull request introduces several improvements to resource management, especially around bulk actions and deletion, and updates the user interface and documentation to match these changes. The most significant updates include broadening the criteria for resource deletion, reorganizing the bulk actions toolbar to feature quick actions, and clarifying user guidance and feedback messages.

**Resource Deletion Policy Updates**
- Resource deletion is now allowed for any non-published resource (draft, curation, or preview), rather than only drafts without a DOI or landing page. Published resources remain protected and cannot be deleted. The confirmation dialog now groups resources by status and warns about preview landing pages being removed. [[1]](diffhunk://#diff-97a05ae65121d8a5b4e27bb2c957110d07b6017912d9937264782930e7625295L168-R186) [[2]](diffhunk://#diff-97a05ae65121d8a5b4e27bb2c957110d07b6017912d9937264782930e7625295L223-R235) [[3]](diffhunk://#diff-97a05ae65121d8a5b4e27bb2c957110d07b6017912d9937264782930e7625295L241-R252) [[4]](diffhunk://#diff-53bfab563aca6d153dad401e415ac164193cb76028faa718eabd04c56337853dL53-R69) [[5]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL48-R52)

**Bulk Actions Toolbar Redesign**
- The bulk actions toolbar now features "Edit" and "Set up landing page" as quick actions directly in the toolbar for faster access. Other actions (export, DOI registration/update, metadata, related items, deletion) remain grouped in the Actions menu. [[1]](diffhunk://#diff-88720e0effe036725d932ad4a8a76d4df5e4e8842e548d45ab967bdea1307823R92-R123) [[2]](diffhunk://#diff-88720e0effe036725d932ad4a8a76d4df5e4e8842e548d45ab967bdea1307823R136-R161) [[3]](diffhunk://#diff-88720e0effe036725d932ad4a8a76d4df5e4e8842e548d45ab967bdea1307823L125-R178) [[4]](diffhunk://#diff-88720e0effe036725d932ad4a8a76d4df5e4e8842e548d45ab967bdea1307823L144-R197) [[5]](diffhunk://#diff-88720e0effe036725d932ad4a8a76d4df5e4e8842e548d45ab967bdea1307823R221)

**User Guidance and Documentation**
- The documentation and UI messages have been updated to reflect the new quick actions and resource deletion rules. Instructions now direct users to use the bulk toolbar for landing page setup and clarify which actions are available where. [[1]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL1537-R1537) [[2]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL1567-R1567) [[3]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR1836-R1850) [[4]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL1854-R1890)

**Feedback and Error Messages**
- Success and error messages for deletion actions now refer to "resource(s)" instead of "draft(s)" to match the expanded deletion policy.

**Minor UI and Import Adjustments**
- UI components and icon imports are updated to support the new toolbar layout and dialogs. [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L4-R4) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R32)

These changes make resource management more flexible for admins, group leaders, and curators, streamline common actions, and provide clearer guidance and feedback to users.