### PR TITLE
Fix: Guard legacy DOI imports and landing pages

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -11,6 +11,7 @@ use App\Services\DataCiteLandingPageImportService;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
+use App\Services\LegacyLandingPageDecisionService;
 use App\Services\LegacyLandingPageImportService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
 use App\Services\MetaworksDownloadUrlService;
@@ -500,13 +501,23 @@ class ImportFromDataCiteJob implements ShouldQueue
         MetaworksDownloadUrlService $metaworksService,
         bool $shouldLookupMetaworks = true,
     ): array {
+        if ($this->shouldSkipLegacyDoi($doi)) {
+            Log::info('Skipping legacy DOI marked as test/delete', ['doi' => $doi]);
+
+            return [
+                'status' => 'skipped',
+                'metaworks_unavailable' => false,
+                'enriched' => false,
+            ];
+        }
+
         try {
             $existingResource = Resource::where('doi', $doi)->first();
 
             if ($existingResource !== null) {
                 Log::debug('Skipping existing DOI', ['doi' => $doi]);
 
-                $dataCiteLandingPageSync = $this->syncDataCiteLandingPage($existingResource, $doiRecord);
+                $dataCiteLandingPageSync = $this->syncDataCiteLandingPageIfAllowed($existingResource, $doi, $doiRecord);
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
                 if ($shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
@@ -544,7 +555,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
                 $existingResource = Resource::where('doi', $doi)->first();
                 $dataCiteLandingPageSync = $existingResource !== null
-                    ? $this->syncDataCiteLandingPage($existingResource, $preparedDoiRecord)
+                    ? $this->syncDataCiteLandingPageIfAllowed($existingResource, $doi, $preparedDoiRecord)
                     : $this->emptyDataCiteLandingPageSyncResult();
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
@@ -564,7 +575,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
             $this->enrichImportedResourceFromLegacyDatabases($importedResource, $doi);
 
-            $this->syncDataCiteLandingPage($importedResource, $preparedDoiRecord);
+            $this->syncDataCiteLandingPageIfAllowed($importedResource, $doi, $preparedDoiRecord);
 
             $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
@@ -595,7 +606,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
                 $existingResource = Resource::where('doi', $doi)->first();
                 $dataCiteLandingPageSync = $existingResource !== null
-                    ? $this->syncDataCiteLandingPage($existingResource, $doiRecord)
+                    ? $this->syncDataCiteLandingPageIfAllowed($existingResource, $doi, $doiRecord)
                     : $this->emptyDataCiteLandingPageSyncResult();
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
@@ -618,11 +629,15 @@ class ImportFromDataCiteJob implements ShouldQueue
      * @param  array<string, mixed>  $doiRecord
      * @return array{changed: bool}
      */
-    private function syncDataCiteLandingPage(Resource $resource, array $doiRecord): array
+    private function syncDataCiteLandingPageIfAllowed(Resource $resource, string $doi, array $doiRecord): array
     {
         $attributes = is_array($doiRecord['attributes'] ?? null)
             ? $doiRecord['attributes']
             : $doiRecord;
+
+        if (! app(LegacyLandingPageDecisionService::class)->shouldImportDataCiteUrlAsExternal($doi, $attributes)) {
+            return $this->emptyDataCiteLandingPageSyncResult();
+        }
 
         try {
             $result = app(DataCiteLandingPageImportService::class)->createExternalForResource($resource, $attributes);
@@ -655,8 +670,8 @@ class ImportFromDataCiteJob implements ShouldQueue
         string $doi,
         MetaworksDownloadUrlService $metaworksService,
     ): array {
-        /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool} $fileResult */
-        $fileResult = ['files' => [], 'allPublic' => false];
+        /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound?: bool} $fileResult */
+        $fileResult = ['files' => [], 'allPublic' => false, 'resourceFound' => false];
 
         try {
             $fileResult = $metaworksService->lookupFileEntries($doi);
@@ -672,15 +687,14 @@ class ImportFromDataCiteJob implements ShouldQueue
             ];
         }
 
-        if ($fileResult['files'] === []) {
-            return $this->emptyLegacyDownloadSyncResult();
-        }
+        $fileResult += ['resourceFound' => false];
 
         try {
             $syncResult = app(LegacyLandingPageImportService::class)->syncMissingFileEntries(
                 resource: $resource,
                 fileEntries: $fileResult['files'],
-                isPublished: $fileResult['allPublic'],
+                isPublished: $fileResult['files'] !== [] && $fileResult['allPublic'],
+                createWhenEmpty: $fileResult['resourceFound'] === true,
             );
         } catch (\Throwable $exception) {
             Log::warning('Failed to sync landing page with download links', [
@@ -833,6 +847,11 @@ class ImportFromDataCiteJob implements ShouldQueue
             'doi' => $normalizedDoi,
             'doiRecord' => $normalizedRecord,
         ];
+    }
+
+    private function shouldSkipLegacyDoi(string $doi): bool
+    {
+        return app(LegacyLandingPageDecisionService::class)->shouldSkipLegacyDoi($doi);
     }
 
     private function normalizeDoi(string $doi): string

--- a/app/Services/LegacyLandingPageDecisionService.php
+++ b/app/Services/LegacyLandingPageDecisionService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+class LegacyLandingPageDecisionService
+{
+    /**
+     * Legacy test/delete DOIs should never create ERNIE resources.
+     */
+    public function shouldSkipLegacyDoi(string $doi): bool
+    {
+        $doi = strtolower(trim($doi));
+
+        return str_contains($doi, 'test') || str_contains($doi, 'delete');
+    }
+
+    /**
+     * DataCite URLs are only trusted for legacy resources that are known to use
+     * external landing pages. Old GFZ Data Services runtime URLs must be ignored.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function shouldImportDataCiteUrlAsExternal(string $doi, array $attributes): bool
+    {
+        $url = isset($attributes['url']) ? trim((string) $attributes['url']) : '';
+
+        if ($url === '' || $this->isLegacyDataServicesUrl($url)) {
+            return false;
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false) {
+            return false;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+            return false;
+        }
+
+        return $this->isGeofonExternalLandingPage($doi, $host);
+    }
+
+    public function isLegacyDataServicesUrl(string $url): bool
+    {
+        $parts = parse_url(trim($url));
+
+        if ($parts === false) {
+            return false;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        return in_array($scheme, ['http', 'https'], true)
+            && in_array($host, ['dataservices.gfz.de', 'dataservices.gfz-potsdam.de'], true);
+    }
+
+    private function isGeofonExternalLandingPage(string $doi, string $host): bool
+    {
+        return str_starts_with(strtolower(trim($doi)), '10.14470/')
+            && in_array($host, ['geofon.gfz.de', 'geofon.gfz-potsdam.de'], true);
+    }
+}

--- a/app/Services/LegacyLandingPageDecisionService.php
+++ b/app/Services/LegacyLandingPageDecisionService.php
@@ -13,7 +13,7 @@ class LegacyLandingPageDecisionService
     {
         $doi = strtolower(trim($doi));
 
-        return str_contains($doi, 'test') || str_contains($doi, 'delete');
+        return preg_match('/(?:^|[^a-z0-9])(?:test|delete)(?:$|[^a-z0-9])/', $doi) === 1;
     }
 
     /**

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -56,11 +56,15 @@ class LegacyLandingPageImportService
      * @param  list<array{url: string, label?: string|null, visible?: string|null}>  $fileEntries
      * @return array{changed: bool, created: bool, ftp_url_added: bool, links_added: int, landing_page: LandingPage|null}
      */
-    public function syncMissingFileEntries(Resource $resource, array $fileEntries, bool $isPublished): array
-    {
+    public function syncMissingFileEntries(
+        Resource $resource,
+        array $fileEntries,
+        bool $isPublished,
+        bool $createWhenEmpty = false,
+    ): array {
         $fileEntries = $this->normaliseFileEntries($fileEntries);
 
-        if ($fileEntries === []) {
+        if ($fileEntries === [] && ! $createWhenEmpty) {
             return $this->syncResult();
         }
 
@@ -73,10 +77,14 @@ class LegacyLandingPageImportService
                 return $this->syncResult(
                     changed: true,
                     created: true,
-                    ftpUrlAdded: true,
+                    ftpUrlAdded: $fileEntries !== [],
                     linksAdded: max(count($fileEntries) - 1, 0),
                     landingPage: $this->createDefaultLandingPage($resource, $fileEntries, $isPublished),
                 );
+            }
+
+            if ($fileEntries === []) {
+                return $this->syncResult(landingPage: $landingPage);
             }
 
             if ($landingPage->isExternal()) {
@@ -86,11 +94,20 @@ class LegacyLandingPageImportService
             $landingPage->loadMissing('links');
 
             $ftpUrlAdded = false;
+            $downloadsUnavailableCleared = false;
             $primaryFile = $fileEntries[0];
 
             if ($this->isBlank($landingPage->ftp_url)) {
-                $landingPage->forceFill(['ftp_url' => $primaryFile['url']])->save();
+                $landingPage->forceFill([
+                    'ftp_url' => $primaryFile['url'],
+                    'downloads_unavailable' => false,
+                ])->save();
                 $ftpUrlAdded = $landingPage->wasChanged('ftp_url');
+                $downloadsUnavailableCleared = $landingPage->wasChanged('downloads_unavailable');
+                $landingPage->refresh()->load('links');
+            } elseif ($landingPage->downloads_unavailable) {
+                $landingPage->forceFill(['downloads_unavailable' => false])->save();
+                $downloadsUnavailableCleared = $landingPage->wasChanged('downloads_unavailable');
                 $landingPage->refresh()->load('links');
             }
 
@@ -115,7 +132,7 @@ class LegacyLandingPageImportService
             }
 
             return $this->syncResult(
-                changed: $ftpUrlAdded || $linksAdded > 0,
+                changed: $ftpUrlAdded || $downloadsUnavailableCleared || $linksAdded > 0,
                 ftpUrlAdded: $ftpUrlAdded,
                 linksAdded: $linksAdded,
                 landingPage: $landingPage->fresh(['links']),
@@ -143,6 +160,7 @@ class LegacyLandingPageImportService
             'resource_id' => $resource->id,
             'template' => 'default_gfz',
             'ftp_url' => $primaryFile['url'] ?? null,
+            'downloads_unavailable' => $primaryFile === null,
             'is_published' => $shouldPublish,
             'published_at' => $shouldPublish ? now() : null,
         ]);

--- a/app/Services/MetaworksDownloadUrlService.php
+++ b/app/Services/MetaworksDownloadUrlService.php
@@ -51,7 +51,7 @@ class MetaworksDownloadUrlService
      * entries are imported as landing page additional links, using the legacy
      * file name first and the description as fallback label.
      *
-     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool}
+     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound: bool}
      */
     public function lookupFileEntries(string $doi): array
     {
@@ -63,7 +63,7 @@ class MetaworksDownloadUrlService
             ->first();
 
         if ($oldResource === null) {
-            return ['files' => [], 'allPublic' => false];
+            return ['files' => [], 'allPublic' => false, 'resourceFound' => false];
         }
 
         // Get all file records for that resource (public and non-public)
@@ -74,7 +74,7 @@ class MetaworksDownloadUrlService
             ->get(['url', 'name', 'description', 'visible']);
 
         if ($files->isEmpty()) {
-            return ['files' => [], 'allPublic' => false];
+            return ['files' => [], 'allPublic' => false, 'resourceFound' => true];
         }
 
         // Determine if all files are publicly visible
@@ -109,7 +109,7 @@ class MetaworksDownloadUrlService
             ];
         }
 
-        return ['files' => $entries, 'allPublic' => $allPublic];
+        return ['files' => $entries, 'allPublic' => $allPublic, 'resourceFound' => true];
     }
 
     private function isValidDownloadUrl(string $doi, string $url): bool

--- a/app/Services/SumarioPendingResourceImportService.php
+++ b/app/Services/SumarioPendingResourceImportService.php
@@ -37,6 +37,16 @@ class SumarioPendingResourceImportService
     public function importPendingByDoi(string $doi, int $userId): array
     {
         $normalisedDoi = $this->normaliseDoi($doi);
+
+        if ($this->shouldSkipLegacyDoi($normalisedDoi)) {
+            return [
+                'status' => 'skipped',
+                'resource' => null,
+                'doi' => $normalisedDoi,
+                'error' => null,
+            ];
+        }
+
         $oldDataset = $this->findPendingDatasetByDoi($normalisedDoi);
 
         if ($oldDataset === null) {
@@ -105,6 +115,15 @@ class SumarioPendingResourceImportService
         foreach ($pendingDatasets as $oldDataset) {
             $summary['processed']++;
             $doi = $this->normaliseDoi((string) $oldDataset->identifier);
+
+            if ($this->shouldSkipLegacyDoi($doi)) {
+                $summary['skipped']++;
+                if (count($summary['skipped_dois']) < $maxStoredDois) {
+                    $summary['skipped_dois'][] = $doi;
+                }
+
+                continue;
+            }
 
             if (Resource::where('doi', $doi)->exists()) {
                 $summary['skipped']++;
@@ -443,6 +462,11 @@ class SumarioPendingResourceImportService
         $year = (int) $year;
 
         return $year >= 1000 && $year <= 9999 ? $year : null;
+    }
+
+    private function shouldSkipLegacyDoi(string $doi): bool
+    {
+        return app(LegacyLandingPageDecisionService::class)->shouldSkipLegacyDoi($doi);
     }
 
     private function normaliseDoi(string $doi): string

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -115,18 +115,18 @@ describe('ImportFromDataCiteJob', function () {
             ->once()
             ->andReturn((function () {
                 yield [
-                    'id' => '10.5880/test.1',
+                    'id' => '10.5880/sample.1',
                     'attributes' => [
-                        'doi' => '10.5880/test.1',
+                        'doi' => '10.5880/sample.1',
                         'titles' => [['title' => 'Test 1']],
                         'publicationYear' => 2024,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
                     ],
                 ];
                 yield [
-                    'id' => '10.5880/test.2',
+                    'id' => '10.5880/sample.2',
                     'attributes' => [
-                        'doi' => '10.5880/test.2',
+                        'doi' => '10.5880/sample.2',
                         'titles' => [['title' => 'Test 2']],
                         'publicationYear' => 2024,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
@@ -367,9 +367,9 @@ describe('ImportFromDataCiteJob', function () {
             ->once()
             ->andReturn((function () {
                 yield [
-                    'id' => '10.5880/test.1',
+                    'id' => '10.5880/sample.1',
                     'attributes' => [
-                        'doi' => '10.5880/test.1',
+                        'doi' => '10.5880/sample.1',
                         'titles' => [['title' => 'Test']],
                         'publicationYear' => 2024,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
@@ -640,11 +640,11 @@ describe('ImportFromDataCiteJob', function () {
         $this->importService
             ->shouldReceive('fetchSingleDoi')
             ->once()
-            ->with('10.5880/test.single')
+            ->with('10.5880/sample.single')
             ->andReturn([
-                'id' => '10.5880/test.single',
+                'id' => '10.5880/sample.single',
                 'attributes' => [
-                    'doi' => '10.5880/test.single',
+                    'doi' => '10.5880/sample.single',
                     'titles' => [['title' => 'Single DOI Test']],
                     'publicationYear' => 2024,
                     'types' => ['resourceTypeGeneral' => 'Dataset'],
@@ -657,7 +657,7 @@ describe('ImportFromDataCiteJob', function () {
             ->andReturn(Resource::factory()->make());
 
         $importId = Str::uuid()->toString();
-        $job = new ImportFromDataCiteJob($this->user->id, $importId, '10.5880/test.single');
+        $job = new ImportFromDataCiteJob($this->user->id, $importId, '10.5880/sample.single');
         $job->handle($this->importService, $this->transformer, $this->metaworksService);
 
         $status = Cache::get("datacite_import:{$importId}");
@@ -1010,9 +1010,9 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->once()
             ->andReturn((function () {
                 yield [
-                    'id' => '10.5880/lp.test.001',
+                    'id' => '10.5880/lp.sample.001',
                     'attributes' => [
-                        'doi' => '10.5880/lp.test.001',
+                        'doi' => '10.5880/lp.sample.001',
                         'titles' => [['title' => 'Test Dataset Title']],
                         'publicationYear' => 2024,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
@@ -1024,22 +1024,22 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         $this->transformer
             ->shouldReceive('transform')
             ->once()
-            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/lp.test.001']));
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/lp.sample.001']));
 
         // Override the default mock: return download URLs (all public)
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
         $metaworksService->shouldReceive('lookupFileEntries')
-            ->with('10.5880/lp.test.001')
+            ->with('10.5880/lp.sample.001')
             ->once()
             ->andReturn([
                 'files' => [
                     [
-                        'url' => 'https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file1.zip',
+                        'url' => 'https://datapub.gfz.de/download/10.5880/GFZ.lp.sample.001/file1.zip',
                         'label' => 'Archive package',
                         'visible' => 'public',
                     ],
                     [
-                        'url' => 'https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip',
+                        'url' => 'https://datapub.gfz.de/download/10.5880/GFZ.lp.sample.001/file2.zip',
                         'label' => 'Supplement table',
                         'visible' => 'public',
                     ],
@@ -1052,17 +1052,17 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         $job->handle($this->importService, $this->transformer, $metaworksService);
 
         // Verify landing page was created
-        $resource = Resource::where('doi', '10.5880/lp.test.001')->first();
+        $resource = Resource::where('doi', '10.5880/lp.sample.001')->first();
         $landingPage = LandingPage::where('resource_id', $resource->id)->first();
         expect($landingPage)->not->toBeNull()
             ->and($landingPage->template)->toBe('default_gfz')
             ->and($landingPage->is_published)->toBeTrue()
             ->and($landingPage->published_at)->not->toBeNull()
-            ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file1.zip');
+            ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.sample.001/file1.zip');
 
         $links = LandingPageLink::where('landing_page_id', $landingPage->id)->orderBy('position')->get();
         expect($links)->toHaveCount(1)
-            ->and($links[0]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.test.001/file2.zip')
+            ->and($links[0]->url)->toBe('https://datapub.gfz.de/download/10.5880/GFZ.lp.sample.001/file2.zip')
             ->and($links[0]->label)->toBe('Supplement table')
             ->and($links[0]->position)->toBe(0);
 
@@ -1164,6 +1164,152 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         expect(LandingPage::where('resource_id', $resource->id)->exists())->toBeFalse();
     });
 
+    it('creates a default landing page with downloads unavailable when a legacy resource has no files', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/gfz.dekorp.ktb8401.001',
+                    'attributes' => [
+                        'doi' => '10.5880/gfz.dekorp.ktb8401.001',
+                        'url' => 'https://dataservices.gfz.de/dekorp/showshort.php?id=493dcc02-011c-11ed-9531-ca1f3ed77ce8',
+                        'titles' => [['title' => 'DEKORP No Files Dataset']],
+                        'publicationYear' => 2022,
+                        'types' => ['resourceTypeGeneral' => 'Dataset'],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/gfz.dekorp.ktb8401.001']));
+
+        $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $metaworksService->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/gfz.dekorp.ktb8401.001')
+            ->andReturn([
+                'files' => [],
+                'allPublic' => false,
+                'resourceFound' => true,
+            ]);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $metaworksService);
+
+        $resource = Resource::where('doi', '10.5880/gfz.dekorp.ktb8401.001')->firstOrFail();
+        $landingPage = $resource->fresh(['landingPage'])->landingPage;
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->template)->toBe('default_gfz')
+            ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->downloads_unavailable)->toBeTrue()
+            ->and($landingPage->is_published)->toBeFalse()
+            ->and(LandingPageDomain::count())->toBe(0);
+    });
+
+    it('ignores old DataCite data services URLs and imports SUMARIO file URLs instead', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/gfz.2.6.2023.010',
+                    'attributes' => [
+                        'doi' => '10.5880/gfz.2.6.2023.010',
+                        'url' => 'https://dataservices.gfz.de/panmetaworks/showshort.php?id=d9d1cfb5-7a4f-11ee-967a-4ffbfe06208e',
+                        'state' => 'findable',
+                        'titles' => [['title' => 'Global energy magnitude catalog']],
+                        'publicationYear' => 2024,
+                        'types' => ['resourceTypeGeneral' => 'Dataset'],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/gfz.2.6.2023.010']));
+
+        $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $metaworksService->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/gfz.2.6.2023.010')
+            ->andReturn([
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/download/10.5880.GFZ.2.6.2023.010-NcaeZB',
+                        'label' => 'download data and description',
+                        'visible' => 'public',
+                    ],
+                ],
+                'allPublic' => true,
+                'resourceFound' => true,
+            ]);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $metaworksService);
+
+        $resource = Resource::where('doi', '10.5880/gfz.2.6.2023.010')->firstOrFail();
+        $landingPage = $resource->fresh(['landingPage.externalDomain'])->landingPage;
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->template)->toBe('default_gfz')
+            ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/10.5880.GFZ.2.6.2023.010-NcaeZB')
+            ->and($landingPage->downloads_unavailable)->toBeFalse()
+            ->and($landingPage->externalDomain)->toBeNull()
+            ->and(LandingPageDomain::count())->toBe(0);
+    });
+
+    it('skips imported legacy resources when the DOI contains test or delete', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/fidgeo.test.to.be.deleted',
+                    'attributes' => [
+                        'doi' => '10.5880/fidgeo.test.to.be.deleted',
+                        'url' => 'https://ernie.rz-vm499.gfz.de/10.5880/fidgeo.test.to.be.deleted/test-title-to-be-deleted',
+                        'titles' => [['title' => 'Test title to be deleted']],
+                    ],
+                ];
+            })());
+
+        $this->transformer->shouldReceive('prepareDoiData')->never();
+        $this->transformer->shouldReceive('transform')->never();
+        $this->metaworksService->shouldReceive('lookupFileEntries')->never();
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['status'])->toBe('completed')
+            ->and($status['imported'])->toBe(0)
+            ->and($status['skipped'])->toBe(1)
+            ->and($status['skipped_dois'])->toBe(['10.5880/fidgeo.test.to.be.deleted'])
+            ->and(Resource::where('doi', '10.5880/fidgeo.test.to.be.deleted')->exists())->toBeFalse();
+    });
     it('does not create landing page for skipped (existing) resources', function () {
         Resource::factory()->create(['doi' => '10.5880/skip.existing']);
 

--- a/tests/pest/Unit/Services/LegacyLandingPageDecisionServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageDecisionServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\LegacyLandingPageDecisionService;
+
+it('skips legacy dois marked as test or delete', function (string $doi): void {
+    $service = new LegacyLandingPageDecisionService;
+
+    expect($service->shouldSkipLegacyDoi($doi))->toBeTrue();
+})->with([
+    'test suffix' => ['10.5880/fidgeo.test.to.be.deleted'],
+    'delete suffix' => ['10.5880/GFZ.DELETE.001'],
+]);
+
+it('does not skip ordinary legacy dois', function (): void {
+    $service = new LegacyLandingPageDecisionService;
+
+    expect($service->shouldSkipLegacyDoi('10.5880/gfz.2.6.2023.010'))->toBeFalse();
+});
+
+it('recognizes old Data Services runtime URLs', function (string $url): void {
+    $service = new LegacyLandingPageDecisionService;
+
+    expect($service->isLegacyDataServicesUrl($url))->toBeTrue();
+})->with([
+    'current old runtime host' => ['https://dataservices.gfz.de/panmetaworks/showshort.php?id=abc'],
+    'legacy potsdam host' => ['http://dataservices.gfz-potsdam.de/dekorp/showshort.php?id=abc'],
+]);
+
+it('allows GEOFON 10.14470 DataCite URLs as external landing pages', function (): void {
+    $service = new LegacyLandingPageDecisionService;
+
+    expect($service->shouldImportDataCiteUrlAsExternal('10.14470/9i763612', [
+        'url' => 'https://geofon.gfz.de/doi/network/4V/2022',
+    ]))->toBeTrue();
+});
+
+it('rejects non-GEOFON and old Data Services DataCite URLs as external landing pages', function (string $doi, string $url): void {
+    $service = new LegacyLandingPageDecisionService;
+
+    expect($service->shouldImportDataCiteUrlAsExternal($doi, ['url' => $url]))->toBeFalse();
+})->with([
+    'old data services runtime URL' => [
+        '10.5880/gfz.2.6.2023.010',
+        'https://dataservices.gfz.de/panmetaworks/showshort.php?id=d9d1cfb5-7a4f-11ee-967a-4ffbfe06208e',
+    ],
+    'geofon host with wrong prefix' => [
+        '10.5880/gfz.2.6.2023.010',
+        'https://geofon.gfz.de/doi/network/4V/2022',
+    ],
+    'other external host' => [
+        '10.5880/gfz.2.6.2023.010',
+        'https://example.org/dataset',
+    ],
+]);

--- a/tests/pest/Unit/Services/LegacyLandingPageDecisionServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageDecisionServiceTest.php
@@ -11,13 +11,21 @@ it('skips legacy dois marked as test or delete', function (string $doi): void {
 })->with([
     'test suffix' => ['10.5880/fidgeo.test.to.be.deleted'],
     'delete suffix' => ['10.5880/GFZ.DELETE.001'],
+    'hyphen separated delete marker' => ['10.5880/gfz-delete-001'],
+    'underscore separated test marker' => ['10.5880/gfz_test_001'],
 ]);
 
-it('does not skip ordinary legacy dois', function (): void {
+it('does not skip ordinary legacy dois', function (string $doi): void {
     $service = new LegacyLandingPageDecisionService;
 
-    expect($service->shouldSkipLegacyDoi('10.5880/gfz.2.6.2023.010'))->toBeFalse();
-});
+    expect($service->shouldSkipLegacyDoi($doi))->toBeFalse();
+})->with([
+    'ordinary GFZ DOI' => ['10.5880/gfz.2.6.2023.010'],
+    'latest contains test as substring' => ['10.5880/latest.2026.001'],
+    'contest contains test as substring' => ['10.5880/contest.dataset.001'],
+    'laTEST contains test as substring with mixed case' => ['10.5880/laTEST.001'],
+    'deleted is not a delete marker segment' => ['10.5880/to.be.deleted'],
+]);
 
 it('recognizes old Data Services runtime URLs', function (string $url): void {
     $service = new LegacyLandingPageDecisionService;

--- a/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
@@ -65,9 +65,34 @@ describe('LegacyLandingPageImportService', function () {
 
         expect($landingPage)->not->toBeNull()
             ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->downloads_unavailable)->toBeTrue()
             ->and($landingPage->is_published)->toBeFalse()
             ->and($resource->fresh(['landingPage'])->publicStatus())->toBe('review');
     });
+
+    it('clears downloads unavailable when legacy files are synced later', function () {
+        $resource = Resource::factory()->create(['doi' => '10.5880/landing.empty.then.files']);
+        $landingPage = LandingPage::factory()->downloadsUnavailable()->draft()->create([
+            'resource_id' => $resource->id,
+            'ftp_url' => null,
+        ]);
+
+        $result = (new LegacyLandingPageImportService)->syncMissingFileEntries(
+            resource: $resource,
+            fileEntries: [
+                ['url' => 'https://datapub.gfz.de/now-available.zip', 'label' => 'Now available', 'visible' => 'public'],
+            ],
+            isPublished: true,
+        );
+
+        $landingPage = $landingPage->fresh();
+
+        expect($result['changed'])->toBeTrue()
+            ->and($result['ftp_url_added'])->toBeTrue()
+            ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/now-available.zip')
+            ->and($landingPage->downloads_unavailable)->toBeFalse();
+    });
+
     it('creates a landing page while syncing missing legacy files for an existing resource', function () {
         $resource = Resource::factory()->create(['doi' => '10.5880/landing.sync.create']);
 

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -271,4 +271,36 @@ describe('SumarioPendingResourceImportService', function () {
 
         expect($result['status'])->toBe('skipped');
     });
+
+    it('skips pending SUMARIO resources whose DOI contains test or delete', function () {
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => 58,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/fidgeo.test.to.be.deleted',
+        ]);
+
+        $editorLoader = Mockery::mock(OldDatasetEditorLoader::class);
+        $editorLoader->shouldNotReceive('loadForEditor');
+
+        $resourceStorage = Mockery::mock(ResourceStorageService::class);
+        $resourceStorage->shouldNotReceive('store');
+
+        $downloadUrlService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $downloadUrlService->shouldNotReceive('lookupFileEntries');
+
+        $service = new SumarioPendingResourceImportService(
+            editorLoader: $editorLoader,
+            resourceStorage: $resourceStorage,
+            datacenterLookup: Mockery::mock(LegacyMetaworksDatacenterLookupService::class),
+            downloadUrlService: $downloadUrlService,
+            landingPageImport: new LegacyLandingPageImportService,
+            doiSuggestionService: app(DoiSuggestionService::class),
+        );
+
+        $result = $service->importPendingByDoi('10.5880/fidgeo.test.to.be.deleted', 1);
+
+        expect($result['status'])->toBe('skipped')
+            ->and($result['doi'])->toBe('10.5880/fidgeo.test.to.be.deleted')
+            ->and(Resource::where('doi', '10.5880/fidgeo.test.to.be.deleted')->exists())->toBeFalse();
+    });
 });


### PR DESCRIPTION
This pull request introduces a new service, `LegacyLandingPageDecisionService`, to centralize and improve the logic for handling legacy DOIs and the import of landing pages and download links. The changes ensure that test/delete DOIs are consistently skipped, that DataCite URLs are only imported for trusted legacy resources, and that the handling of landing pages and download links is more robust and explicit. Several methods and services have been updated to use these new decision points, and tests have been adjusted accordingly.

**Centralization of legacy DOI and landing page logic:**

* Added the new `LegacyLandingPageDecisionService` which encapsulates logic to decide whether a legacy DOI should be skipped and whether a DataCite URL should be imported as an external landing page. This service checks for "test" or "delete" DOIs and validates trusted hosts for external landing pages.

**Import and processing improvements:**

* Updated `ImportFromDataCiteJob` and `SumarioPendingResourceImportService` to use `LegacyLandingPageDecisionService` for skipping legacy DOIs and deciding when to import DataCite URLs, ensuring consistent and centralized decision-making. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R14) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R504-R520) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L547-R558) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L567-R578) [[5]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L598-R609) [[6]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L621-R641) [[7]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R852-R856) [[8]](diffhunk://#diff-b799a2f884a1af868f6fdba21a80fe75421b4c69a6e4e66bd8000adf50523241R40-R49) [[9]](diffhunk://#diff-b799a2f884a1af868f6fdba21a80fe75421b4c69a6e4e66bd8000adf50523241R119-R127) [[10]](diffhunk://#diff-b799a2f884a1af868f6fdba21a80fe75421b4c69a6e4e66bd8000adf50523241R467-R471)

**Landing page and download link handling:**

* Enhanced the logic in `LegacyLandingPageImportService` to allow landing pages to be created even when no files are present (if the resource is found), to clear the `downloads_unavailable` flag when appropriate, and to more accurately track changes (including when downloads become available). [[1]](diffhunk://#diff-1082b7d7d3ab6693f59f3d1d8fb16512f1a5773154f9e3363442e8282af70f65L59-R67) [[2]](diffhunk://#diff-1082b7d7d3ab6693f59f3d1d8fb16512f1a5773154f9e3363442e8282af70f65L76-R110) [[3]](diffhunk://#diff-1082b7d7d3ab6693f59f3d1d8fb16512f1a5773154f9e3363442e8282af70f65L118-R135) [[4]](diffhunk://#diff-1082b7d7d3ab6693f59f3d1d8fb16512f1a5773154f9e3363442e8282af70f65R163)
* Modified `MetaworksDownloadUrlService` to return an explicit `resourceFound` flag, which is propagated through the download link import process to enable creation of landing pages for resources with no files. [[1]](diffhunk://#diff-f92941e9f4c86abb080698a198ee9cbe15dfc075060ef0143350e61d61c1fdecL54-R54) [[2]](diffhunk://#diff-f92941e9f4c86abb080698a198ee9cbe15dfc075060ef0143350e61d61c1fdecL66-R66) [[3]](diffhunk://#diff-f92941e9f4c86abb080698a198ee9cbe15dfc075060ef0143350e61d61c1fdecL77-R77) [[4]](diffhunk://#diff-f92941e9f4c86abb080698a198ee9cbe15dfc075060ef0143350e61d61c1fdecL112-R112)

**Testing updates:**

* Updated test fixtures in `ImportFromDataCiteJobTest.php` to use non-test/sample DOIs, reflecting the new logic that skips "test" or "delete" DOIs. [[1]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dL118-R129) [[2]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dL370-R372) [[3]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dL643-R647)