### PR TITLE
Feature: Sort Assistance Suggestions by Resource Date

### DIFF
--- a/app/Services/Assistance/GenericTableAssistant.php
+++ b/app/Services/Assistance/GenericTableAssistant.php
@@ -55,13 +55,16 @@ abstract class GenericTableAssistant extends AbstractAssistant
 
     // ── GenericTableAssistant provides all storage logic ─────────────
 
-    #[\Override]
+       #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         /** @var LengthAwarePaginator<int, Model> */
         return AssistantSuggestion::where('assistant_id', $this->getId())
             ->with('resource')
-            ->orderByDesc('discovered_at')
+            ->join('resources', 'assistant_suggestions.resource_id', '=', 'resources.id')
+            ->select('assistant_suggestions.*')
+            ->orderByDesc('resources.created_at')
+            ->orderByDesc('assistant_suggestions.discovered_at')
             ->paginate($perPage, ['*'], $this->getId() . '_page');
     }
 

--- a/app/Services/Assistance/GenericTableAssistant.php
+++ b/app/Services/Assistance/GenericTableAssistant.php
@@ -39,7 +39,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
      * Call $onProgress('message') to report progress to the job queue.
      *
      * @param  Closure(string): void  $onProgress  Call this to report progress messages
-     * @return int  Number of new suggestions stored
+     * @return int Number of new suggestions stored
      */
     abstract protected function discover(Closure $onProgress): int;
 
@@ -55,7 +55,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
 
     // ── GenericTableAssistant provides all storage logic ─────────────
 
-       #[\Override]
+    #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         /** @var LengthAwarePaginator<int, Model> */
@@ -65,7 +65,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
             ->select('assistant_suggestions.*')
             ->orderByDesc('resources.created_at')
             ->orderByDesc('assistant_suggestions.discovered_at')
-            ->paginate($perPage, ['*'], $this->getId() . '_page');
+            ->paginate($perPage, ['*'], $this->getId().'_page');
     }
 
     #[\Override]
@@ -141,7 +141,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
      * Run the discovery process. Called by the generic job.
      *
      * @param  Closure(string): void  $onProgress
-     * @return int  Number of new suggestions found
+     * @return int Number of new suggestions found
      */
     public function runDiscovery(Closure $onProgress): int
     {
@@ -161,7 +161,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
      * @param  string  $suggestedLabel  Human-readable label for the suggestion
      * @param  float|null  $similarityScore  Match confidence (0.0 to 1.0), or null
      * @param  array<string, mixed>|null  $metadata  Extra assistant-specific data
-     * @return bool  True if stored, false if skipped (duplicate or dismissed)
+     * @return bool True if stored, false if skipped (duplicate or dismissed)
      */
     protected function storeSuggestion(
         int $resourceId,

--- a/modules/assistants/OrcidSuggestion/Assistant.php
+++ b/modules/assistants/OrcidSuggestion/Assistant.php
@@ -32,7 +32,7 @@ class Assistant extends AbstractAssistant
     #[\Override]
     protected function getManifestPath(): string
     {
-        return __DIR__ . '/manifest.json';
+        return __DIR__.'/manifest.json';
     }
 
     /**

--- a/modules/assistants/OrcidSuggestion/Assistant.php
+++ b/modules/assistants/OrcidSuggestion/Assistant.php
@@ -83,7 +83,9 @@ class Assistant extends AbstractAssistant
 
         return SuggestedOrcid::with(['resource.titles.titleType', 'person'])
             ->joinSub($enrichableCounts, 'enrichable_counts', 'suggested_orcids.resource_id', '=', 'enrichable_counts.resource_id')
+            ->join('resources', 'suggested_orcids.resource_id', '=', 'resources.id')
             ->select('suggested_orcids.*', 'enrichable_counts.enrichable_count')
+            ->orderByDesc('resources.created_at')
             ->orderByDesc('enrichable_counts.enrichable_count')
             ->orderByDesc('suggested_orcids.similarity_score')
             ->paginate(perPage: $perPage, pageName: 'orcid_page');

--- a/modules/assistants/RelationSuggestion/Assistant.php
+++ b/modules/assistants/RelationSuggestion/Assistant.php
@@ -32,11 +32,14 @@ class Assistant extends AbstractAssistant
         return __DIR__ . '/manifest.json';
     }
 
-    #[\Override]
+       #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         return SuggestedRelation::with(['resource.titles.titleType', 'identifierType', 'relationType'])
-            ->orderBy('discovered_at', 'desc')
+            ->join('resources', 'suggested_relations.resource_id', '=', 'resources.id')
+            ->select('suggested_relations.*')
+            ->orderByDesc('resources.created_at')
+            ->orderByDesc('suggested_relations.discovered_at')
             ->paginate($perPage, ['*'], 'relation_page');
     }
 

--- a/modules/assistants/RelationSuggestion/Assistant.php
+++ b/modules/assistants/RelationSuggestion/Assistant.php
@@ -29,10 +29,10 @@ class Assistant extends AbstractAssistant
     #[\Override]
     protected function getManifestPath(): string
     {
-        return __DIR__ . '/manifest.json';
+        return __DIR__.'/manifest.json';
     }
 
-       #[\Override]
+    #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         return SuggestedRelation::with(['resource.titles.titleType', 'identifierType', 'relationType'])

--- a/modules/assistants/RorSuggestion/Assistant.php
+++ b/modules/assistants/RorSuggestion/Assistant.php
@@ -40,7 +40,9 @@ class Assistant extends AbstractAssistant
 
         return SuggestedRor::with(['resource.titles.titleType'])
             ->joinSub($enrichableCounts, 'enrichable_counts', 'suggested_rors.resource_id', '=', 'enrichable_counts.resource_id')
+            ->join('resources', 'suggested_rors.resource_id', '=', 'resources.id')
             ->select('suggested_rors.*', 'enrichable_counts.enrichable_count')
+            ->orderByDesc('resources.created_at')
             ->orderByDesc('enrichable_counts.enrichable_count')
             ->orderByDesc('suggested_rors.similarity_score')
             ->paginate(perPage: $perPage, pageName: 'ror_page');

--- a/modules/assistants/RorSuggestion/Assistant.php
+++ b/modules/assistants/RorSuggestion/Assistant.php
@@ -29,7 +29,7 @@ class Assistant extends AbstractAssistant
     #[\Override]
     protected function getManifestPath(): string
     {
-        return __DIR__ . '/manifest.json';
+        return __DIR__.'/manifest.json';
     }
 
     #[\Override]

--- a/tests/pest/Feature/Services/GenericTableAssistantTest.php
+++ b/tests/pest/Feature/Services/GenericTableAssistantTest.php
@@ -266,6 +266,41 @@ describe('loadSuggestions', function () {
             ->and($item['resource_doi'])->toBe($resource->doi)
             ->and($item)->toHaveKeys(['id', 'assistant_id', 'resource_id', 'target_type', 'target_id', 'discovered_at']);
     });
+
+    it('sorts suggestions by newest resource first', function () {
+        $olderResource = Resource::factory()->create([
+            'created_at' => now()->subDays(10),
+        ]);
+        $newerResource = Resource::factory()->create([
+            'created_at' => now()->subDay(),
+        ]);
+        $assistant = new TestGenericAssistant;
+
+        AssistantSuggestion::create([
+            'assistant_id' => $assistant->getId(),
+            'resource_id' => $olderResource->id,
+            'target_type' => 'right',
+            'target_id' => 1,
+            'suggested_value' => 'older',
+            'suggested_label' => 'Older suggestion',
+            'discovered_at' => now(),
+        ]);
+
+        AssistantSuggestion::create([
+            'assistant_id' => $assistant->getId(),
+            'resource_id' => $newerResource->id,
+            'target_type' => 'right',
+            'target_id' => 2,
+            'suggested_value' => 'newer',
+            'suggested_label' => 'Newer suggestion',
+            'discovered_at' => now()->subDays(5),
+        ]);
+
+        $items = $assistant->loadSuggestions(25)->items();
+
+        expect($items[0]['suggested_value'])->toBe('newer')
+            ->and($items[1]['suggested_value'])->toBe('older');
+    });
 });
 
 // =========================================================================

--- a/tests/pest/Feature/Services/GenericTableAssistantTest.php
+++ b/tests/pest/Feature/Services/GenericTableAssistantTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\CacheKey;
 use App\Models\AssistantDismissed;
 use App\Models\AssistantSuggestion;
 use App\Models\Resource;
@@ -19,13 +20,13 @@ class TestGenericAssistant extends GenericTableAssistant
 
     private ?Closure $discoverCallback = null;
 
-    #[\Override]
+    #[Override]
     protected function getManifestPath(): string
     {
         return base_path('modules/assistants/RelationSuggestion/manifest.json');
     }
 
-    #[\Override]
+    #[Override]
     protected function discover(Closure $onProgress): int
     {
         if ($this->discoverCallback !== null) {
@@ -35,7 +36,7 @@ class TestGenericAssistant extends GenericTableAssistant
         return $this->discoverResult;
     }
 
-    #[\Override]
+    #[Override]
     protected function applyAccepted(AssistantSuggestion $suggestion): array
     {
         return ['success' => true, 'message' => 'Applied test suggestion.'];
@@ -74,7 +75,7 @@ class TestGenericAssistant extends GenericTableAssistant
 describe('storeSuggestion', function () {
     it('stores a new suggestion', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $stored = $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -93,7 +94,7 @@ describe('storeSuggestion', function () {
 
     it('skips duplicate suggestions', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $first = $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -124,7 +125,7 @@ describe('storeSuggestion', function () {
 
     it('does not update existing suggestion when duplicate is stored', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -157,7 +158,7 @@ describe('storeSuggestion', function () {
     it('skips previously dismissed suggestions', function () {
         $resource = Resource::factory()->create();
         $user = User::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         // Pre-dismiss the suggestion
         AssistantDismissed::create([
@@ -184,7 +185,7 @@ describe('storeSuggestion', function () {
 
     it('stores with metadata', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -208,7 +209,7 @@ describe('storeSuggestion', function () {
 describe('countPending', function () {
     it('counts suggestions for this assistant only', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -241,7 +242,7 @@ describe('countPending', function () {
 describe('loadSuggestions', function () {
     it('returns paginated and transformed suggestions', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -310,7 +311,7 @@ describe('loadSuggestions', function () {
 describe('acceptSuggestion', function () {
     it('applies and deletes the accepted suggestion', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $suggestion = AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -329,7 +330,7 @@ describe('acceptSuggestion', function () {
     });
 
     it('returns failure for non-existent suggestion', function () {
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
         $result = $assistant->acceptSuggestion(9999);
 
         expect($result['success'])->toBeFalse();
@@ -337,9 +338,9 @@ describe('acceptSuggestion', function () {
 
     it('invalidates total pending count cache', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
-        $cacheEnum = \App\Enums\CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
+        $cacheEnum = CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
         $cacheKey = $cacheEnum->key();
         $tags = $cacheEnum->tags();
         Cache::tags($tags)->put($cacheKey, 5, now()->addHour());
@@ -364,7 +365,7 @@ describe('declineSuggestion', function () {
     it('creates dismissed record and deletes suggestion', function () {
         $resource = Resource::factory()->create();
         $user = User::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $suggestion = AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -394,9 +395,9 @@ describe('declineSuggestion', function () {
     it('invalidates total pending count cache', function () {
         $resource = Resource::factory()->create();
         $user = User::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
-        $cacheEnum = \App\Enums\CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
+        $cacheEnum = CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
         $cacheKey = $cacheEnum->key();
         $tags = $cacheEnum->tags();
         Cache::tags($tags)->put($cacheKey, 5, now()->addHour());
@@ -423,7 +424,7 @@ describe('declineSuggestion', function () {
 
 describe('runDiscovery', function () {
     it('delegates to discover() method', function () {
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
         $assistant->setDiscoverResult(7);
 
         $progressMessages = [];


### PR DESCRIPTION
## Summary

* Sort assistance suggestions by the related resource creation date, newest first.
* Keep existing secondary ordering within the same resource, such as discovery date, enrichable count, or similarity score.
* Apply the sorting consistently across generic assistants and existing ORCID, ROR, and relation suggestion assistants.

Closes #909

## Testing

* `php -l app/Services/Assistance/GenericTableAssistant.php`
* `php -l modules/assistants/RelationSuggestion/Assistant.php`
* `php -l modules/assistants/RorSuggestion/Assistant.php`
* `php -l modules/assistants/OrcidSuggestion/Assistant.php`