### PR TITLE
Practice task issue920 lennartubben

### DIFF
--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -184,7 +184,7 @@ function paginated<T>(data: T[]): PaginatedData<BaseSuggestionItem> {
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe('OrcidSuggestionCard – ORCID link', () => {
-    it('renders the resource DOI as an underlined link that opens in a new tab', () => {
+    it('renders the resource DOI as a clickable landing page link', () => {
         const suggestion = makeOrcidSuggestion({ resource_doi: '10.5880/test.2024.001' });
 
         render(
@@ -196,8 +196,34 @@ describe('OrcidSuggestionCard – ORCID link', () => {
 
         const link = screen.getByRole('link', { name: '10.5880/test.2024.001' });
         expect(link).toHaveAttribute('href', 'https://doi.org/10.5880%2Ftest.2024.001');
-        expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('renders the resource DOI link as underlined', () => {
+        const suggestion = makeOrcidSuggestion({ resource_doi: '10.5880/test.2024.001' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '10.5880/test.2024.001' });
         expect(link).toHaveClass('underline');
+    });
+
+    it('opens the resource DOI landing page in a new tab', () => {
+        const suggestion = makeOrcidSuggestion({ resource_doi: '10.5880/test.2024.001' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '10.5880/test.2024.001' });
+        expect(link).toHaveAttribute('target', '_blank');
     });
 
     it('renders the suggested ORCID as a clickable link', () => {

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -184,6 +184,22 @@ function paginated<T>(data: T[]): PaginatedData<BaseSuggestionItem> {
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe('OrcidSuggestionCard – ORCID link', () => {
+    it('renders the resource DOI as an underlined link that opens in a new tab', () => {
+        const suggestion = makeOrcidSuggestion({ resource_doi: '10.5880/test.2024.001' });
+
+        render(
+            <AssistancePage
+                sections={{ 'orcid-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('orcid-suggestion', 'orcids', 'ORCID Suggestions')]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '10.5880/test.2024.001' });
+        expect(link).toHaveAttribute('href', 'https://doi.org/10.5880%2Ftest.2024.001');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveClass('underline');
+    });
+
     it('renders the suggested ORCID as a clickable link', () => {
         const suggestion = makeOrcidSuggestion();
 


### PR DESCRIPTION
In this pull request, the assistance-link.test.tsx was eddited to recieve another test (3 tests) for the issue #920. 
These Tests check if the resource doi is displayed as a, clickable landing page link, is underlined and opens the doi in a new tab when clicked.

This part of the Task was written by me.