### PR TITLE
Feature: Better display of creators and contributors on landing pages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -642,16 +642,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.12.3",
+            "version": "7.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3"
+                "reference": "a4decaa9745dc567467970e43f183e260cfa51fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
-                "reference": "9aa17bcdd777ee31df9fc83c337ca4ca2340def3",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a4decaa9745dc567467970e43f183e260cfa51fd",
+                "reference": "a4decaa9745dc567467970e43f183e260cfa51fd",
                 "shasum": ""
             },
             "require": {
@@ -670,7 +670,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.5.1",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -750,7 +750,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.12.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.0"
             },
             "funding": [
                 {
@@ -766,7 +766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:29:02+00:00"
+            "time": "2026-06-29T13:31:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -3692,16 +3692,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.23",
+            "version": "v0.12.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4"
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4dcc0f08047d52bbde475eda481146fd8e27e1a4",
-                "reference": "4dcc0f08047d52bbde475eda481146fd8e27e1a4",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
                 "shasum": ""
             },
             "require": {
@@ -3765,9 +3765,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.23"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.24"
             },
-            "time": "2026-05-23T13:41:31+00:00"
+            "time": "2026-06-29T15:41:09+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4250,16 +4250,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a"
+                "reference": "b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
-                "reference": "f5a856c6ecb56b3c21ed94a5b7bf940d857d110a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d",
+                "reference": "b711a8ab808b6c074c6b8caef70d0fd8d6b6d07d",
                 "shasum": ""
             },
             "require": {
@@ -4326,7 +4326,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.0"
+                "source": "https://github.com/symfony/console/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4346,7 +4346,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-16T12:55:20+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -4419,16 +4419,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -4466,7 +4466,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4486,7 +4486,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -4571,16 +4571,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
-                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
@@ -4633,7 +4633,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4653,20 +4653,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -4713,7 +4713,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4733,20 +4733,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "58d2e767a66052c1487356f953445634a8194c64"
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/58d2e767a66052c1487356f953445634a8194c64",
-                "reference": "58d2e767a66052c1487356f953445634a8194c64",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
                 "shasum": ""
             },
             "require": {
@@ -4781,7 +4781,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.1.0"
+                "source": "https://github.com/symfony/finder/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4801,20 +4801,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-27T09:05:56+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "af11474600f06718086c2cda4fa6fa8d0a672e7e"
+                "reference": "6a168c8fcee806b57ac020244da14293d1f9a883"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/af11474600f06718086c2cda4fa6fa8d0a672e7e",
-                "reference": "af11474600f06718086c2cda4fa6fa8d0a672e7e",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6a168c8fcee806b57ac020244da14293d1f9a883",
+                "reference": "6a168c8fcee806b57ac020244da14293d1f9a883",
                 "shasum": ""
             },
             "require": {
@@ -4862,7 +4862,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v8.1.0"
+                "source": "https://github.com/symfony/http-foundation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4882,20 +4882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-12T08:43:41+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "cefeb37c82eed3e0c42fa25ba64cd3a908d90f39"
+                "reference": "89d8d6e7fbab3d9eda89ccb5ecdf44a74c4ec9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/cefeb37c82eed3e0c42fa25ba64cd3a908d90f39",
-                "reference": "cefeb37c82eed3e0c42fa25ba64cd3a908d90f39",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/89d8d6e7fbab3d9eda89ccb5ecdf44a74c4ec9d2",
+                "reference": "89d8d6e7fbab3d9eda89ccb5ecdf44a74c4ec9d2",
                 "shasum": ""
             },
             "require": {
@@ -4971,7 +4971,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v8.1.0"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4991,20 +4991,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T08:46:08+00:00"
+            "time": "2026-06-27T09:27:36+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "9418d772df3a03a142e3bc06f602adb2b8724877"
+                "reference": "4fa583a7377f28d54e4de442fba76375b2e20a12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/9418d772df3a03a142e3bc06f602adb2b8724877",
-                "reference": "9418d772df3a03a142e3bc06f602adb2b8724877",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/4fa583a7377f28d54e4de442fba76375b2e20a12",
+                "reference": "4fa583a7377f28d54e4de442fba76375b2e20a12",
                 "shasum": ""
             },
             "require": {
@@ -5051,7 +5051,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v8.1.0"
+                "source": "https://github.com/symfony/mailer/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -5071,7 +5071,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-16T12:55:20+00:00"
         },
         {
             "name": "symfony/mime",
@@ -6135,16 +6135,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -6198,7 +6198,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6218,7 +6218,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
@@ -6312,16 +6312,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
-                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
                 "shasum": ""
             },
             "require": {
@@ -6381,7 +6381,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.0"
+                "source": "https://github.com/symfony/translation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -6401,20 +6401,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-06T11:11:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -6463,7 +6463,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6483,7 +6483,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/uid",
@@ -6565,16 +6565,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e"
+                "reference": "40096a2515a979f3125c5c928603995b8664c62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
-                "reference": "c2c4df1d21477cc21c9f6dc1b14d07c3abc4963e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/40096a2515a979f3125c5c928603995b8664c62a",
+                "reference": "40096a2515a979f3125c5c928603995b8664c62a",
                 "shasum": ""
             },
             "require": {
@@ -6628,7 +6628,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v8.1.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -6648,7 +6648,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T10:54:51+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7550,16 +7550,16 @@
         },
         {
             "name": "amphp/http-server",
-            "version": "v3.4.5",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/http-server.git",
-                "reference": "ae0fd01e16aba336247852df0c3f8c649a31896d"
+                "reference": "8a971bf92cf8cf2bc511f37a75b39126d5305315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/http-server/zipball/ae0fd01e16aba336247852df0c3f8c649a31896d",
-                "reference": "ae0fd01e16aba336247852df0c3f8c649a31896d",
+                "url": "https://api.github.com/repos/amphp/http-server/zipball/8a971bf92cf8cf2bc511f37a75b39126d5305315",
+                "reference": "8a971bf92cf8cf2bc511f37a75b39126d5305315",
                 "shasum": ""
             },
             "require": {
@@ -7635,7 +7635,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/http-server/issues",
-                "source": "https://github.com/amphp/http-server/tree/v3.4.5"
+                "source": "https://github.com/amphp/http-server/tree/v3.4.6"
             },
             "funding": [
                 {
@@ -7643,7 +7643,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-01T03:55:07+00:00"
+            "time": "2026-06-27T10:31:48+00:00"
         },
         {
             "name": "amphp/parser",
@@ -7709,16 +7709,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.4",
+            "version": "v1.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "a044733e080940d1483f56caff0c412ad6982776"
+                "reference": "92f121dde31cd1d89d5d0f9eba64ac40271b236e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/a044733e080940d1483f56caff0c412ad6982776",
-                "reference": "a044733e080940d1483f56caff0c412ad6982776",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/92f121dde31cd1d89d5d0f9eba64ac40271b236e",
+                "reference": "92f121dde31cd1d89d5d0f9eba64ac40271b236e",
                 "shasum": ""
             },
             "require": {
@@ -7764,7 +7764,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.4"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.5"
             },
             "funding": [
                 {
@@ -7772,7 +7772,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-06T05:37:57+00:00"
+            "time": "2026-06-27T14:17:20+00:00"
         },
         {
             "name": "amphp/process",
@@ -12041,16 +12041,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.1.0",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0"
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
-                "reference": "efb42bd2c6f4f3ccfd4683583449938b5fc146b0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8e4cdd4311683516be06944f4b85244063cdb886",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886",
                 "shasum": ""
             },
             "require": {
@@ -12093,7 +12093,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.1.0"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -12113,7 +12113,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-06-09T11:06:24+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/resources/js/pages/LandingPages/components/ContributorsSection.tsx
+++ b/resources/js/pages/LandingPages/components/ContributorsSection.tsx
@@ -2,7 +2,7 @@ import type { LandingPageContributor } from '@/types/landing-page';
 
 import { formatPersonName } from '../lib/formatPersonName';
 import { CollapsibleList } from './CollapsibleList';
-import { OrcidIcon, RorIcon } from './PidIcons';
+import { PersonMetadataLine } from './PersonMetadataLine';
 
 interface ContributorsSectionProps {
     contributors: LandingPageContributor[];
@@ -20,7 +20,9 @@ export function ContributorsSection({ contributors, displayLimit = 50 }: Contrib
 
     return (
         <section className="mt-6" data-testid="contributors-section" aria-labelledby="heading-contributors">
-            <h3 id="heading-contributors" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Contributors</h3>
+            <h3 id="heading-contributors" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Contributors
+            </h3>
             <CollapsibleList
                 items={contributors}
                 threshold={displayLimit}
@@ -33,50 +35,20 @@ export function ContributorsSection({ contributors, displayLimit = 50 }: Contrib
                 )}
                 renderItem={(contributor) => {
                     const contributorable = contributor.contributorable;
-                    const firstAffiliation = contributor.affiliations[0];
                     const isPerson = contributorable.type === 'Person';
                     const hasOrcid = isPerson && contributorable.name_identifier && contributorable.name_identifier_scheme === 'ORCID';
                     const formattedName = isPerson ? formatPersonName(contributorable.family_name, contributorable.given_name) : contributorable.name;
-                    const personName = formattedName === 'Unknown' && contributorable.name ? contributorable.name : formattedName;
+                    const personName = (formattedName === 'Unknown' && contributorable.name ? contributorable.name : formattedName) ?? 'Unknown';
+                    const roleLabel = contributor.contributor_types.length > 0 ? contributor.contributor_types.join(', ') : null;
 
                     return (
-                        <li key={contributor.id} className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
-                            <span>{personName}</span>
-
-                            {hasOrcid && (
-                                <a
-                                    href={`https://orcid.org/${contributorable.name_identifier}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="-m-3 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center p-3"
-                                    aria-label={`ORCID profile of ${personName}`}
-                                >
-                                    <OrcidIcon />
-                                </a>
-                            )}
-
-                            {firstAffiliation && (
-                                <>
-                                    {(!isPerson || !hasOrcid) && <span>; </span>}
-                                    <span>{firstAffiliation.name}</span>
-
-                                    {firstAffiliation.affiliation_identifier && firstAffiliation.affiliation_identifier_scheme === 'ROR' && (
-                                        <a
-                                            href={firstAffiliation.affiliation_identifier}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="-m-3 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center p-3"
-                                            aria-label={`ROR profile of ${firstAffiliation.name}`}
-                                        >
-                                            <RorIcon />
-                                        </a>
-                                    )}
-                                </>
-                            )}
-
-                            {contributor.contributor_types.length > 0 && (
-                                <span className="text-gray-500 dark:text-gray-400">({contributor.contributor_types.join(', ')})</span>
-                            )}
+                        <li key={contributor.id} className="text-sm leading-6 text-gray-700 dark:text-gray-300">
+                            <PersonMetadataLine
+                                name={personName}
+                                orcid={hasOrcid ? contributorable.name_identifier : null}
+                                affiliations={contributor.affiliations}
+                                roleLabel={roleLabel}
+                            />
                         </li>
                     );
                 }}

--- a/resources/js/pages/LandingPages/components/CreatorsSection.tsx
+++ b/resources/js/pages/LandingPages/components/CreatorsSection.tsx
@@ -2,7 +2,7 @@ import type { LandingPageCreator } from '@/types/landing-page';
 
 import { formatPersonName } from '../lib/formatPersonName';
 import { CollapsibleList } from './CollapsibleList';
-import { OrcidIcon, RorIcon } from './PidIcons';
+import { PersonMetadataLine } from './PersonMetadataLine';
 
 interface CreatorsSectionProps {
     creators: LandingPageCreator[];
@@ -19,7 +19,9 @@ export function CreatorsSection({ creators, displayLimit = 50 }: CreatorsSection
 
     return (
         <section className="mt-6" data-testid="creators-section" aria-labelledby="heading-creators">
-            <h3 id="heading-creators" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Creators</h3>
+            <h3 id="heading-creators" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Creators
+            </h3>
             <CollapsibleList
                 items={creators}
                 threshold={displayLimit}
@@ -32,46 +34,18 @@ export function CreatorsSection({ creators, displayLimit = 50 }: CreatorsSection
                 )}
                 renderItem={(creator) => {
                     const creatorable = creator.creatorable;
-                    const firstAffiliation = creator.affiliations[0];
                     const isPerson = creatorable.type === 'Person';
                     const hasOrcid = isPerson && creatorable.name_identifier && creatorable.name_identifier_scheme === 'ORCID';
                     const formattedName = isPerson ? formatPersonName(creatorable.family_name, creatorable.given_name) : creatorable.name;
-                    const personName = formattedName === 'Unknown' && creatorable.name ? creatorable.name : formattedName;
+                    const personName = (formattedName === 'Unknown' && creatorable.name ? creatorable.name : formattedName) ?? 'Unknown';
 
                     return (
-                        <li key={creator.id} className="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
-                            <span>{personName}</span>
-
-                            {hasOrcid && (
-                                <a
-                                    href={`https://orcid.org/${creatorable.name_identifier}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="-m-3 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center p-3"
-                                    aria-label={`ORCID profile of ${personName}`}
-                                >
-                                    <OrcidIcon />
-                                </a>
-                            )}
-
-                            {firstAffiliation && (
-                                <>
-                                    {(!isPerson || !hasOrcid) && <span>; </span>}
-                                    <span>{firstAffiliation.name}</span>
-
-                                    {firstAffiliation.affiliation_identifier && firstAffiliation.affiliation_identifier_scheme === 'ROR' && (
-                                        <a
-                                            href={firstAffiliation.affiliation_identifier}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="-m-3 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center p-3"
-                                            aria-label={`ROR profile of ${firstAffiliation.name}`}
-                                        >
-                                            <RorIcon />
-                                        </a>
-                                    )}
-                                </>
-                            )}
+                        <li key={creator.id} className="text-sm leading-6 text-gray-700 dark:text-gray-300">
+                            <PersonMetadataLine
+                                name={personName}
+                                orcid={hasOrcid ? creatorable.name_identifier : null}
+                                affiliations={creator.affiliations}
+                            />
                         </li>
                     );
                 }}

--- a/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
+++ b/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
@@ -11,8 +11,11 @@ interface PersonMetadataLineProps {
     roleLabel?: string | null;
 }
 
+const PID_ICON_LINK_CLASS =
+    '-m-3 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center p-3 align-text-bottom transition-opacity hover:opacity-80';
+
 function resolveOrcidUrl(identifier: string): string {
-    const normalized = identifier.trim().replace(/^https?:\/\/orcid\.org\//i, '');
+    const normalized = identifier.trim().replace(/^(?:https?:\/\/)?(?:www\.)?orcid\.org\//i, '');
 
     return `https://orcid.org/${normalized}`;
 }
@@ -41,7 +44,7 @@ export function PersonMetadataLine({ name, orcid, affiliations = [], roleLabel }
                         href={resolveOrcidUrl(normalizedOrcid)}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex align-text-bottom"
+                        className={PID_ICON_LINK_CLASS}
                         aria-label={`ORCID profile of ${name}`}
                     >
                         <OrcidIcon />
@@ -63,7 +66,7 @@ export function PersonMetadataLine({ name, orcid, affiliations = [], roleLabel }
                                     href={affiliation.affiliation_identifier ?? undefined}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex align-text-bottom"
+                                    className={PID_ICON_LINK_CLASS}
                                     aria-label={`ROR profile of ${affiliation.name}`}
                                 >
                                     <RorIcon />

--- a/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
+++ b/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
@@ -1,0 +1,80 @@
+import { Fragment } from 'react';
+
+import type { LandingPageAffiliation } from '@/types/landing-page';
+
+import { OrcidIcon, RorIcon } from './PidIcons';
+
+interface PersonMetadataLineProps {
+    name: string;
+    orcid?: string | null;
+    affiliations?: LandingPageAffiliation[];
+    roleLabel?: string | null;
+}
+
+function resolveOrcidUrl(identifier: string): string {
+    const normalized = identifier.trim().replace(/^https?:\/\/orcid\.org\//i, '');
+
+    return `https://orcid.org/${normalized}`;
+}
+
+function isRorAffiliation(affiliation: LandingPageAffiliation): boolean {
+    return (
+        affiliation.affiliation_identifier !== null &&
+        affiliation.affiliation_identifier.trim() !== '' &&
+        affiliation.affiliation_identifier_scheme?.toUpperCase() === 'ROR'
+    );
+}
+
+export function PersonMetadataLine({ name, orcid, affiliations = [], roleLabel }: PersonMetadataLineProps) {
+    const normalizedOrcid = orcid?.trim() ?? '';
+    const hasOrcid = normalizedOrcid !== '';
+    const visibleAffiliations = affiliations.filter((affiliation) => affiliation.name.trim() !== '');
+
+    return (
+        <span className="break-words">
+            <span>{name}</span>
+
+            {hasOrcid && (
+                <>
+                    <span aria-hidden="true"> </span>
+                    <a
+                        href={resolveOrcidUrl(normalizedOrcid)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex align-text-bottom"
+                        aria-label={`ORCID profile of ${name}`}
+                    >
+                        <OrcidIcon />
+                    </a>
+                </>
+            )}
+
+            {visibleAffiliations.map((affiliation, index) => {
+                const hasRor = isRorAffiliation(affiliation);
+
+                return (
+                    <Fragment key={`${affiliation.id}-${index}`}>
+                        <span>; </span>
+                        <span>{affiliation.name}</span>
+                        {hasRor && (
+                            <>
+                                <span aria-hidden="true"> </span>
+                                <a
+                                    href={affiliation.affiliation_identifier ?? undefined}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex align-text-bottom"
+                                    aria-label={`ROR profile of ${affiliation.name}`}
+                                >
+                                    <RorIcon />
+                                </a>
+                            </>
+                        )}
+                    </Fragment>
+                );
+            })}
+
+            {roleLabel && <span className="text-gray-500 dark:text-gray-400"> ({roleLabel})</span>}
+        </span>
+    );
+}

--- a/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
+++ b/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
@@ -13,6 +13,7 @@ interface PersonMetadataLineProps {
 
 const PID_ICON_LINK_CLASS =
     '-m-3 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center p-3 align-text-bottom transition-opacity hover:opacity-80';
+const ROR_ID_PATTERN = /^0[a-z0-9]{6}\d{2}$/;
 
 function resolveOrcidUrl(identifier: string): string {
     const normalized = identifier.trim().replace(/^(?:https?:\/\/)?(?:www\.)?orcid\.org\//i, '');
@@ -35,7 +36,7 @@ function resolveRorUrl(affiliation: LandingPageAffiliation): string | null {
 
     const rorId = (rorUrlMatch?.[1] ?? identifier).replace(/^\/+|\/+$/g, '').toLowerCase();
 
-    if (!/^[a-z0-9]+$/.test(rorId)) {
+    if (!ROR_ID_PATTERN.test(rorId)) {
         return null;
     }
 

--- a/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
+++ b/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
@@ -20,12 +20,14 @@ function resolveOrcidUrl(identifier: string): string {
     return `https://orcid.org/${normalized}`;
 }
 
-function isRorAffiliation(affiliation: LandingPageAffiliation): boolean {
-    return (
-        affiliation.affiliation_identifier !== null &&
-        affiliation.affiliation_identifier.trim() !== '' &&
-        affiliation.affiliation_identifier_scheme?.toUpperCase() === 'ROR'
-    );
+function resolveRorUrl(affiliation: LandingPageAffiliation): string | null {
+    const normalizedIdentifier = affiliation.affiliation_identifier?.trim() ?? '';
+
+    if (normalizedIdentifier === '' || affiliation.affiliation_identifier_scheme?.toUpperCase() !== 'ROR') {
+        return null;
+    }
+
+    return normalizedIdentifier;
 }
 
 export function PersonMetadataLine({ name, orcid, affiliations = [], roleLabel }: PersonMetadataLineProps) {
@@ -53,17 +55,17 @@ export function PersonMetadataLine({ name, orcid, affiliations = [], roleLabel }
             )}
 
             {visibleAffiliations.map((affiliation, index) => {
-                const hasRor = isRorAffiliation(affiliation);
+                const rorUrl = resolveRorUrl(affiliation);
 
                 return (
                     <Fragment key={`${affiliation.id}-${index}`}>
                         <span>; </span>
                         <span>{affiliation.name}</span>
-                        {hasRor && (
+                        {rorUrl && (
                             <>
                                 <span aria-hidden="true"> </span>
                                 <a
-                                    href={affiliation.affiliation_identifier ?? undefined}
+                                    href={rorUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className={PID_ICON_LINK_CLASS}

--- a/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
+++ b/resources/js/pages/LandingPages/components/PersonMetadataLine.tsx
@@ -21,13 +21,25 @@ function resolveOrcidUrl(identifier: string): string {
 }
 
 function resolveRorUrl(affiliation: LandingPageAffiliation): string | null {
-    const normalizedIdentifier = affiliation.affiliation_identifier?.trim() ?? '';
+    const identifier = affiliation.affiliation_identifier?.trim() ?? '';
 
-    if (normalizedIdentifier === '' || affiliation.affiliation_identifier_scheme?.toUpperCase() !== 'ROR') {
+    if (identifier === '' || affiliation.affiliation_identifier_scheme?.toUpperCase() !== 'ROR') {
         return null;
     }
 
-    return normalizedIdentifier;
+    const rorUrlMatch = identifier.match(/^(?:https?:\/\/)?(?:www\.)?ror\.org\/(.+)$/i);
+
+    if (!rorUrlMatch && /^https?:\/\//i.test(identifier)) {
+        return null;
+    }
+
+    const rorId = (rorUrlMatch?.[1] ?? identifier).replace(/^\/+|\/+$/g, '').toLowerCase();
+
+    if (!/^[a-z0-9]+$/.test(rorId)) {
+        return null;
+    }
+
+    return `https://ror.org/${rorId}`;
 }
 
 export function PersonMetadataLine({ name, orcid, affiliations = [], roleLabel }: PersonMetadataLineProps) {

--- a/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
@@ -78,7 +78,7 @@ describe('ContributorsSection', () => {
                 {
                     id: 1,
                     name: "ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso",
-                    affiliation_identifier: ' https://ror.org/01abcde23 ',
+                    affiliation_identifier: ' ror.org/01ABCDe23/ ',
                     affiliation_identifier_scheme: 'ROR',
                 },
                 {

--- a/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
@@ -78,7 +78,7 @@ describe('ContributorsSection', () => {
                 {
                     id: 1,
                     name: "ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso",
-                    affiliation_identifier: 'https://ror.org/01abcde23',
+                    affiliation_identifier: ' https://ror.org/01abcde23 ',
                     affiliation_identifier_scheme: 'ROR',
                 },
                 {

--- a/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
@@ -52,12 +52,14 @@ describe('ContributorsSection', () => {
                 name: 'Doe, John',
                 given_name: 'John',
                 family_name: 'Doe',
-                name_identifier: '0000-0001-2345-6789',
+                name_identifier: 'www.orcid.org/0000-0001-2345-6789',
                 name_identifier_scheme: 'ORCID',
             },
         });
         render(<ContributorsSection contributors={[contributor]} />);
-        expect(screen.getByLabelText('ORCID profile of Doe, John')).toBeInTheDocument();
+        const orcidLink = screen.getByLabelText('ORCID profile of Doe, John');
+        expect(orcidLink).toHaveAttribute('href', 'https://orcid.org/0000-0001-2345-6789');
+        expect(orcidLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
     });
 
     it('renders all contributor affiliations and keeps roles at the end', () => {
@@ -97,11 +99,12 @@ describe('ContributorsSection', () => {
         expect(listItem).toHaveTextContent('(DataCollector, ProjectLeader)');
         expect(screen.getByText("ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toBeInTheDocument();
         expect(screen.getByText('Light Pollution Science and Technology Institute, Thiene, Italy')).toBeInTheDocument();
-        expect(screen.getByLabelText('ORCID profile of Cinzano, Pierantonio')).toHaveAttribute('href', 'https://orcid.org/0000-0003-1111-2222');
-        expect(screen.getByLabelText("ROR profile of ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toHaveAttribute(
-            'href',
-            'https://ror.org/01abcde23',
-        );
+        const orcidLink = screen.getByLabelText('ORCID profile of Cinzano, Pierantonio');
+        expect(orcidLink).toHaveAttribute('href', 'https://orcid.org/0000-0003-1111-2222');
+        expect(orcidLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
+        const rorLink = screen.getByLabelText("ROR profile of ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso");
+        expect(rorLink).toHaveAttribute('href', 'https://ror.org/01abcde23');
+        expect(rorLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
     });
 
     it('does not show expand button when under threshold', () => {

--- a/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx
@@ -60,6 +60,50 @@ describe('ContributorsSection', () => {
         expect(screen.getByLabelText('ORCID profile of Doe, John')).toBeInTheDocument();
     });
 
+    it('renders all contributor affiliations and keeps roles at the end', () => {
+        const contributor = mockContributor({
+            contributorable: {
+                id: 5,
+                type: 'Person',
+                name: 'Cinzano, Pierantonio',
+                given_name: 'Pierantonio',
+                family_name: 'Cinzano',
+                name_identifier: '0000-0003-1111-2222',
+                name_identifier_scheme: 'ORCID',
+            },
+            contributor_types: ['DataCollector', 'ProjectLeader'],
+            affiliations: [
+                {
+                    id: 1,
+                    name: "ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso",
+                    affiliation_identifier: 'https://ror.org/01abcde23',
+                    affiliation_identifier_scheme: 'ROR',
+                },
+                {
+                    id: 2,
+                    name: 'Light Pollution Science and Technology Institute, Thiene, Italy',
+                    affiliation_identifier: null,
+                    affiliation_identifier_scheme: null,
+                },
+            ],
+        });
+
+        render(<ContributorsSection contributors={[contributor]} />);
+
+        const listItem = screen.getByRole('listitem');
+        expect(listItem).not.toHaveClass('flex');
+        expect(listItem).toHaveClass('leading-6');
+        expect(listItem).toHaveTextContent('Cinzano, Pierantonio');
+        expect(listItem).toHaveTextContent('(DataCollector, ProjectLeader)');
+        expect(screen.getByText("ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toBeInTheDocument();
+        expect(screen.getByText('Light Pollution Science and Technology Institute, Thiene, Italy')).toBeInTheDocument();
+        expect(screen.getByLabelText('ORCID profile of Cinzano, Pierantonio')).toHaveAttribute('href', 'https://orcid.org/0000-0003-1111-2222');
+        expect(screen.getByLabelText("ROR profile of ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toHaveAttribute(
+            'href',
+            'https://ror.org/01abcde23',
+        );
+    });
+
     it('does not show expand button when under threshold', () => {
         const contributors = Array.from({ length: 5 }, (_, i) => mockContributor({ id: i + 1 }));
         render(<ContributorsSection contributors={contributors} />);

--- a/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
@@ -43,13 +43,14 @@ describe('CreatorsSection', () => {
                 name: 'Doe, John',
                 given_name: 'John',
                 family_name: 'Doe',
-                name_identifier: '0000-0001-2345-6789',
+                name_identifier: 'orcid.org/0000-0001-2345-6789',
                 name_identifier_scheme: 'ORCID',
             },
         });
         render(<CreatorsSection creators={[creator]} />);
         const orcidLink = screen.getByLabelText('ORCID profile of Doe, John');
         expect(orcidLink).toHaveAttribute('href', 'https://orcid.org/0000-0001-2345-6789');
+        expect(orcidLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
     });
 
     it('renders affiliation with ROR link', () => {
@@ -103,15 +104,15 @@ describe('CreatorsSection', () => {
         expect(listItem).toHaveTextContent('Falchi, Fabio');
         expect(screen.getByText("ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toBeInTheDocument();
         expect(screen.getByText('Light Pollution Science and Technology Institute, Thiene, Italy')).toBeInTheDocument();
-        expect(screen.getByLabelText('ORCID profile of Falchi, Fabio')).toHaveAttribute('href', 'https://orcid.org/0000-0002-1111-2222');
-        expect(screen.getByLabelText("ROR profile of ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toHaveAttribute(
-            'href',
-            'https://ror.org/01abcde23',
-        );
-        expect(screen.getByLabelText('ROR profile of Light Pollution Science and Technology Institute, Thiene, Italy')).toHaveAttribute(
-            'href',
-            'https://ror.org/04z8jg394',
-        );
+        const orcidLink = screen.getByLabelText('ORCID profile of Falchi, Fabio');
+        expect(orcidLink).toHaveAttribute('href', 'https://orcid.org/0000-0002-1111-2222');
+        expect(orcidLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
+        const firstRorLink = screen.getByLabelText("ROR profile of ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso");
+        expect(firstRorLink).toHaveAttribute('href', 'https://ror.org/01abcde23');
+        expect(firstRorLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
+        const secondRorLink = screen.getByLabelText('ROR profile of Light Pollution Science and Technology Institute, Thiene, Italy');
+        expect(secondRorLink).toHaveAttribute('href', 'https://ror.org/04z8jg394');
+        expect(secondRorLink).toHaveClass('min-h-11', 'min-w-11', 'p-3');
     });
 
     it('renders institution name for non-person creators', () => {

--- a/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
@@ -68,6 +68,52 @@ describe('CreatorsSection', () => {
         expect(screen.getByLabelText('ROR profile of GFZ Potsdam')).toBeInTheDocument();
     });
 
+    it('renders all creator affiliations in a prose list item', () => {
+        const creator = mockCreator({
+            creatorable: {
+                id: 2,
+                type: 'Person',
+                name: 'Falchi, Fabio',
+                given_name: 'Fabio',
+                family_name: 'Falchi',
+                name_identifier: '0000-0002-1111-2222',
+                name_identifier_scheme: 'ORCID',
+            },
+            affiliations: [
+                {
+                    id: 1,
+                    name: "ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso",
+                    affiliation_identifier: 'https://ror.org/01abcde23',
+                    affiliation_identifier_scheme: 'ROR',
+                },
+                {
+                    id: 2,
+                    name: 'Light Pollution Science and Technology Institute, Thiene, Italy',
+                    affiliation_identifier: 'https://ror.org/04z8jg394',
+                    affiliation_identifier_scheme: 'ROR',
+                },
+            ],
+        });
+
+        render(<CreatorsSection creators={[creator]} />);
+
+        const listItem = screen.getByRole('listitem');
+        expect(listItem).not.toHaveClass('flex');
+        expect(listItem).toHaveClass('leading-6');
+        expect(listItem).toHaveTextContent('Falchi, Fabio');
+        expect(screen.getByText("ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toBeInTheDocument();
+        expect(screen.getByText('Light Pollution Science and Technology Institute, Thiene, Italy')).toBeInTheDocument();
+        expect(screen.getByLabelText('ORCID profile of Falchi, Fabio')).toHaveAttribute('href', 'https://orcid.org/0000-0002-1111-2222');
+        expect(screen.getByLabelText("ROR profile of ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso")).toHaveAttribute(
+            'href',
+            'https://ror.org/01abcde23',
+        );
+        expect(screen.getByLabelText('ROR profile of Light Pollution Science and Technology Institute, Thiene, Italy')).toHaveAttribute(
+            'href',
+            'https://ror.org/04z8jg394',
+        );
+    });
+
     it('renders institution name for non-person creators', () => {
         const creator = mockCreator({
             creatorable: {
@@ -106,18 +152,20 @@ describe('CreatorsSection', () => {
     });
 
     it('limits initially visible creators and shows the full list on request', () => {
-        const creators = Array.from({ length: 4 }, (_, i) => mockCreator({
-            id: i + 1,
-            creatorable: {
+        const creators = Array.from({ length: 4 }, (_, i) =>
+            mockCreator({
                 id: i + 1,
-                type: 'Person',
-                name: `Creator, ${i + 1}`,
-                given_name: `${i + 1}`,
-                family_name: 'Creator',
-                name_identifier: null,
-                name_identifier_scheme: null,
-            },
-        }));
+                creatorable: {
+                    id: i + 1,
+                    type: 'Person',
+                    name: `Creator, ${i + 1}`,
+                    given_name: `${i + 1}`,
+                    family_name: 'Creator',
+                    name_identifier: null,
+                    name_identifier_scheme: null,
+                },
+            }),
+        );
 
         render(<CreatorsSection creators={creators} displayLimit={2} />);
 

--- a/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
@@ -59,7 +59,7 @@ describe('CreatorsSection', () => {
                 {
                     id: 1,
                     name: 'GFZ Potsdam',
-                    affiliation_identifier: 'https://ror.org/04z8jg394',
+                    affiliation_identifier: ' https://ror.org/04z8jg394 ',
                     affiliation_identifier_scheme: 'ROR',
                 },
             ],
@@ -84,13 +84,13 @@ describe('CreatorsSection', () => {
                 {
                     id: 1,
                     name: "ISTIL - Istituto di Scienza e Tecnologia dell'Inquinamento Luminoso",
-                    affiliation_identifier: 'https://ror.org/01abcde23',
+                    affiliation_identifier: ' https://ror.org/01abcde23 ',
                     affiliation_identifier_scheme: 'ROR',
                 },
                 {
                     id: 2,
                     name: 'Light Pollution Science and Technology Institute, Thiene, Italy',
-                    affiliation_identifier: 'https://ror.org/04z8jg394',
+                    affiliation_identifier: ' https://ror.org/04z8jg394 ',
                     affiliation_identifier_scheme: 'ROR',
                 },
             ],

--- a/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
@@ -59,14 +59,34 @@ describe('CreatorsSection', () => {
                 {
                     id: 1,
                     name: 'GFZ Potsdam',
-                    affiliation_identifier: ' https://ror.org/04z8jg394 ',
+                    affiliation_identifier: ' www.ror.org/04z8jg394 ',
                     affiliation_identifier_scheme: 'ROR',
                 },
             ],
         });
         render(<CreatorsSection creators={[creator]} />);
         expect(screen.getByText('GFZ Potsdam')).toBeInTheDocument();
-        expect(screen.getByLabelText('ROR profile of GFZ Potsdam')).toBeInTheDocument();
+        const rorLink = screen.getByLabelText('ROR profile of GFZ Potsdam');
+        expect(rorLink).toBeInTheDocument();
+        expect(rorLink).toHaveAttribute('href', 'https://ror.org/04z8jg394');
+    });
+
+    it('does not render ROR link for non-ROR absolute URL identifiers', () => {
+        const creator = mockCreator({
+            affiliations: [
+                {
+                    id: 1,
+                    name: 'Example Institute',
+                    affiliation_identifier: 'https://example.com/institution',
+                    affiliation_identifier_scheme: 'ROR',
+                },
+            ],
+        });
+
+        render(<CreatorsSection creators={[creator]} />);
+
+        expect(screen.getByText('Example Institute')).toBeInTheDocument();
+        expect(screen.queryByLabelText('ROR profile of Example Institute')).not.toBeInTheDocument();
     });
 
     it('renders all creator affiliations in a prose list item', () => {
@@ -90,7 +110,7 @@ describe('CreatorsSection', () => {
                 {
                     id: 2,
                     name: 'Light Pollution Science and Technology Institute, Thiene, Italy',
-                    affiliation_identifier: ' https://ror.org/04z8jg394 ',
+                    affiliation_identifier: '04Z8JG394',
                     affiliation_identifier_scheme: 'ROR',
                 },
             ],

--- a/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx
@@ -80,6 +80,12 @@ describe('CreatorsSection', () => {
                     affiliation_identifier: 'https://example.com/institution',
                     affiliation_identifier_scheme: 'ROR',
                 },
+                {
+                    id: 2,
+                    name: 'Invalid ROR Institute',
+                    affiliation_identifier: 'abc',
+                    affiliation_identifier_scheme: 'ROR',
+                },
             ],
         });
 
@@ -87,6 +93,8 @@ describe('CreatorsSection', () => {
 
         expect(screen.getByText('Example Institute')).toBeInTheDocument();
         expect(screen.queryByLabelText('ROR profile of Example Institute')).not.toBeInTheDocument();
+        expect(screen.getByText('Invalid ROR Institute')).toBeInTheDocument();
+        expect(screen.queryByLabelText('ROR profile of Invalid ROR Institute')).not.toBeInTheDocument();
     });
 
     it('renders all creator affiliations in a prose list item', () => {


### PR DESCRIPTION
This pull request refactors the display logic for contributors and creators on landing pages to improve code reuse, accessibility, and correctness. The main change is the introduction of a new `PersonMetadataLine` component, which centralizes the rendering of personal metadata (names, ORCID, affiliations, and roles) and ensures all affiliations and persistent identifiers are displayed consistently. Related tests have been updated and expanded to verify the new rendering logic.

**Component refactoring and code reuse:**

* Introduced the `PersonMetadataLine` component to encapsulate the display of names, ORCID links, affiliations (with ROR links), and roles, replacing duplicated logic in both `ContributorsSection` and `CreatorsSection`. This ensures all affiliations are shown, persistent IDs are normalized, and roles are consistently placed at the end. (`resources/js/pages/LandingPages/components/PersonMetadataLine.tsx`)
* Updated `ContributorsSection` and `CreatorsSection` to use `PersonMetadataLine` for rendering each item, removing their inline logic for ORCID, ROR, and affiliation display. (`resources/js/pages/LandingPages/components/ContributorsSection.tsx`, `resources/js/pages/LandingPages/components/CreatorsSection.tsx`) [[1]](diffhunk://#diff-e5cc8e9a5a63671b14886f80d703e92841a2d76c01529d00669655c1c3ea8e72L5-R5) [[2]](diffhunk://#diff-e5cc8e9a5a63671b14886f80d703e92841a2d76c01529d00669655c1c3ea8e72L36-R51) [[3]](diffhunk://#diff-df67ff385a3f2d51edecb67d15f0de37c90cc56b4c0206de205cbab1005cb633L5-R5) [[4]](diffhunk://#diff-df67ff385a3f2d51edecb67d15f0de37c90cc56b4c0206de205cbab1005cb633L35-R48)

**Accessibility and UI improvements:**

* Ensured that ORCID and ROR links are always rendered with appropriate aria-labels and consistent styling classes, improving accessibility and visual consistency.

**Bug fixes and normalization:**

* Normalized ORCID and ROR identifiers to handle various input formats, ensuring correct URLs regardless of input (e.g., stripping prefixes like `www.orcid.org/`).

**Test updates and enhancements:**

* Expanded and updated tests for both contributors and creators to verify that all affiliations are rendered, roles appear at the end, and that links use normalized URLs and correct CSS classes. (`tests/vitest/pages/LandingPages/__tests__/ContributorsSection.test.tsx`, `tests/vitest/pages/LandingPages/__tests__/CreatorsSection.test.tsx`) [[1]](diffhunk://#diff-c4eda52b530785bc9394532cf5efb9548d7ed8068c47349da5b63b9a3a8dd297L55-R107) [[2]](diffhunk://#diff-b294ff9ead61ad6d5f0552712fe06202da7bac4b87c9d8c6736cb03d960b99b5L46-R53) [[3]](diffhunk://#diff-b294ff9ead61ad6d5f0552712fe06202da7bac4b87c9d8c6736cb03d960b99b5R72-R117)

These changes together improve maintainability, correctness, and user experience for contributor and creator lists on landing pages.