### PR TITLE
Feature: Enable row-based editor opening in resources

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -642,16 +642,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.13.0",
+            "version": "7.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "a4decaa9745dc567467970e43f183e260cfa51fd"
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a4decaa9745dc567467970e43f183e260cfa51fd",
-                "reference": "a4decaa9745dc567467970e43f183e260cfa51fd",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
                 "shasum": ""
             },
             "require": {
@@ -750,7 +750,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.13.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
             },
             "funding": [
                 {
@@ -766,7 +766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-29T13:31:06+00:00"
+            "time": "2026-06-29T20:14:18+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1132,16 +1132,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.17.0",
+            "version": "v13.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "0802b7a81f3252d78200b8037ac183a686a529f0"
+                "reference": "138e5806ed7e4e21591948b661119d3810f052cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/0802b7a81f3252d78200b8037ac183a686a529f0",
-                "reference": "0802b7a81f3252d78200b8037ac183a686a529f0",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/138e5806ed7e4e21591948b661119d3810f052cf",
+                "reference": "138e5806ed7e4e21591948b661119d3810f052cf",
                 "shasum": ""
             },
             "require": {
@@ -1352,7 +1352,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-06-23T19:42:45+00:00"
+            "time": "2026-06-30T12:54:13+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -10581,11 +10581,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
-                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4048833dd47b377287818841877fb3087289509c",
+                "reference": "4048833dd47b377287818841877fb3087289509c",
                 "shasum": ""
             },
             "require": {
@@ -10641,7 +10641,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-05T09:00:01+00:00"
+            "time": "2026-06-30T21:15:26+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,9 +561,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
       "dev": true,
       "funding": [
         {
@@ -1731,12 +1731,12 @@
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accessible-icon": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.10.tgz",
-      "integrity": "sha512-TraSwZUqTcVbiDV2/RXzAXC7aeVVXchq0daPFZE7zAxYFaMzjOUggLOfQH9KFLgRizuwVKZO/crveV1eeO3/ZQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.11.tgz",
+      "integrity": "sha512-HQDOFTKwSnmUij6l54wYJJtxTAnxI71+YJLOrjm2ladFB8HAV5Jt7hwaZPhWTGBkYoW4+ZAOfNZrLDh/qvxSYA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-visually-hidden": "1.2.6"
+        "@radix-ui/react-visually-hidden": "1.2.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1754,19 +1754,19 @@
       }
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.14.tgz",
-      "integrity": "sha512-iE8YB9nmTBH8zd73ofBISZ8JCzgMoMkATJr7qDwa6u5F1+7mTM81V6fa71jgZ65rpjVpecDf1vSnwIFP9Ly1zw==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.15.tgz",
+      "integrity": "sha512-24Zz/0SYx8F2bSVThBnQrdJs2VbKelyuJordcFRRdA0fRAhrq/wSegGCqaQz34VQoiWqSMGYCYXEhynLSlyQlg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collapsible": "1.1.14",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collapsible": "1.1.15",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -1785,16 +1785,16 @@
       }
     },
     "node_modules/@radix-ui/react-alert-dialog": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.17.tgz",
-      "integrity": "sha512-563ygGeyWPrxyVCNp7OV4rE2aIXhFPknpFyo4wbDlcyMMPZ6ySh+zC5WTvY0ZFLgPTg/QB6tA8PyDQyJ2b4cPg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.18.tgz",
+      "integrity": "sha512-6c2cXpNlAgHDhKguK24XcWHHayMpK+lk7/WwBXBco+ZJ4Dv7xP++GBM280KgTD/HCRu3jSdfe8WQiZssonYaIA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dialog": "1.1.17",
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-dialog": "1.1.18",
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1812,12 +1812,12 @@
       }
     },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
-      "integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz",
+      "integrity": "sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1835,12 +1835,12 @@
       }
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.10.tgz",
-      "integrity": "sha512-kbI7NrqhDeuytYrq7JjAsoXczvL8wgj2tc1MyaYWm+50bMKHCHQtVWCryslx4cCpmCTTkBcwQckE4CmmGV2haQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.11.tgz",
+      "integrity": "sha512-IUAhIVpBUvP5NNICjlaB1OFmtRLGqQqTF3ZOSGPoq3XeLXRFtHiWTRxSVEULgOd9GQR2c7tsYqDnhUennapZnw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1858,13 +1858,13 @@
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.0.tgz",
-      "integrity": "sha512-am/CwltXtmtdtP+5FbYblYDnMa/zuKcMJP1i3/SJMDXXfj2mG+BTqLH2wucqeyyiQMursUtg/5cK+Nh2pCaSOA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.1.tgz",
+      "integrity": "sha512-+8PWoLLZv3AVb5m0pvoiOca/bQGzc9vPVb+982HB2x3Un0DpYEPM3zLMl4oqRpBsocJuNqLkiv/HXTnTrlwr4g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-is-hydrated": "0.1.1",
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -1885,16 +1885,16 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.5.tgz",
-      "integrity": "sha512-pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.6.tgz",
+      "integrity": "sha512-eUEUoGMDpfkgHWSE97ZZaUJtzR1M7EKnNIpD1Q16+8JR9NWghcaqMulx9PuCQ720w0UclfYn6FEbCdd5Hx087g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
         "@radix-ui/react-use-size": "1.1.2"
@@ -1915,9 +1915,9 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.14.tgz",
-      "integrity": "sha512-9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.15.tgz",
+      "integrity": "sha512-8A1zibu5skAQ+UVbaeNH5hVMibiFCRJzgMuM14LTWGttnTZKQL9jwYnhAbHRuxrtCqPXa4JvvnVUq1pTNgyZYw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -1925,7 +1925,7 @@
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
@@ -1945,14 +1945,14 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
-      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.11.tgz",
+      "integrity": "sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
@@ -2001,15 +2001,15 @@
       }
     },
     "node_modules/@radix-ui/react-context-menu": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.1.tgz",
-      "integrity": "sha512-XbrxS68W5dyiE4fAb96yvJwSVU5x66B20A99sD5Mk3xSWK/LqeOnx6TZnim1KieMjXS/CTFq8reOAjWxas2G8Q==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.2.tgz",
+      "integrity": "sha512-qzsA/ZPhF6yMxBOTIk1nlCkoy2mswSbwYL+ErBa2iP0s4WWrlxmczArYqMcpVfEjmM7KJj/ADPXky0yZfbSxtQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-menu": "2.1.18",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2028,21 +2028,21 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
-      "integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz",
+      "integrity": "sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-focus-scope": "1.1.11",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
@@ -2079,16 +2079,16 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
-      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz",
+      "integrity": "sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
-        "@radix-ui/react-use-escape-keydown": "1.1.2"
+        "@radix-ui/react-use-effect-event": "0.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2106,17 +2106,17 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.18.tgz",
-      "integrity": "sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.19.tgz",
+      "integrity": "sha512-HZccBkbK0LOi8nYKIp5jll/zIRW0cCOmG6WWyqsSpmXCU+ZlcBbTqIwlBvPCu886C5RVu6c/kHV7xSP8IgYNHw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-menu": "2.1.18",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2150,13 +2150,13 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
-      "integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz",
+      "integrity": "sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
@@ -2175,17 +2175,17 @@
       }
     },
     "node_modules/@radix-ui/react-form": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.10.tgz",
-      "integrity": "sha512-1NfuvctVtX4sU3Mmq/IdrR8UunxiCMiVg3A5UENKhFzxUBeOyaQQ+lmaQaV7Tc8cqvBKsJL3/KGBsixK0D8WFg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.11.tgz",
+      "integrity": "sha512-0mTMJHv1gQAuEQoq5VDpTD3MRgmfUFdXAVFhpqR7wBeUr+tyRsof0wv/4XdPHLwQrefhoH2FiGHCggrCJhalIw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-label": "2.1.10",
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-label": "2.1.11",
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2203,19 +2203,19 @@
       }
     },
     "node_modules/@radix-ui/react-hover-card": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.17.tgz",
-      "integrity": "sha512-GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.18.tgz",
+      "integrity": "sha512-rt+Fx4HoCeEwFL2IdoV2QaPltqDLlzxN77i9nwB3Y70scFlfAHh1QCdE2TXKuFJtA1TNygb0oivnFBZifgtZOw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
-        "@radix-ui/react-popper": "1.3.1",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2252,12 +2252,12 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
-      "integrity": "sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.11.tgz",
+      "integrity": "sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2275,25 +2275,25 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.18.tgz",
-      "integrity": "sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.19.tgz",
+      "integrity": "sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-focus-scope": "1.1.11",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.1",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "aria-hidden": "^1.2.4",
@@ -2315,20 +2315,20 @@
       }
     },
     "node_modules/@radix-ui/react-menubar": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.18.tgz",
-      "integrity": "sha512-hX7EGx/oFq6DPY27GQuP/2wP48GHf5LG6r06VgNJlG+znmDS8OfopZcRcGly3L4lsB9FqpmLx6JQSE9P3BUpyw==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.19.tgz",
+      "integrity": "sha512-Glt6mebxcgQvLeVkH3HiqV5bgQubE+31ELxLs7q0GlYI5k0XYkOkeuPrhXoylxK8eufvIt9CJjzY1TfFMXK3qw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-menu": "2.1.18",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2347,25 +2347,25 @@
       }
     },
     "node_modules/@radix-ui/react-navigation-menu": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.16.tgz",
-      "integrity": "sha512-nJ0SkrSQgudyYhMiYeHA1ayLVuduEJCFLan1RZZN7c9kqzzCFLaU9kuy81uNtqzweM9YaQPgWzxi9MwQ9jZ04g==",
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.17.tgz",
+      "integrity": "sha512-fYeYQvbeNn5AQk2RBbpO7koLm2YbS00UYxC/IL2sgLlninEH5UNIv+X3E0KJ1Vy4WIo+dhN9w8GNqSHhbHWCIg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-previous": "1.1.2",
-        "@radix-ui/react-visually-hidden": "1.2.6"
+        "@radix-ui/react-visually-hidden": "1.2.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2383,19 +2383,19 @@
       }
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.10.tgz",
-      "integrity": "sha512-GHkcJ+WVj91At+OvUVTD4R3W0/wxw9t/sG5xFUBYXaCbtWiooZX5Md376QjJqgH4VsVyXrbVNHO2O4NYcmjfVg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.11.tgz",
+      "integrity": "sha512-Rsgab65u73E5kPVh8OS6PgPwJgPyf08GFfJDGAbMdF4DL7CgDhFOaDnXuk/DiMEVF6kgQwl0oJmFklvipmiOLg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-effect-event": "0.0.3",
         "@radix-ui/react-use-is-hydrated": "0.1.1",
@@ -2417,16 +2417,16 @@
       }
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.5.tgz",
-      "integrity": "sha512-fVuA82u0b/fClpbEJv8yp1nU9eSvoSEOERsU/hhf3FXGPIvkmE7oEaHEu8poowoXO39/Va7zq2E0TUcYr1dBRg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.6.tgz",
+      "integrity": "sha512-pQ3xGp/uemomASPH97Eb3shfXX8QlG11bBJyEvRBV+vwtO4HvQlS06Yj9f31Ao7XepvF98SFrRgVDQ7jv+2xjQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-effect-event": "0.0.3",
         "@radix-ui/react-use-is-hydrated": "0.1.1"
@@ -2447,22 +2447,22 @@
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.17.tgz",
-      "integrity": "sha512-/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.18.tgz",
+      "integrity": "sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-focus-scope": "1.1.11",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.1",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
@@ -2484,16 +2484,16 @@
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
-      "integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.2.tgz",
+      "integrity": "sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.10",
+        "@radix-ui/react-arrow": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-rect": "1.1.2",
@@ -2516,12 +2516,12 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
-      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
@@ -2563,9 +2563,9 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
-      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.3.0"
@@ -2586,13 +2586,13 @@
       }
     },
     "node_modules/@radix-ui/react-progress": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.10.tgz",
-      "integrity": "sha512-JYzEg60lk79PwKM27WZyKd7PW8O4OM5jOaFfRPfOyeXmMw7tLJh5kSj+CEjVTehszuwml/AdCzPGMXBTGf4BBw==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.11.tgz",
+      "integrity": "sha512-KqiGJcFaZDc+BvveAgU3ZhACg2MvSUDrCBx4lRR/ZVRNal0bvt8lBpvnSkep9heeOuF8Qfw3fszLDX4OpQ2NVw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2610,9 +2610,9 @@
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.1.tgz",
-      "integrity": "sha512-/SSxZdKEo2Eo29FFRKd06EfFDYp8HryKg0WYg7QLXaydPzl52YfSvCH2a3QDBRdtcuwACroJT8UVjQVgOJ7P9A==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.2.tgz",
+      "integrity": "sha512-W8Uo9riHnlzLLWy+r2mVHUyuEWqD/+be4PZzbEvaGoFSBDHkm+GYWjtcE6u3AmPKNyfanWpnVfpZ2GqPCdzzsw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2620,8 +2620,8 @@
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
         "@radix-ui/react-use-size": "1.1.2"
@@ -2642,18 +2642,18 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
-      "integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.14.tgz",
+      "integrity": "sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.12.tgz",
-      "integrity": "sha512-xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.13.tgz",
+      "integrity": "sha512-7tncSubo2G0UY1e8rk+72qe3XRzrGnOLtZQ1PL1KoBfRUNX0NrJT5akb+0kfwSCc3gVR4wdHqyhAQBDpDNOwDw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
@@ -2684,7 +2684,7 @@
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
@@ -2704,31 +2704,31 @@
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.1.tgz",
-      "integrity": "sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.2.tgz",
+      "integrity": "sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-focus-scope": "1.1.11",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.1",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-previous": "1.1.2",
-        "@radix-ui/react-visually-hidden": "1.2.6",
+        "@radix-ui/react-visually-hidden": "1.2.7",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -2748,12 +2748,12 @@
       }
     },
     "node_modules/@radix-ui/react-separator": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.10.tgz",
-      "integrity": "sha512-Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.11.tgz",
+      "integrity": "sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2771,18 +2771,18 @@
       }
     },
     "node_modules/@radix-ui/react-slider": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.1.tgz",
-      "integrity": "sha512-r91WSpQucNGFKAIxT8FT0H0zyjd5tJlqObLp7LOMV4z49KoDCwjy01w3vDOU4e1wxhF9IgjYco7SB6byOW7Buw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.2.tgz",
+      "integrity": "sha512-qt5C1ppJz66aUDrH1VccjPrq7aFchK0wBrn6xsxlCHNUyE57dRRQ7lp1QFpF7OscMexZF8MCGBTVBlENHPkNiA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-previous": "1.1.2",
@@ -2822,15 +2822,15 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.1.tgz",
-      "integrity": "sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.2.tgz",
+      "integrity": "sha512-tgRBI3DdNwAJYE4BBZyZcz/HRRCvAsPkRvG1wvKc+41tBGMxPn/a87T/wikXAvyDypNQ9kaZwHbeZe+veHCGpA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
         "@radix-ui/react-use-size": "1.1.2"
@@ -2851,9 +2851,9 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
-      "integrity": "sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.16.tgz",
+      "integrity": "sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
@@ -2861,8 +2861,8 @@
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2881,23 +2881,23 @@
       }
     },
     "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.17.tgz",
-      "integrity": "sha512-uL4kyyWy000pPL43fGGCV5qT6ZchCWEQZOSlkYiPwPt8Hy1iW38RjeptIvz1/SZesrW6Vn58Ct3sV7tfEfiAbw==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.18.tgz",
+      "integrity": "sha512-YNEnTHV47hPep+U0QvVM02OJNka9uygREc+k4Nh5VSZBg4MmE+myI442x3hCGfRpX7N2WSSYSJKws4gE+Z8lgg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2",
-        "@radix-ui/react-visually-hidden": "1.2.6"
+        "@radix-ui/react-visually-hidden": "1.2.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2915,13 +2915,13 @@
       }
     },
     "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.12.tgz",
-      "integrity": "sha512-AsAVsYNZIlRBsci7BhE+QyQeKd1h6TffJYt+lF0QQkd5OpQ3klfIByPsCb4G0h/Fq6PJwh1FYNluzBFYzhk4+w==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.13.tgz",
+      "integrity": "sha512-bI2ILJrzwgmAsH05TsJ9pVrzqQwAip7OM2/krqAdYn0R16bl86UPWbe5VPHsALat0EnqpV01cGtkleaUKPNdNg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2940,17 +2940,17 @@
       }
     },
     "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.13.tgz",
-      "integrity": "sha512-Xb9PLtlvU66F36LiKba6dFswu6V2mDkgidO4fNSbQHQwmZ9ObxMIO17MN/LJ4aWJecVuSVLAHPZjyeMzJrgeiA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.14.tgz",
+      "integrity": "sha512-TK1vusNKb8IRhF23FTbRgUNZ9zfs5rGIyI7LfR3h26p9LrQ060i0uW9QWeD8baZMddaaP0DBGlIa6pbZG+mitg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
-        "@radix-ui/react-toggle": "1.1.12",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-toggle": "1.1.13",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2969,18 +2969,18 @@
       }
     },
     "node_modules/@radix-ui/react-toolbar": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.13.tgz",
-      "integrity": "sha512-Za1l4f6fzTkGgz/iynAMN8iaqiKff2wm2/QwiLmHPtDQreWEBrvSimgQFIekxMUdRPhILM7xdIXxuS/o/DGZag==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.14.tgz",
+      "integrity": "sha512-L/EkWVqlnj3lL2toHh4C7PwH2jxfa7OCq6lGfXSCii99ve2S4Ux5rc9HnOa7LN9exHa/Nl9kmCAmP9BuDPy5UA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-context": "1.1.4",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-roving-focus": "1.1.13",
-        "@radix-ui/react-separator": "1.1.10",
-        "@radix-ui/react-toggle-group": "1.1.13"
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-separator": "1.1.11",
+        "@radix-ui/react-toggle-group": "1.1.14"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2998,23 +2998,23 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
-      "integrity": "sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.11.tgz",
+      "integrity": "sha512-8XZ6Py3y3W2nEzAUGCN5cfVKaUi+CVApcz1d6lrNVVf2hvYEixMRkq8k9ggPKnQUpRRuOV5avt8uvxViH2jLwA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.1",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
-        "@radix-ui/react-visually-hidden": "1.2.6"
+        "@radix-ui/react-visually-hidden": "1.2.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3084,9 +3084,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
-      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.3.tgz",
+      "integrity": "sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.2"
@@ -3183,12 +3183,12 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
-      "integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz",
+      "integrity": "sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6"
+        "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.35.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.35.1.tgz",
-      "integrity": "sha512-8XcUIR6bCI4KmVg6RJyzL3peZhld/tu7oO8WGVaHp43byhcds6ProHlfqEFa+dZA+qA+dUMebgRELVOe5AW4Lg==",
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.36.0.tgz",
+      "integrity": "sha512-0ky8u/Zzx4zT35rJZY27KOuzXMI29JLt5FMbfzFV7AtVlK3DLjDmJjqprnhqUMJlt04R+FKSXahBZo1dUF6R5A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3263,20 +3263,10 @@
         }
       }
     },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
-      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -3290,9 +3280,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -3306,9 +3296,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -3322,9 +3312,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -3338,9 +3328,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -3354,9 +3344,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -3373,9 +3363,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -3392,9 +3382,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -3411,9 +3401,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -3430,9 +3420,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -3449,9 +3439,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -3468,9 +3458,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -3484,9 +3474,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -3533,9 +3523,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -3549,9 +3539,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -3565,9 +3555,9 @@
       }
     },
     "node_modules/@rolldown/debug": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/debug/-/debug-1.1.3.tgz",
-      "integrity": "sha512-1OMsP69fnm1Ky82qFODn6ekpmKetcIZ5Zk+wRR4apdJhhMs4DztmK6Bxnr70Lg6BRjWcesEnpU1cjHD2O74oYg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/debug/-/debug-1.1.4.tgz",
+      "integrity": "sha512-K/hi4hdSOdfwwC0tFt30ovGk0TjlaQPk1aBQkfzvTjLX6d18WRX4aeYrYnHKtL0d6a8ciyra2LKsZjlyD4VAuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4236,9 +4226,9 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
+      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -4247,36 +4237,36 @@
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.1"
+        "tailwindcss": "4.3.2"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
+      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-x64": "4.3.1",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+        "@tailwindcss/oxide-android-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-x64": "4.3.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
-      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
+      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
       "cpu": [
         "arm64"
       ],
@@ -4290,9 +4280,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
+      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
       "cpu": [
         "arm64"
       ],
@@ -4306,9 +4296,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
-      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
+      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
       "cpu": [
         "x64"
       ],
@@ -4322,9 +4312,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
-      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
+      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
       "cpu": [
         "x64"
       ],
@@ -4338,9 +4328,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
-      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
+      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
       "cpu": [
         "arm"
       ],
@@ -4354,9 +4344,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
-      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
+      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
       "cpu": [
         "arm64"
       ],
@@ -4373,9 +4363,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
-      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
+      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
       "cpu": [
         "arm64"
       ],
@@ -4392,9 +4382,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
-      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
       "cpu": [
         "x64"
       ],
@@ -4411,9 +4401,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
-      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
+      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
       "cpu": [
         "x64"
       ],
@@ -4430,9 +4420,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
-      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
+      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -4447,9 +4437,9 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
         "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
@@ -4459,9 +4449,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
-      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
+      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
       "cpu": [
         "arm64"
       ],
@@ -4475,9 +4465,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
-      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
+      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
       "cpu": [
         "x64"
       ],
@@ -4491,23 +4481,23 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
-      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
+      "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.3.1",
-        "@tailwindcss/oxide": "4.3.1",
-        "tailwindcss": "4.3.1"
+        "@tailwindcss/node": "4.3.2",
+        "@tailwindcss/oxide": "4.3.2",
+        "tailwindcss": "4.3.2"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.1.tgz",
-      "integrity": "sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4515,9 +4505,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.101.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.1.tgz",
-      "integrity": "sha512-37RQ9U2PxlXQiv1era2t+uHgVhmiyvxqTMu30+KoVf0rufiucu6rpGRKFJk61Wh5OAZFKqCQd6lxTzFWfLZiuQ==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.2.tgz",
+      "integrity": "sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4526,12 +4516,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.1.tgz",
-      "integrity": "sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.1"
+        "@tanstack/query-core": "5.101.2"
       },
       "funding": {
         "type": "github",
@@ -4542,20 +4532,20 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.101.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.1.tgz",
-      "integrity": "sha512-OXFR9XKdEslraq3cpl3kCUeNvTIq/xGWEZiFZdn2bLB/q4WxSALMEDKYZ5yYjMQytsfnQxwQYqV4qtVEf0nuog==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.2.tgz",
+      "integrity": "sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.101.1"
+        "@tanstack/query-devtools": "5.101.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.101.1",
+        "@tanstack/react-query": "^5.101.2",
         "react": "^18 || ^19"
       }
     },
@@ -5188,17 +5178,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
-      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/type-utils": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -5211,7 +5201,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.0",
+        "@typescript-eslint/parser": "^8.62.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -5227,16 +5217,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
-      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5252,14 +5242,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
-      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.0",
-        "@typescript-eslint/types": "^8.62.0",
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5274,14 +5264,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
-      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5292,9 +5282,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
-      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5309,15 +5299,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
-      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -5334,9 +5324,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
-      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5348,16 +5338,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
-      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.0",
-        "@typescript-eslint/tsconfig-utils": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -5389,16 +5379,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
-      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5413,13 +5403,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
-      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/types": "8.62.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5864,9 +5854,9 @@
       "license": "MIT"
     },
     "node_modules/@yaireo/tagify": {
-      "version": "4.37.1",
-      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.37.1.tgz",
-      "integrity": "sha512-/+0ZZ55rd4sG5Nlop2QF9D2oo3kbRgn/KlsW6oN1MwKVS7DDB2mIrGnizk740M0qzXvQfE7JhbCeWDuC8+6kmA==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/@yaireo/tagify/-/tagify-4.38.0.tgz",
+      "integrity": "sha512-/ZyG2NWQGNcTK4ay2aPE3ka/ZQmhTo+bUKb81SqjtQlt3VrGoxCNhmvKTV/mBJbY69BOXXeBEi+a5JLrvp6wLA==",
       "license": "MIT",
       "engines": {
         "node": ">=22",
@@ -6313,9 +6303,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6440,9 +6430,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "dev": true,
       "funding": [
         {
@@ -7552,9 +7542,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.378",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
-      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+      "version": "1.5.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
+      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
       "dev": true,
       "license": "ISC"
     },
@@ -7725,9 +7715,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7772,13 +7762,14 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.3.tgz",
-      "integrity": "sha512-3OJmZ3m4VNhTWEfn/bPv7yoSd/7Kx0MYdm27o7SqgS45l03O4purW3zO4B/4JroAWHluvmQaXqrPXFtT4IKYEw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
         "is-date-object": "^1.1.0",
@@ -7824,9 +7815,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -8339,12 +8330,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
-      "integrity": "sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.0",
+        "motion-dom": "^12.42.2",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -8892,9 +8883,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.9.tgz",
+      "integrity": "sha512-sc/z0Cyti70bZa0ZU4sWfAElfovFb9Ni8tArJZLuklYWxegPiK3pDOql1Rq5H0FIRAW9LSQRG6OX4KqBldbhBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10133,9 +10124,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -10316,9 +10307,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
-      "integrity": "sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"
@@ -10565,9 +10556,9 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
-      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -10986,9 +10977,9 @@
       }
     },
     "node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11166,9 +11157,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11204,9 +11195,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -11440,66 +11431,66 @@
       "license": "MIT"
     },
     "node_modules/radix-ui": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.0.tgz",
-      "integrity": "sha512-EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.1.tgz",
+      "integrity": "sha512-QXDXJtB6sK83mLASONYUZCauatcWb+knFviFpN1EhtdbbmlsRmzCLrbZSKztnNiem2KOHIBbiDbauVB7SORXMw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-accessible-icon": "1.1.10",
-        "@radix-ui/react-accordion": "1.2.14",
-        "@radix-ui/react-alert-dialog": "1.1.17",
-        "@radix-ui/react-arrow": "1.1.10",
-        "@radix-ui/react-aspect-ratio": "1.1.10",
-        "@radix-ui/react-avatar": "1.2.0",
-        "@radix-ui/react-checkbox": "1.3.5",
-        "@radix-ui/react-collapsible": "1.1.14",
-        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-accessible-icon": "1.1.11",
+        "@radix-ui/react-accordion": "1.2.15",
+        "@radix-ui/react-alert-dialog": "1.1.18",
+        "@radix-ui/react-arrow": "1.1.11",
+        "@radix-ui/react-aspect-ratio": "1.1.11",
+        "@radix-ui/react-avatar": "1.2.1",
+        "@radix-ui/react-checkbox": "1.3.6",
+        "@radix-ui/react-collapsible": "1.1.15",
+        "@radix-ui/react-collection": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-context-menu": "2.3.1",
-        "@radix-ui/react-dialog": "1.1.17",
+        "@radix-ui/react-context-menu": "2.3.2",
+        "@radix-ui/react-dialog": "1.1.18",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
-        "@radix-ui/react-dropdown-menu": "2.1.18",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-dropdown-menu": "2.1.19",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
-        "@radix-ui/react-form": "0.1.10",
-        "@radix-ui/react-hover-card": "1.1.17",
-        "@radix-ui/react-label": "2.1.10",
-        "@radix-ui/react-menu": "2.1.18",
-        "@radix-ui/react-menubar": "1.1.18",
-        "@radix-ui/react-navigation-menu": "1.2.16",
-        "@radix-ui/react-one-time-password-field": "0.1.10",
-        "@radix-ui/react-password-toggle-field": "0.1.5",
-        "@radix-ui/react-popover": "1.1.17",
-        "@radix-ui/react-popper": "1.3.1",
-        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-focus-scope": "1.1.11",
+        "@radix-ui/react-form": "0.1.11",
+        "@radix-ui/react-hover-card": "1.1.18",
+        "@radix-ui/react-label": "2.1.11",
+        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/react-menubar": "1.1.19",
+        "@radix-ui/react-navigation-menu": "1.2.17",
+        "@radix-ui/react-one-time-password-field": "0.1.11",
+        "@radix-ui/react-password-toggle-field": "0.1.6",
+        "@radix-ui/react-popover": "1.1.18",
+        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-portal": "1.1.13",
         "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-progress": "1.1.10",
-        "@radix-ui/react-radio-group": "1.4.1",
-        "@radix-ui/react-roving-focus": "1.1.13",
-        "@radix-ui/react-scroll-area": "1.2.12",
-        "@radix-ui/react-select": "2.3.1",
-        "@radix-ui/react-separator": "1.1.10",
-        "@radix-ui/react-slider": "1.4.1",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-progress": "1.1.11",
+        "@radix-ui/react-radio-group": "1.4.2",
+        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-scroll-area": "1.2.13",
+        "@radix-ui/react-select": "2.3.2",
+        "@radix-ui/react-separator": "1.1.11",
+        "@radix-ui/react-slider": "1.4.2",
         "@radix-ui/react-slot": "1.3.0",
-        "@radix-ui/react-switch": "1.3.1",
-        "@radix-ui/react-tabs": "1.1.15",
-        "@radix-ui/react-toast": "1.2.17",
-        "@radix-ui/react-toggle": "1.1.12",
-        "@radix-ui/react-toggle-group": "1.1.13",
-        "@radix-ui/react-toolbar": "1.1.13",
-        "@radix-ui/react-tooltip": "1.2.10",
+        "@radix-ui/react-switch": "1.3.2",
+        "@radix-ui/react-tabs": "1.1.16",
+        "@radix-ui/react-toast": "1.2.18",
+        "@radix-ui/react-toggle": "1.1.13",
+        "@radix-ui/react-toggle-group": "1.1.14",
+        "@radix-ui/react-toolbar": "1.1.14",
+        "@radix-ui/react-tooltip": "1.2.11",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-effect-event": "0.0.3",
-        "@radix-ui/react-use-escape-keydown": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.3",
         "@radix-ui/react-use-is-hydrated": "0.1.1",
         "@radix-ui/react-use-layout-effect": "1.1.2",
         "@radix-ui/react-use-size": "1.1.2",
-        "@radix-ui/react-visually-hidden": "1.2.6"
+        "@radix-ui/react-visually-hidden": "1.2.7"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -11784,9 +11775,9 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.2.tgz",
-      "integrity": "sha512-+kfFbDZ8mygc7g0vxOcDzCVGuwiIUOnILqPoUHo6/uP+Mmyx6HzZU+kj1aOPDlktXuobYbr6BtQekvJwHRX4Eg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.0.tgz",
+      "integrity": "sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -11850,9 +11841,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.0.tgz",
-      "integrity": "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
+      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
       "license": "MIT",
       "workspaces": [
         "www"
@@ -11863,7 +11854,7 @@
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
         "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
+        "immer": "^11.1.8",
         "react-redux": "8.x.x || 9.x.x",
         "reselect": "5.2.0",
         "tiny-invariant": "^1.3.3",
@@ -12090,12 +12081,12 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.137.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -12105,27 +12096,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.3",
-        "@rolldown/binding-darwin-arm64": "1.1.3",
-        "@rolldown/binding-darwin-x64": "1.1.3",
-        "@rolldown/binding-freebsd-x64": "1.1.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
-        "@rolldown/binding-linux-arm64-musl": "1.1.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-musl": "1.1.3",
-        "@rolldown/binding-openharmony-arm64": "1.1.3",
-        "@rolldown/binding-wasm32-wasi": "1.1.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
-        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -12570,9 +12561,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/srvx": {
-      "version": "0.11.17",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.17.tgz",
-      "integrity": "sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==",
+      "version": "0.11.18",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.18.tgz",
+      "integrity": "sha512-7/EW5sPdC1bU7iq1tgTvCZqUQDkJdsqIVzYqBv7SuBfQQ10oWkKj4KYNOw0H4Ig26bXuUYDA7XTKxB+/HC5SRw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12948,9 +12939,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -13025,22 +13016,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.4.tgz",
-      "integrity": "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.4"
+        "tldts-core": "^7.4.5"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
-      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13301,16 +13292,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
-      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.0",
-        "@typescript-eslint/parser": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0"
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13406,9 +13397,9 @@
       "license": "MIT"
     },
     "node_modules/unplugin": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.2.0.tgz",
-      "integrity": "sha512-6nGlT7EHsS+tTcTdAkYFqXIUwDrMJyJvHFNYGSr4x2/2ySIcV4f5e1RAJUeDyfOJPR8TF0auE8l+82PLhKjqsA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13705,9 +13696,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
-      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -13755,15 +13746,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -122,6 +122,10 @@
         ],
         "improvements": [
             {
+                "title": "Faster Resource Editing from the Resources Table",
+                "description": "On the /resources page, clicking a resource row now opens that resource directly in the Data Editor in a new browser tab. Existing controls keep their own behavior: row checkboxes still manage selection, published and preview status badges still open and copy DOI or preview URLs, and ERNIE reuses the existing fallback dialog if the browser blocks the editor tab."
+            },
+            {
                 "title": "Resizable Resources Table Columns",
                 "description": "The Resources table now lets curators manually adjust every visible metadata column except the selection checkbox. Column widths are saved in the browser, can be reset to defaults, and long values stay on one line with ellipsis plus hover tooltips for the full text. Resize handles support mouse dragging and keyboard controls on tablet and desktop screens."
             },

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1832,6 +1832,9 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             actions toolbar sits directly below the filter row and shows how many resources are
                             selected.
                         </p>
+                        <p>
+                            Click anywhere else on a resource row to open that resource in the Data Editor in a new browser tab. Existing row controls keep their own behavior: the checkbox selects the row, and clickable published or preview status badges still open and copy the DOI or preview URL.
+                        </p>
 
                         <h4>Quick Resource Actions</h4>
                         <p>

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -237,9 +237,10 @@ const RESOURCE_ROW_INTERACTIVE_SELECTOR = [
 ].join(',');
 
 const shouldIgnoreResourceRowActivation = (event: ReactMouseEvent<HTMLTableRowElement> | ReactKeyboardEvent<HTMLTableRowElement>): boolean => {
-    const target = event.target;
+    const eventTarget = event.target;
+    const target = eventTarget instanceof Element ? eventTarget : eventTarget instanceof Text ? eventTarget.parentElement : null;
 
-    if (!(target instanceof Element)) {
+    if (target === null) {
         return false;
     }
 

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -224,6 +224,30 @@ const formatDeleteStatusCount = (status: ResourceDeleteStatus, count: number): s
 
 const getResourceActionLabel = (resource: Resource): string => resource.title ?? resource.doi ?? `Resource #${resource.id}`;
 
+const RESOURCE_ROW_INTERACTIVE_SELECTOR = [
+    'a',
+    'button',
+    'input',
+    'select',
+    'textarea',
+    '[role="button"]',
+    '[role="checkbox"]',
+    '[role="menuitem"]',
+    '[data-resource-row-action]',
+].join(',');
+
+const shouldIgnoreResourceRowActivation = (event: ReactMouseEvent<HTMLTableRowElement> | ReactKeyboardEvent<HTMLTableRowElement>): boolean => {
+    const target = event.target;
+
+    if (!(target instanceof Element)) {
+        return false;
+    }
+
+    const interactiveElement = target.closest(RESOURCE_ROW_INTERACTIVE_SELECTOR);
+
+    return interactiveElement !== null && event.currentTarget.contains(interactiveElement);
+};
+
 const getFilenameFromContentDisposition = (contentDisposition: string | undefined, fallback: string): string => {
     const filenameMatch = contentDisposition?.match(/filename="?([^"]+)"?/);
 
@@ -502,6 +526,7 @@ function ColumnResizeHandle({ columnKey, width, disabled, onResize }: ColumnResi
             tabIndex={disabled ? -1 : 0}
             title={`Resize ${label} column`}
             data-testid={`resources-column-resize-${columnKey}`}
+            data-resource-row-action="true"
             onPointerDown={handlePointerDown}
             onKeyDown={handleKeyDown}
         >
@@ -1291,30 +1316,77 @@ function ResourcesPage({
             toast.error(errorMessage);
         }
     }, []);
+
+    const openResourceEditorTab = useCallback((resource: Resource): BlockedEditorTab | null => {
+        if (typeof resource.id !== 'number') {
+            return null;
+        }
+
+        const url = editorRoute({ query: { resourceId: resource.id } }).url;
+        const opened = window.open(url, '_blank', 'noopener,noreferrer');
+
+        if (opened !== null) {
+            return null;
+        }
+
+        return {
+            id: resource.id,
+            label: getResourceActionLabel(resource),
+            url,
+        };
+    }, []);
+
+    const warnAboutBlockedEditorTabs = useCallback((blockedTabs: BlockedEditorTab[]) => {
+        if (blockedTabs.length === 0) {
+            return;
+        }
+
+        setBlockedEditorTabs(blockedTabs);
+        toast.warning('Your browser blocked one or more editor tabs. Use the fallback links to continue editing.');
+    }, []);
+
     const handleEditSelectedResources = useCallback(() => {
         if (selectedResources.length === 0) {
             toast.error('Select one or more resources first.');
             return;
         }
 
-        const blockedTabs: BlockedEditorTab[] = [];
-        selectedResources.forEach((resource) => {
-            const url = editorRoute({ query: { resourceId: resource.id } }).url;
-            const opened = window.open(url, '_blank', 'noopener,noreferrer');
-            if (opened === null) {
-                blockedTabs.push({
-                    id: resource.id,
-                    label: getResourceActionLabel(resource),
-                    url,
-                });
-            }
-        });
+        const blockedTabs = selectedResources.map(openResourceEditorTab).filter((tab): tab is BlockedEditorTab => tab !== null);
+        warnAboutBlockedEditorTabs(blockedTabs);
+    }, [openResourceEditorTab, selectedResources, warnAboutBlockedEditorTabs]);
 
-        if (blockedTabs.length > 0) {
-            setBlockedEditorTabs(blockedTabs);
-            toast.warning('Your browser blocked one or more editor tabs. Use the fallback links to continue editing.');
-        }
-    }, [selectedResources]);
+    const handleResourceRowActivation = useCallback(
+        (resource: Resource) => {
+            const blockedTab = openResourceEditorTab(resource);
+            warnAboutBlockedEditorTabs(blockedTab ? [blockedTab] : []);
+        },
+        [openResourceEditorTab, warnAboutBlockedEditorTabs],
+    );
+
+    const handleResourceRowClick = useCallback(
+        (resource: Resource, event: ReactMouseEvent<HTMLTableRowElement>) => {
+            if (shouldIgnoreResourceRowActivation(event)) {
+                return;
+            }
+
+            handleResourceRowActivation(resource);
+        },
+        [handleResourceRowActivation],
+    );
+
+    const handleResourceRowKeyDown = useCallback(
+        (resource: Resource, event: ReactKeyboardEvent<HTMLTableRowElement>) => {
+            const isActivationKey = event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar';
+
+            if (!isActivationKey || shouldIgnoreResourceRowActivation(event)) {
+                return;
+            }
+
+            event.preventDefault();
+            handleResourceRowActivation(resource);
+        },
+        [handleResourceRowActivation],
+    );
 
     const handleBatchExportSelectedResources = useCallback(
         async (action: ResourceExportAction) => {
@@ -1706,6 +1778,7 @@ function ResourcesPage({
                             }
                             aria-label={ariaLabel}
                             title={ariaLabel}
+                            data-resource-row-action={isClickable ? 'true' : undefined}
                         >
                             <span className="truncate">{statusLabel}</span>
                         </span>
@@ -1992,15 +2065,25 @@ function ResourcesPage({
                                             {loading && sortedResources.length === 0 && <LoadingSkeleton />}
                                             {sortedResources.map((resource, index) => {
                                                 const isLast = index === sortedResources.length - 1;
+                                                const hasEditableResource = typeof resource.id === 'number';
                                                 const resourceLabel =
-                                                    resource.doi ?? resource.title ?? (resource.id !== undefined ? `#${resource.id}` : 'entry');
+                                                    resource.doi ?? resource.title ?? (hasEditableResource ? `#${resource.id}` : 'entry');
+
                                                 return (
                                                     <TableRow
                                                         key={deriveResourceRowKey(resource)}
-                                                        className="hover:bg-gray-50 dark:hover:bg-gray-800"
+                                                        className={cn(
+                                                            'hover:bg-gray-50 dark:hover:bg-gray-800',
+                                                            hasEditableResource &&
+                                                                'cursor-pointer focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none',
+                                                        )}
                                                         ref={isLast ? lastResourceElementRef : null}
-                                                        data-state={
-                                                            resource.id !== undefined && selectedIds.has(resource.id) ? 'selected' : undefined
+                                                        data-state={hasEditableResource && selectedIds.has(resource.id) ? 'selected' : undefined}
+                                                        tabIndex={hasEditableResource ? 0 : undefined}
+                                                        aria-label={hasEditableResource ? `Open resource ${resourceLabel} in editor` : undefined}
+                                                        onClick={hasEditableResource ? (event) => handleResourceRowClick(resource, event) : undefined}
+                                                        onKeyDown={
+                                                            hasEditableResource ? (event) => handleResourceRowKeyDown(resource, event) : undefined
                                                         }
                                                     >
                                                         <TableCell className="w-12 min-w-12 align-middle">

--- a/tests/vitest/components/citations/RelatedItemForm.test.tsx
+++ b/tests/vitest/components/citations/RelatedItemForm.test.tsx
@@ -132,10 +132,10 @@ describe('RelatedItemForm', () => {
         );
 
         // Title field should now contain the autofilled value
-        expect(screen.getByDisplayValue('Autofilled Title')).toBeInTheDocument();
+        expect(await screen.findByDisplayValue('Autofilled Title')).toBeInTheDocument();
         // Open publication details to reveal publisher input
         await user.click(screen.getByRole('button', { name: /Publication details/ }));
-        expect(screen.getByDisplayValue('ACME')).toBeInTheDocument();
+        expect(await screen.findByDisplayValue('ACME')).toBeInTheDocument();
     });
 
     it('invokes onCancel when the Cancel button is clicked', async () => {

--- a/tests/vitest/components/igsns/modals/ImportSingleIgsnModal.test.tsx
+++ b/tests/vitest/components/igsns/modals/ImportSingleIgsnModal.test.tsx
@@ -221,7 +221,9 @@ describe('ImportSingleIgsnModal', () => {
         expect(await screen.findByText('Import complete')).toBeInTheDocument();
         expect(screen.getByText('Related IGSNs included')).toBeInTheDocument();
         expect(screen.getByText(/2 related IGSNs included/i)).toBeInTheDocument();
-        expect(mockOnSuccess).toHaveBeenCalledOnce();
+        await waitFor(() => {
+            expect(mockOnSuccess).toHaveBeenCalledOnce();
+        });
     });
 
     it('sends cancel request while running', async () => {
@@ -367,7 +369,9 @@ describe('ImportSingleIgsnModal', () => {
         vi.advanceTimersByTime(2000);
 
         expect(await screen.findByText('Import complete')).toBeInTheDocument();
-        expect(mockOnSuccess).toHaveBeenCalledOnce();
+        await waitFor(() => {
+            expect(mockOnSuccess).toHaveBeenCalledOnce();
+        });
     });
 
     it('shows failed status from polling using failed DOI fallback error text', async () => {
@@ -455,7 +459,9 @@ describe('ImportSingleIgsnModal', () => {
         expect(screen.getByText('Import cancelled').closest('[role="alert"]')).toHaveClass('border-yellow-200');
         expect(screen.getByText('Import cancelled').closest('[role="alert"]')).not.toHaveClass('border-green-200');
         expect(screen.getByText(/Import stopped after processing 1 of 3 IGSNs/i)).toBeInTheDocument();
-        expect(mockOnSuccess).toHaveBeenCalledOnce();
+        await waitFor(() => {
+            expect(mockOnSuccess).toHaveBeenCalledOnce();
+        });
     });
 
     it('shows skipped and failed DOI details after expanding result sections', async () => {

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -233,6 +233,24 @@ describe('Docs page', () => {
         expect(screen.getByText(/DataCite Metadata Schema 4\.7/i)).toBeInTheDocument();
     });
 
+    it('documents opening resources from the resources table row', async () => {
+        const { user } = renderDocsPage('beginner');
+
+        await openDatasetsTab(user);
+
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return text.includes('Click anywhere else on a resource row to open that resource in the Data Editor in a new browser tab.');
+            }),
+        ).toBeInTheDocument();
+    });
+
     it('hides controlled keywords section when all vocabulary families are disabled', async () => {
         const { user } = renderDocsPage(
             'beginner',

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -170,6 +170,13 @@ const clickResourceAction = async (testId: string) => {
 
     await userEvent.click(screen.getByTestId(testId));
 };
+
+const waitForFilterOptionsToLoad = async () => {
+    await waitFor(() => {
+        expect(axiosGetMock).toHaveBeenCalledWith('/resources/filter-options');
+    });
+};
+
 describe('ResourcesPage - bulk selection', () => {
     let originalCreateObjectURL: typeof URL.createObjectURL | undefined;
     let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined;
@@ -277,8 +284,9 @@ describe('ResourcesPage - bulk selection', () => {
         });
     });
 
-    it('renders selection checkboxes and the idle toolbar hint', () => {
+    it('renders selection checkboxes and the idle toolbar hint', async () => {
         render(<ResourcesPage {...buildProps()} />);
+        await waitForFilterOptionsToLoad();
 
         expect(screen.getByTestId('resources-select-all')).toBeInTheDocument();
         expect(screen.getByTestId('resources-row-checkbox-1')).toBeInTheDocument();
@@ -287,8 +295,9 @@ describe('ResourcesPage - bulk selection', () => {
         expect(screen.getByText(/select rows to enable resource actions/i)).toBeInTheDocument();
     });
 
-    it('updates selected count when rows are toggled', () => {
+    it('updates selected count when rows are toggled', async () => {
         render(<ResourcesPage {...buildProps()} />);
+        await waitForFilterOptionsToLoad();
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-2'));
         expect(screen.getByText(/^1 resource selected$/i)).toBeInTheDocument();
@@ -342,9 +351,10 @@ describe('ResourcesPage - bulk selection', () => {
         expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    it('shows fallback editor links when a row editor tab is blocked', () => {
+    it('shows fallback editor links when a row editor tab is blocked', async () => {
         openMock.mockReturnValueOnce(null);
         render(<ResourcesPage {...buildProps()} />);
+        await waitForFilterOptionsToLoad();
 
         fireEvent.click(screen.getByRole('row', { name: /open resource 10\.9999\/one in editor/i }));
 
@@ -922,9 +932,10 @@ describe('ResourcesPage - bulk selection', () => {
         }
     });
 
-    it('renders the import buttons alongside the action toolbar', () => {
+    it('renders the import buttons alongside the action toolbar', async () => {
         const props = { ...buildProps(), canImportFromDataCite: true };
         render(<ResourcesPage {...props} />);
+        await waitForFilterOptionsToLoad();
 
         expect(within(screen.getByTestId('app-layout')).getByRole('button', { name: /import all old resources/i })).toBeInTheDocument();
         expect(within(screen.getByTestId('app-layout')).getByRole('button', { name: /import old single resource/i })).toBeInTheDocument();

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -342,6 +342,18 @@ describe('ResourcesPage - bulk selection', () => {
         expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
+    it('shows fallback editor links when a row editor tab is blocked', () => {
+        openMock.mockReturnValueOnce(null);
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByRole('row', { name: /open resource 10\.9999\/one in editor/i }));
+
+        expect(toastMock.warning).toHaveBeenCalledWith(expect.stringContaining('fallback links'));
+        expect(screen.getByTestId('blocked-editor-tabs-dialog')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('href', '/editor?resourceId=1');
+        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('target', '_blank');
+    });
+
     it('keeps single-resource actions visible but reports a useful error for multi-selection', async () => {
         render(<ResourcesPage {...buildProps()} />);
 

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -93,7 +93,9 @@ const clickResourceAction = async (testId: string) => {
 
 describe('ResourcesPage', () => {
     let originalOpen: typeof window.open;
+    let originalClipboard: Clipboard | undefined;
     let openMock: ReturnType<typeof vi.fn>;
+    let clipboardWriteTextMock: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         routerMock.get.mockClear();
@@ -106,9 +108,16 @@ describe('ResourcesPage', () => {
         buildCurationQueryFromResourceMock.mockResolvedValue({});
         editorRouteMock.mockClear();
         originalOpen = window.open;
+        originalClipboard = navigator.clipboard;
         openMock = vi.fn().mockReturnValue({ closed: false });
+        clipboardWriteTextMock = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(window, 'open', {
             value: openMock,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: clipboardWriteTextMock },
             configurable: true,
             writable: true,
         });
@@ -130,6 +139,11 @@ describe('ResourcesPage', () => {
         document.head.innerHTML = '';
         Object.defineProperty(window, 'open', {
             value: originalOpen,
+            configurable: true,
+            writable: true,
+        });
+        Object.defineProperty(navigator, 'clipboard', {
+            value: originalClipboard,
             configurable: true,
             writable: true,
         });
@@ -282,5 +296,187 @@ describe('ResourcesPage', () => {
         expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
         expect(buildCurationQueryFromResourceMock).not.toHaveBeenCalled();
         expect(routerMock.get).not.toHaveBeenCalled();
+    });
+
+    it('opens the curation editor in a new tab when a resource row is clicked', () => {
+        const resource = {
+            id: 1,
+            doi: '10.9999/example',
+            year: 2024,
+            title: 'Primary title',
+            resourcetypegeneral: 'Dataset',
+            curator: 'Test Curator',
+            publicstatus: 'curation',
+            landingPage: null,
+        };
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+                sort={{ key: 'id' as const, direction: 'asc' as const }}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('row', { name: /open resource 10\.9999\/example in editor/i }));
+
+        expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: resource.id } });
+        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+        expect(routerMock.get).not.toHaveBeenCalled();
+    });
+
+    it('opens the curation editor from keyboard row activation', () => {
+        const resource = {
+            id: 7,
+            doi: null,
+            year: 2024,
+            title: 'Keyboard resource',
+            resourcetypegeneral: 'Dataset',
+            curator: 'Test Curator',
+            publicstatus: 'curation',
+            landingPage: null,
+        };
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+                sort={{ key: 'id' as const, direction: 'asc' as const }}
+            />,
+        );
+
+        const row = screen.getByRole('row', { name: /open resource keyboard resource in editor/i });
+        fireEvent.keyDown(row, { key: 'Enter' });
+
+        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=7', '_blank', 'noopener,noreferrer');
+
+        openMock.mockClear();
+        editorRouteMock.mockClear();
+
+        fireEvent.keyDown(row, { key: ' ' });
+
+        expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: resource.id } });
+        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=7', '_blank', 'noopener,noreferrer');
+    });
+
+    it('opens the editor when a non-interactive status cell area is clicked', () => {
+        const resource = {
+            id: 1,
+            doi: '10.9999/example',
+            year: 2024,
+            title: 'Primary title',
+            resourcetypegeneral: 'Dataset',
+            curator: 'Test Curator',
+            publicstatus: 'curation',
+            landingPage: null,
+        };
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+                sort={{ key: 'id' as const, direction: 'asc' as const }}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('Curation'));
+
+        expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: resource.id } });
+        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+    });
+
+    it('does not open the editor when the row checkbox is clicked', () => {
+        const resource = {
+            id: 1,
+            doi: '10.9999/example',
+            year: 2024,
+            title: 'Primary title',
+            resourcetypegeneral: 'Dataset',
+            curator: 'Test Curator',
+            publicstatus: 'curation',
+            landingPage: null,
+        };
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+                sort={{ key: 'id' as const, direction: 'asc' as const }}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+
+        expect(screen.getByText(/^1 resource selected$/i)).toBeInTheDocument();
+        expect(editorRouteMock).not.toHaveBeenCalled();
+        expect(openMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps the published status badge behavior separate from row editor activation', () => {
+        const resource = {
+            id: 1,
+            doi: '10.9999/example',
+            year: 2024,
+            title: 'Primary title',
+            resourcetypegeneral: 'Dataset',
+            curator: 'Test Curator',
+            publicstatus: 'published',
+            landingPage: { id: 1, is_published: true, public_url: 'https://example.test/resource' },
+        };
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+                sort={{ key: 'id' as const, direction: 'asc' as const }}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /published - click to open doi and copy url to clipboard/i }));
+
+        expect(clipboardWriteTextMock).toHaveBeenCalledWith('https://doi.org/10.9999/example');
+        expect(openMock).toHaveBeenCalledWith('https://doi.org/10.9999/example', '_blank', 'noopener,noreferrer');
+        expect(editorRouteMock).not.toHaveBeenCalled();
+        expect(openMock).not.toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
     });
 });

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -93,7 +93,7 @@ const clickResourceAction = async (testId: string) => {
 
 describe('ResourcesPage', () => {
     let originalOpen: typeof window.open;
-    let originalClipboard: Clipboard | undefined;
+    let originalClipboardDescriptor: PropertyDescriptor | undefined;
     let openMock: ReturnType<typeof vi.fn>;
     let clipboardWriteTextMock: ReturnType<typeof vi.fn>;
 
@@ -108,7 +108,7 @@ describe('ResourcesPage', () => {
         buildCurationQueryFromResourceMock.mockResolvedValue({});
         editorRouteMock.mockClear();
         originalOpen = window.open;
-        originalClipboard = navigator.clipboard;
+        originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
         openMock = vi.fn().mockReturnValue({ closed: false });
         clipboardWriteTextMock = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(window, 'open', {
@@ -142,11 +142,11 @@ describe('ResourcesPage', () => {
             configurable: true,
             writable: true,
         });
-        Object.defineProperty(navigator, 'clipboard', {
-            value: originalClipboard,
-            configurable: true,
-            writable: true,
-        });
+        if (originalClipboardDescriptor) {
+            Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+        } else {
+            Reflect.deleteProperty(navigator, 'clipboard');
+        }
     });
 
     it('renders a table with the streamlined dataset overview', async () => {
@@ -475,6 +475,45 @@ describe('ResourcesPage', () => {
         fireEvent.click(screen.getByRole('button', { name: /published - click to open doi and copy url to clipboard/i }));
 
         expect(clipboardWriteTextMock).toHaveBeenCalledWith('https://doi.org/10.9999/example');
+        expect(openMock).toHaveBeenCalledWith('https://doi.org/10.9999/example', '_blank', 'noopener,noreferrer');
+        expect(editorRouteMock).not.toHaveBeenCalled();
+        expect(openMock).not.toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+    });
+
+    it('does not activate the row when an interactive status badge text node is clicked', () => {
+        const resource = {
+            id: 1,
+            doi: '10.9999/example',
+            year: 2024,
+            title: 'Primary title',
+            resourcetypegeneral: 'Dataset',
+            curator: 'Test Curator',
+            publicstatus: 'published',
+            landingPage: { id: 1, is_published: true, public_url: 'https://example.test/resource' },
+        };
+
+        render(
+            <ResourcesPage
+                resources={[resource as never]}
+                pagination={{
+                    current_page: 1,
+                    last_page: 1,
+                    per_page: 50,
+                    total: 1,
+                    from: 1,
+                    to: 1,
+                    has_more: false,
+                }}
+                sort={{ key: 'id' as const, direction: 'asc' as const }}
+            />,
+        );
+
+        const statusTextNode = screen.getByText('Published').firstChild;
+
+        expect(statusTextNode).toBeInstanceOf(Text);
+
+        fireEvent.click(statusTextNode as Text);
+
         expect(openMock).toHaveBeenCalledWith('https://doi.org/10.9999/example', '_blank', 'noopener,noreferrer');
         expect(editorRouteMock).not.toHaveBeenCalled();
         expect(openMock).not.toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
This pull request adds a major usability improvement to the Resources table: now, clicking anywhere on a resource row (except on interactive controls like checkboxes or status badges) will open that resource directly in the Data Editor in a new browser tab. The implementation ensures that existing controls retain their behavior, and provides a fallback dialog if the browser blocks the new tab. The documentation and test coverage have been updated to reflect and verify this new feature.

**Resource Row Editor Activation:**

* Added logic to make resource table rows keyboard and mouse accessible for opening the Data Editor in a new tab, while ensuring checkboxes and status badges retain their existing behavior. This includes handling browser tab blocking with a fallback dialog (`resources/js/pages/resources.tsx`). [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L1294-R1390) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R227-R251) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R530) [[4]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R1782) [[5]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R2069-R2087)

**Documentation:**

* Updated the documentation on the `/resources` page to explain the new row-click behavior for opening the Data Editor (`resources/js/pages/docs.tsx`).
* Added a changelog entry describing the faster resource editing feature (`resources/data/changelog.json`).

**Testing:**

* Added and updated tests to verify row activation via mouse and keyboard, ensure that interactive controls do not trigger the editor, and that the fallback dialog appears when a tab is blocked (`tests/vitest/pages/__tests__/resources.test.tsx`, `tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx`, `tests/vitest/pages/__tests__/docs.test.tsx`). [[1]](diffhunk://#diff-5809bb7f17b87658ea64212ec03769ca87f5123e6b1b042c41b59f69732c0aa6R300-R520) [[2]](diffhunk://#diff-2935c8699c7ba6bc08c2be86bece7e5b6510b65c4b227f1ba9b39d6d6b1f8edbR345-R356) [[3]](diffhunk://#diff-ab62124414fa6f6ebd421e5cd97c4b86b0cfe9389eb25f608fc655caadf26148R236-R253)

Overall, this change streamlines the curator workflow for editing resources and ensures robust, accessible, and well-documented behavior.