### PR TITLE
Feature: Landing Page Preview for Data Editor

### DIFF
--- a/app/Http/Controllers/EditorController.php
+++ b/app/Http/Controllers/EditorController.php
@@ -271,6 +271,7 @@ class EditorController extends Controller
                 'fundingReferences.funderIdentifierType',
                 'instruments',
                 'datacenters',
+                'landingPage.externalDomain',
             ])
             ->findOrFail($resourceId);
 

--- a/app/Services/Editor/EditorDataTransformer.php
+++ b/app/Services/Editor/EditorDataTransformer.php
@@ -81,6 +81,14 @@ class EditorDataTransformer
             'mslLaboratories' => $this->transformMslLaboratories($resource),
             'instruments' => $this->transformInstruments($resource),
             'initialDatacenters' => $resource->datacenters->pluck('id')->all(),
+            'landingPage' => $resource->landingPage ? [
+                'id' => $resource->landingPage->id,
+                'is_published' => $resource->landingPage->is_published,
+                'status' => $resource->landingPage->status,
+                'public_url' => $resource->landingPage->public_url,
+                'preview_url' => $resource->landingPage->preview_url,
+                'external_url' => $resource->landingPage->external_url,
+            ] : null,
         ];
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3256,9 +3256,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.36.0.tgz",
-      "integrity": "sha512-0ky8u/Zzx4zT35rJZY27KOuzXMI29JLt5FMbfzFV7AtVlK3DLjDmJjqprnhqUMJlt04R+FKSXahBZo1dUF6R5A==",
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.37.0.tgz",
+      "integrity": "sha512-2xKvVy2re6xiWfrWHJj633oEoVAYHisPsxEwoxtSxMqB+RhW2uqM98+JPjrLQPpj2m1bXrj08KXwpSFfojV0/g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,8 +1,12 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-06-26",
+        "date": "2026-07-03",
         "features": [
+            {
+                "title": "Landing Page Preview from the Data Editor",
+                "description": "Curators can now click Show LP Preview next to Save Draft and Save & Validate in the Data Editor. ERNIE saves the current metadata as a draft first, then opens the existing landing page preview or public URL in a new browser tab. If no landing page exists yet, the regular setup modal opens and automatically launches the newly created preview after setup."
+            },
             {
                 "title": "RAiD Persistent Identifier Support",
                 "description": "Editor Settings now include RAiD (Research Activity Identifier) alongside PID4INST and ROR. Admins and Group Leaders can enable RAiD separately for ERNIE and ELMO, check DataCite-backed RAiD project counts for updates, trigger background refreshes, and expose normalized RAiD project metadata to ELMO through the API-key protected vocabulary endpoint."

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2780,12 +2780,13 @@ export default function DataCiteForm({
     }, []);
 
     const handleLandingPageSetupSuccess = useCallback(
-        (landingPage?: LandingPageConfig | null) => {
+        (landingPage?: LandingPageConfig | null, preopenedPreviewWindow?: Window | null) => {
             if (landingPage) {
                 const summary = toEditorLandingPageSummary(landingPage);
                 setLandingPageForPreview(summary);
-                openLandingPagePreview(summary);
+                openLandingPagePreview(summary, preopenedPreviewWindow);
             } else {
+                preopenedPreviewWindow?.close();
                 setLandingPageForPreview(null);
             }
 
@@ -3527,6 +3528,7 @@ export default function DataCiteForm({
                     isOpen={isLandingPageSetupOpen}
                     onClose={handleCloseLandingPageSetup}
                     onSuccess={handleLandingPageSetupSuccess}
+                    openPreviewOnSuccess={true}
                 />
             )}
             {/* DOI Conflict Modal */}

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -146,6 +146,8 @@ function getLandingPagePreviewMissingUrlMessage(landingPage: LandingPagePreviewT
 }
 
 function openLandingPagePreviewPlaceholder(): Window | null {
+    // Do not pass `noopener` here: browsers may return `null` for noopener
+    // windows, and this flow needs the WindowProxy to navigate after async save.
     const previewWindow = window.open(LANDING_PAGE_PLACEHOLDER_URL, '_blank');
 
     if (previewWindow) {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -1,6 +1,6 @@
 import { router, usePage } from '@inertiajs/react';
 import axios from 'axios';
-import { AlertCircle, Calendar, CheckCircle, ChevronsDown, ChevronsUp, Circle, Save } from 'lucide-react';
+import { AlertCircle, Calendar, CheckCircle, ChevronsDown, ChevronsUp, Circle, Eye, Save } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -14,6 +14,7 @@ import {
 import { AccordionSectionHeader, SectionHelpAction } from '@/components/curation/section-header';
 import { mapBackendErrors, type MappedError } from '@/components/curation/utils/error-field-mapper';
 import { scheduleScrollToError } from '@/components/curation/utils/scroll-to-error';
+import SetupLandingPageModal from '@/components/landing-pages/modals/SetupLandingPageModal';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -28,6 +29,7 @@ import { buildDateTime, hasValidDateValue, parseDateTime } from '@/lib/date-util
 import { resources } from '@/routes';
 import { store, storeDraft } from '@/routes/editor/resources';
 import type { CurationAccordionItemValue, InstrumentSelection, MSLLaboratory, RelatedIdentifier, SharedData } from '@/types';
+import type { LandingPageConfig } from '@/types/landing-page';
 import type { SelectedKeyword, VocabularyKeyword } from '@/types/vocabulary';
 import { getVocabularyTypeFromScheme } from '@/types/vocabulary';
 import {
@@ -64,6 +66,7 @@ import {
     type DataCiteFormData,
     type DataCiteFormProps,
     type DateEntry,
+    type EditorLandingPageSummary,
     type LicenseEntry,
     MAIN_TITLE_SLUG,
     type RawRightsInput,
@@ -86,7 +89,7 @@ import {
 import { resolveInitialLanguageCode } from './utils/language-resolver';
 
 // Re-export types for backward compatibility with existing imports
-export type { DataCiteFormProps, InitialAuthor, InitialContributor, RawRightsInput } from './types/datacite-form-types';
+export type { DataCiteFormProps, EditorLandingPageSummary, InitialAuthor, InitialContributor, RawRightsInput } from './types/datacite-form-types';
 
 // Re-export helper functions for backward compatibility
 export { canAddDate, canAddLicense, canAddTitle } from './utils/form-helpers';
@@ -103,6 +106,39 @@ type DraftSaveResponse = {
     message?: string;
     resource?: { id: number };
 };
+
+type LandingPagePreviewTarget = {
+    status?: 'draft' | 'published' | string;
+    public_url?: string | null;
+    preview_url?: string | null;
+    external_url?: string | null;
+};
+
+type LandingPagePreviewSetupResource = {
+    id: number;
+    doi?: string | null;
+    title?: string;
+    resourcetypegeneral?: string;
+};
+
+function getLandingPagePreviewTarget(landingPage: LandingPagePreviewTarget): string | null {
+    if (landingPage.status === 'draft') {
+        return landingPage.preview_url ?? null;
+    }
+
+    return landingPage.public_url ?? landingPage.external_url ?? null;
+}
+
+function toEditorLandingPageSummary(landingPage: LandingPageConfig): EditorLandingPageSummary {
+    return {
+        id: landingPage.id,
+        is_published: landingPage.status === 'published',
+        status: landingPage.status,
+        public_url: landingPage.public_url,
+        preview_url: landingPage.preview_url,
+        external_url: landingPage.external_url,
+    };
+}
 
 function normalizeAccordionItems(
     items: readonly string[],
@@ -192,6 +228,7 @@ export default function DataCiteForm({
     initialLicenses = [],
     initialRawRights = [],
     initialResourceId,
+    initialLandingPage = null,
     initialAuthors = [],
     initialContributors = [],
     initialDescriptions = [],
@@ -1884,9 +1921,39 @@ export default function DataCiteForm({
         return Number.isFinite(parsed) ? parsed : null;
     });
 
+    const [landingPageForPreview, setLandingPageForPreview] = useState<EditorLandingPageSummary | null>(initialLandingPage);
+    const [isPreparingLandingPagePreview, setIsPreparingLandingPagePreview] = useState(false);
+    const [pendingLandingPageSetupResource, setPendingLandingPageSetupResource] = useState<LandingPagePreviewSetupResource | null>(null);
+    const [isLandingPageSetupOpen, setIsLandingPageSetupOpen] = useState(false);
+
     const saveUrl = useMemo(() => store.url(), []);
     const draftSaveUrl = useMemo(() => storeDraft.url(), []);
     const resourcesUrl = useMemo(() => resources.url(), []);
+    const mainTitleForLandingPage = useMemo(() => {
+        return titles.find((title) => title.titleType === MAIN_TITLE_SLUG)?.title.trim() || titles[0]?.title.trim() || undefined;
+    }, [titles]);
+    const selectedResourceTypeName = useMemo(() => {
+        return resourceTypes.find((type) => String(type.id) === form.resourceType)?.name;
+    }, [form.resourceType, resourceTypes]);
+    const buildLandingPageSetupResource = useCallback(
+        (resourceId: number): LandingPagePreviewSetupResource => ({
+            id: resourceId,
+            doi: form.doi?.trim() || null,
+            title: mainTitleForLandingPage,
+            resourcetypegeneral: selectedResourceTypeName,
+        }),
+        [form.doi, mainTitleForLandingPage, selectedResourceTypeName],
+    );
+    const openLandingPagePreview = useCallback((landingPage: LandingPagePreviewTarget) => {
+        const previewTarget = getLandingPagePreviewTarget(landingPage);
+
+        if (!previewTarget) {
+            toast.error('Unable to open landing page preview. The preview URL is missing.');
+            return;
+        }
+
+        window.open(previewTarget, '_blank', 'noopener,noreferrer');
+    }, []);
     const draftAutosaveMessage = useMemo(() => {
         if (draftAutosaveStatus === 'idle') {
             return null;
@@ -2212,7 +2279,7 @@ export default function DataCiteForm({
     }, [buildPayload, resolvedResourceId]);
 
     const saveDraftSilently = useCallback(async () => {
-        if (!isDraftSaveable || dateValidationIssues.length > 0 || isSaving || isSavingDraft || draftAutosaveInFlightRef.current) {
+        if (!isDraftSaveable || dateValidationIssues.length > 0 || isSaving || isSavingDraft || isPreparingLandingPagePreview || draftAutosaveInFlightRef.current) {
             return;
         }
 
@@ -2257,7 +2324,7 @@ export default function DataCiteForm({
         } finally {
             draftAutosaveInFlightRef.current = false;
         }
-    }, [buildPayload, dateValidationIssues.length, draftSaveUrl, isDraftSaveable, isSaving, isSavingDraft, markDraftAutosaveSaved]);
+    }, [buildPayload, dateValidationIssues.length, draftSaveUrl, isDraftSaveable, isPreparingLandingPagePreview, isSaving, isSavingDraft, markDraftAutosaveSaved]);
 
     useEffect(() => {
         const autosaveTimerId = window.setInterval(() => {
@@ -2563,6 +2630,122 @@ export default function DataCiteForm({
             setIsSavingDraft(false);
         }
     };
+
+    const saveDraftForLandingPagePreview = useCallback(async (): Promise<{ resourceId: number } | null> => {
+        if (!isDraftSaveable) return null;
+
+        setIsPreparingLandingPagePreview(true);
+        setErrorMessage(null);
+        setMappedValidationErrors([]);
+        clearBackendErrors();
+
+        if (dateValidationIssues.length > 0) {
+            setHasAttemptedSubmit(true);
+            revealValidationErrors({ dates: dateValidationIssues }, 'Please resolve the date validation issues before opening the landing page preview.');
+            setIsPreparingLandingPagePreview(false);
+            return null;
+        }
+
+        const payload = buildPayload();
+
+        try {
+            const response = await axios.post(draftSaveUrl, payload, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                },
+            });
+
+            const data = response.data as DraftSaveResponse | null;
+            const savedResourceId = data?.resource?.id ?? resolvedResourceId;
+
+            if (!savedResourceId) {
+                setErrorMessage('Unable to open landing page preview because the draft resource ID is missing.');
+                return null;
+            }
+
+            setResolvedResourceId(savedResourceId);
+            updateDraftAutosaveSignature(payload, savedResourceId);
+            setHasAttemptedSubmit(false);
+
+            return { resourceId: savedResourceId };
+        } catch (error) {
+            if (axios.isAxiosError(error)) {
+                const response = error.response;
+
+                if (response?.status === 419) {
+                    setErrorMessage('Your session has expired. Please refresh the page and try again.');
+                    return null;
+                }
+
+                if (response) {
+                    const defaultError = 'Unable to save draft before opening the landing page preview.';
+                    const parsed = response.data as { message?: string; errors?: Record<string, string[]> } | null;
+
+                    if (parsed?.errors) {
+                        applyBackendValidationErrors(parsed.errors, parsed.message, defaultError);
+                    } else {
+                        setErrorMessage(parsed?.message || defaultError);
+                    }
+
+                    return null;
+                }
+            }
+
+            console.error('Failed to save draft before opening landing page preview', error);
+            setErrorMessage('A network error prevented saving the draft before opening the landing page preview. Please try again.');
+            return null;
+        } finally {
+            setIsPreparingLandingPagePreview(false);
+        }
+    }, [
+        applyBackendValidationErrors,
+        buildPayload,
+        clearBackendErrors,
+        dateValidationIssues,
+        draftSaveUrl,
+        isDraftSaveable,
+        resolvedResourceId,
+        revealValidationErrors,
+        updateDraftAutosaveSignature,
+    ]);
+
+    const handleShowLandingPagePreview = useCallback(async () => {
+        const result = await saveDraftForLandingPagePreview();
+
+        if (!result) {
+            return;
+        }
+
+        if (landingPageForPreview) {
+            openLandingPagePreview(landingPageForPreview);
+            return;
+        }
+
+        setPendingLandingPageSetupResource(buildLandingPageSetupResource(result.resourceId));
+        setIsLandingPageSetupOpen(true);
+    }, [buildLandingPageSetupResource, landingPageForPreview, openLandingPagePreview, saveDraftForLandingPagePreview]);
+
+    const handleCloseLandingPageSetup = useCallback(() => {
+        setIsLandingPageSetupOpen(false);
+        setPendingLandingPageSetupResource(null);
+    }, []);
+
+    const handleLandingPageSetupSuccess = useCallback(
+        (landingPage?: LandingPageConfig | null) => {
+            if (landingPage) {
+                const summary = toEditorLandingPageSummary(landingPage);
+                setLandingPageForPreview(summary);
+                openLandingPagePreview(summary);
+            } else {
+                setLandingPageForPreview(null);
+            }
+
+            setIsLandingPageSetupOpen(false);
+            setPendingLandingPageSetupResource(null);
+        },
+        [openLandingPagePreview],
+    );
 
     // ===================================================================
     // Status Badge Rendering Helper
@@ -3219,7 +3402,7 @@ export default function DataCiteForm({
                                     type="button"
                                     variant="outline"
                                     data-testid="save-draft-button"
-                                    disabled={!isDraftSaveable || isSavingDraft || isSaving}
+                                    disabled={!isDraftSaveable || isSavingDraft || isSaving || isPreparingLandingPagePreview}
                                     aria-busy={isSavingDraft}
                                     onClick={handleSaveDraft}
                                 >
@@ -3238,11 +3421,33 @@ export default function DataCiteForm({
                         <TooltipTrigger asChild>
                             <span tabIndex={0}>
                                 <Button
+                                    type="button"
+                                    variant="outline"
+                                    data-testid="show-lp-preview-button"
+                                    disabled={!isDraftSaveable || dateValidationIssues.length > 0 || isSavingDraft || isSaving || isPreparingLandingPagePreview}
+                                    aria-busy={isPreparingLandingPagePreview}
+                                    onClick={() => void handleShowLandingPagePreview()}
+                                >
+                                    <Eye className="mr-2 h-4 w-4" />
+                                    {isPreparingLandingPagePreview ? 'Preparing...' : 'Show LP Preview'}
+                                </Button>
+                            </span>
+                        </TooltipTrigger>
+                        {!isDraftSaveable && !isPreparingLandingPagePreview && (
+                            <TooltipContent side="top" align="end" className="max-w-sm">
+                                <p className="text-sm">Enter a Main Title to preview the landing page.</p>
+                            </TooltipContent>
+                        )}
+                    </Tooltip>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span tabIndex={0}>
+                                <Button
                                     type="submit"
                                     data-testid="save-resource-button"
-                                    disabled={isSaving || isSavingDraft || hasLegacyKeywords}
+                                    disabled={isSaving || isSavingDraft || isPreparingLandingPagePreview || hasLegacyKeywords}
                                     aria-busy={isSaving}
-                                    aria-disabled={isSaving || isSavingDraft || hasLegacyKeywords}
+                                    aria-disabled={isSaving || isSavingDraft || isPreparingLandingPagePreview || hasLegacyKeywords}
                                 >
                                     {isSaving ? 'Saving...' : 'Save & Validate'}
                                 </Button>
@@ -3268,6 +3473,14 @@ export default function DataCiteForm({
                     </p>
                 )}
             </div>
+            {pendingLandingPageSetupResource && (
+                <SetupLandingPageModal
+                    resource={pendingLandingPageSetupResource}
+                    isOpen={isLandingPageSetupOpen}
+                    onClose={handleCloseLandingPageSetup}
+                    onSuccess={handleLandingPageSetupSuccess}
+                />
+            )}
             {/* DOI Conflict Modal */}
             {conflictData && (
                 <DoiConflictModal

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -121,12 +121,18 @@ type LandingPagePreviewSetupResource = {
     resourcetypegeneral?: string;
 };
 
+function normalizeLandingPagePreviewTarget(url?: string | null): string | null {
+    const trimmedUrl = url?.trim();
+
+    return trimmedUrl || null;
+}
+
 function getLandingPagePreviewTarget(landingPage: LandingPagePreviewTarget): string | null {
     if (landingPage.status === 'draft') {
-        return landingPage.preview_url ?? null;
+        return normalizeLandingPagePreviewTarget(landingPage.preview_url);
     }
 
-    return landingPage.public_url ?? landingPage.external_url ?? null;
+    return normalizeLandingPagePreviewTarget(landingPage.public_url) ?? normalizeLandingPagePreviewTarget(landingPage.external_url);
 }
 
 function getLandingPagePreviewMissingUrlMessage(landingPage: LandingPagePreviewTarget): string {

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -109,7 +109,7 @@ type DraftSaveResponse = {
 };
 
 type LandingPagePreviewTarget = {
-    status?: 'draft' | 'published' | string;
+    status?: LandingPageConfig['status'];
     public_url?: string | null;
     preview_url?: string | null;
     external_url?: string | null;

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -99,6 +99,8 @@ const ABSTRACT_MAX_LENGTH = 17500;
 const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
 const SECTION_TRIGGER_CLASS_NAME = 'hover:no-underline';
 const DRAFT_AUTOSAVE_INTERVAL_MS = 60_000;
+const LANDING_PAGE_PLACEHOLDER_URL = 'about:blank';
+const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
 
 type DraftAutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -141,6 +143,16 @@ function getLandingPagePreviewMissingUrlMessage(landingPage: LandingPagePreviewT
     }
 
     return 'Unable to open landing page. The public or external URL is missing.';
+}
+
+function openLandingPagePreviewPlaceholder(): Window | null {
+    const previewWindow = window.open(LANDING_PAGE_PLACEHOLDER_URL, '_blank');
+
+    if (previewWindow) {
+        previewWindow.opener = null;
+    }
+
+    return previewWindow;
 }
 
 function toEditorLandingPageSummary(landingPage: LandingPageConfig): EditorLandingPageSummary {
@@ -1958,18 +1970,24 @@ export default function DataCiteForm({
         }),
         [form.doi, mainTitleForLandingPage, selectedResourceTypeName],
     );
-    const openLandingPagePreview = useCallback((landingPage: LandingPagePreviewTarget) => {
+    const openLandingPagePreview = useCallback((landingPage: LandingPagePreviewTarget, preopenedWindow?: Window | null) => {
         const previewTarget = getLandingPagePreviewTarget(landingPage);
 
         if (!previewTarget) {
+            preopenedWindow?.close();
             toast.error(getLandingPagePreviewMissingUrlMessage(landingPage));
+            return;
+        }
+
+        if (preopenedWindow) {
+            preopenedWindow.location.href = previewTarget;
             return;
         }
 
         const openedWindow = window.open(previewTarget, '_blank', 'noopener,noreferrer');
 
         if (!openedWindow) {
-            toast.error('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
+            toast.error(LANDING_PAGE_POPUP_BLOCKED_MESSAGE);
         }
     }, []);
     const draftAutosaveMessage = useMemo(() => {
@@ -2729,14 +2747,26 @@ export default function DataCiteForm({
     ]);
 
     const handleShowLandingPagePreview = useCallback(async () => {
+        let preopenedPreviewWindow: Window | null = null;
+
+        if (landingPageForPreview) {
+            preopenedPreviewWindow = openLandingPagePreviewPlaceholder();
+
+            if (!preopenedPreviewWindow) {
+                toast.error(LANDING_PAGE_POPUP_BLOCKED_MESSAGE);
+                return;
+            }
+        }
+
         const result = await saveDraftForLandingPagePreview();
 
         if (!result) {
+            preopenedPreviewWindow?.close();
             return;
         }
 
         if (landingPageForPreview) {
-            openLandingPagePreview(landingPageForPreview);
+            openLandingPagePreview(landingPageForPreview, preopenedPreviewWindow);
             return;
         }
 

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -14,6 +14,7 @@ import {
 import { AccordionSectionHeader, SectionHelpAction } from '@/components/curation/section-header';
 import { mapBackendErrors, type MappedError } from '@/components/curation/utils/error-field-mapper';
 import { scheduleScrollToError } from '@/components/curation/utils/scroll-to-error';
+import { LANDING_PAGE_POPUP_BLOCKED_MESSAGE, openLandingPagePreviewPlaceholder } from '@/components/landing-pages/landing-page-preview-window';
 import SetupLandingPageModal from '@/components/landing-pages/modals/SetupLandingPageModal';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
@@ -99,8 +100,6 @@ const ABSTRACT_MAX_LENGTH = 17500;
 const CURATION_ACCORDION_PREFERENCE_URL = '/settings/curation-accordion';
 const SECTION_TRIGGER_CLASS_NAME = 'hover:no-underline';
 const DRAFT_AUTOSAVE_INTERVAL_MS = 60_000;
-const LANDING_PAGE_PLACEHOLDER_URL = 'about:blank';
-const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
 
 type DraftAutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -143,18 +142,6 @@ function getLandingPagePreviewMissingUrlMessage(landingPage: LandingPagePreviewT
     }
 
     return 'Unable to open landing page. The public or external URL is missing.';
-}
-
-function openLandingPagePreviewPlaceholder(): Window | null {
-    // Do not pass `noopener` here: browsers may return `null` for noopener
-    // windows, and this flow needs the WindowProxy to navigate after async save.
-    const previewWindow = window.open(LANDING_PAGE_PLACEHOLDER_URL, '_blank');
-
-    if (previewWindow) {
-        previewWindow.opener = null;
-    }
-
-    return previewWindow;
 }
 
 function toEditorLandingPageSummary(landingPage: LandingPageConfig): EditorLandingPageSummary {
@@ -3475,7 +3462,7 @@ export default function DataCiteForm({
                                     type="button"
                                     variant="outline"
                                     data-testid="show-lp-preview-button"
-                                    disabled={!isDraftSaveable || dateValidationIssues.length > 0 || isSavingDraft || isSaving || isPreparingLandingPagePreview}
+                                    disabled={!isDraftSaveable || isSavingDraft || isSaving || isPreparingLandingPagePreview}
                                     aria-busy={isPreparingLandingPagePreview}
                                     onClick={() => void handleShowLandingPagePreview()}
                                 >

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -129,6 +129,14 @@ function getLandingPagePreviewTarget(landingPage: LandingPagePreviewTarget): str
     return landingPage.public_url ?? landingPage.external_url ?? null;
 }
 
+function getLandingPagePreviewMissingUrlMessage(landingPage: LandingPagePreviewTarget): string {
+    if (landingPage.status === 'draft') {
+        return 'Unable to open landing page preview. The preview URL is missing.';
+    }
+
+    return 'Unable to open landing page. The public or external URL is missing.';
+}
+
 function toEditorLandingPageSummary(landingPage: LandingPageConfig): EditorLandingPageSummary {
     return {
         id: landingPage.id,
@@ -1948,11 +1956,15 @@ export default function DataCiteForm({
         const previewTarget = getLandingPagePreviewTarget(landingPage);
 
         if (!previewTarget) {
-            toast.error('Unable to open landing page preview. The preview URL is missing.');
+            toast.error(getLandingPagePreviewMissingUrlMessage(landingPage));
             return;
         }
 
-        window.open(previewTarget, '_blank', 'noopener,noreferrer');
+        const openedWindow = window.open(previewTarget, '_blank', 'noopener,noreferrer');
+
+        if (!openedWindow) {
+            toast.error('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
+        }
     }, []);
     const draftAutosaveMessage = useMemo(() => {
         if (draftAutosaveStatus === 'idle') {

--- a/resources/js/components/curation/types/datacite-form-types.ts
+++ b/resources/js/components/curation/types/datacite-form-types.ts
@@ -193,6 +193,15 @@ export type InitialContributor =
 // Component Props
 // ============================================================================
 
+export interface EditorLandingPageSummary {
+    id: number;
+    is_published: boolean;
+    status: 'draft' | 'published';
+    public_url: string;
+    preview_url?: string | null;
+    external_url?: string | null;
+}
+
 export interface DataCiteFormProps {
     resourceTypes: ResourceType[];
     titleTypes: TitleType[];
@@ -215,6 +224,7 @@ export interface DataCiteFormProps {
     initialLicenses?: string[];
     initialRawRights?: RawRightsInput[];
     initialResourceId?: string;
+    initialLandingPage?: EditorLandingPageSummary | null;
     initialAuthors?: InitialAuthor[];
     initialContributors?: InitialContributor[];
     initialDescriptions?: { type: string; description: string; language?: string | null }[];

--- a/resources/js/components/landing-pages/landing-page-preview-window.ts
+++ b/resources/js/components/landing-pages/landing-page-preview-window.ts
@@ -1,0 +1,14 @@
+export const LANDING_PAGE_PREVIEW_PLACEHOLDER_URL = 'about:blank';
+export const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
+
+export function openLandingPagePreviewPlaceholder(): Window | null {
+    // Do not pass `noopener` here: browsers may return `null` for noopener
+    // windows, and this flow needs the WindowProxy to navigate after async save.
+    const previewWindow = window.open(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
+
+    if (previewWindow) {
+        previewWindow.opener = null;
+    }
+
+    return previewWindow;
+}

--- a/resources/js/components/landing-pages/landing-page-preview-window.ts
+++ b/resources/js/components/landing-pages/landing-page-preview-window.ts
@@ -1,6 +1,20 @@
 export const LANDING_PAGE_PREVIEW_PLACEHOLDER_URL = 'about:blank';
 export const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
 
+function applyNoReferrerPolicy(previewWindow: Window): void {
+    try {
+        const previewDocument = previewWindow.document;
+        previewDocument.open();
+        previewDocument.write(
+            '<!doctype html><html><head><meta name="referrer" content="no-referrer"></head><body></body></html>',
+        );
+        previewDocument.close();
+    } catch {
+        // If the placeholder document cannot be touched, the tab can still be
+        // closed or navigated; the opener reference is removed before this runs.
+    }
+}
+
 export function openLandingPagePreviewPlaceholder(): Window | null {
     // Do not pass `noopener` here: browsers may return `null` for noopener
     // windows, and this flow needs the WindowProxy to navigate after async save.
@@ -8,6 +22,7 @@ export function openLandingPagePreviewPlaceholder(): Window | null {
 
     if (previewWindow) {
         previewWindow.opener = null;
+        applyNoReferrerPolicy(previewWindow);
     }
 
     return previewWindow;

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -70,6 +70,8 @@ type DownloadUrlSuggestionEntry = {
 };
 
 function openLandingPagePreviewPlaceholder(): Window | null {
+    // Do not pass `noopener` here: browsers may return `null` for noopener
+    // windows, and this flow needs the WindowProxy to navigate after async save.
     const previewWindow = window.open(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
 
     if (previewWindow) {

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -627,7 +627,6 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
         setIsSaving(true);
 
-
         try {
             await axios.delete(`/resources/${resource.id}/landing-page`);
             clearPersistedDraftState();

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -7,6 +7,7 @@ import { AlertTriangle, Copy, Eye, Globe, GripVertical, Plus, X } from 'lucide-r
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { LANDING_PAGE_POPUP_BLOCKED_MESSAGE, openLandingPagePreviewPlaceholder } from '@/components/landing-pages/landing-page-preview-window';
 import { ExternalLandingPageFields } from '@/components/landing-pages/modals/ExternalLandingPageFields';
 import {
     buildLandingPagePreviewPayload,
@@ -60,26 +61,12 @@ const EMPTY_DOWNLOAD_URL_SUGGESTIONS: LandingPageDownloadUrlSuggestions = {
 };
 
 const LANDING_PAGE_DRAFT_STORAGE_PREFIX = 'setup-landing-page-modal:draft';
-const LANDING_PAGE_PREVIEW_PLACEHOLDER_URL = 'about:blank';
-const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
 
 type DownloadUrlSuggestionEntry = {
     id: string;
     value: string;
     usageCount: number;
 };
-
-function openLandingPagePreviewPlaceholder(): Window | null {
-    // Do not pass `noopener` here: browsers may return `null` for noopener
-    // windows, and this flow needs the WindowProxy to navigate after async save.
-    const previewWindow = window.open(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
-
-    if (previewWindow) {
-        previewWindow.opener = null;
-    }
-
-    return previewWindow;
-}
 
 type PersistedLandingPageDraftState = {
     template: string;

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -49,7 +49,7 @@ interface SetupLandingPageModalProps {
     resource: Resource;
     isOpen: boolean;
     onClose: () => void;
-    onSuccess?: () => void;
+    onSuccess?: (landingPage?: LandingPageConfig | null) => void;
     existingConfig?: LandingPageConfig | null;
 }
 
@@ -577,7 +577,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 // Ignore errors from clearing preview session
             }
 
-            onSuccess?.();
+            onSuccess?.(response.data.landing_page ?? null);
         } catch (error) {
             console.error('Failed to save landing page:', error);
             toast.error(getLandingPageRequestErrorMessage(error, 'Failed to save landing page configuration'));
@@ -614,7 +614,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setPreviewUrl('');
             applyDraftState(buildDraftStateFromConfig(null));
             toast.success('Landing page preview removed successfully');
-            onSuccess?.();
+            onSuccess?.(null);
             onClose();
         } catch (error) {
             console.error('Failed to remove preview:', error);

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -59,12 +59,24 @@ const EMPTY_DOWNLOAD_URL_SUGGESTIONS: LandingPageDownloadUrlSuggestions = {
 };
 
 const LANDING_PAGE_DRAFT_STORAGE_PREFIX = 'setup-landing-page-modal:draft';
+const LANDING_PAGE_PREVIEW_PLACEHOLDER_URL = 'about:blank';
+const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
 
 type DownloadUrlSuggestionEntry = {
     id: string;
     value: string;
     usageCount: number;
 };
+
+function openLandingPagePreviewPlaceholder(): Window | null {
+    const previewWindow = window.open(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
+
+    if (previewWindow) {
+        previewWindow.opener = null;
+    }
+
+    return previewWindow;
+}
 
 type PersistedLandingPageDraftState = {
     template: string;
@@ -804,6 +816,13 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 return;
             }
 
+            const previewWindow = openLandingPagePreviewPlaceholder();
+
+            if (!previewWindow) {
+                toast.error(LANDING_PAGE_POPUP_BLOCKED_MESSAGE);
+                return;
+            }
+
             try {
                 const payload = buildLandingPagePreviewPayload({
                     template,
@@ -822,11 +841,12 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 // Store preview in session and get preview URL
                 const response = await axios.post<{ preview_url: string }>(`/resources/${resource.id}/landing-page/preview`, payload);
 
-                // Open preview in new tab
+                // Open preview in the tab that was created synchronously by the click handler.
                 const previewUrlFromServer = response.data?.preview_url;
                 const fallbackPreviewUrl = `/resources/${resource.id}/landing-page/preview`;
-                window.open(previewUrlFromServer || fallbackPreviewUrl, '_blank', 'noopener,noreferrer');
+                previewWindow.location.href = previewUrlFromServer || fallbackPreviewUrl;
             } catch (error) {
+                previewWindow.close();
                 console.error('Failed to create preview:', error);
                 toast.error(getLandingPageRequestErrorMessage(error, 'Failed to create preview'));
             }

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -49,8 +49,9 @@ interface SetupLandingPageModalProps {
     resource: Resource;
     isOpen: boolean;
     onClose: () => void;
-    onSuccess?: (landingPage?: LandingPageConfig | null) => void;
+    onSuccess?: (landingPage?: LandingPageConfig | null, preopenedPreviewWindow?: Window | null) => void;
     existingConfig?: LandingPageConfig | null;
+    openPreviewOnSuccess?: boolean;
 }
 
 const EMPTY_DOWNLOAD_URL_SUGGESTIONS: LandingPageDownloadUrlSuggestions = {
@@ -261,7 +262,7 @@ function SortableLinkItem({
     );
 }
 
-export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig }: SetupLandingPageModalProps) {
+export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig, openPreviewOnSuccess = false }: SetupLandingPageModalProps) {
     // PhysicalObject resources (IGSNs) default to the IGSN renderer; everything
     // else uses the standard `default_gfz` template.
     const initialTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, existingConfig?.template);
@@ -544,6 +545,17 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             return;
         }
 
+        let preopenedPreviewWindow: Window | null = null;
+
+        if (openPreviewOnSuccess) {
+            preopenedPreviewWindow = openLandingPagePreviewPlaceholder();
+
+            if (!preopenedPreviewWindow) {
+                toast.error(LANDING_PAGE_POPUP_BLOCKED_MESSAGE);
+                return;
+            }
+        }
+
         setIsSaving(true);
 
         try {
@@ -589,8 +601,15 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 // Ignore errors from clearing preview session
             }
 
-            onSuccess?.(response.data.landing_page ?? null);
+            const savedLandingPage = response.data.landing_page ?? null;
+
+            if (preopenedPreviewWindow) {
+                onSuccess?.(savedLandingPage, preopenedPreviewWindow);
+            } else {
+                onSuccess?.(savedLandingPage);
+            }
         } catch (error) {
+            preopenedPreviewWindow?.close();
             console.error('Failed to save landing page:', error);
             toast.error(getLandingPageRequestErrorMessage(error, 'Failed to save landing page configuration'));
         } finally {
@@ -618,6 +637,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         }
 
         setIsSaving(true);
+
 
         try {
             await axios.delete(`/resources/${resource.id}/landing-page`);

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -838,12 +838,17 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={5} title="Save">
                                 <p>
-                                    Choose one of two options:
+                                    Choose one of these actions:
                                 </p>
                                 <ul>
                                     <li>
                                         <strong>"Save Draft"</strong> – Save an incomplete dataset with just a Main Title. You can return later to
                                         complete it. Drafts are shown with an amber badge in the resource list and on the dashboard.
+                                    </li>
+                                    <li>
+                                        <strong>"Show LP Preview"</strong> – Save the current editor values as a draft first, then open the landing
+                                        page preview. If no landing page exists yet, ERNIE opens the setup modal. After creating the preview there,
+                                        the landing page opens in a new browser tab.
                                     </li>
                                     <li>
                                         <strong>"Save &amp; Validate"</strong> – Save and validate the complete dataset. All mandatory fields
@@ -1526,6 +1531,12 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             imported legacy files, and additional download links in the setup modal, but hides the complete Files section on the
                             preview and public landing page until the option is disabled again.
                         </p>
+                        <p>
+                            From the Data Editor, click <strong>Show LP Preview</strong> next to <strong>Save Draft</strong> and{' '}
+                            <strong>Save &amp; Validate</strong> to save the current metadata as a draft and open the landing page flow immediately.
+                            Existing landing pages open in a new browser tab. If the resource has no landing page yet, ERNIE opens the setup modal and
+                            automatically opens the preview after you create it.
+                        </p>
 
                         <WorkflowSteps>
                             <WorkflowSteps.Step number={1} title="Navigate to Resources">
@@ -1534,7 +1545,10 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 </p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={2} title="Create Landing Page">
-                                <p>Select the resource and click the <strong>Set up landing page</strong> quick action in the bulk toolbar to open the setup modal.</p>
+                                <p>
+                                    Select the resource and click the <strong>Set up landing page</strong> quick action in the bulk toolbar, or use{' '}
+                                    <strong>Show LP Preview</strong> directly in the Data Editor.
+                                </p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={3} title="Preview">
                                 <p>Review how the landing page will appear before publishing.</p>

--- a/resources/js/pages/editor.tsx
+++ b/resources/js/pages/editor.tsx
@@ -1,7 +1,7 @@
 import { Head, usePage } from '@inertiajs/react';
 import { useCallback, useEffect, useState } from 'react';
 
-import DataCiteForm, { type InitialAuthor, type InitialContributor, type RawRightsInput } from '@/components/curation/datacite-form';
+import DataCiteForm, { type EditorLandingPageSummary, type InitialAuthor, type InitialContributor, type RawRightsInput } from '@/components/curation/datacite-form';
 import { type FundingReferenceEntry } from '@/components/curation/fields/funding-reference';
 import { type SpatialTemporalCoverageEntry } from '@/components/curation/fields/spatial-temporal-coverage/types';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -38,6 +38,7 @@ interface EditorProps {
     initialLicenses?: string[];
     initialRawRights?: RawRightsInput[];
     resourceId?: string;
+    landingPage?: EditorLandingPageSummary | null;
     authors?: InitialAuthor[];
     contributors?: InitialContributor[];
     descriptions?: { type: string; description: string }[];
@@ -70,6 +71,7 @@ export default function Editor({
     initialLicenses = [],
     initialRawRights = [],
     resourceId,
+    landingPage = null,
     authors = [],
     contributors = [],
     descriptions = [],
@@ -274,6 +276,7 @@ export default function Editor({
                         initialLicenses={initialLicenses}
                         initialRawRights={initialRawRights}
                         initialResourceId={resourceId}
+                        initialLandingPage={landingPage}
                         initialAuthors={authors}
                         initialContributors={contributors}
                         initialDescriptions={descriptions}

--- a/tests/pest/Feature/Resources/EditorTest.php
+++ b/tests/pest/Feature/Resources/EditorTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
+use App\Models\Resource;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -23,4 +26,61 @@ test('authenticated users can view editor page', function () {
         ->where('titles', [])
         ->where('initialLicenses', [])
     );
+});
+
+test('editor exposes draft landing page preview summary for existing resource', function () {
+    $user = User::factory()->create();
+    $resource = Resource::factory()->create(['doi' => null]);
+    $landingPage = LandingPage::factory()
+        ->withoutDoi()
+        ->draft()
+        ->create([
+            'resource_id' => $resource->id,
+            'slug' => 'editor-draft-resource',
+            'template' => 'default_gfz',
+        ]);
+
+    withoutVite();
+
+    $this->actingAs($user)
+        ->get(route('editor', ['resourceId' => $resource->id]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('editor')
+            ->where('landingPage.id', $landingPage->id)
+            ->where('landingPage.is_published', false)
+            ->where('landingPage.status', 'draft')
+            ->where('landingPage.public_url', $landingPage->public_url)
+            ->where('landingPage.preview_url', $landingPage->preview_url)
+        );
+});
+
+test('editor exposes published external landing page public url for existing resource', function () {
+    $user = User::factory()->create();
+    $resource = Resource::factory()->create(['doi' => '10.5880/editor.external']);
+    $externalDomain = LandingPageDomain::factory()->withDomain('https://example.org/')->create();
+    $landingPage = LandingPage::factory()
+        ->published()
+        ->external()
+        ->create([
+            'resource_id' => $resource->id,
+            'doi_prefix' => '10.5880/editor.external',
+            'slug' => 'editor-external-resource',
+            'external_domain_id' => $externalDomain->id,
+            'external_path' => 'datasets/editor-resource',
+        ]);
+
+    withoutVite();
+
+    $this->actingAs($user)
+        ->get(route('editor', ['resourceId' => $resource->id]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('editor')
+            ->where('landingPage.id', $landingPage->id)
+            ->where('landingPage.is_published', true)
+            ->where('landingPage.status', 'published')
+            ->where('landingPage.public_url', 'https://example.org/datasets/editor-resource')
+            ->where('landingPage.external_url', 'https://example.org/datasets/editor-resource')
+        );
 });

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4718,7 +4718,7 @@ describe('DataCiteForm', () => {
             const previewWindow = {
                 location: { href: 'about:blank' },
                 close,
-                opener: null,
+                opener: { source: 'test-opener' },
             } as unknown as Window;
 
             return { close, previewWindow };
@@ -4766,6 +4766,7 @@ describe('DataCiteForm', () => {
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
             expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxios.post).toHaveBeenCalledWith(
                     '/editor/resources/draft',
@@ -5045,6 +5046,7 @@ describe('DataCiteForm', () => {
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
             expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxios.post).toHaveBeenCalledWith(
                     '/editor/resources/draft',

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4715,13 +4715,21 @@ describe('DataCiteForm', () => {
     describe('Landing page preview (Issue #968)', () => {
         const createPreopenedPreviewWindow = () => {
             const close = vi.fn();
+            const documentClose = vi.fn();
+            const documentOpen = vi.fn();
+            const documentWrite = vi.fn();
             const previewWindow = {
                 location: { href: 'about:blank' },
                 close,
+                document: {
+                    close: documentClose,
+                    open: documentOpen,
+                    write: documentWrite,
+                },
                 opener: { source: 'test-opener' },
             } as unknown as Window;
 
-            return { close, previewWindow };
+            return { close, documentClose, documentOpen, documentWrite, previewWindow };
         };
 
         it('renders the preview button and enables it after a Main Title is entered', { timeout: 30000 }, async () => {
@@ -4766,7 +4774,7 @@ describe('DataCiteForm', () => {
 
         it('saves the current editor state as a draft and opens an existing draft landing page preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const { previewWindow } = createPreopenedPreviewWindow();
+            const { documentWrite, previewWindow } = createPreopenedPreviewWindow();
             const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -4793,6 +4801,8 @@ describe('DataCiteForm', () => {
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
             expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(documentWrite).toHaveBeenCalledWith(expect.stringContaining('name="referrer"'));
+            expect(documentWrite).toHaveBeenCalledWith(expect.stringContaining('content="no-referrer"'));
             expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxios.post).toHaveBeenCalledWith(

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -19,7 +19,8 @@ type MockSetupLandingPageModalProps = {
         resourcetypegeneral?: string;
     };
     onClose?: () => void;
-    onSuccess?: (landingPage?: LandingPageConfig | null) => void;
+    onSuccess?: (landingPage?: LandingPageConfig | null, preopenedPreviewWindow?: Window | null) => void;
+    openPreviewOnSuccess?: boolean;
 };
 
 const { mockRouterPut, mockRouterVisit, mockSetupLandingPageModal, mockUsePageProps } = vi.hoisted(() => ({
@@ -4882,6 +4883,7 @@ describe('DataCiteForm', () => {
                     resourcetypegeneral: 'PhysicalObject',
                 }),
             );
+            expect(modalProps.openPreviewOnSuccess).toBe(true);
             expect(openSpy).not.toHaveBeenCalled();
             expect(mockRouterVisit).not.toHaveBeenCalled();
         });
@@ -4916,8 +4918,9 @@ describe('DataCiteForm', () => {
             });
         });
 
-        it('opens the new landing page preview after setup succeeds from the editor', { timeout: 30000 }, async () => {
+        it('opens the new landing page preview in the tab preopened by setup save', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const { previewWindow } = createPreopenedPreviewWindow();
             const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -4939,21 +4942,25 @@ describe('DataCiteForm', () => {
             const modalProps = calls[calls.length - 1][0];
 
             await act(async () => {
-                modalProps.onSuccess({
-                    id: 15,
-                    resource_id: 100,
-                    template: 'default_gfz',
-                    status: 'draft',
-                    public_url: 'https://example.test/draft-new-lp',
-                    preview_url: 'https://example.test/draft-new-lp?preview=token',
-                    external_url: null,
-                    view_count: 0,
-                    created_at: '2026-07-03T00:00:00Z',
-                    updated_at: '2026-07-03T00:00:00Z',
-                });
+                modalProps.onSuccess(
+                    {
+                        id: 15,
+                        resource_id: 100,
+                        template: 'default_gfz',
+                        status: 'draft',
+                        public_url: 'https://example.test/draft-new-lp',
+                        preview_url: 'https://example.test/draft-new-lp?preview=token',
+                        external_url: null,
+                        view_count: 0,
+                        created_at: '2026-07-03T00:00:00Z',
+                        updated_at: '2026-07-03T00:00:00Z',
+                    },
+                    previewWindow,
+                );
             });
 
-            expect(openSpy).toHaveBeenCalledWith('https://example.test/draft-new-lp?preview=token', '_blank', 'noopener,noreferrer');
+            expect(openSpy).not.toHaveBeenCalled();
+            expect(previewWindow.location.href).toBe('https://example.test/draft-new-lp?preview=token');
         });
 
         it('shows the preparing state while the preview draft save is in progress', { timeout: 30000 }, async () => {
@@ -5265,8 +5272,9 @@ describe('DataCiteForm', () => {
             expect(mockRouterVisit).not.toHaveBeenCalled();
         });
 
-        it('closes the setup modal without opening a tab when setup reports no landing page', { timeout: 30000 }, async () => {
+        it('closes the setup modal and preopened tab when setup reports no landing page', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const { close, previewWindow } = createPreopenedPreviewWindow();
             const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -5288,13 +5296,15 @@ describe('DataCiteForm', () => {
             const modalProps = calls[calls.length - 1][0];
 
             await act(async () => {
-                modalProps.onSuccess(null);
+                modalProps.onSuccess(null, previewWindow);
             });
 
             await waitFor(() => {
                 expect(screen.queryByTestId('setup-landing-page-modal')).not.toBeInTheDocument();
             });
             expect(openSpy).not.toHaveBeenCalled();
+            expect(close).toHaveBeenCalledTimes(1);
+            expect(previewWindow.location.href).toBe('about:blank');
         });
     });
     describe('Save Draft (Issue #548)', () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4725,6 +4725,8 @@ describe('DataCiteForm', () => {
             expect(previewButton).toBeEnabled();
         });
 
+
+
         it('saves the current editor state as a draft and opens an existing draft landing page preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
             const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
@@ -4834,6 +4836,36 @@ describe('DataCiteForm', () => {
             expect(mockRouterVisit).not.toHaveBeenCalled();
         });
 
+        it('closes the setup landing page modal from the editor flow', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 98 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Close Setup Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+            expect(await screen.findByTestId('setup-landing-page-modal')).toBeInTheDocument();
+
+            const calls = mockSetupLandingPageModal.mock.calls;
+            const modalProps = calls[calls.length - 1][0];
+
+            await act(async () => {
+                modalProps.onClose();
+            });
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('setup-landing-page-modal')).not.toBeInTheDocument();
+            });
+        });
+
         it('opens the new landing page preview after setup succeeds from the editor', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
             const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
@@ -4872,6 +4904,302 @@ describe('DataCiteForm', () => {
             });
 
             expect(openSpy).toHaveBeenCalledWith('https://example.test/draft-new-lp?preview=token', '_blank', 'noopener,noreferrer');
+        });
+
+        it('shows the preparing state while the preview draft save is in progress', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const draftSave = createDeferred<{
+                data: { message: string; resource: { id: number } };
+                status: number;
+                statusText: string;
+                headers: Record<string, never>;
+                config: Record<string, never>;
+            }>();
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockReturnValue(draftSave.promise);
+
+            renderDataCiteForm({
+                initialResourceId: '102',
+                initialTitles: [{ title: 'Preparing Preview Dataset', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 16,
+                    is_published: true,
+                    status: 'published',
+                    public_url: 'https://example.test/preparing-published',
+                    preview_url: null,
+                    external_url: null,
+                },
+            });
+
+            const previewButton = screen.getByTestId('show-lp-preview-button');
+            await user.click(previewButton);
+
+            await waitFor(() => {
+                expect(previewButton).toHaveTextContent('Preparing...');
+            });
+            expect(screen.getByTestId('save-draft-button')).toBeDisabled();
+            expect(screen.getByTestId('save-resource-button')).toBeDisabled();
+
+            await act(async () => {
+                draftSave.resolve({
+                    data: { message: 'Draft saved.', resource: { id: 102 } },
+                    status: 200,
+                    statusText: 'OK',
+                    headers: {},
+                    config: {},
+                });
+            });
+
+            await waitFor(() => {
+                expect(openSpy).toHaveBeenCalledWith('https://example.test/preparing-published', '_blank', 'noopener,noreferrer');
+            });
+        });
+
+        it('falls back to the existing resource ID and external URL for published external landing pages', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.' },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '44',
+                initialTitles: [{ title: 'External Dataset', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 9,
+                    is_published: true,
+                    status: 'published',
+                    public_url: undefined as unknown as string,
+                    preview_url: null,
+                    external_url: 'https://external.example.org/dataset',
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            await waitFor(() => {
+                expect(mockedAxios.post).toHaveBeenCalledWith(
+                    '/editor/resources/draft',
+                    expect.objectContaining({ resourceId: 44 }),
+                    expect.any(Object),
+                );
+            });
+            expect(openSpy).toHaveBeenCalledWith('https://external.example.org/dataset', '_blank', 'noopener,noreferrer');
+        });
+
+        it('shows an error instead of opening a draft landing page without a preview URL', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const { toast } = await import('sonner');
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 45 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '45',
+                initialTitles: [{ title: 'Draft Without Preview URL', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 10,
+                    is_published: false,
+                    status: 'draft',
+                    public_url: 'https://example.test/draft-without-preview',
+                    preview_url: null,
+                    external_url: null,
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Unable to open landing page preview. The preview URL is missing.');
+            });
+            expect(openSpy).not.toHaveBeenCalled();
+        });
+
+        it('shows an error instead of opening a published landing page without any URL', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const { toast } = await import('sonner');
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 46 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '46',
+                initialTitles: [{ title: 'Published Without URL', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 11,
+                    is_published: true,
+                    status: 'published',
+                    public_url: undefined as unknown as string,
+                    preview_url: null,
+                    external_url: null,
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            await waitFor(() => {
+                expect(toast.error).toHaveBeenCalledWith('Unable to open landing page preview. The preview URL is missing.');
+            });
+            expect(openSpy).not.toHaveBeenCalled();
+        });
+
+        it('shows an error when draft saving succeeds without any resource ID', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved without resource.' },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Missing Resource ID Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(await screen.findByText('Unable to open landing page preview because the draft resource ID is missing.')).toBeInTheDocument();
+            expect(screen.queryByTestId('setup-landing-page-modal')).not.toBeInTheDocument();
+            expect(openSpy).not.toHaveBeenCalled();
+        });
+
+        it('keeps the user in the editor when the preview draft save hits an expired session', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 419, data: {} },
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Expired Session Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(await screen.findByText('Your session has expired. Please refresh the page and try again.')).toBeInTheDocument();
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+            expect(mockSetupLandingPageModal).not.toHaveBeenCalledWith(expect.objectContaining({ isOpen: true }));
+        });
+
+        it('shows backend messages when preview draft saving fails without field errors', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockRejectedValue({
+                isAxiosError: true,
+                response: {
+                    status: 500,
+                    data: { message: 'Preview draft generation is temporarily unavailable.' },
+                },
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Backend Message Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(await screen.findByText('Preview draft generation is temporarily unavailable.')).toBeInTheDocument();
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+        });
+
+        it('shows mapped backend validation errors when preview draft saving fails with field errors', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockRejectedValue({
+                isAxiosError: true,
+                response: {
+                    status: 422,
+                    data: {
+                        message: 'Preview draft validation failed.',
+                        errors: {
+                            titles: ['A landing page preview title is required.'],
+                        },
+                    },
+                },
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Validation Error Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(await screen.findByText('Preview draft validation failed.')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /^A landing page preview title is required\.$/i })).toBeInTheDocument();
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+        });
+
+        it('shows a network error when preview draft saving fails without an axios response', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockRejectedValue(new Error('Network Error'));
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Network Error Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(
+                await screen.findByText('A network error prevented saving the draft before opening the landing page preview. Please try again.'),
+            ).toBeInTheDocument();
+            expect(consoleSpy).toHaveBeenCalledWith('Failed to save draft before opening landing page preview', expect.any(Error));
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+        });
+
+        it('closes the setup modal without opening a tab when setup reports no landing page', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 101 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Setup Removed Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+            expect(await screen.findByTestId('setup-landing-page-modal')).toBeInTheDocument();
+
+            const calls = mockSetupLandingPageModal.mock.calls;
+            const modalProps = calls[calls.length - 1][0];
+
+            await act(async () => {
+                modalProps.onSuccess(null);
+            });
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('setup-landing-page-modal')).not.toBeInTheDocument();
+            });
+            expect(openSpy).not.toHaveBeenCalled();
         });
     });
     describe('Save Draft (Issue #548)', () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4737,6 +4737,33 @@ describe('DataCiteForm', () => {
             expect(previewButton).toBeEnabled();
         });
 
+        it('shows guided date validation feedback when landing page preview is clicked with invalid dates', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 42 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Invalid Preview Date Dataset', titleType: 'main-title' }],
+                initialDates: [{ dateType: 'available', dateMode: 'single', startDate: '2999-01-01', endDate: '' }],
+            });
+
+            const previewButton = screen.getByTestId('show-lp-preview-button');
+            expect(previewButton).toBeEnabled();
+
+            await user.click(previewButton);
+
+            expect(mockedAxios.post).not.toHaveBeenCalled();
+            expect(openSpy).not.toHaveBeenCalled();
+            expect(await screen.findByText('Please resolve the date validation issues before opening the landing page preview.')).toBeInTheDocument();
+        });
+
         it('saves the current editor state as a draft and opens an existing draft landing page preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
             const { previewWindow } = createPreopenedPreviewWindow();

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -8,12 +8,26 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type 
 import DataCiteForm, { canAddLicense, canAddTitle, type DataCiteFormProps } from '@/components/curation/datacite-form';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
 import type { DateType, DescriptionType, Language, License, ResourceType, Role, TitleType } from '@/types';
+import type { LandingPageConfig } from '@/types/landing-page';
 
-const { mockRouterPut, mockRouterVisit, mockUsePageProps } = vi.hoisted(() => ({
+type MockSetupLandingPageModalProps = {
+    isOpen: boolean;
+    resource?: {
+        id: number;
+        doi?: string | null;
+        title?: string;
+        resourcetypegeneral?: string;
+    };
+    onClose?: () => void;
+    onSuccess?: (landingPage?: LandingPageConfig | null) => void;
+};
+
+const { mockRouterPut, mockRouterVisit, mockSetupLandingPageModal, mockUsePageProps } = vi.hoisted(() => ({
     mockRouterPut: vi.fn(),
     mockRouterVisit: vi.fn().mockImplementation((_url: string, options?: { onSuccess?: () => void }) => {
         options?.onSuccess?.();
     }),
+    mockSetupLandingPageModal: vi.fn(),
     mockUsePageProps: vi.fn(() => ({
         curationAccordionOpenItems: null as string[] | null,
     })),
@@ -34,6 +48,17 @@ vi.mock('@inertiajs/react', () => ({
 
 vi.mock('axios');
 vi.mock('@/hooks/use-ror-affiliations');
+vi.mock('@/components/landing-pages/modals/SetupLandingPageModal', () => ({
+    default: (props: MockSetupLandingPageModalProps) => {
+        mockSetupLandingPageModal(props);
+
+        if (!props.isOpen) {
+            return null;
+        }
+
+        return <div data-testid="setup-landing-page-modal" />;
+    },
+}));
 vi.mock('sonner', () => ({
     toast: {
         success: vi.fn(),
@@ -293,6 +318,7 @@ describe('DataCiteForm', () => {
         // Reset router mock for each test
         mockRouterPut.mockClear();
         mockRouterVisit.mockClear();
+        mockSetupLandingPageModal.mockClear();
         mockRouterVisit.mockImplementation((_url: string, options?: { onSuccess?: () => void }) => {
             options?.onSuccess?.();
         });
@@ -4685,6 +4711,169 @@ describe('DataCiteForm', () => {
         });
     });
 
+    describe('Landing page preview (Issue #968)', () => {
+        it('renders the preview button and enables it after a Main Title is entered', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+            renderDataCiteForm();
+
+            const previewButton = screen.getByTestId('show-lp-preview-button');
+            expect(previewButton).toBeDisabled();
+
+            await user.type(screen.getByRole('textbox', { name: /Title/ }), 'Preview Dataset');
+
+            expect(previewButton).toBeEnabled();
+        });
+
+        it('saves the current editor state as a draft and opens an existing draft landing page preview URL', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 42 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '42',
+                initialTitles: [{ title: 'Preview Dataset', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 7,
+                    is_published: false,
+                    status: 'draft',
+                    public_url: 'https://example.test/draft-without-token',
+                    preview_url: 'https://example.test/draft-preview?preview=token',
+                    external_url: null,
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            await waitFor(() => {
+                expect(mockedAxios.post).toHaveBeenCalledWith(
+                    '/editor/resources/draft',
+                    expect.objectContaining({ resourceId: 42 }),
+                    expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) }),
+                );
+            });
+            expect(openSpy).toHaveBeenCalledWith('https://example.test/draft-preview?preview=token', '_blank', 'noopener,noreferrer');
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+        });
+
+        it('opens an existing published landing page public URL after saving the draft', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 43 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '43',
+                initialTitles: [{ title: 'Published Dataset', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 8,
+                    is_published: true,
+                    status: 'published',
+                    public_url: 'https://example.test/published-resource',
+                    preview_url: 'https://example.test/published-resource?preview=token',
+                    external_url: null,
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            await waitFor(() => {
+                expect(openSpy).toHaveBeenCalledWith('https://example.test/published-resource', '_blank', 'noopener,noreferrer');
+            });
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+        });
+
+        it('opens the setup landing page modal after draft saving when no landing page exists', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 99 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                resourceTypes: [
+                    { id: 1, name: 'Dataset' },
+                    { id: 2, name: 'PhysicalObject' },
+                ],
+                initialResourceType: '2',
+                initialTitles: [{ title: 'Sample Preview', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(await screen.findByTestId('setup-landing-page-modal')).toBeInTheDocument();
+            const calls = mockSetupLandingPageModal.mock.calls;
+            const modalProps = calls[calls.length - 1][0];
+
+            expect(modalProps.resource).toEqual(
+                expect.objectContaining({
+                    id: 99,
+                    title: 'Sample Preview',
+                    resourcetypegeneral: 'PhysicalObject',
+                }),
+            );
+            expect(openSpy).not.toHaveBeenCalled();
+            expect(mockRouterVisit).not.toHaveBeenCalled();
+        });
+
+        it('opens the new landing page preview after setup succeeds from the editor', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 100 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'New LP Dataset', titleType: 'main-title' }],
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+            expect(await screen.findByTestId('setup-landing-page-modal')).toBeInTheDocument();
+
+            const calls = mockSetupLandingPageModal.mock.calls;
+            const modalProps = calls[calls.length - 1][0];
+
+            await act(async () => {
+                modalProps.onSuccess({
+                    id: 15,
+                    resource_id: 100,
+                    template: 'default_gfz',
+                    status: 'draft',
+                    public_url: 'https://example.test/draft-new-lp',
+                    preview_url: 'https://example.test/draft-new-lp?preview=token',
+                    external_url: null,
+                    view_count: 0,
+                    created_at: '2026-07-03T00:00:00Z',
+                    updated_at: '2026-07-03T00:00:00Z',
+                });
+            });
+
+            expect(openSpy).toHaveBeenCalledWith('https://example.test/draft-new-lp?preview=token', '_blank', 'noopener,noreferrer');
+        });
+    });
     describe('Save Draft (Issue #548)', () => {
         it('disables the draft button when no Main Title is entered', { timeout: 30000 }, async () => {
             render(

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4712,6 +4712,17 @@ describe('DataCiteForm', () => {
     });
 
     describe('Landing page preview (Issue #968)', () => {
+        const createPreopenedPreviewWindow = () => {
+            const close = vi.fn();
+            const previewWindow = {
+                location: { href: 'about:blank' },
+                close,
+                opener: null,
+            } as unknown as Window;
+
+            return { close, previewWindow };
+        };
+
         it('renders the preview button and enables it after a Main Title is entered', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
 
@@ -4725,11 +4736,10 @@ describe('DataCiteForm', () => {
             expect(previewButton).toBeEnabled();
         });
 
-
-
         it('saves the current editor state as a draft and opens an existing draft landing page preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 42 } },
@@ -4754,6 +4764,7 @@ describe('DataCiteForm', () => {
 
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(mockedAxios.post).toHaveBeenCalledWith(
                     '/editor/resources/draft',
@@ -4761,13 +4772,17 @@ describe('DataCiteForm', () => {
                     expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/json' }) }),
                 );
             });
-            expect(openSpy).toHaveBeenCalledWith('https://example.test/draft-preview?preview=token', '_blank', 'noopener,noreferrer');
+            await waitFor(() => {
+                expect(previewWindow.location.href).toBe('https://example.test/draft-preview?preview=token');
+            });
+            expect(openSpy).toHaveBeenCalledTimes(1);
             expect(mockRouterVisit).not.toHaveBeenCalled();
         });
 
         it('opens an existing published landing page public URL after saving the draft', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 43 } },
@@ -4792,15 +4807,17 @@ describe('DataCiteForm', () => {
 
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
-                expect(openSpy).toHaveBeenCalledWith('https://example.test/published-resource', '_blank', 'noopener,noreferrer');
+                expect(previewWindow.location.href).toBe('https://example.test/published-resource');
             });
+            expect(openSpy).toHaveBeenCalledTimes(1);
             expect(mockRouterVisit).not.toHaveBeenCalled();
         });
 
         it('shows a toast when the browser blocks the landing page tab', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
             const { toast } = await import('sonner');
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -4826,9 +4843,8 @@ describe('DataCiteForm', () => {
 
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
-            await waitFor(() => {
-                expect(openSpy).toHaveBeenCalledWith('https://example.test/published-resource', '_blank', 'noopener,noreferrer');
-            });
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(mockedAxios.post).not.toHaveBeenCalled();
             expect(toast.error).toHaveBeenCalledWith('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
         });
 
@@ -4942,7 +4958,8 @@ describe('DataCiteForm', () => {
 
         it('shows the preparing state while the preview draft save is in progress', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const draftSave = createDeferred<{
                 data: { message: string; resource: { id: number } };
                 status: number;
@@ -4969,6 +4986,7 @@ describe('DataCiteForm', () => {
             const previewButton = screen.getByTestId('show-lp-preview-button');
             await user.click(previewButton);
 
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(previewButton).toHaveTextContent('Preparing...');
             });
@@ -4986,13 +5004,15 @@ describe('DataCiteForm', () => {
             });
 
             await waitFor(() => {
-                expect(openSpy).toHaveBeenCalledWith('https://example.test/preparing-published', '_blank', 'noopener,noreferrer');
+                expect(previewWindow.location.href).toBe('https://example.test/preparing-published');
             });
+            expect(openSpy).toHaveBeenCalledTimes(1);
         });
 
         it('falls back to the existing resource ID and external URL for published external landing pages', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.' },
@@ -5017,6 +5037,7 @@ describe('DataCiteForm', () => {
 
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(mockedAxios.post).toHaveBeenCalledWith(
                     '/editor/resources/draft',
@@ -5024,12 +5045,15 @@ describe('DataCiteForm', () => {
                     expect.any(Object),
                 );
             });
-            expect(openSpy).toHaveBeenCalledWith('https://external.example.org/dataset', '_blank', 'noopener,noreferrer');
+            await waitFor(() => {
+                expect(previewWindow.location.href).toBe('https://external.example.org/dataset');
+            });
         });
 
         it('shows an error instead of opening a draft landing page without a preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const { close, previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const { toast } = await import('sonner');
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -5055,15 +5079,18 @@ describe('DataCiteForm', () => {
 
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(toast.error).toHaveBeenCalledWith('Unable to open landing page preview. The preview URL is missing.');
             });
-            expect(openSpy).not.toHaveBeenCalled();
+            expect(close).toHaveBeenCalledTimes(1);
+            expect(previewWindow.location.href).toBe('about:blank');
         });
 
         it('shows an error instead of opening a published landing page without any URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
+            const { close, previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
             const { toast } = await import('sonner');
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -5089,10 +5116,44 @@ describe('DataCiteForm', () => {
 
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(toast.error).toHaveBeenCalledWith('Unable to open landing page. The public or external URL is missing.');
             });
-            expect(openSpy).not.toHaveBeenCalled();
+            expect(close).toHaveBeenCalledTimes(1);
+            expect(previewWindow.location.href).toBe('about:blank');
+        });
+
+        it('closes the preopened landing page tab when preview draft saving fails', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const { close, previewWindow } = createPreopenedPreviewWindow();
+            const openSpy = vi.spyOn(window, 'open').mockReturnValue(previewWindow);
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 419, data: {} },
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '47',
+                initialTitles: [{ title: 'Existing Preview Save Failure', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 12,
+                    is_published: true,
+                    status: 'published',
+                    public_url: 'https://example.test/save-failure',
+                    preview_url: null,
+                    external_url: null,
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(await screen.findByText('Your session has expired. Please refresh the page and try again.')).toBeInTheDocument();
+            expect(close).toHaveBeenCalledTimes(1);
+            expect(previewWindow.location.href).toBe('about:blank');
+            expect(mockRouterVisit).not.toHaveBeenCalled();
         });
 
         it('shows an error when draft saving succeeds without any resource ID', { timeout: 30000 }, async () => {

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -5009,9 +5009,9 @@ describe('DataCiteForm', () => {
                     id: 9,
                     is_published: true,
                     status: 'published',
-                    public_url: undefined as unknown as string,
+                    public_url: '   ',
                     preview_url: null,
-                    external_url: 'https://external.example.org/dataset',
+                    external_url: '  https://external.example.org/dataset  ',
                 },
             });
 
@@ -5048,7 +5048,7 @@ describe('DataCiteForm', () => {
                     is_published: false,
                     status: 'draft',
                     public_url: 'https://example.test/draft-without-preview',
-                    preview_url: null,
+                    preview_url: '   ',
                     external_url: null,
                 },
             });
@@ -5081,9 +5081,9 @@ describe('DataCiteForm', () => {
                     id: 11,
                     is_published: true,
                     status: 'published',
-                    public_url: undefined as unknown as string,
+                    public_url: '   ',
                     preview_url: null,
-                    external_url: null,
+                    external_url: '',
                 },
             });
 

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -4729,7 +4729,7 @@ describe('DataCiteForm', () => {
 
         it('saves the current editor state as a draft and opens an existing draft landing page preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 42 } },
@@ -4767,7 +4767,7 @@ describe('DataCiteForm', () => {
 
         it('opens an existing published landing page public URL after saving the draft', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 43 } },
@@ -4798,9 +4798,43 @@ describe('DataCiteForm', () => {
             expect(mockRouterVisit).not.toHaveBeenCalled();
         });
 
-        it('opens the setup landing page modal after draft saving when no landing page exists', { timeout: 30000 }, async () => {
+        it('shows a toast when the browser blocks the landing page tab', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
             const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const { toast } = await import('sonner');
+            const mockedAxios = axios as unknown as { post: Mock };
+            mockedAxios.post.mockResolvedValue({
+                data: { message: 'Draft saved.', resource: { id: 43 } },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: {},
+            });
+
+            renderDataCiteForm({
+                initialResourceId: '43',
+                initialTitles: [{ title: 'Blocked Popup Dataset', titleType: 'main-title' }],
+                initialLandingPage: {
+                    id: 8,
+                    is_published: true,
+                    status: 'published',
+                    public_url: 'https://example.test/published-resource',
+                    preview_url: 'https://example.test/published-resource?preview=token',
+                    external_url: null,
+                },
+            });
+
+            await user.click(screen.getByTestId('show-lp-preview-button'));
+
+            await waitFor(() => {
+                expect(openSpy).toHaveBeenCalledWith('https://example.test/published-resource', '_blank', 'noopener,noreferrer');
+            });
+            expect(toast.error).toHaveBeenCalledWith('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
+        });
+
+        it('opens the setup landing page modal after draft saving when no landing page exists', { timeout: 30000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 99 } },
@@ -4868,7 +4902,7 @@ describe('DataCiteForm', () => {
 
         it('opens the new landing page preview after setup succeeds from the editor', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 100 } },
@@ -4908,7 +4942,7 @@ describe('DataCiteForm', () => {
 
         it('shows the preparing state while the preview draft save is in progress', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const draftSave = createDeferred<{
                 data: { message: string; resource: { id: number } };
                 status: number;
@@ -4958,7 +4992,7 @@ describe('DataCiteForm', () => {
 
         it('falls back to the existing resource ID and external URL for published external landing pages', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.' },
@@ -4995,7 +5029,7 @@ describe('DataCiteForm', () => {
 
         it('shows an error instead of opening a draft landing page without a preview URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const { toast } = await import('sonner');
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -5029,7 +5063,7 @@ describe('DataCiteForm', () => {
 
         it('shows an error instead of opening a published landing page without any URL', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const { toast } = await import('sonner');
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
@@ -5056,14 +5090,14 @@ describe('DataCiteForm', () => {
             await user.click(screen.getByTestId('show-lp-preview-button'));
 
             await waitFor(() => {
-                expect(toast.error).toHaveBeenCalledWith('Unable to open landing page preview. The preview URL is missing.');
+                expect(toast.error).toHaveBeenCalledWith('Unable to open landing page. The public or external URL is missing.');
             });
             expect(openSpy).not.toHaveBeenCalled();
         });
 
         it('shows an error when draft saving succeeds without any resource ID', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved without resource.' },
@@ -5172,7 +5206,7 @@ describe('DataCiteForm', () => {
 
         it('closes the setup modal without opening a tab when setup reports no landing page', { timeout: 30000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
-            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+            const openSpy = vi.spyOn(window, 'open').mockImplementation(() => window);
             const mockedAxios = axios as unknown as { post: Mock };
             mockedAxios.post.mockResolvedValue({
                 data: { message: 'Draft saved.', resource: { id: 101 } },

--- a/tests/vitest/components/landing-pages/__tests__/landing-page-preview-window.test.ts
+++ b/tests/vitest/components/landing-pages/__tests__/landing-page-preview-window.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    LANDING_PAGE_PREVIEW_PLACEHOLDER_URL,
+    openLandingPagePreviewPlaceholder,
+} from '@/components/landing-pages/landing-page-preview-window';
+
+describe('landing-page-preview-window', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('opens a placeholder tab with a no-referrer policy and no opener reference', () => {
+        const documentClose = vi.fn();
+        const documentOpen = vi.fn();
+        const documentWrite = vi.fn();
+        const previewWindow = {
+            close: vi.fn(),
+            document: {
+                close: documentClose,
+                open: documentOpen,
+                write: documentWrite,
+            },
+            location: { href: LANDING_PAGE_PREVIEW_PLACEHOLDER_URL },
+            opener: { source: 'test-opener' },
+        } as unknown as Window;
+        const open = vi.fn().mockReturnValue(previewWindow);
+        vi.stubGlobal('open', open);
+
+        const result = openLandingPagePreviewPlaceholder();
+
+        expect(open).toHaveBeenCalledWith(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
+        expect(result).toBe(previewWindow);
+        expect(documentOpen).toHaveBeenCalledOnce();
+        expect(documentWrite).toHaveBeenCalledWith(expect.stringContaining('name="referrer"'));
+        expect(documentWrite).toHaveBeenCalledWith(expect.stringContaining('content="no-referrer"'));
+        expect(documentClose).toHaveBeenCalledOnce();
+        expect(previewWindow.opener).toBeNull();
+    });
+
+    it('returns null when the browser blocks the placeholder tab', () => {
+        const open = vi.fn().mockReturnValue(null);
+        vi.stubGlobal('open', open);
+
+        expect(openLandingPagePreviewPlaceholder()).toBeNull();
+        expect(open).toHaveBeenCalledWith(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
+    });
+
+    it('still returns the placeholder tab when the no-referrer document cannot be written', () => {
+        const previewWindow = {
+            close: vi.fn(),
+            get document() {
+                throw new Error('Document access failed');
+            },
+            location: { href: LANDING_PAGE_PREVIEW_PLACEHOLDER_URL },
+            opener: { source: 'test-opener' },
+        } as unknown as Window;
+        const open = vi.fn().mockReturnValue(previewWindow);
+        vi.stubGlobal('open', open);
+
+        const result = openLandingPagePreviewPlaceholder();
+
+        expect(result).toBe(previewWindow);
+        expect(previewWindow.opener).toBeNull();
+    });
+});

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -982,6 +982,7 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('removes draft landing page preview', async () => {
+            const onSuccess = vi.fn();
             // Use a draft config (not published)
             const draftConfig = { ...mockExistingConfig, status: 'draft' as const };
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: draftConfig } });
@@ -997,6 +998,7 @@ describe('SetupLandingPageModal', () => {
                     resource={mockResource}
                     isOpen={true}
                     onClose={mockOnClose}
+                    onSuccess={onSuccess}
                 />,
             );
 
@@ -1014,6 +1016,7 @@ describe('SetupLandingPageModal', () => {
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
                 );
             });
+            expect(onSuccess).toHaveBeenCalledWith(null);
 
             // Cleanup
             vi.unstubAllGlobals();
@@ -2455,7 +2458,49 @@ describe('SetupLandingPageModal', () => {
             await user.click(saveButton);
 
             await waitFor(() => {
-                expect(onSuccess).toHaveBeenCalled();
+                expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ id: mockExistingConfig.id, status: 'draft' }));
+            });
+        });
+
+        it('calls onSuccess with null when the save response contains no landing page', async () => {
+            const onSuccess = vi.fn();
+
+            mockedAxiosGet.mockImplementation((url: string) => {
+                if (url.includes('/api/landing-page-templates')) {
+                    return Promise.resolve({ data: { templates: [] } });
+                }
+                if (url.includes('/api/landing-page-domains')) {
+                    return Promise.resolve({ data: { domains: [] } });
+                }
+                return Promise.reject({ isAxiosError: true, response: { status: 404 } });
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page request accepted',
+                    preview_url: '/preview',
+                },
+            });
+            mockedAxiosDelete.mockResolvedValue({});
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    onSuccess={onSuccess}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('dialog')).toBeInTheDocument();
+            });
+
+            await user.click(screen.getByRole('button', { name: /Create Preview/i }));
+
+            await waitFor(() => {
+                expect(onSuccess).toHaveBeenCalledWith(null);
             });
         });
 

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -94,6 +94,17 @@ describe('SetupLandingPageModal', () => {
 
     const mockOnClose = vi.fn();
 
+    const createPreopenedPreviewWindow = () => {
+        const close = vi.fn();
+        const previewWindow = {
+            location: { href: 'about:blank' },
+            close,
+            opener: null,
+        } as unknown as Window;
+
+        return { close, previewWindow };
+    };
+
     beforeEach(() => {
         vi.clearAllMocks();
         window.sessionStorage.clear();
@@ -1240,7 +1251,8 @@ describe('SetupLandingPageModal', () => {
                 data: { preview_url: '/resources/123/landing-page/preview' },
             });
 
-            const mockOpen = vi.fn();
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const mockOpen = vi.fn().mockReturnValue(previewWindow);
             vi.stubGlobal('open', mockOpen);
 
             const user = userEvent.setup();
@@ -1256,6 +1268,7 @@ describe('SetupLandingPageModal', () => {
             await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
             await user.click(screen.getByRole('button', { name: /^Preview$/i }));
 
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(mockedAxiosPost).toHaveBeenCalledWith(
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
@@ -1267,12 +1280,84 @@ describe('SetupLandingPageModal', () => {
                 );
             });
 
-            expect(mockOpen).toHaveBeenCalledWith(
-                '/resources/123/landing-page/preview',
-                '_blank',
-                'noopener,noreferrer',
+            await waitFor(() => {
+                expect(previewWindow.location.href).toBe('/resources/123/landing-page/preview');
+            });
+            expect(mockOpen).toHaveBeenCalledTimes(1);
+
+            vi.unstubAllGlobals();
+        });
+
+        it('shows a toast without generating a session preview when the placeholder tab is blocked', async () => {
+            const draftConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft',
+                downloads_unavailable: false,
+            };
+            mockedAxiosGet.mockResolvedValue({ data: { landing_page: draftConfig } });
+
+            const mockOpen = vi.fn().mockReturnValue(null);
+            vi.stubGlobal('open', mockOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
             );
 
+            await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(mockedAxiosPost).not.toHaveBeenCalled();
+            expect(mockedToastError).toHaveBeenCalledWith('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
+
+            vi.unstubAllGlobals();
+        });
+
+        it('closes the preopened session preview tab when preview generation fails', async () => {
+            const draftConfig: LandingPageConfig = {
+                ...mockExistingConfig,
+                status: 'draft',
+                downloads_unavailable: false,
+            };
+            mockedAxiosGet.mockResolvedValue({ data: { landing_page: draftConfig } });
+            mockedAxiosPost.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 500, data: { message: 'Preview generation failed.' } },
+            });
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const { close, previewWindow } = createPreopenedPreviewWindow();
+            const mockOpen = vi.fn().mockReturnValue(previewWindow);
+            vi.stubGlobal('open', mockOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                />,
+            );
+
+            await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
+            await user.click(screen.getByRole('button', { name: /^Preview$/i }));
+
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            await waitFor(() => {
+                expect(mockedToastError).toHaveBeenCalledWith('Preview generation failed.');
+            });
+            expect(close).toHaveBeenCalledTimes(1);
+            expect(previewWindow.location.href).toBe('about:blank');
+            expect(consoleSpy).toHaveBeenCalledWith('Failed to create preview:', expect.any(Object));
+
+            consoleSpy.mockRestore();
             vi.unstubAllGlobals();
         });
 
@@ -2290,7 +2375,8 @@ describe('SetupLandingPageModal', () => {
                 });
             });
 
-            const mockOpen = vi.fn();
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const mockOpen = vi.fn().mockReturnValue(previewWindow);
             vi.stubGlobal('open', mockOpen);
 
             const user = userEvent.setup();
@@ -2323,6 +2409,7 @@ describe('SetupLandingPageModal', () => {
             expect(previewButton).toBeDefined();
             await user.click(previewButton!);
 
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
             await waitFor(() => {
                 expect(mockedAxiosPost).toHaveBeenCalledWith(
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
@@ -2331,6 +2418,9 @@ describe('SetupLandingPageModal', () => {
                         landing_page_template_id: 8,
                     }),
                 );
+            });
+            await waitFor(() => {
+                expect(previewWindow.location.href).toBe('/resources/123/landing-page/preview');
             });
 
             vi.unstubAllGlobals();

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -96,13 +96,21 @@ describe('SetupLandingPageModal', () => {
 
     const createPreopenedPreviewWindow = () => {
         const close = vi.fn();
+        const documentClose = vi.fn();
+        const documentOpen = vi.fn();
+        const documentWrite = vi.fn();
         const previewWindow = {
             location: { href: 'about:blank' },
             close,
+            document: {
+                close: documentClose,
+                open: documentOpen,
+                write: documentWrite,
+            },
             opener: { source: 'test-opener' },
         } as unknown as Window;
 
-        return { close, previewWindow };
+        return { close, documentClose, documentOpen, documentWrite, previewWindow };
     };
 
     beforeEach(() => {
@@ -843,7 +851,7 @@ describe('SetupLandingPageModal', () => {
                 },
             });
             const onSuccess = vi.fn();
-            const { previewWindow } = createPreopenedPreviewWindow();
+            const { documentWrite, previewWindow } = createPreopenedPreviewWindow();
             const mockOpen = vi.fn().mockReturnValue(previewWindow);
             vi.stubGlobal('open', mockOpen);
 
@@ -862,6 +870,8 @@ describe('SetupLandingPageModal', () => {
             await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(documentWrite).toHaveBeenCalledWith(expect.stringContaining('name="referrer"'));
+            expect(documentWrite).toHaveBeenCalledWith(expect.stringContaining('content="no-referrer"'));
             expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxiosPost).toHaveBeenCalledWith(

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -827,6 +827,122 @@ describe('SetupLandingPageModal', () => {
             });
         });
 
+        it('passes a preopened preview tab to onSuccess when auto-opening after save is requested', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+            const landingPage = {
+                ...mockExistingConfig,
+                status: 'draft' as const,
+            };
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    message: 'Landing page created',
+                    landing_page: landingPage,
+                },
+            });
+            const onSuccess = vi.fn();
+            const { previewWindow } = createPreopenedPreviewWindow();
+            const mockOpen = vi.fn().mockReturnValue(previewWindow);
+            vi.stubGlobal('open', mockOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    onSuccess={onSuccess}
+                    openPreviewOnSuccess={true}
+                />,
+            );
+
+            await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
+
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({ template: 'default_gfz', status: 'draft' }),
+                );
+            });
+            expect(onSuccess).toHaveBeenCalledWith(landingPage, previewWindow);
+            expect(previewWindow.location.href).toBe('about:blank');
+
+            vi.unstubAllGlobals();
+        });
+
+        it('does not save when the auto-open preview tab is blocked', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+            const mockOpen = vi.fn().mockReturnValue(null);
+            vi.stubGlobal('open', mockOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    openPreviewOnSuccess={true}
+                />,
+            );
+
+            await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
+
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(mockedAxiosPost).not.toHaveBeenCalled();
+            expect(mockedToastError).toHaveBeenCalledWith(
+                'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.',
+            );
+
+            vi.unstubAllGlobals();
+        });
+
+        it('closes the preopened preview tab when auto-open save fails', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+            mockedAxiosPost.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 500, data: { message: 'Preview save failed.' } },
+            });
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const { close, previewWindow } = createPreopenedPreviewWindow();
+            const mockOpen = vi.fn().mockReturnValue(previewWindow);
+            vi.stubGlobal('open', mockOpen);
+
+            const user = userEvent.setup();
+
+            render(
+                <SetupLandingPageModal
+                    resource={mockResource}
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    openPreviewOnSuccess={true}
+                />,
+            );
+
+            await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
+
+            expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            await waitFor(() => {
+                expect(mockedToastError).toHaveBeenCalledWith('Preview save failed.');
+            });
+            expect(close).toHaveBeenCalledTimes(1);
+            expect(previewWindow.location.href).toBe('about:blank');
+            expect(consoleSpy).toHaveBeenCalledWith('Failed to save landing page:', expect.any(Object));
+
+            consoleSpy.mockRestore();
+            vi.unstubAllGlobals();
+        });
+
         it('sends downloads unavailable while preserving the entered download URL', async () => {
             mockedAxiosGet.mockRejectedValue({
                 isAxiosError: true,
@@ -1314,7 +1430,9 @@ describe('SetupLandingPageModal', () => {
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
             expect(mockedAxiosPost).not.toHaveBeenCalled();
-            expect(mockedToastError).toHaveBeenCalledWith('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
+            expect(mockedToastError).toHaveBeenCalledWith(
+                'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.',
+            );
 
             vi.unstubAllGlobals();
         });

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -99,7 +99,7 @@ describe('SetupLandingPageModal', () => {
         const previewWindow = {
             location: { href: 'about:blank' },
             close,
-            opener: null,
+            opener: { source: 'test-opener' },
         } as unknown as Window;
 
         return { close, previewWindow };
@@ -862,6 +862,7 @@ describe('SetupLandingPageModal', () => {
             await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxiosPost).toHaveBeenCalledWith(
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
@@ -1385,6 +1386,7 @@ describe('SetupLandingPageModal', () => {
             await user.click(screen.getByRole('button', { name: /^Preview$/i }));
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxiosPost).toHaveBeenCalledWith(
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),
@@ -2528,6 +2530,7 @@ describe('SetupLandingPageModal', () => {
             await user.click(previewButton!);
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
+            expect(previewWindow.opener).toBeNull();
             await waitFor(() => {
                 expect(mockedAxiosPost).toHaveBeenCalledWith(
                     expect.stringContaining(`/resources/${mockResource.id}/landing-page/preview`),

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -360,6 +360,28 @@ describe('Docs page', () => {
         expect(screen.getByText('Creating Landing Pages')).toBeInTheDocument();
     });
 
+    it('documents the landing page preview action in the Data Editor', async () => {
+        const { user } = renderDocsPage('curator');
+
+        await openDatasetsTab(user);
+
+        expect(screen.getAllByText('Show LP Preview').length).toBeGreaterThan(0);
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return (
+                    text.includes('From the Data Editor, click Show LP Preview next to Save Draft and Save & Validate') &&
+                    text.includes('automatically opens the preview after you create it.')
+                );
+            }),
+        ).toBeInTheDocument();
+    });
+
     it('documents resource quick actions and grouped delete behavior for curators', async () => {
         const { user } = renderDocsPage('curator');
 

--- a/tests/vitest/pages/__tests__/editor.test.tsx
+++ b/tests/vitest/pages/__tests__/editor.test.tsx
@@ -254,6 +254,31 @@ describe('Editor page', () => {
         );
     });
 
+    it('passes landing page summary to DataCiteForm when provided', async () => {
+        const landingPage = {
+            id: 1,
+            is_published: false,
+            status: 'draft' as const,
+            public_url: 'https://example.test/draft-resource',
+            preview_url: 'https://example.test/draft-resource?preview=token',
+            external_url: null,
+        };
+
+        render(
+            <Editor
+                maxTitles={99}
+                maxLicenses={99}
+                googleMapsApiKey="test-api-key"
+                landingPage={landingPage}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(renderForm).toHaveBeenCalledWith(
+                expect.objectContaining({ initialLandingPage: landingPage }),
+            ),
+        );
+    });
     it('passes initial licenses to DataCiteForm when provided', async () => {
         const initialLicenses = ['MIT'];
         render(


### PR DESCRIPTION
This pull request introduces a major new feature to the Data Editor: the ability for curators to preview the landing page (LP) directly from the editor. It adds a "Show LP Preview" button, which saves the current draft and opens the landing page preview or public URL in a new tab. If no landing page exists yet, a setup modal is launched and the preview opens after setup. The implementation includes backend support, frontend UI/UX changes, and updates to the data transformer and changelog.

**Landing Page Preview Feature:**

- Added a "Show LP Preview" button to the Data Editor, allowing curators to preview the landing page. This button saves the current draft, handles validation, and opens the preview or public URL in a new tab. If a landing page does not exist, a setup modal is displayed and the preview is opened after setup. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R3469-R3499) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R2670-R2798) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R3525-R3533)
- Implemented supporting state management, error handling, and utility functions in the `datacite-form.tsx` component to manage the preview workflow and user feedback. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R1950-R1992) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R112-R168) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R102-R103) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2215-R2318) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L2260-R2363) [[6]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3222-R3454)

**Backend and Data Transformation:**

- Updated the backend resource loading to include the landing page's external domain and added landing page summary data (ID, status, URLs) to the editor's data transformer output. [[1]](diffhunk://#diff-1012c99432cc3612cb095dbccf2ae7fa10d9acdfc8b622fa82a4623277274d30R274) [[2]](diffhunk://#diff-05d8086ed1dbd0fcd8a47572e4ab4dbe3a98b3c66a475313a0d9b39f10de73c4R84-R91)

**UI and TypeScript Enhancements:**

- Added new imports, types, and modal integration for landing page preview and setup in the Data Editor's TypeScript code. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R17) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R32) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R69) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L89-R92) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R257)

**Changelog Update:**

- Updated the changelog to document the new landing page preview feature for curators.

These changes collectively make it much easier for curators to preview and validate landing pages as part of their editorial workflow.