### PR TITLE
Feature: Floating Editor Actions in Data Editor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10580,11 +10580,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.3",
+            "version": "2.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4048833dd47b377287818841877fb3087289509c",
-                "reference": "4048833dd47b377287818841877fb3087289509c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f0fe3fb03bb53ce68cc2416785b260e62226ec27",
+                "reference": "f0fe3fb03bb53ce68cc2416785b260e62226ec27",
                 "shasum": ""
             },
             "require": {
@@ -10640,7 +10640,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-30T21:15:26+00:00"
+            "time": "2026-07-03T07:00:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5433,14 +5433,14 @@
       }
     },
     "node_modules/@vis.gl/react-google-maps": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
-      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.9.0.tgz",
+      "integrity": "sha512-ELL/zo8mRMPGDQZwHRClf2tE1/PMYYKjg+C/dUn8rmlQ0e+s7rkcNmCgaeBAV48GJzEcrBsr+vjDv4AvzJrlUA==",
       "license": "MIT",
       "dependencies": {
         "@googlemaps/js-api-loader": "^2.0.2",
-        "@types/google.maps": "^3.54.10",
-        "fast-deep-equal": "^3.1.3"
+        "@types/google.maps": "^3.64.0",
+        "fast-equals": "^6.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
@@ -7544,9 +7544,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.385",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
-      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+      "version": "1.5.387",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8142,7 +8142,17 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
@@ -8885,9 +8895,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "11.1.9",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.9.tgz",
-      "integrity": "sha512-sc/z0Cyti70bZa0ZU4sWfAElfovFb9Ni8tArJZLuklYWxegPiK3pDOql1Rq5H0FIRAW9LSQRG6OX4KqBldbhBA==",
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -11782,9 +11792,9 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.0.tgz",
-      "integrity": "sha512-t/Gp57qSCxGQ52ckhz+8lM7dnuymeU95TEzl2U203qEbGkSLHrtm7US2/ANzq/zOlja3CwPTAfCDuh1unv9mfw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.1.tgz",
+      "integrity": "sha512-ElE/UpOvMLRWtAqbCgyizHXcbws8RPMyN3cBqmdY17Nxr5f01+DEwzOLqhgcy68GSnjtIUFgKWKl8aIgx5aypQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -11848,9 +11858,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
-      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
+      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
       "license": "MIT",
       "workspaces": [
         "www"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "types": "npm run types:app && npm run types:test",
     "types:app": "tsc -p tsconfig.json --noEmit",
     "types:test": "tsc -p tests/vitest/tsconfig.json --noEmit",
-    "shadcn": "npx shadcn@4.7.0",
+    "shadcn": "npx shadcn@4.13.0",
     "test": "node ./scripts/run-vitest.mjs",
     "test:run": "node ./scripts/run-vitest.mjs run",
     "test:coverage": "node ./scripts/run-vitest.mjs run --coverage",

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -130,6 +130,10 @@
         ],
         "improvements": [
             {
+                "title": "Always-Available Data Editor Actions",
+                "description": "The Data Editor now keeps Save Draft, Show LP Preview, and Save & Validate anchored in the bottom-right corner so curators can use them from any point in the form. On smaller pointer-based screens the action group fades back until the cursor moves near it or a button receives focus, while touch devices keep the compact buttons visible."
+            },
+            {
                 "title": "Faster Resource Editing from the Resources Table",
                 "description": "On the /resources page, clicking a resource row now opens that resource directly in the Data Editor in a new browser tab. Existing controls keep their own behavior: row checkboxes still manage selection, published and preview status badges still open and copy DOI or preview URLs, and ERNIE reuses the existing fallback dialog if the browser blocks the editor tab."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -3520,7 +3520,7 @@ export default function DataCiteForm({
                 </div>
                 {draftAutosaveMessage && (
                     <p
-                        className={`${draftAutosaveStatus === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'} max-w-[calc(100vw-1rem)] text-right opacity-20 transition-opacity duration-200 ease-out group-hover:opacity-100 focus-within:opacity-100 lg:opacity-100 [@media(hover:none)]:opacity-100`}
+                        className={`${draftAutosaveStatus === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'} max-w-[calc(100vw-1rem)] text-right opacity-20 transition-opacity duration-200 ease-out group-hover:opacity-100 group-focus-within:opacity-100 lg:opacity-100 [@media(hover:none)]:opacity-100`}
                         data-testid="draft-autosave-status"
                         aria-live="polite"
                     >

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2845,9 +2845,10 @@ export default function DataCiteForm({
     );
 
     const editorActionButtonClassName = 'h-8 px-3 text-xs sm:h-9 sm:px-4 sm:text-sm';
-    const showSaveDraftDisabledTooltip = !isDraftSaveable && !isSavingDraft;
-    const showLandingPagePreviewDisabledTooltip = !isDraftSaveable && !isPreparingLandingPagePreview;
-    const showSaveValidateDisabledTooltip = hasLegacyKeywords && !isSaving;
+    const isEditorActionInFlight = isSaving || isSavingDraft || isPreparingLandingPagePreview;
+    const showSaveDraftDisabledTooltip = !isDraftSaveable && !isEditorActionInFlight;
+    const showLandingPagePreviewDisabledTooltip = !isDraftSaveable && !isEditorActionInFlight;
+    const showSaveValidateDisabledTooltip = hasLegacyKeywords && !isEditorActionInFlight;
 
     const renderEditorActions = () => (
         <>

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2844,6 +2844,86 @@ export default function DataCiteForm({
         </>
     );
 
+    const editorActionButtonClassName = 'h-8 px-3 text-xs sm:h-9 sm:px-4 sm:text-sm';
+
+    const renderEditorActions = () => (
+        <>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <span tabIndex={0}>
+                        {/* Save Draft is intentionally NOT disabled by hasLegacyKeywords.
+                            Drafts are partial saves; legacy keyword replacement is only
+                            required for full validation (Save & Validate). */}
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className={editorActionButtonClassName}
+                            data-testid="save-draft-button"
+                            disabled={!isDraftSaveable || isSavingDraft || isSaving || isPreparingLandingPagePreview}
+                            aria-busy={isSavingDraft}
+                            onClick={handleSaveDraft}
+                        >
+                            <Save className="mr-2 h-4 w-4" />
+                            {isSavingDraft ? 'Saving...' : 'Save Draft'}
+                        </Button>
+                    </span>
+                </TooltipTrigger>
+                {!isDraftSaveable && !isSavingDraft && (
+                    <TooltipContent side="top" align="end" className="max-w-sm">
+                        <p className="text-sm">Enter a Main Title to save as draft.</p>
+                    </TooltipContent>
+                )}
+            </Tooltip>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <span tabIndex={0}>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            className={editorActionButtonClassName}
+                            data-testid="show-lp-preview-button"
+                            disabled={!isDraftSaveable || isSavingDraft || isSaving || isPreparingLandingPagePreview}
+                            aria-busy={isPreparingLandingPagePreview}
+                            onClick={() => void handleShowLandingPagePreview()}
+                        >
+                            <Eye className="mr-2 h-4 w-4" />
+                            {isPreparingLandingPagePreview ? 'Preparing...' : 'Show LP Preview'}
+                        </Button>
+                    </span>
+                </TooltipTrigger>
+                {!isDraftSaveable && !isPreparingLandingPagePreview && (
+                    <TooltipContent side="top" align="end" className="max-w-sm">
+                        <p className="text-sm">Enter a Main Title to preview the landing page.</p>
+                    </TooltipContent>
+                )}
+            </Tooltip>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <span tabIndex={0}>
+                        <Button
+                            type="submit"
+                            className={editorActionButtonClassName}
+                            data-testid="save-resource-button"
+                            disabled={isSaving || isSavingDraft || isPreparingLandingPagePreview || hasLegacyKeywords}
+                            aria-busy={isSaving}
+                            aria-disabled={isSaving || isSavingDraft || isPreparingLandingPagePreview || hasLegacyKeywords}
+                        >
+                            {isSaving ? 'Saving...' : 'Save & Validate'}
+                        </Button>
+                    </span>
+                </TooltipTrigger>
+                {hasLegacyKeywords && !isSaving && (
+                    <TooltipContent side="top" align="end" className="max-w-sm">
+                        <div className="space-y-2">
+                            <p className="text-sm font-semibold">Cannot save: Legacy keywords detected</p>
+                            <p className="text-xs">Please replace all legacy MSL keywords with keywords from the current vocabulary.</p>
+                        </div>
+                    </TooltipContent>
+                )}
+            </Tooltip>
+        </>
+    );
+
     // Build global error messages array for ValidationAlert when no mapped navigation errors are present.
     const globalErrorMessages = useMemo(() => {
         if (errorMessage && mappedValidationErrors.length === 0) {
@@ -2870,7 +2950,7 @@ export default function DataCiteForm({
     );
 
     return (
-        <form onSubmit={handleSubmit} noValidate className="space-y-6">
+        <form onSubmit={handleSubmit} noValidate className="space-y-6 pb-36 sm:pb-28 lg:pb-24">
             {mappedValidationErrors.length > 0 ? (
                 <ClickableValidationAlert
                     ref={errorRef}
@@ -3428,82 +3508,19 @@ export default function DataCiteForm({
                         : []
                 }
             />
-            <div className="flex flex-col items-end gap-2">
-                <div className="flex justify-end gap-3">
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span tabIndex={0}>
-                                {/* Save Draft is intentionally NOT disabled by hasLegacyKeywords.
-                                    Drafts are partial saves; legacy keyword replacement is only
-                                    required for full validation (Save & Validate). */}
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    data-testid="save-draft-button"
-                                    disabled={!isDraftSaveable || isSavingDraft || isSaving || isPreparingLandingPagePreview}
-                                    aria-busy={isSavingDraft}
-                                    onClick={handleSaveDraft}
-                                >
-                                    <Save className="mr-2 h-4 w-4" />
-                                    {isSavingDraft ? 'Saving...' : 'Save Draft'}
-                                </Button>
-                            </span>
-                        </TooltipTrigger>
-                        {!isDraftSaveable && !isSavingDraft && (
-                            <TooltipContent side="top" align="end" className="max-w-sm">
-                                <p className="text-sm">Enter a Main Title to save as draft.</p>
-                            </TooltipContent>
-                        )}
-                    </Tooltip>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span tabIndex={0}>
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    data-testid="show-lp-preview-button"
-                                    disabled={!isDraftSaveable || isSavingDraft || isSaving || isPreparingLandingPagePreview}
-                                    aria-busy={isPreparingLandingPagePreview}
-                                    onClick={() => void handleShowLandingPagePreview()}
-                                >
-                                    <Eye className="mr-2 h-4 w-4" />
-                                    {isPreparingLandingPagePreview ? 'Preparing...' : 'Show LP Preview'}
-                                </Button>
-                            </span>
-                        </TooltipTrigger>
-                        {!isDraftSaveable && !isPreparingLandingPagePreview && (
-                            <TooltipContent side="top" align="end" className="max-w-sm">
-                                <p className="text-sm">Enter a Main Title to preview the landing page.</p>
-                            </TooltipContent>
-                        )}
-                    </Tooltip>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span tabIndex={0}>
-                                <Button
-                                    type="submit"
-                                    data-testid="save-resource-button"
-                                    disabled={isSaving || isSavingDraft || isPreparingLandingPagePreview || hasLegacyKeywords}
-                                    aria-busy={isSaving}
-                                    aria-disabled={isSaving || isSavingDraft || isPreparingLandingPagePreview || hasLegacyKeywords}
-                                >
-                                    {isSaving ? 'Saving...' : 'Save & Validate'}
-                                </Button>
-                            </span>
-                        </TooltipTrigger>
-                        {hasLegacyKeywords && !isSaving && (
-                            <TooltipContent side="top" align="end" className="max-w-sm">
-                                <div className="space-y-2">
-                                    <p className="text-sm font-semibold">Cannot save: Legacy keywords detected</p>
-                                    <p className="text-xs">Please replace all legacy MSL keywords with keywords from the current vocabulary.</p>
-                                </div>
-                            </TooltipContent>
-                        )}
-                    </Tooltip>
+            <div
+                data-testid="editor-floating-actions"
+                className="group fixed right-2 bottom-2 z-40 flex max-w-[calc(100vw-1rem)] flex-col items-end gap-2 p-2 sm:right-4 sm:bottom-4 sm:max-w-[calc(100vw-2rem)] lg:right-6 lg:bottom-6 lg:p-0"
+            >
+                <div
+                    data-testid="editor-floating-actions-panel"
+                    className="flex max-w-full flex-wrap justify-end gap-2 opacity-20 transition-opacity duration-200 ease-out group-hover:opacity-100 hover:opacity-100 focus-within:opacity-100 sm:gap-3 lg:opacity-100 [@media(hover:none)]:opacity-100"
+                >
+                    {renderEditorActions()}
                 </div>
                 {draftAutosaveMessage && (
                     <p
-                        className={draftAutosaveStatus === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}
+                        className={`${draftAutosaveStatus === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'} max-w-[calc(100vw-1rem)] text-right opacity-20 transition-opacity duration-200 ease-out group-hover:opacity-100 focus-within:opacity-100 lg:opacity-100 [@media(hover:none)]:opacity-100`}
                         data-testid="draft-autosave-status"
                         aria-live="polite"
                     >

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -2845,12 +2845,15 @@ export default function DataCiteForm({
     );
 
     const editorActionButtonClassName = 'h-8 px-3 text-xs sm:h-9 sm:px-4 sm:text-sm';
+    const showSaveDraftDisabledTooltip = !isDraftSaveable && !isSavingDraft;
+    const showLandingPagePreviewDisabledTooltip = !isDraftSaveable && !isPreparingLandingPagePreview;
+    const showSaveValidateDisabledTooltip = hasLegacyKeywords && !isSaving;
 
     const renderEditorActions = () => (
         <>
             <Tooltip>
                 <TooltipTrigger asChild>
-                    <span tabIndex={0}>
+                    <span tabIndex={showSaveDraftDisabledTooltip ? 0 : undefined}>
                         {/* Save Draft is intentionally NOT disabled by hasLegacyKeywords.
                             Drafts are partial saves; legacy keyword replacement is only
                             required for full validation (Save & Validate). */}
@@ -2868,7 +2871,7 @@ export default function DataCiteForm({
                         </Button>
                     </span>
                 </TooltipTrigger>
-                {!isDraftSaveable && !isSavingDraft && (
+                {showSaveDraftDisabledTooltip && (
                     <TooltipContent side="top" align="end" className="max-w-sm">
                         <p className="text-sm">Enter a Main Title to save as draft.</p>
                     </TooltipContent>
@@ -2876,7 +2879,7 @@ export default function DataCiteForm({
             </Tooltip>
             <Tooltip>
                 <TooltipTrigger asChild>
-                    <span tabIndex={0}>
+                    <span tabIndex={showLandingPagePreviewDisabledTooltip ? 0 : undefined}>
                         <Button
                             type="button"
                             variant="outline"
@@ -2891,7 +2894,7 @@ export default function DataCiteForm({
                         </Button>
                     </span>
                 </TooltipTrigger>
-                {!isDraftSaveable && !isPreparingLandingPagePreview && (
+                {showLandingPagePreviewDisabledTooltip && (
                     <TooltipContent side="top" align="end" className="max-w-sm">
                         <p className="text-sm">Enter a Main Title to preview the landing page.</p>
                     </TooltipContent>
@@ -2899,7 +2902,7 @@ export default function DataCiteForm({
             </Tooltip>
             <Tooltip>
                 <TooltipTrigger asChild>
-                    <span tabIndex={0}>
+                    <span tabIndex={showSaveValidateDisabledTooltip ? 0 : undefined}>
                         <Button
                             type="submit"
                             className={editorActionButtonClassName}
@@ -2912,7 +2915,7 @@ export default function DataCiteForm({
                         </Button>
                     </span>
                 </TooltipTrigger>
-                {hasLegacyKeywords && !isSaving && (
+                {showSaveValidateDisabledTooltip && (
                     <TooltipContent side="top" align="end" className="max-w-sm">
                         <div className="space-y-2">
                             <p className="text-sm font-semibold">Cannot save: Legacy keywords detected</p>

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -836,8 +836,10 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                 <p>Fill in spatial and temporal coverage using the interactive tools.</p>
                             </WorkflowSteps.Step>
                             <WorkflowSteps.Step number={5} title="Save">
-                                <p>
-                                    Choose one of these actions:
+                                <p>Choose one of these actions from the bottom-right editor action bar:</p>
+                                <p className="mt-2">
+                                    The action bar stays available while you move through the form. On smaller pointer-based screens it fades back
+                                    until you hover near the bottom-right corner or focus a button; on touch screens it remains visible and compact.
                                 </p>
                                 <ul>
                                     <li>
@@ -1545,10 +1547,10 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             again.
                         </p>
                         <p>
-                            From the Data Editor, click <strong>Show LP Preview</strong> next to <strong>Save Draft</strong> and{' '}
-                            <strong>Save &amp; Validate</strong> to save the current metadata as a draft and open the landing page flow immediately.
-                            Existing landing pages open in a new browser tab. If the resource has no landing page yet, ERNIE opens the setup modal and
-                            automatically opens the preview after you create it.
+                            From the Data Editor, click <strong>Show LP Preview</strong> in the bottom-right action bar next to{' '}
+                            <strong>Save Draft</strong> and <strong>Save &amp; Validate</strong> to save the current metadata as a draft and open the
+                            landing page flow immediately. Existing landing pages open in a new browser tab. If the resource has no landing page yet,
+                            ERNIE opens the setup modal and automatically opens the preview after you create it.
                         </p>
 
                         <WorkflowSteps>

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -5119,6 +5119,15 @@ describe('DataCiteForm', () => {
             renderDataCiteForm({
                 initialResourceId: '102',
                 initialTitles: [{ title: 'Preparing Preview Dataset', titleType: 'main-title' }],
+                initialGcmdKeywords: [
+                    {
+                        id: 'legacy-preview-keyword',
+                        path: 'MSL > Legacy Preview Keyword',
+                        text: 'Legacy Preview Keyword',
+                        scheme: 'MSL',
+                        isLegacy: 'true',
+                    },
+                ],
                 initialLandingPage: {
                     id: 16,
                     is_published: true,
@@ -5130,6 +5139,11 @@ describe('DataCiteForm', () => {
             });
 
             const previewButton = screen.getByTestId('show-lp-preview-button');
+            const saveButton = screen.getByTestId('save-resource-button');
+
+            expect(saveButton).toBeDisabled();
+            expect(saveButton.parentElement).toHaveAttribute('tabindex', '0');
+
             await user.click(previewButton);
 
             expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
@@ -5137,7 +5151,8 @@ describe('DataCiteForm', () => {
                 expect(previewButton).toHaveTextContent('Preparing...');
             });
             expect(screen.getByTestId('save-draft-button')).toBeDisabled();
-            expect(screen.getByTestId('save-resource-button')).toBeDisabled();
+            expect(saveButton).toBeDisabled();
+            expect(saveButton.parentElement).not.toHaveAttribute('tabindex');
 
             await act(async () => {
                 draftSave.resolve({

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -440,6 +440,66 @@ describe('DataCiteForm', () => {
             />,
         );
 
+    describe('Floating editor actions (Issue #969)', () => {
+        it('keeps the editor action buttons in a fixed bottom-right action cluster', () => {
+            renderDataCiteForm();
+
+            const floatingActions = screen.getByTestId('editor-floating-actions');
+            const floatingPanel = screen.getByTestId('editor-floating-actions-panel');
+            const form = floatingActions.closest('form');
+
+            expect(form).toHaveClass('pb-36');
+            expect(form).toHaveClass('sm:pb-28');
+            expect(form).toHaveClass('lg:pb-24');
+            expect(floatingActions).toHaveClass('fixed');
+            expect(floatingActions).toHaveClass('right-2');
+            expect(floatingActions).toHaveClass('bottom-2');
+            expect(floatingActions).toHaveClass('z-40');
+            expect(floatingActions).toHaveClass('lg:right-6');
+            expect(floatingActions).toHaveClass('lg:bottom-6');
+            expect(floatingPanel).toHaveClass('flex');
+            expect(floatingPanel).toHaveClass('flex-wrap');
+            expect(floatingPanel).toHaveClass('justify-end');
+
+            expect(screen.getAllByTestId('save-draft-button')).toHaveLength(1);
+            expect(screen.getAllByTestId('show-lp-preview-button')).toHaveLength(1);
+            expect(screen.getAllByTestId('save-resource-button')).toHaveLength(1);
+        });
+
+        it('uses transparent small-screen idle state with hover, focus, and touch reveal fallbacks', () => {
+            renderDataCiteForm();
+
+            const floatingPanel = screen.getByTestId('editor-floating-actions-panel');
+
+            expect(floatingPanel).toHaveClass('opacity-20');
+            expect(floatingPanel).toHaveClass('group-hover:opacity-100');
+            expect(floatingPanel).toHaveClass('hover:opacity-100');
+            expect(floatingPanel).toHaveClass('focus-within:opacity-100');
+            expect(floatingPanel).toHaveClass('lg:opacity-100');
+            expect(floatingPanel.className).toContain('[@media(hover:none)]:opacity-100');
+        });
+
+        it('keeps actions compact and preserves form submit semantics', () => {
+            renderDataCiteForm();
+
+            const draftButton = screen.getByTestId('save-draft-button');
+            const previewButton = screen.getByTestId('show-lp-preview-button');
+            const saveButton = screen.getByTestId('save-resource-button');
+            const form = screen.getByTestId('editor-floating-actions').closest('form');
+
+            for (const button of [draftButton, previewButton, saveButton]) {
+                expect(button).toHaveClass('h-8');
+                expect(button).toHaveClass('px-3');
+                expect(button).toHaveClass('text-xs');
+                expect(button).toHaveClass('sm:h-9');
+                expect(button).toHaveClass('sm:px-4');
+                expect(button).toHaveClass('sm:text-sm');
+                expect(button.closest('form')).toBe(form);
+            }
+
+            expect(saveButton).toHaveAttribute('type', 'submit');
+        });
+    });
     describe('Consolidated accordion section headers', () => {
         it('renders Resource Information as one visible section header with metadata in the trigger', () => {
             renderDataCiteForm();

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -5736,7 +5736,11 @@ describe('DataCiteForm', () => {
                     }),
                 );
                 expect(mockRouterVisit).not.toHaveBeenCalled();
-                expect(screen.getByTestId('draft-autosave-status')).toHaveTextContent(/Draft autosaved/);
+
+                const autosaveStatus = screen.getByTestId('draft-autosave-status');
+                expect(autosaveStatus).toHaveTextContent(/Draft autosaved/);
+                expect(autosaveStatus).toHaveClass('group-focus-within:opacity-100');
+                expect(autosaveStatus).not.toHaveClass('focus-within:opacity-100');
             } finally {
                 view.unmount();
                 vi.useRealTimers();

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -499,6 +499,47 @@ describe('DataCiteForm', () => {
 
             expect(saveButton).toHaveAttribute('type', 'submit');
         });
+
+        it('only makes action tooltip wrappers tabbable while their disabled tooltip is available', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            renderDataCiteForm();
+
+            const draftButton = screen.getByTestId('save-draft-button');
+            const previewButton = screen.getByTestId('show-lp-preview-button');
+            const saveButton = screen.getByTestId('save-resource-button');
+
+            expect(draftButton.parentElement).toHaveAttribute('tabindex', '0');
+            expect(previewButton.parentElement).toHaveAttribute('tabindex', '0');
+            expect(saveButton).toBeEnabled();
+            expect(saveButton.parentElement).not.toHaveAttribute('tabindex');
+
+            await user.type(screen.getByRole('textbox', { name: /Title/ }), 'Keyboard Friendly Dataset');
+
+            expect(draftButton).toBeEnabled();
+            expect(previewButton).toBeEnabled();
+            expect(draftButton.parentElement).not.toHaveAttribute('tabindex');
+            expect(previewButton.parentElement).not.toHaveAttribute('tabindex');
+        });
+
+        it('keeps the Save & Validate wrapper tabbable only for the legacy-keywords tooltip state', () => {
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Legacy Keyword Dataset', titleType: 'main-title' }],
+                initialGcmdKeywords: [
+                    {
+                        id: 'legacy-msl-keyword',
+                        path: 'MSL > Legacy Keyword',
+                        text: 'Legacy Keyword',
+                        scheme: 'MSL',
+                        isLegacy: 'true',
+                    },
+                ],
+            });
+
+            const saveButton = screen.getByTestId('save-resource-button');
+
+            expect(saveButton).toBeDisabled();
+            expect(saveButton.parentElement).toHaveAttribute('tabindex', '0');
+        });
     });
     describe('Consolidated accordion section headers', () => {
         it('renders Resource Information as one visible section header with metadata in the trigger', () => {

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -375,7 +375,21 @@ describe('Docs page', () => {
                 const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
 
                 return (
-                    text.includes('From the Data Editor, click Show LP Preview next to Save Draft and Save & Validate') &&
+                    text.includes('The action bar stays available while you move through the form.') &&
+                    text.includes('on touch screens it remains visible and compact.')
+                );
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return (
+                    text.includes('From the Data Editor, click Show LP Preview in the bottom-right action bar next to Save Draft and Save & Validate') &&
                     text.includes('automatically opens the preview after you create it.')
                 );
             }),


### PR DESCRIPTION
This pull request introduces a major UX improvement to the Data Editor by making the Save Draft, Show LP Preview, and Save & Validate actions always available in a floating action bar anchored at the bottom-right corner of the form. The action bar adapts its visibility based on device type and user interaction, ensuring curators can access key actions from anywhere in the form. The documentation and tests have been updated to match this new behavior.

**Data Editor UI/UX Enhancements:**

* Refactored the Data Editor (`datacite-form.tsx`) to move the Save Draft, Show LP Preview, and Save & Validate buttons into a fixed, floating action bar at the bottom-right of the screen, always accessible while editing. The action bar fades back on small pointer-based screens and reveals itself on hover, focus, or on touch devices, where it remains visible and compact. [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R2847-R2926) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3431-R3523)
* Added extra bottom padding to the form to prevent content from being hidden behind the floating action bar.

**Documentation Updates:**

* Updated the Data Editor documentation to describe the new floating action bar, its behavior on different devices, and how to access actions from anywhere in the form. [[1]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL839-R842) [[2]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL1548-R1553)

**Testing Improvements:**

* Added and updated tests to verify the floating action bar's presence, positioning, responsive behaviors, and that editor actions remain accessible and compact across screen sizes. [[1]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R443-R502) [[2]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9L5679-R5743)
* Updated docs page tests to check for the new documentation text describing the floating action bar.

**Changelog and Dependency Updates:**

* Added a changelog entry describing the always-available Data Editor actions.
* Updated the `shadcn` dependency to version 4.13.0 in `package.json`.