### PR TITLE
Fix: Skip data description file probes

### DIFF
--- a/app/Services/SizeFormatFileProbeService.php
+++ b/app/Services/SizeFormatFileProbeService.php
@@ -792,9 +792,7 @@ class SizeFormatFileProbeService
     {
         $normalized = strtolower(html_entity_decode(rawurldecode(basename($filename)), ENT_QUOTES | ENT_HTML5));
 
-        return str_contains($normalized, 'data-description')
-            || str_contains($normalized, 'data_description')
-            || str_contains(str_replace(['-', '_'], '', $normalized), 'datadescription');
+        return preg_match('/(^|[^a-z0-9])data[-_]?description(?=$|[^a-z0-9])/', $normalized) === 1;
     }
 
     private function extractFileMetadata(string $filename): ?string

--- a/app/Services/SizeFormatFileProbeService.php
+++ b/app/Services/SizeFormatFileProbeService.php
@@ -782,15 +782,22 @@ class SizeFormatFileProbeService
         $path = parse_url($url, PHP_URL_PATH);
 
         if (! is_string($path) || $path === '') {
-            return basename($url);
+            return $this->decodeFilenameSegment(basename($url));
         }
 
-        return basename(rawurldecode($path));
+        return $this->decodeFilenameSegment(basename($path));
+    }
+
+    private function decodeFilenameSegment(string $filename): string
+    {
+        $encodedSeparatorsPreserved = str_ireplace(['%2f', '%5c'], ['%252F', '%255C'], $filename);
+
+        return rawurldecode($encodedSeparatorsPreserved);
     }
 
     private function isDataDescriptionFile(string $filename): bool
     {
-        $normalized = strtolower(html_entity_decode(rawurldecode(basename($filename)), ENT_QUOTES | ENT_HTML5));
+        $normalized = strtolower(html_entity_decode($this->decodeFilenameSegment(basename($filename)), ENT_QUOTES | ENT_HTML5));
 
         return preg_match('/(^|[^a-z0-9])data[-_]?description(?=$|[^a-z0-9])/', $normalized) === 1;
     }

--- a/app/Services/SizeFormatFileProbeService.php
+++ b/app/Services/SizeFormatFileProbeService.php
@@ -284,6 +284,10 @@ class SizeFormatFileProbeService
             return $this->skip($fileUrl, 'unsupported_source_url');
         }
 
+        if ($this->isDataDescriptionFile($this->filenameFromUrl($fileUrl))) {
+            return $this->skip($fileUrl, 'data_description_file');
+        }
+
         try {
             $response = $headResponse ?? Http::timeout(10)
                 ->connectTimeout(5)
@@ -584,6 +588,10 @@ class SizeFormatFileProbeService
                 continue;
             }
 
+            if ($this->isDataDescriptionFile($filename)) {
+                continue;
+            }
+
             $fileMetadata = $this->extractFileMetadata($filename);
 
             $files[] = [
@@ -767,6 +775,26 @@ class SizeFormatFileProbeService
         }
 
         return array_values($uniqueFiles);
+    }
+
+    private function filenameFromUrl(string $url): string
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (! is_string($path) || $path === '') {
+            return basename($url);
+        }
+
+        return basename(rawurldecode($path));
+    }
+
+    private function isDataDescriptionFile(string $filename): bool
+    {
+        $normalized = strtolower(html_entity_decode(rawurldecode(basename($filename)), ENT_QUOTES | ENT_HTML5));
+
+        return str_contains($normalized, 'data-description')
+            || str_contains($normalized, 'data_description')
+            || str_contains(str_replace(['-', '_'], '', $normalized), 'datadescription');
     }
 
     private function extractFileMetadata(string $filename): ?string

--- a/tests/pest/Unit/SizeFormatFileProbeServiceTest.php
+++ b/tests/pest/Unit/SizeFormatFileProbeServiceTest.php
@@ -97,6 +97,33 @@ it('skips direct data description file probes before sending http requests', fun
     Http::assertNothingSent();
 });
 
+it('extracts direct probe filenames before decoding encoded slashes', function () {
+    $url = 'https://datapub.gfz.de/download/dataset/archive%2Fdata-description.pdf';
+
+    Http::fake([
+        $url => Http::response('', 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Length' => '2048',
+        ]),
+    ]);
+
+    $service = app(SizeFormatFileProbeService::class);
+    $result = $service->inferMetadataFromFileUrl($url);
+
+    expect($result['probe_method'])->toBe('HTTP_HEAD')
+        ->and($result['suggestions'])->toHaveCount(2)
+        ->and($result['suggestions'][0])->toMatchArray([
+            'type' => 'format',
+            'inferred_value' => 'application/pdf',
+        ])
+        ->and($result['suggestions'][1])->toMatchArray([
+            'type' => 'size',
+            'inferred_value' => '2 KB',
+        ]);
+
+    Http::assertSentCount(1);
+});
+
 it('applies data description filename matching narrowly and case insensitively', function () {
     Http::fake([
         'https://datapub.gfz.de/download/dataset/' => Http::response(<<<'HTML'

--- a/tests/pest/Unit/SizeFormatFileProbeServiceTest.php
+++ b/tests/pest/Unit/SizeFormatFileProbeServiceTest.php
@@ -104,8 +104,9 @@ it('applies data description filename matching narrowly and case insensitively',
             <a href="sample_data_description.pdf">sample_data_description.pdf</a> 2026-06-14 10:01 2K
             <a href="sample_DataDescription.PDF">sample_DataDescription.PDF</a> 2026-06-14 10:02 3K
             <a href="sample_description.pdf">sample_description.pdf</a> 2026-06-14 10:03 4K
-            <a href="readme.pdf">readme.pdf</a> 2026-06-14 10:04 5K
-            <a href="data.csv">data.csv</a> 2026-06-14 10:05 6K
+            <a href="metadata_description.pdf">metadata_description.pdf</a> 2026-06-14 10:04 7K
+            <a href="readme.pdf">readme.pdf</a> 2026-06-14 10:05 5K
+            <a href="data.csv">data.csv</a> 2026-06-14 10:06 6K
             HTML),
     ]);
 
@@ -115,6 +116,7 @@ it('applies data description filename matching narrowly and case insensitively',
 
     expect($filenames)->toEqualCanonicalizing([
         'sample_description.pdf',
+        'metadata_description.pdf',
         'readme.pdf',
         'data.csv',
     ]);
@@ -131,12 +133,13 @@ it('applies data description filename matching narrowly and case insensitively',
     expect(array_column($formatSuggestions, 'inferred_value'))->toEqualCanonicalizing([
         'application/pdf',
         'application/pdf',
+        'application/pdf',
         'text/csv',
     ])
         ->and($sizeSuggestions)->toHaveCount(1)
-        ->and($sizeSuggestions[0]['inferred_value'])->toBe('15 KB')
-        ->and($sizeSuggestions[0]['evidence']['parsed_file_count'])->toBe(3)
-        ->and($sizeSuggestions[0]['evidence']['total_file_count'])->toBe(3);
+        ->and($sizeSuggestions[0]['inferred_value'])->toBe('22 KB')
+        ->and($sizeSuggestions[0]['evidence']['parsed_file_count'])->toBe(4)
+        ->and($sizeSuggestions[0]['evidence']['total_file_count'])->toBe(4);
 });
 
 it('does not explore directories outside the original download tree', function () {

--- a/tests/pest/Unit/SizeFormatFileProbeServiceTest.php
+++ b/tests/pest/Unit/SizeFormatFileProbeServiceTest.php
@@ -43,6 +43,102 @@ it('explores nested directories and creates one total size suggestion', function
     Http::assertSentCount(3);
 });
 
+it('excludes data description files from directory format and size suggestions', function () {
+    Http::fake([
+        'https://datapub.gfz.de/download/10.5880.FIDGEO.2026.047-Mnbvfgh/' => Http::response(<<<'HTML'
+            <a href="2026-047_Moreira-et-al_data/">2026-047_Moreira-et-al_data/</a> 2026-07-03 14:38 -
+            <a href="2026-047_Moreira-et-al_data-description.pdf">2026-047_Moreira-et-al_data-description.pdf</a> 2026-07-03 14:38 450K
+            HTML),
+        'https://datapub.gfz.de/download/10.5880.FIDGEO.2026.047-Mnbvfgh/2026-047_Moreira-et-al_data/' => Http::response(<<<'HTML'
+            <a href="2026-047_Moreira-et-al_data-Lisbon1.csv">2026-047_Moreira-et-al_data-Lisbon1.csv</a> 2026-07-03 14:38 41K
+            <a href="2026-047_Moreira-et-al_data-Lisbon2.csv">2026-047_Moreira-et-al_data-Lisbon2.csv</a> 2026-07-03 14:38 53K
+            HTML),
+    ]);
+
+    $service = app(SizeFormatFileProbeService::class);
+    $result = $service->probeDirectoryListing('https://datapub.gfz.de/download/10.5880.FIDGEO.2026.047-Mnbvfgh/');
+
+    expect($result['raw_evidence']['files'])->toHaveCount(2)
+        ->and(array_column($result['raw_evidence']['files'], 'filename'))->toEqualCanonicalizing([
+            '2026-047_Moreira-et-al_data-Lisbon1.csv',
+            '2026-047_Moreira-et-al_data-Lisbon2.csv',
+        ]);
+
+    $formatSuggestions = array_values(array_filter(
+        $result['suggestions'],
+        fn (array $suggestion): bool => $suggestion['type'] === 'format',
+    ));
+    $sizeSuggestions = array_values(array_filter(
+        $result['suggestions'],
+        fn (array $suggestion): bool => $suggestion['type'] === 'size',
+    ));
+
+    expect(array_column($formatSuggestions, 'inferred_value'))
+        ->each->toBe('text/csv')
+        ->and(array_column($formatSuggestions, 'source_url'))->not->toContain('https://datapub.gfz.de/download/10.5880.FIDGEO.2026.047-Mnbvfgh/2026-047_Moreira-et-al_data-description.pdf')
+        ->and($sizeSuggestions)->toHaveCount(1)
+        ->and($sizeSuggestions[0]['inferred_value'])->toBe('94 KB')
+        ->and($sizeSuggestions[0]['evidence']['parsed_file_count'])->toBe(2)
+        ->and($sizeSuggestions[0]['evidence']['total_file_count'])->toBe(2);
+
+    Http::assertSentCount(2);
+});
+
+it('skips direct data description file probes before sending http requests', function () {
+    Http::fake();
+
+    $service = app(SizeFormatFileProbeService::class);
+    $result = $service->inferMetadataFromFileUrl('https://datapub.gfz.de/download/10.5880.FIDGEO.2026.047-Mnbvfgh/2026-047_Moreira-et-al_data-description.pdf');
+
+    expect($result['probe_method'])->toBe('SKIP')
+        ->and($result['skip_reason'])->toBe('data_description_file')
+        ->and($result['suggestions'])->toBeEmpty();
+
+    Http::assertNothingSent();
+});
+
+it('applies data description filename matching narrowly and case insensitively', function () {
+    Http::fake([
+        'https://datapub.gfz.de/download/dataset/' => Http::response(<<<'HTML'
+            <a href="sample_data-description.pdf">sample_data-description.pdf</a> 2026-06-14 10:00 1K
+            <a href="sample_data_description.pdf">sample_data_description.pdf</a> 2026-06-14 10:01 2K
+            <a href="sample_DataDescription.PDF">sample_DataDescription.PDF</a> 2026-06-14 10:02 3K
+            <a href="sample_description.pdf">sample_description.pdf</a> 2026-06-14 10:03 4K
+            <a href="readme.pdf">readme.pdf</a> 2026-06-14 10:04 5K
+            <a href="data.csv">data.csv</a> 2026-06-14 10:05 6K
+            HTML),
+    ]);
+
+    $service = app(SizeFormatFileProbeService::class);
+    $result = $service->probeDirectoryListing('https://datapub.gfz.de/download/dataset/');
+    $filenames = array_column($result['raw_evidence']['files'], 'filename');
+
+    expect($filenames)->toEqualCanonicalizing([
+        'sample_description.pdf',
+        'readme.pdf',
+        'data.csv',
+    ]);
+
+    $formatSuggestions = array_values(array_filter(
+        $result['suggestions'],
+        fn (array $suggestion): bool => $suggestion['type'] === 'format',
+    ));
+    $sizeSuggestions = array_values(array_filter(
+        $result['suggestions'],
+        fn (array $suggestion): bool => $suggestion['type'] === 'size',
+    ));
+
+    expect(array_column($formatSuggestions, 'inferred_value'))->toEqualCanonicalizing([
+        'application/pdf',
+        'application/pdf',
+        'text/csv',
+    ])
+        ->and($sizeSuggestions)->toHaveCount(1)
+        ->and($sizeSuggestions[0]['inferred_value'])->toBe('15 KB')
+        ->and($sizeSuggestions[0]['evidence']['parsed_file_count'])->toBe(3)
+        ->and($sizeSuggestions[0]['evidence']['total_file_count'])->toBe(3);
+});
+
 it('does not explore directories outside the original download tree', function () {
     Http::fake([
         'https://datapub.gfz.de/download/dataset/' => Http::response(<<<'HTML'


### PR DESCRIPTION
This pull request updates the `SizeFormatFileProbeService` to improve how it handles "data description" files, ensuring these files are excluded from format and size inference. It introduces new logic to reliably detect such files by name, skips them during directory probing and direct file probing, and adds comprehensive tests to confirm the correct behavior.

### Data description file handling improvements

* Added the `isDataDescriptionFile` method to detect files whose names match "data description" (case-insensitive, with optional dash or underscore) and the `filenameFromUrl` helper for robust filename extraction.
* Updated `inferMetadataFromFileUrl` to skip probing and HTTP requests for direct "data description" files, returning a specific skip reason.
* Updated `extractFilesFromApacheIndex` to exclude "data description" files from directory listings before format and size inference.

### Testing

* Added new unit tests to verify that "data description" files are excluded from directory-based suggestions, skipped in direct probes, and that filename matching is case-insensitive and narrowly applied.