### PR TITLE
Fix: Enforce canonical subject scheme names in enrichment

### DIFF
--- a/app/Services/SubjectEnrichment/SubjectEnrichmentAcceptanceService.php
+++ b/app/Services/SubjectEnrichment/SubjectEnrichmentAcceptanceService.php
@@ -148,12 +148,14 @@ final readonly class SubjectEnrichmentAcceptanceService
             return $this->invalid('Suppressed subject metadata suggestions cannot be accepted.');
         }
 
-        $scheme = $this->lookup->normalizeSupportedScheme($this->filledString($proposed['subject_scheme'] ?? null));
+        $proposedSubjectScheme = $this->filledString($proposed['subject_scheme'] ?? null);
+        $scheme = $this->lookup->normalizeSupportedScheme($proposedSubjectScheme);
         if ($scheme === null) {
             return $this->invalid('This subject metadata suggestion proposes an unsupported subject scheme.');
         }
 
-        if ($this->filledString($proposed['subject_scheme'] ?? null) !== $scheme) {
+        $canonicalSubjectScheme = $this->lookup->canonicalSubjectScheme($scheme);
+        if ($canonicalSubjectScheme === null || $proposedSubjectScheme !== $canonicalSubjectScheme) {
             return $this->invalid('This subject metadata suggestion does not propose the canonical subject scheme.');
         }
 
@@ -280,8 +282,9 @@ final readonly class SubjectEnrichmentAcceptanceService
         }
 
         $concept = $result->concept;
+        $expectedSubjectScheme = $this->lookup->canonicalSubjectScheme($concept->scheme) ?? $concept->scheme;
         $expected = [
-            'subject_scheme' => $concept->scheme,
+            'subject_scheme' => $expectedSubjectScheme,
             'scheme_uri' => $concept->schemeUri,
             'value_uri' => $concept->valueUri(),
             'classification_code' => $concept->classificationCode,

--- a/app/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryService.php
+++ b/app/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryService.php
@@ -20,6 +20,7 @@ final readonly class SubjectEnrichmentDiscoveryService
     public function __construct(
         private SubjectEnrichmentMatchInputProvider $inputProvider,
         private SubjectEnrichmentMatcher $matcher,
+        private SubjectVocabularyLookupService $lookup,
     ) {}
 
     /**
@@ -170,9 +171,10 @@ final readonly class SubjectEnrichmentDiscoveryService
     private function proposedPayload(SubjectEnrichmentMatchInput $input, SubjectVocabularyConcept $concept): array
     {
         $valueUri = $concept->valueUri();
+        $subjectScheme = $this->lookup->canonicalSubjectScheme($concept->scheme) ?? $concept->scheme;
         $updates = [];
 
-        $this->addUpdate($updates, 'subject_scheme', $input->subjectScheme, $concept->scheme);
+        $this->addUpdate($updates, 'subject_scheme', $input->subjectScheme, $subjectScheme);
         $this->addUpdate($updates, 'scheme_uri', $input->schemeUri, $concept->schemeUri);
         $this->addUpdate($updates, 'value_uri', $input->valueUri, $valueUri);
         $this->addUpdate($updates, 'classification_code', $input->classificationCode, $concept->classificationCode);
@@ -180,7 +182,7 @@ final readonly class SubjectEnrichmentDiscoveryService
         $this->addUpdate($updates, 'language', $input->language, $concept->language);
 
         return [
-            'subject_scheme' => $concept->scheme,
+            'subject_scheme' => $subjectScheme,
             'scheme_uri' => $concept->schemeUri,
             'value_uri' => $valueUri,
             'classification_code' => $concept->classificationCode,
@@ -274,7 +276,9 @@ final readonly class SubjectEnrichmentDiscoveryService
 
     private function suggestedLabel(SubjectVocabularyConcept $concept): string
     {
-        return sprintf('Complete subject metadata for "%s" from %s', $concept->label, $concept->scheme);
+        $subjectScheme = $this->lookup->canonicalSubjectScheme($concept->scheme) ?? $concept->scheme;
+
+        return sprintf('Complete subject metadata for "%s" from %s', $concept->label, $subjectScheme);
     }
 
     private function filledString(mixed $value): ?string

--- a/app/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryService.php
+++ b/app/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryService.php
@@ -194,7 +194,9 @@ final readonly class SubjectEnrichmentDiscoveryService
                 'value',
                 'resource_id',
             ],
-            'concept' => $concept->toVocabularyPayload(),
+            'concept' => array_replace($concept->toVocabularyPayload(), [
+                'scheme' => $subjectScheme,
+            ]),
         ];
     }
 

--- a/app/Services/SubjectEnrichment/SubjectEnrichmentMatcher.php
+++ b/app/Services/SubjectEnrichment/SubjectEnrichmentMatcher.php
@@ -194,7 +194,9 @@ final readonly class SubjectEnrichmentMatcher
 
     private function hasUsefulControlledUpdate(SubjectEnrichmentMatchInput $input, SubjectVocabularyConcept $concept): bool
     {
-        if ($input->subjectScheme !== $concept->scheme) {
+        $subjectScheme = $this->lookup->canonicalSubjectScheme($concept->scheme) ?? $concept->scheme;
+
+        if ($input->subjectScheme !== $subjectScheme) {
             return true;
         }
 

--- a/app/Services/SubjectEnrichment/SubjectVocabularyLookupService.php
+++ b/app/Services/SubjectEnrichment/SubjectVocabularyLookupService.php
@@ -15,10 +15,11 @@ use Illuminate\Support\Facades\Storage;
  */
 final class SubjectVocabularyLookupService
 {
-    /** @var array<string, array{file: string, scheme_uri?: string, scheme_uri_config?: string, source: string, source_registry_url?: string, source_registry_url_config?: string, generated_by: string, version?: string, version_config?: string}> */
+    /** @var array<string, array{file: string, subject_scheme?: string, scheme_uri?: string, scheme_uri_config?: string, source: string, source_registry_url?: string, source_registry_url_config?: string, generated_by: string, version?: string, version_config?: string}> */
     private const SOURCES = [
         'Science Keywords' => [
             'file' => 'gcmd-science-keywords.json',
+            'subject_scheme' => 'GCMD Science Keywords',
             'scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
             'source' => 'nasa_gcmd_kms',
             'source_registry_url' => 'https://cmr.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords?format=rdf',
@@ -26,6 +27,7 @@ final class SubjectVocabularyLookupService
         ],
         'Platforms' => [
             'file' => 'gcmd-platforms.json',
+            'subject_scheme' => 'GCMD Platforms',
             'scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms',
             'source' => 'nasa_gcmd_kms',
             'source_registry_url' => 'https://cmr.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms?format=rdf',
@@ -33,6 +35,7 @@ final class SubjectVocabularyLookupService
         ],
         'Instruments' => [
             'file' => 'gcmd-instruments.json',
+            'subject_scheme' => 'GCMD Instruments',
             'scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments',
             'source' => 'nasa_gcmd_kms',
             'source_registry_url' => 'https://cmr.earthdata.nasa.gov/kms/concepts/concept_scheme/instruments?format=rdf',
@@ -148,6 +151,16 @@ final class SubjectVocabularyLookupService
         return $this->configuredString($source['scheme_uri_config'] ?? null)
             ?? $source['scheme_uri']
             ?? null;
+    }
+
+    public function canonicalSubjectScheme(string $scheme): ?string
+    {
+        $source = self::SOURCES[$scheme] ?? null;
+        if ($source === null) {
+            return null;
+        }
+
+        return $source['subject_scheme'] ?? $scheme;
     }
 
     public function findById(string $scheme, ?string $id): SubjectVocabularyMatchSet

--- a/modules/assistants/SubjectMetadataEnrichment/Assistant.php
+++ b/modules/assistants/SubjectMetadataEnrichment/Assistant.php
@@ -76,12 +76,6 @@ final class Assistant extends GenericTableAssistant
             return false;
         }
 
-        $suggestion = AssistantSuggestion::where('assistant_id', $this->getId())
-            ->where('target_type', $targetType)
-            ->where('target_id', $targetId)
-            ->where('suggested_value', $suggestedValue)
-            ->first();
-
         $attributes = [
             'resource_id' => $resourceId,
             'suggested_label' => $suggestedLabel,
@@ -89,15 +83,19 @@ final class Assistant extends GenericTableAssistant
             'metadata' => $metadata,
         ];
 
-        if (! $suggestion instanceof AssistantSuggestion) {
-            AssistantSuggestion::create(array_merge([
+        $suggestion = AssistantSuggestion::firstOrCreate(
+            [
                 'assistant_id' => $this->getId(),
                 'target_type' => $targetType,
                 'target_id' => $targetId,
                 'suggested_value' => $suggestedValue,
+            ],
+            array_merge($attributes, [
                 'discovered_at' => now(),
-            ], $attributes));
+            ]),
+        );
 
+        if ($suggestion->wasRecentlyCreated) {
             return true;
         }
 

--- a/modules/assistants/SubjectMetadataEnrichment/Assistant.php
+++ b/modules/assistants/SubjectMetadataEnrichment/Assistant.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Assistants\SubjectMetadataEnrichment;
 
+use App\Models\AssistantDismissed;
 use App\Models\AssistantSuggestion;
 use App\Services\Assistance\GenericTableAssistant;
 use App\Services\SubjectEnrichment\SubjectEnrichmentAcceptanceService;
@@ -40,7 +41,7 @@ final class Assistant extends GenericTableAssistant
                 string $suggestedLabel,
                 ?float $similarityScore,
                 ?array $metadata,
-            ): bool => $this->storeSuggestion(
+            ): bool => $this->storeOrRefreshSuggestion(
                 resourceId: $resourceId,
                 targetType: $targetType,
                 targetId: $targetId,
@@ -51,6 +52,64 @@ final class Assistant extends GenericTableAssistant
             ),
             onProgress: $onProgress,
         );
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $metadata
+     */
+    private function storeOrRefreshSuggestion(
+        int $resourceId,
+        string $targetType,
+        int $targetId,
+        string $suggestedValue,
+        string $suggestedLabel,
+        ?float $similarityScore = null,
+        ?array $metadata = null,
+    ): bool {
+        $isDismissed = AssistantDismissed::where('assistant_id', $this->getId())
+            ->where('target_type', $targetType)
+            ->where('target_id', $targetId)
+            ->where('dismissed_value', $suggestedValue)
+            ->exists();
+
+        if ($isDismissed) {
+            return false;
+        }
+
+        $suggestion = AssistantSuggestion::where('assistant_id', $this->getId())
+            ->where('target_type', $targetType)
+            ->where('target_id', $targetId)
+            ->where('suggested_value', $suggestedValue)
+            ->first();
+
+        $attributes = [
+            'resource_id' => $resourceId,
+            'suggested_label' => $suggestedLabel,
+            'similarity_score' => $similarityScore,
+            'metadata' => $metadata,
+        ];
+
+        if (! $suggestion instanceof AssistantSuggestion) {
+            AssistantSuggestion::create(array_merge([
+                'assistant_id' => $this->getId(),
+                'target_type' => $targetType,
+                'target_id' => $targetId,
+                'suggested_value' => $suggestedValue,
+                'discovered_at' => now(),
+            ], $attributes));
+
+            return true;
+        }
+
+        $suggestion->forceFill($attributes);
+        if (! $suggestion->isDirty()) {
+            return false;
+        }
+
+        $suggestion->discovered_at = now();
+        $suggestion->save();
+
+        return true;
     }
 
     /** @return array{success: bool, message: string} */

--- a/tests/pest/Browser/SubjectMetadataEnrichmentAssistanceTest.php
+++ b/tests/pest/Browser/SubjectMetadataEnrichmentAssistanceTest.php
@@ -53,6 +53,7 @@ function subjectBrowserDiscoveryService(): SubjectEnrichmentDiscoveryService
     return new SubjectEnrichmentDiscoveryService(
         inputProvider: new SubjectEnrichmentMatchInputProvider,
         matcher: new SubjectEnrichmentMatcher($lookup),
+        lookup: $lookup,
     );
 }
 

--- a/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentAcceptanceServiceTest.php
@@ -151,6 +151,7 @@ function subjectAcceptanceDiscoveryService(): SubjectEnrichmentDiscoveryService
     return new SubjectEnrichmentDiscoveryService(
         inputProvider: new SubjectEnrichmentMatchInputProvider,
         matcher: new SubjectEnrichmentMatcher($lookup),
+        lookup: $lookup,
     );
 }
 
@@ -263,12 +264,39 @@ it('accepts controlled GCMD suggestions and preserves the imported subject text'
         ->and(AssistantSuggestion::find($suggestion->id))->toBeNull()
         ->and($subject->value)->toBe('Science Keywords > EARTH SCIENCE > ATMOSPHERE > AEROSOLS > PARTICULATE MATTER')
         ->and($subject->resource_id)->toBe($resource->id)
-        ->and($subject->subject_scheme)->toBe('Science Keywords')
+        ->and($subject->subject_scheme)->toBe('GCMD Science Keywords')
         ->and($subject->scheme_uri)->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
         ->and($subject->value_uri)->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/0e916c3b-d9ac-4fe1-bc7c-18772784f7fb')
         ->and($subject->classification_code)->toBeNull()
         ->and($subject->breadcrumb_path)->toBe('EARTH SCIENCE > ATMOSPHERE > AEROSOLS > PARTICULATE MATTER')
         ->and($subject->getAttribute('language'))->toBe('en');
+});
+
+it('rejects suggestions that propose internal GCMD lookup keys as subject schemes', function (): void {
+    subjectAcceptancePutVocabulary('gcmd-science-keywords.json', subjectAcceptanceGcmdData());
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.81420')->create();
+    $subject = subjectAcceptanceCreateSubject($resource, [
+        'subject_scheme' => 'NASA/GCMD Earth Science Keywords',
+    ]);
+    $suggestion = subjectAcceptanceSuggestionFor($subject);
+
+    $metadata = $suggestion->metadata;
+    if (! is_array($metadata)) {
+        throw new RuntimeException('Expected subject enrichment metadata.');
+    }
+
+    $metadata['proposed']['subject_scheme'] = 'Science Keywords';
+    $metadata['proposed']['updates']['subject_scheme'] = 'Science Keywords';
+    $suggestion->update(['metadata' => $metadata]);
+
+    $result = app(Assistant::class)->acceptSuggestion($suggestion->id);
+    $subject->refresh();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('canonical subject scheme')
+        ->and($subject->subject_scheme)->toBe('NASA/GCMD Earth Science Keywords')
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull();
 });
 
 it('accepts globally unique free keyword transfers while preserving the free keyword value', function (): void {

--- a/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryEdgeCasesTest.php
+++ b/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryEdgeCasesTest.php
@@ -46,6 +46,7 @@ function discoveryEdgeService(): SubjectEnrichmentDiscoveryService
     return new SubjectEnrichmentDiscoveryService(
         inputProvider: new SubjectEnrichmentMatchInputProvider,
         matcher: new SubjectEnrichmentMatcher($lookup),
+        lookup: $lookup,
     );
 }
 

--- a/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryServiceTest.php
@@ -104,6 +104,7 @@ function subjectEnrichmentDiscoveryService(): SubjectEnrichmentDiscoveryService
     return new SubjectEnrichmentDiscoveryService(
         inputProvider: new SubjectEnrichmentMatchInputProvider,
         matcher: new SubjectEnrichmentMatcher($lookup),
+        lookup: $lookup,
     );
 }
 
@@ -168,13 +169,13 @@ it('stores high-confidence suggestions for controlled GCMD path-only subjects', 
         ->and($storedSuggestions[0]['metadata']['current']['subject_id'])->toBe($subject->id)
         ->and($storedSuggestions[0]['metadata']['current']['subject_scheme'])->toBe('NASA/GCMD Earth Science Keywords')
         ->and($storedSuggestions[0]['metadata']['current']['normalized_subject_scheme'])->toBe('Science Keywords')
-        ->and($storedSuggestions[0]['metadata']['proposed']['subject_scheme'])->toBe('Science Keywords')
+        ->and($storedSuggestions[0]['metadata']['proposed']['subject_scheme'])->toBe('GCMD Science Keywords')
         ->and($storedSuggestions[0]['metadata']['proposed']['scheme_uri'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
         ->and($storedSuggestions[0]['metadata']['proposed']['value_uri'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/0e916c3b-d9ac-4fe1-bc7c-18772784f7fb')
         ->and($storedSuggestions[0]['metadata']['proposed']['classification_code'])->toBeNull()
         ->and($storedSuggestions[0]['metadata']['proposed']['breadcrumb_path'])->toBe('EARTH SCIENCE > ATMOSPHERE > AEROSOLS > PARTICULATE MATTER')
         ->and($storedSuggestions[0]['metadata']['proposed']['updates'])->toMatchArray([
-            'subject_scheme' => 'Science Keywords',
+            'subject_scheme' => 'GCMD Science Keywords',
             'scheme_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
             'value_uri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/0e916c3b-d9ac-4fe1-bc7c-18772784f7fb',
             'breadcrumb_path' => 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS > PARTICULATE MATTER',
@@ -187,6 +188,63 @@ it('stores high-confidence suggestions for controlled GCMD path-only subjects', 
         ->and($storedSuggestions[0]['metadata']['confidence']['evidence'])->toContain('single_candidate')
         ->and($storedSuggestions[0]['metadata']['ambiguity']['status'])->toBe('none')
         ->and(implode("\n", $progressMessages))->toContain('Stored 1 subject enrichment suggestion(s)');
+});
+
+it('keeps the canonical GCMD Platforms subject scheme when enriching platform metadata', function (): void {
+    $schemeUri = 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms';
+    $valueUri = 'https://gcmd.earthdata.nasa.gov/kms/concept/11111111-1111-4111-8111-111111111111';
+
+    subjectEnrichmentDiscoveryPutVocabulary('gcmd-platforms.json', [
+        'lastUpdated' => '2026-07-04T00:00:00Z',
+        'data' => [
+            [
+                'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/platforms-root',
+                'text' => 'Platforms',
+                'language' => 'en',
+                'scheme' => 'GCMD Platforms',
+                'schemeURI' => $schemeUri,
+                'children' => [
+                    [
+                        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/space-based-platforms',
+                        'text' => 'Space-based Platforms',
+                        'language' => 'en',
+                        'scheme' => 'GCMD Platforms',
+                        'schemeURI' => $schemeUri,
+                        'children' => [
+                            [
+                                'id' => $valueUri,
+                                'text' => 'VOYAGER 1',
+                                'language' => 'en',
+                                'scheme' => 'GCMD Platforms',
+                                'schemeURI' => $schemeUri,
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.81310')->create();
+    subjectEnrichmentDiscoveryCreateSubject($resource, [
+        'value' => 'Platforms > Space-based Platforms > VOYAGER 1',
+        'subject_scheme' => 'GCMD Platforms',
+    ]);
+
+    [$count, $storedSuggestions] = subjectEnrichmentRunDiscovery(subjectEnrichmentDiscoveryService());
+
+    expect($count)->toBe(1)
+        ->and($storedSuggestions)->toHaveCount(1)
+        ->and($storedSuggestions[0]['metadata']['current']['subject_scheme'])->toBe('GCMD Platforms')
+        ->and($storedSuggestions[0]['metadata']['current']['normalized_subject_scheme'])->toBe('Platforms')
+        ->and($storedSuggestions[0]['metadata']['proposed']['subject_scheme'])->toBe('GCMD Platforms')
+        ->and($storedSuggestions[0]['metadata']['proposed']['updates'])->not->toHaveKey('subject_scheme')
+        ->and($storedSuggestions[0]['metadata']['proposed']['updates'])->toMatchArray([
+            'scheme_uri' => $schemeUri,
+            'value_uri' => $valueUri,
+            'breadcrumb_path' => 'Space-based Platforms > VOYAGER 1',
+        ]);
 });
 
 it('stores free keyword suggestions only when the exact concept label is globally unique and includes the transfer warning', function (): void {

--- a/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/SubjectEnrichment/SubjectEnrichmentDiscoveryServiceTest.php
@@ -170,6 +170,7 @@ it('stores high-confidence suggestions for controlled GCMD path-only subjects', 
         ->and($storedSuggestions[0]['metadata']['current']['subject_scheme'])->toBe('NASA/GCMD Earth Science Keywords')
         ->and($storedSuggestions[0]['metadata']['current']['normalized_subject_scheme'])->toBe('Science Keywords')
         ->and($storedSuggestions[0]['metadata']['proposed']['subject_scheme'])->toBe('GCMD Science Keywords')
+        ->and($storedSuggestions[0]['metadata']['proposed']['concept']['scheme'])->toBe('GCMD Science Keywords')
         ->and($storedSuggestions[0]['metadata']['proposed']['scheme_uri'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords')
         ->and($storedSuggestions[0]['metadata']['proposed']['value_uri'])->toBe('https://gcmd.earthdata.nasa.gov/kms/concept/0e916c3b-d9ac-4fe1-bc7c-18772784f7fb')
         ->and($storedSuggestions[0]['metadata']['proposed']['classification_code'])->toBeNull()
@@ -239,6 +240,7 @@ it('keeps the canonical GCMD Platforms subject scheme when enriching platform me
         ->and($storedSuggestions[0]['metadata']['current']['subject_scheme'])->toBe('GCMD Platforms')
         ->and($storedSuggestions[0]['metadata']['current']['normalized_subject_scheme'])->toBe('Platforms')
         ->and($storedSuggestions[0]['metadata']['proposed']['subject_scheme'])->toBe('GCMD Platforms')
+        ->and($storedSuggestions[0]['metadata']['proposed']['concept']['scheme'])->toBe('GCMD Platforms')
         ->and($storedSuggestions[0]['metadata']['proposed']['updates'])->not->toHaveKey('subject_scheme')
         ->and($storedSuggestions[0]['metadata']['proposed']['updates'])->toMatchArray([
             'scheme_uri' => $schemeUri,

--- a/tests/pest/Feature/Services/SubjectEnrichment/SubjectMetadataEnrichmentAssistantTest.php
+++ b/tests/pest/Feature/Services/SubjectEnrichment/SubjectMetadataEnrichmentAssistantTest.php
@@ -119,6 +119,7 @@ it('refreshes existing subject metadata suggestions when the canonical subject s
         ->and(AssistantSuggestion::query()->count())->toBe(1)
         ->and($suggestion->suggested_label)->toBe('Complete subject metadata for "VOYAGER 1" from GCMD Platforms')
         ->and($suggestion->metadata['proposed']['subject_scheme'])->toBe('GCMD Platforms')
+        ->and($suggestion->metadata['proposed']['concept']['scheme'])->toBe('GCMD Platforms')
         ->and($suggestion->metadata['proposed']['updates'])->not->toHaveKey('subject_scheme')
         ->and($suggestion->metadata['proposed']['updates'])->toMatchArray([
             'scheme_uri' => $schemeUri,

--- a/tests/pest/Feature/Services/SubjectEnrichment/SubjectMetadataEnrichmentAssistantTest.php
+++ b/tests/pest/Feature/Services/SubjectEnrichment/SubjectMetadataEnrichmentAssistantTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use App\Models\AssistantSuggestion;
 use App\Models\Resource;
+use App\Models\Subject;
 use App\Services\Assistance\AssistantManifest;
 use App\Services\SubjectEnrichment\SubjectEnrichmentDiscoveryService;
+use Illuminate\Support\Facades\Storage;
 use Modules\Assistants\SubjectMetadataEnrichment\Assistant;
 
 it('parses and autoloads the subject metadata enrichment assistant manifest', function (): void {
@@ -27,7 +29,7 @@ it('keeps invalid subject enrichment suggestions when acceptance metadata is inc
         'target_type' => SubjectEnrichmentDiscoveryService::TARGET_TYPE,
         'target_id' => 123,
         'suggested_value' => 'https://gcmd.earthdata.nasa.gov/kms/concept/example',
-        'suggested_label' => 'Complete subject metadata for "Example" from Science Keywords',
+        'suggested_label' => 'Complete subject metadata for "Example" from GCMD Science Keywords',
         'similarity_score' => 1.0,
         'metadata' => [],
         'discovered_at' => now(),
@@ -41,4 +43,86 @@ it('keeps invalid subject enrichment suggestions when acceptance metadata is inc
         'message' => 'This subject metadata suggestion does not match its target subject.',
     ])
         ->and(AssistantSuggestion::query()->whereKey($suggestion->id)->exists())->toBeTrue();
+});
+it('refreshes existing subject metadata suggestions when the canonical subject scheme changes', function (): void {
+    Storage::fake('local');
+
+    $schemeUri = 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/platforms';
+    $valueUri = 'https://gcmd.earthdata.nasa.gov/kms/concept/11111111-1111-4111-8111-111111111111';
+
+    Storage::disk('local')->put('gcmd-platforms.json', json_encode([
+        'data' => [
+            [
+                'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/platforms-root',
+                'text' => 'Platforms',
+                'language' => 'en',
+                'scheme' => 'GCMD Platforms',
+                'schemeURI' => $schemeUri,
+                'children' => [
+                    [
+                        'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/space-based-platforms',
+                        'text' => 'Space-based Platforms',
+                        'language' => 'en',
+                        'scheme' => 'GCMD Platforms',
+                        'schemeURI' => $schemeUri,
+                        'children' => [
+                            [
+                                'id' => $valueUri,
+                                'text' => 'VOYAGER 1',
+                                'language' => 'en',
+                                'scheme' => 'GCMD Platforms',
+                                'schemeURI' => $schemeUri,
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    $resource = Resource::factory()->withDoi('10.5880/GFZ.2026.81311')->create();
+    $subject = Subject::forceCreate([
+        'resource_id' => $resource->id,
+        'value' => 'Platforms > Space-based Platforms > VOYAGER 1',
+        'language' => 'en',
+        'subject_scheme' => 'GCMD Platforms',
+        'scheme_uri' => null,
+        'value_uri' => null,
+        'classification_code' => null,
+        'breadcrumb_path' => null,
+    ]);
+
+    $suggestion = AssistantSuggestion::create([
+        'assistant_id' => SubjectEnrichmentDiscoveryService::ASSISTANT_ID,
+        'resource_id' => $resource->id,
+        'target_type' => SubjectEnrichmentDiscoveryService::TARGET_TYPE,
+        'target_id' => $subject->id,
+        'suggested_value' => $valueUri,
+        'suggested_label' => 'Complete subject metadata for "VOYAGER 1" from Platforms',
+        'similarity_score' => 1.0,
+        'metadata' => [
+            'proposed' => [
+                'subject_scheme' => 'Platforms',
+                'updates' => [
+                    'subject_scheme' => 'Platforms',
+                ],
+            ],
+        ],
+        'discovered_at' => now()->subDay(),
+    ]);
+
+    $count = app(Assistant::class)->runDiscovery(function (string $message): void {});
+    $suggestion->refresh();
+
+    expect($count)->toBe(1)
+        ->and(AssistantSuggestion::query()->count())->toBe(1)
+        ->and($suggestion->suggested_label)->toBe('Complete subject metadata for "VOYAGER 1" from GCMD Platforms')
+        ->and($suggestion->metadata['proposed']['subject_scheme'])->toBe('GCMD Platforms')
+        ->and($suggestion->metadata['proposed']['updates'])->not->toHaveKey('subject_scheme')
+        ->and($suggestion->metadata['proposed']['updates'])->toMatchArray([
+            'scheme_uri' => $schemeUri,
+            'value_uri' => $valueUri,
+            'breadcrumb_path' => 'Space-based Platforms > VOYAGER 1',
+        ]);
 });

--- a/tests/pest/Unit/Services/SubjectEnrichment/SubjectEnrichmentMatcherTest.php
+++ b/tests/pest/Unit/Services/SubjectEnrichment/SubjectEnrichmentMatcherTest.php
@@ -247,7 +247,7 @@ it('suppresses controlled subjects that already have complete matching metadata'
 
     $result = matcherService()->match(matcherInput([
         'value' => 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS > PARTICULATE MATTER',
-        'subjectScheme' => 'Science Keywords',
+        'subjectScheme' => 'GCMD Science Keywords',
         'normalizedSubjectScheme' => 'Science Keywords',
         'schemeUri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
         'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/0e916c3b-d9ac-4fe1-bc7c-18772784f7fb',
@@ -265,7 +265,7 @@ it('still matches complete controlled records when only the language differs', f
 
     $result = matcherService()->match(matcherInput([
         'value' => 'EARTH SCIENCE > ATMOSPHERE > AEROSOLS > PARTICULATE MATTER',
-        'subjectScheme' => 'Science Keywords',
+        'subjectScheme' => 'GCMD Science Keywords',
         'normalizedSubjectScheme' => 'Science Keywords',
         'schemeUri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
         'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/0e916c3b-d9ac-4fe1-bc7c-18772784f7fb',

--- a/tests/pest/Unit/Services/SubjectEnrichment/SubjectVocabularyLookupEdgeCasesTest.php
+++ b/tests/pest/Unit/Services/SubjectEnrichment/SubjectVocabularyLookupEdgeCasesTest.php
@@ -22,6 +22,11 @@ it('reports source metadata for missing supported caches and rejects unsupported
 
     expect($lookup->normalizeSupportedScheme('NASA/GCMD Earth Science Keywords'))->toBe('Science Keywords')
         ->and($lookup->normalizeSupportedScheme('unknown scheme'))->toBeNull()
+        ->and($lookup->canonicalSubjectScheme('Science Keywords'))->toBe('GCMD Science Keywords')
+        ->and($lookup->canonicalSubjectScheme('Platforms'))->toBe('GCMD Platforms')
+        ->and($lookup->canonicalSubjectScheme('Instruments'))->toBe('GCMD Instruments')
+        ->and($lookup->canonicalSubjectScheme('EPOS MSL vocabulary'))->toBe('EPOS MSL vocabulary')
+        ->and($lookup->canonicalSubjectScheme('unknown scheme'))->toBeNull()
         ->and($lookup->canonicalSchemeUri('unknown scheme'))->toBeNull()
         ->and($lookup->isSchemeAvailable('unknown scheme'))->toBeFalse()
         ->and($lookup->isSchemeAvailable('Science Keywords'))->toBeFalse();


### PR DESCRIPTION
This pull request improves the handling of subject schemes for subject metadata enrichment by introducing canonical subject scheme normalization, updating related services and tests, and enhancing suggestion storage logic. The main goal is to ensure that suggestions and accepted metadata always use the canonical, externally recognized subject scheme labels (e.g., "GCMD Science Keywords" instead of internal keys like "Science Keywords"), reducing ambiguity and improving data consistency.

**Subject Scheme Normalization and Canonicalization**

* Added a `canonicalSubjectScheme` method to `SubjectVocabularyLookupService` and updated the service's source definitions to include canonical `subject_scheme` values for GCMD vocabularies. [[1]](diffhunk://#diff-ca8d028eb4a29370af963c6c83ccf1a768b1e69edf47d6c3aaaed8c4c5c592fcL18-R38) [[2]](diffhunk://#diff-ca8d028eb4a29370af963c6c83ccf1a768b1e69edf47d6c3aaaed8c4c5c592fcR156-R165)
* Updated `SubjectEnrichmentDiscoveryService`, `SubjectEnrichmentMatcher`, and `SubjectEnrichmentAcceptanceService` to always use the canonical subject scheme when proposing, matching, or validating suggestions. [[1]](diffhunk://#diff-4b377ce44f3441f0159f81e05cf70cfcd7e86c72aa56876e94662a0efb7e2655R23) [[2]](diffhunk://#diff-4b377ce44f3441f0159f81e05cf70cfcd7e86c72aa56876e94662a0efb7e2655R174-R185) [[3]](diffhunk://#diff-4b377ce44f3441f0159f81e05cf70cfcd7e86c72aa56876e94662a0efb7e2655L195-R199) [[4]](diffhunk://#diff-4b377ce44f3441f0159f81e05cf70cfcd7e86c72aa56876e94662a0efb7e2655L277-R283) [[5]](diffhunk://#diff-60e10d3b8f5776da8a94e5150359d0526126520fd98c7ac160b760ba6afb212eL197-R199) [[6]](diffhunk://#diff-e48fda8b102ab9ebdec09922b9a54a822289b8277f1b4877b5441c849b4ec8d0L151-R158) [[7]](diffhunk://#diff-e48fda8b102ab9ebdec09922b9a54a822289b8277f1b4877b5441c849b4ec8d0R285-R287)

**Suggestion Storage and Dismissal Handling**

* Added a new `storeOrRefreshSuggestion` method in the assistant to prevent re-storing dismissed suggestions and to update suggestion metadata only when it changes. [[1]](diffhunk://#diff-082da46690f76085583484f1cdae626ba98133c91fa790689bc7106e72a94427R7) [[2]](diffhunk://#diff-082da46690f76085583484f1cdae626ba98133c91fa790689bc7106e72a94427L43-R44) [[3]](diffhunk://#diff-082da46690f76085583484f1cdae626ba98133c91fa790689bc7106e72a94427R57-R112)

**Test Updates and Coverage**

* Updated all relevant tests to expect canonical subject scheme values in suggestions and accepted metadata, including new test cases to reject suggestions with internal keys and to verify correct behavior for GCMD vocabularies. [[1]](diffhunk://#diff-dead964599342043438a418f00d0e85bf708a740533d7aa455dc4d21c2ff615eR154) [[2]](diffhunk://#diff-dead964599342043438a418f00d0e85bf708a740533d7aa455dc4d21c2ff615eL266-R301) [[3]](diffhunk://#diff-e8cf6bdc18662c3e01088a101343c2f59ce602b1b842e10a0e36103bb899cc47R107) [[4]](diffhunk://#diff-e8cf6bdc18662c3e01088a101343c2f59ce602b1b842e10a0e36103bb899cc47L171-R179) [[5]](diffhunk://#diff-e8cf6bdc18662c3e01088a101343c2f59ce602b1b842e10a0e36103bb899cc47R194-R251) [[6]](diffhunk://#diff-48dc38ea1ae94ee68d474905b8540047f191fc771b3e17cbe4a2745fadf82163R49) [[7]](diffhunk://#diff-d08fb6dec945376d8fce41fa96babc8adf480c67f7a3d342a2a957496cf11598R56) [[8]](diffhunk://#diff-e501216b14da905a14639f28b14db30885d5a31a1a199701388ba8b1d5b399e9R7-R10)

These changes collectively ensure that subject metadata enrichment is robust, consistent, and aligned with canonical vocabulary definitions.