### PR TITLE
Feature: Link Assistance Resource Headers to Editor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -642,16 +642,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.13.1",
+            "version": "7.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bcd989ad36c92d42a3715379af91f2defee5b8dd",
+                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd",
                 "shasum": ""
             },
             "require": {
@@ -669,7 +669,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
                 "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
@@ -750,7 +750,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.2"
             },
             "funding": [
                 {
@@ -766,7 +766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-29T20:14:18+00:00"
+            "time": "2026-07-05T19:00:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -1,4 +1,4 @@
-import { Head, router } from '@inertiajs/react';
+import { Head, Link, router } from '@inertiajs/react';
 import axios from 'axios';
 import { AlertTriangle, Building2, Check, RefreshCw, User, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import AppLayout from '@/layouts/app-layout';
+import { editor as editorRoute } from '@/routes';
 import { type BreadcrumbItem } from '@/types';
 import {
     type AcceptResponse,
@@ -57,6 +58,10 @@ function isValidRorUrl(url: string): boolean {
     } catch {
         return false;
     }
+}
+
+function resourceEditorUrl(resourceId: number): string {
+    return editorRoute({ query: { resourceId } }).url;
 }
 
 function SuggestionCard({
@@ -601,10 +606,7 @@ function SubjectMetadataEnrichmentCard({
                                         {warningMessages.map((warning) => (
                                             <li key={warning}>{warning}</li>
                                         ))}
-                                        {warningMessages.length === 0 &&
-                                            warnings.map((warning) => (
-                                                <li key={warning}>{warning}</li>
-                                            ))}
+                                        {warningMessages.length === 0 && warnings.map((warning) => <li key={warning}>{warning}</li>)}
                                     </ul>
                                 </div>
                             </div>
@@ -1013,7 +1015,6 @@ function SizeFormatSuggestionCard({
 }
 // ── Per-section state ────────────────────────────────────────────────
 
-
 function DescriptionPreviewBlock({ title, value }: { title: string; value: string | null | undefined }) {
     const text = typeof value === 'string' && value.trim() !== '' ? value : null;
 
@@ -1021,7 +1022,7 @@ function DescriptionPreviewBlock({ title, value }: { title: string; value: strin
         <div className="min-w-0 rounded-md border bg-muted/20 p-3">
             <p className="mb-2 text-xs font-semibold text-muted-foreground uppercase">{title}</p>
             {text ? (
-                <div className="max-h-56 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground">{text}</div>
+                <div className="max-h-56 overflow-auto text-xs leading-relaxed break-words whitespace-pre-wrap text-foreground">{text}</div>
             ) : (
                 <p className="text-xs text-muted-foreground">No text captured.</p>
             )}
@@ -1109,7 +1110,7 @@ function DescriptionSegmentationSuggestionCard({
                                                     </Badge>
                                                 )}
                                             </div>
-                                            <div className="max-h-48 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground">
+                                            <div className="max-h-48 overflow-auto text-xs leading-relaxed break-words whitespace-pre-wrap text-foreground">
                                                 {metadataText(segment.value) ?? 'No text captured.'}
                                             </div>
                                             {(evidenceLabel || evidenceTypes.length > 0) && (
@@ -1573,21 +1574,21 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                     if (!sectionData) return null;
 
                     // Group items by resource
-                    const grouped = sectionData.data.reduce<Record<number, { doi: string; title: string; items: BaseSuggestionItem[] }>>(
-                        (groups, item) => {
-                            const resourceId = item.resource_id;
-                            if (!groups[resourceId]) {
-                                groups[resourceId] = {
-                                    doi: item.resource_doi ?? '',
-                                    title: item.resource_title ?? 'Untitled',
-                                    items: [],
-                                };
-                            }
-                            groups[resourceId].items.push(item);
-                            return groups;
-                        },
-                        {},
-                    );
+                    const grouped = sectionData.data.reduce<
+                        Record<number, { resourceId: number; doi: string; title: string; items: BaseSuggestionItem[] }>
+                    >((groups, item) => {
+                        const resourceId = item.resource_id;
+                        if (!groups[resourceId]) {
+                            groups[resourceId] = {
+                                resourceId,
+                                doi: item.resource_doi ?? '',
+                                title: item.resource_title ?? 'Untitled',
+                                items: [],
+                            };
+                        }
+                        groups[resourceId].items.push(item);
+                        return groups;
+                    }, {});
 
                     return (
                         <Card key={manifest.id}>
@@ -1617,24 +1618,34 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                             <CardContent>
                                 {Object.keys(grouped).length > 0 ? (
                                     <div className="space-y-6">
-                                        {Object.entries(grouped).map(([resourceId, group]) => (
-                                            <div key={resourceId} className="space-y-3">
-                                                <div className="flex items-baseline gap-2">
-                                                    <span className="font-mono text-sm font-semibold text-primary">{group.doi}</span>
-                                                    <span className="text-sm text-muted-foreground">— {group.title}</span>
-                                                    <Badge variant="secondary" className="ml-auto text-xs">
-                                                        {group.items.length} suggestion(s)
-                                                    </Badge>
+                                        {Object.entries(grouped).map(([resourceKey, group]) => {
+                                            const resourceLabel = group.doi || `Resource #${group.resourceId}`;
+
+                                            return (
+                                                <div key={resourceKey} className="space-y-3">
+                                                    <div className="flex items-baseline gap-2">
+                                                        <Link
+                                                            href={resourceEditorUrl(group.resourceId)}
+                                                            className="font-mono text-sm font-semibold break-all text-primary underline underline-offset-4 hover:text-primary/80 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none"
+                                                            title={`Open ${resourceLabel} in editor`}
+                                                        >
+                                                            {resourceLabel}
+                                                        </Link>
+                                                        <span className="text-sm text-muted-foreground">— {group.title}</span>
+                                                        <Badge variant="secondary" className="ml-auto text-xs">
+                                                            {group.items.length} suggestion(s)
+                                                        </Badge>
+                                                    </div>
+                                                    <div className="space-y-2 pl-4">
+                                                        {group.items.map((item) => (
+                                                            <div key={item.id as number}>
+                                                                {renderCard(manifest, item, state?.processingIds.has(item.id as number) ?? false)}
+                                                            </div>
+                                                        ))}
+                                                    </div>
                                                 </div>
-                                                <div className="space-y-2 pl-4">
-                                                    {group.items.map((item) => (
-                                                        <div key={item.id as number}>
-                                                            {renderCard(manifest, item, state?.processingIds.has(item.id as number) ?? false)}
-                                                        </div>
-                                                    ))}
-                                                </div>
-                                            </div>
-                                        ))}
+                                            );
+                                        })}
                                     </div>
                                 ) : (
                                     <div className="flex flex-col items-center justify-center py-12 text-center">

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -64,6 +64,14 @@ function resourceEditorUrl(resourceId: number): string {
     return editorRoute({ query: { resourceId } }).url;
 }
 
+function normalizedResourceHeaderValue(value: string | null | undefined): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function firstNonEmptyResourceHeaderValue(current: string, candidate: string): string {
+    return current === '' ? candidate : current;
+}
+
 function SuggestionCard({
     suggestion,
     onAccept,
@@ -1578,14 +1586,21 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                         Record<number, { resourceId: number; doi: string; title: string; items: BaseSuggestionItem[] }>
                     >((groups, item) => {
                         const resourceId = item.resource_id;
+                        const itemDoi = normalizedResourceHeaderValue(item.resource_doi);
+                        const itemTitle = normalizedResourceHeaderValue(item.resource_title);
+
                         if (!groups[resourceId]) {
                             groups[resourceId] = {
                                 resourceId,
-                                doi: item.resource_doi ?? '',
-                                title: item.resource_title ?? 'Untitled',
+                                doi: itemDoi,
+                                title: itemTitle,
                                 items: [],
                             };
+                        } else {
+                            groups[resourceId].doi = firstNonEmptyResourceHeaderValue(groups[resourceId].doi, itemDoi);
+                            groups[resourceId].title = firstNonEmptyResourceHeaderValue(groups[resourceId].title, itemTitle);
                         }
+
                         groups[resourceId].items.push(item);
                         return groups;
                     }, {});
@@ -1619,7 +1634,8 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                                 {Object.keys(grouped).length > 0 ? (
                                     <div className="space-y-6">
                                         {Object.entries(grouped).map(([resourceKey, group]) => {
-                                            const resourceLabel = group.doi || `Resource #${group.resourceId}`;
+                                            const resourceLabel = group.doi === '' ? `Resource #${group.resourceId}` : group.doi;
+                                            const resourceTitle = group.title === '' ? 'Untitled' : group.title;
 
                                             return (
                                                 <div key={resourceKey} className="space-y-3">
@@ -1631,7 +1647,7 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                                                         >
                                                             {resourceLabel}
                                                         </Link>
-                                                        <span className="text-sm text-muted-foreground">— {group.title}</span>
+                                                        <span className="text-sm text-muted-foreground">— {resourceTitle}</span>
                                                         <Badge variant="secondary" className="ml-auto text-xs">
                                                             {group.items.length} suggestion(s)
                                                         </Badge>

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -511,6 +511,38 @@ describe('Assistance resource header links', () => {
         expect(link).toHaveAttribute('href', '/editor?resourceId=99');
         expect(link).toHaveAttribute('title', 'Open Resource #99 in editor');
     });
+
+    it('groups repeated resource suggestions while preserving fallback labels', () => {
+        const suggestions = [
+            makeSizeFormatSuggestion({
+                id: 101,
+                resource_id: 101,
+                resource_doi: undefined,
+                resource_title: undefined,
+                suggested_label: 'First missing metadata suggestion',
+            }),
+            makeSizeFormatSuggestion({
+                id: 102,
+                resource_id: 101,
+                resource_doi: '10.5880/ignored.2026.102',
+                resource_title: 'Ignored later title',
+                suggested_label: 'Second suggestion for same resource',
+            }),
+        ];
+
+        render(
+            <AssistancePage
+                sections={{ [SIZE_FORMAT_ASSISTANT_ID]: paginated(suggestions) }}
+                manifests={[makeManifest(SIZE_FORMAT_ASSISTANT_ID, SIZE_FORMAT_ROUTE_PREFIX, SIZE_FORMAT_ASSISTANT_NAME)]}
+            />,
+        );
+
+        expect(screen.getByRole('link', { name: 'Resource #101' })).toHaveAttribute('href', '/editor?resourceId=101');
+        expect(screen.getByText(/Untitled/)).toBeInTheDocument();
+        expect(screen.getByText('2 suggestion(s)')).toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: 'Accept' })).toHaveLength(2);
+        expect(screen.queryByRole('link', { name: '10.5880/ignored.2026.102' })).not.toBeInTheDocument();
+    });
 });
 
 describe('OrcidSuggestionCard – ORCID link', () => {

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -19,6 +19,11 @@ import type {
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
     usePage: () => ({ props: {} }),
     router: { reload: vi.fn(), get: vi.fn() },
 }));
@@ -240,7 +245,9 @@ function makeCrossrefFunderRorSuggestion(overrides: Partial<SuggestedCrossrefFun
         ...rest,
     };
 }
-function makeSubjectMetadataEnrichmentSuggestion(overrides: Partial<SuggestedSubjectMetadataEnrichmentItem> = {}): SuggestedSubjectMetadataEnrichmentItem {
+function makeSubjectMetadataEnrichmentSuggestion(
+    overrides: Partial<SuggestedSubjectMetadataEnrichmentItem> = {},
+): SuggestedSubjectMetadataEnrichmentItem {
     const metadata: SuggestedSubjectMetadataEnrichmentItem['metadata'] = {
         contract_version: '1.0',
         issue: 813,
@@ -439,6 +446,72 @@ function paginated<T>(data: T[]): PaginatedData<BaseSuggestionItem> {
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
+
+describe('Assistance resource header links', () => {
+    it('renders the resource DOI as a visible editor link', () => {
+        const suggestion = makeSizeFormatSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ [SIZE_FORMAT_ASSISTANT_ID]: paginated([suggestion]) }}
+                manifests={[makeManifest(SIZE_FORMAT_ASSISTANT_ID, SIZE_FORMAT_ROUTE_PREFIX, SIZE_FORMAT_ASSISTANT_NAME)]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '10.5880/test.2026.004' });
+
+        expect(link).toHaveAttribute('href', '/editor?resourceId=40');
+        expect(link).toHaveAttribute('title', 'Open 10.5880/test.2026.004 in editor');
+        expect(link).toHaveClass('text-primary', 'underline');
+    });
+
+    it('links each resource group to its own editor target', () => {
+        const suggestions = [
+            makeSizeFormatSuggestion({
+                id: 41,
+                resource_id: 41,
+                resource_doi: '10.5880/test.2026.041',
+                resource_title: 'First resource',
+            }),
+            makeSizeFormatSuggestion({
+                id: 42,
+                resource_id: 42,
+                resource_doi: '10.5880/test.2026.042',
+                resource_title: 'Second resource',
+            }),
+        ];
+
+        render(
+            <AssistancePage
+                sections={{ [SIZE_FORMAT_ASSISTANT_ID]: paginated(suggestions) }}
+                manifests={[makeManifest(SIZE_FORMAT_ASSISTANT_ID, SIZE_FORMAT_ROUTE_PREFIX, SIZE_FORMAT_ASSISTANT_NAME)]}
+            />,
+        );
+
+        expect(screen.getByRole('link', { name: '10.5880/test.2026.041' })).toHaveAttribute('href', '/editor?resourceId=41');
+        expect(screen.getByRole('link', { name: '10.5880/test.2026.042' })).toHaveAttribute('href', '/editor?resourceId=42');
+    });
+
+    it('keeps the editor reachable when a suggestion has no DOI', () => {
+        const suggestion = makeSizeFormatSuggestion({
+            resource_id: 99,
+            resource_doi: '',
+            resource_title: 'Draft resource without DOI',
+        });
+
+        render(
+            <AssistancePage
+                sections={{ [SIZE_FORMAT_ASSISTANT_ID]: paginated([suggestion]) }}
+                manifests={[makeManifest(SIZE_FORMAT_ASSISTANT_ID, SIZE_FORMAT_ROUTE_PREFIX, SIZE_FORMAT_ASSISTANT_NAME)]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: 'Resource #99' });
+
+        expect(link).toHaveAttribute('href', '/editor?resourceId=99');
+        expect(link).toHaveAttribute('title', 'Open Resource #99 in editor');
+    });
+});
 
 describe('OrcidSuggestionCard – ORCID link', () => {
     it('renders the suggested ORCID as a clickable link', () => {
@@ -974,7 +1047,9 @@ describe('SubjectMetadataEnrichmentCard - DataCite Subject preview', () => {
         );
 
         expect(screen.getByText('Ambiguity: warning')).toBeInTheDocument();
-        expect(screen.getByText('This Free Keyword could be transferred into a Thesaurus Keyword if you accept this suggestion.')).toBeInTheDocument();
+        expect(
+            screen.getByText('This Free Keyword could be transferred into a Thesaurus Keyword if you accept this suggestion.'),
+        ).toBeInTheDocument();
         expect(screen.getByText('Vocabulary: EPOS MSL vocabulary')).toBeInTheDocument();
         expect(screen.getByText('Source: utrecht_msl_vocabulary')).toBeInTheDocument();
         expect(screen.getByText('File: msl-vocabulary.json')).toBeInTheDocument();
@@ -1185,7 +1260,9 @@ describe('DescriptionSegmentationSuggestionCard - description split preview', ()
         const suggestion = makeDescriptionSegmentationSuggestion({ id: 916 });
         const user = userEvent.setup();
 
-        mockedAxiosPost.mockResolvedValueOnce({ data: { success: true, message: 'Description segmentation applied.' } }).mockResolvedValueOnce({ data: {} });
+        mockedAxiosPost
+            .mockResolvedValueOnce({ data: { success: true, message: 'Description segmentation applied.' } })
+            .mockResolvedValueOnce({ data: {} });
 
         render(
             <AssistancePage

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -492,11 +492,11 @@ describe('Assistance resource header links', () => {
         expect(screen.getByRole('link', { name: '10.5880/test.2026.042' })).toHaveAttribute('href', '/editor?resourceId=42');
     });
 
-    it('keeps the editor reachable when a suggestion has no DOI', () => {
+    it('keeps the editor reachable with fallback labels when a suggestion has no DOI or title', () => {
         const suggestion = makeSizeFormatSuggestion({
             resource_id: 99,
-            resource_doi: '',
-            resource_title: 'Draft resource without DOI',
+            resource_doi: undefined,
+            resource_title: undefined,
         });
 
         render(
@@ -510,22 +510,23 @@ describe('Assistance resource header links', () => {
 
         expect(link).toHaveAttribute('href', '/editor?resourceId=99');
         expect(link).toHaveAttribute('title', 'Open Resource #99 in editor');
+        expect(screen.getByText(/Untitled/)).toBeInTheDocument();
     });
 
-    it('groups repeated resource suggestions while preserving fallback labels', () => {
+    it('promotes the first non-empty resource DOI and title from later grouped suggestions', () => {
         const suggestions = [
             makeSizeFormatSuggestion({
                 id: 101,
                 resource_id: 101,
-                resource_doi: undefined,
-                resource_title: undefined,
-                suggested_label: 'First missing metadata suggestion',
+                resource_doi: '   ',
+                resource_title: '   ',
+                suggested_label: 'First blank metadata suggestion',
             }),
             makeSizeFormatSuggestion({
                 id: 102,
                 resource_id: 101,
-                resource_doi: '10.5880/ignored.2026.102',
-                resource_title: 'Ignored later title',
+                resource_doi: '  10.5880/promoted.2026.102  ',
+                resource_title: '  Promoted later title  ',
                 suggested_label: 'Second suggestion for same resource',
             }),
         ];
@@ -537,11 +538,47 @@ describe('Assistance resource header links', () => {
             />,
         );
 
-        expect(screen.getByRole('link', { name: 'Resource #101' })).toHaveAttribute('href', '/editor?resourceId=101');
-        expect(screen.getByText(/Untitled/)).toBeInTheDocument();
+        const link = screen.getByRole('link', { name: '10.5880/promoted.2026.102' });
+
+        expect(link).toHaveAttribute('href', '/editor?resourceId=101');
+        expect(link).toHaveAttribute('title', 'Open 10.5880/promoted.2026.102 in editor');
+        expect(screen.getByText(/Promoted later title/)).toBeInTheDocument();
         expect(screen.getByText('2 suggestion(s)')).toBeInTheDocument();
         expect(screen.getAllByRole('button', { name: 'Accept' })).toHaveLength(2);
-        expect(screen.queryByRole('link', { name: '10.5880/ignored.2026.102' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Resource #101' })).not.toBeInTheDocument();
+    });
+
+    it('keeps the first non-empty resource DOI and title when later grouped suggestions conflict', () => {
+        const suggestions = [
+            makeSizeFormatSuggestion({
+                id: 201,
+                resource_id: 201,
+                resource_doi: '10.5880/original.2026.201',
+                resource_title: 'Original grouped title',
+                suggested_label: 'Original metadata suggestion',
+            }),
+            makeSizeFormatSuggestion({
+                id: 202,
+                resource_id: 201,
+                resource_doi: '10.5880/conflict.2026.201',
+                resource_title: 'Conflicting grouped title',
+                suggested_label: 'Conflicting metadata suggestion',
+            }),
+        ];
+
+        render(
+            <AssistancePage
+                sections={{ [SIZE_FORMAT_ASSISTANT_ID]: paginated(suggestions) }}
+                manifests={[makeManifest(SIZE_FORMAT_ASSISTANT_ID, SIZE_FORMAT_ROUTE_PREFIX, SIZE_FORMAT_ASSISTANT_NAME)]}
+            />,
+        );
+
+        const link = screen.getByRole('link', { name: '10.5880/original.2026.201' });
+
+        expect(link).toHaveAttribute('href', '/editor?resourceId=201');
+        expect(screen.getByText(/Original grouped title/)).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: '10.5880/conflict.2026.201' })).not.toBeInTheDocument();
+        expect(screen.queryByText(/Conflicting grouped title/)).not.toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
This pull request enhances the `AssistancePage` by making each resource group header a clickable link to the resource editor, improving navigation and accessibility. The resource label now falls back to a generic identifier if a DOI is missing, and new tests ensure this behavior is robust. Minor code style and formatting improvements are also included.

**Resource editor linking improvements:**
* Each resource group header in `AssistancePage` now displays as a clickable `Link` to the resource editor, using the resource's DOI or a fallback label if the DOI is missing (`resources/js/pages/assistance.tsx`). [[1]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL1-R1) [[2]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceR12) [[3]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceR63-R66) [[4]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL1576-R1591) [[5]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL1620-R1633) [[6]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL1637-R1648)
* Added a helper function `resourceEditorUrl` to generate editor URLs for each resource (`resources/js/pages/assistance.tsx`).

**Testing enhancements:**
* Added a new test suite to verify that resource headers link correctly to the editor, use fallback labels, and group suggestions as expected (`tests/vitest/pages/__tests__/assistance-links.test.tsx`).
* Updated test mocks to support the new `Link` component (`tests/vitest/pages/__tests__/assistance-links.test.tsx`).

**Code style and formatting:**
* Minor formatting adjustments for improved readability in both code and tests (`resources/js/pages/assistance.tsx`, `tests/vitest/pages/__tests__/assistance-links.test.tsx`). [[1]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL604-R609) [[2]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL1016-R1025) [[3]](diffhunk://#diff-c6d2a0a0326b6bd4cfbdac9f6ac6953d225b574de6bb860c8d569ef4287dceceL1112-R1113) [[4]](diffhunk://#diff-9de343647b0bb5087df6379d5fa8f004c0c989f4ae223d75cef051311e7c84e4L243-R250) [[5]](diffhunk://#diff-9de343647b0bb5087df6379d5fa8f004c0c989f4ae223d75cef051311e7c84e4L977-R1084) [[6]](diffhunk://#diff-9de343647b0bb5087df6379d5fa8f004c0c989f4ae223d75cef051311e7c84e4L1188-R1297)