### PR TITLE
Feature: Bulk acceptance for matching ROR affiliations

### DIFF
--- a/app/Http/Controllers/AssistanceController.php
+++ b/app/Http/Controllers/AssistanceController.php
@@ -148,8 +148,13 @@ class AssistanceController extends Controller
         $validated = $request->validated();
 
         $result = $this->rorDiscoveryService->acceptMatchingAffiliationRors((string) $validated['bulk_token']);
+        $statusCode = match (true) {
+            $result['success'] => 200,
+            $result['retryable'] ?? false => 500,
+            default => 422,
+        };
 
-        return response()->json($result, $result['success'] ? 200 : 422);
+        return response()->json($result, $statusCode);
     }
 
     /**

--- a/app/Http/Controllers/AssistanceController.php
+++ b/app/Http/Controllers/AssistanceController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Assistance\AcceptRorAffiliationMatchesRequest;
 use App\Http\Requests\Assistance\DeclineSuggestionRequest;
 use App\Models\User;
 use App\Services\Assistance\AssistantRegistrar;
@@ -142,11 +143,9 @@ class AssistanceController extends Controller
     /**
      * Accept further exact creator-affiliation matches for an accepted ROR suggestion.
      */
-    public function acceptRorAffiliationMatches(Request $request): JsonResponse
+    public function acceptRorAffiliationMatches(AcceptRorAffiliationMatchesRequest $request): JsonResponse
     {
-        $validated = $request->validate([
-            'bulk_token' => ['required', 'string'],
-        ]);
+        $validated = $request->validated();
 
         $result = $this->rorDiscoveryService->acceptMatchingAffiliationRors((string) $validated['bulk_token']);
 

--- a/app/Http/Controllers/AssistanceController.php
+++ b/app/Http/Controllers/AssistanceController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Assistance\DeclineSuggestionRequest;
 use App\Models\User;
 use App\Services\Assistance\AssistantRegistrar;
+use App\Services\RorDiscoveryService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -24,6 +25,7 @@ class AssistanceController extends Controller
 {
     public function __construct(
         private readonly AssistantRegistrar $registrar,
+        private readonly RorDiscoveryService $rorDiscoveryService,
     ) {}
 
     /**
@@ -135,6 +137,20 @@ class AssistanceController extends Controller
         $result = $assistant->acceptSuggestion($suggestion);
 
         return response()->json($result);
+    }
+
+    /**
+     * Accept further exact creator-affiliation matches for an accepted ROR suggestion.
+     */
+    public function acceptRorAffiliationMatches(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'bulk_token' => ['required', 'string'],
+        ]);
+
+        $result = $this->rorDiscoveryService->acceptMatchingAffiliationRors((string) $validated['bulk_token']);
+
+        return response()->json($result, $result['success'] ? 200 : 422);
     }
 
     /**

--- a/app/Http/Requests/Assistance/AcceptRorAffiliationMatchesRequest.php
+++ b/app/Http/Requests/Assistance/AcceptRorAffiliationMatchesRequest.php
@@ -23,7 +23,7 @@ class AcceptRorAffiliationMatchesRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'bulk_token' => ['required', 'string'],
+            'bulk_token' => ['required', 'string', 'uuid'],
         ];
     }
 }

--- a/app/Http/Requests/Assistance/AcceptRorAffiliationMatchesRequest.php
+++ b/app/Http/Requests/Assistance/AcceptRorAffiliationMatchesRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Assistance;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the short-lived token used to bulk-accept matching ROR affiliation suggestions.
+ */
+class AcceptRorAffiliationMatchesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'bulk_token' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Providers/AssistantServiceProvider.php
+++ b/app/Providers/AssistantServiceProvider.php
@@ -27,7 +27,7 @@ class AssistantServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(AssistantRegistrar::class, function () {
-            return new AssistantRegistrar();
+            return new AssistantRegistrar;
         });
     }
 
@@ -87,6 +87,12 @@ class AssistantServiceProvider extends ServiceProvider
                         ->name("assistance.check.{$id}.status")
                         ->defaults('assistantId', $id);
 
+                    if ($id === 'ror-suggestion') {
+                        Route::post("/{$prefix}/bulk-affiliation-accept", [AssistanceController::class, 'acceptRorAffiliationMatches'])
+                            ->name("assistance.{$id}.bulk-affiliation-accept")
+                            ->defaults('assistantId', $id);
+                    }
+
                     // Accept suggestion
                     Route::post("/{$prefix}/{suggestion}/accept", [AssistanceController::class, 'accept'])
                         ->where('suggestion', '[0-9]+')
@@ -121,7 +127,7 @@ class AssistantServiceProvider extends ServiceProvider
     private function cacheManifestPaths(): void
     {
         $basePath = base_path('modules/assistants');
-        $paths = is_dir($basePath) ? glob($basePath . '/*/manifest.json') : [];
+        $paths = is_dir($basePath) ? glob($basePath.'/*/manifest.json') : [];
         /** @var list<string> $paths */
         $paths = $paths !== false ? $paths : [];
 
@@ -134,7 +140,7 @@ class AssistantServiceProvider extends ServiceProvider
 
         $result = file_put_contents(
             $cachePath,
-            '<?php return ' . var_export($paths, true) . ';' . PHP_EOL,
+            '<?php return '.var_export($paths, true).';'.PHP_EOL,
         );
 
         if ($result === false) {

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\Enums\CacheKey;
 use App\Models\Affiliation;
+use App\Models\Institution;
 use App\Models\Person;
 use App\Models\Resource;
 use App\Models\ResourceCreator;
@@ -240,6 +241,9 @@ class RorAffiliationBulkAcceptanceService
         }
 
         $creatorName = $this->creatorName($creator);
+        if ($creatorName === null) {
+            return null;
+        }
 
         return [
             'creator_name' => $creatorName,
@@ -253,15 +257,19 @@ class RorAffiliationBulkAcceptanceService
         ];
     }
 
-    private function creatorName(ResourceCreator $creator): string
+    private function creatorName(ResourceCreator $creator): ?string
     {
-        $creatorable = $creator->creatorable;
+        $creatorable = $creator->getRelationValue('creatorable');
 
         if ($creatorable instanceof Person) {
             return $this->partyMapper->formatPersonName($creatorable);
         }
 
-        return $this->partyMapper->formatInstitutionName($creatorable);
+        if ($creatorable instanceof Institution) {
+            return $this->partyMapper->formatInstitutionName($creatorable);
+        }
+
+        return null;
     }
 
     /**

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -25,6 +25,8 @@ class RorAffiliationBulkAcceptanceService
 
     private const CACHE_TTL_MINUTES = 15;
 
+    private const MATCHING_SUGGESTION_BATCH_SIZE = 500;
+
     public function __construct(
         private readonly DataCitePartyMappingService $partyMapper,
         private readonly DataCiteSyncService $dataCiteSyncService,
@@ -207,29 +209,75 @@ class RorAffiliationBulkAcceptanceService
     {
         $matches = [];
 
-        $candidates = SuggestedRor::where('entity_type', 'affiliation')
+        SuggestedRor::query()
+            ->select(['id', 'entity_id'])
+            ->where('entity_type', 'affiliation')
             ->where('suggested_ror_id', $sourceContext['suggested_ror_id'])
             ->where('id', '!=', $acceptedSuggestionId)
-            ->get();
+            ->chunkById(self::MATCHING_SUGGESTION_BATCH_SIZE, function ($candidates) use (&$matches, $sourceContext): void {
+                $affiliationIds = $candidates->pluck('entity_id')
+                    ->map(fn ($id): int => (int) $id)
+                    ->unique()
+                    ->values()
+                    ->all();
 
-        foreach ($candidates as $candidate) {
-            $context = $this->contextForSuggestion($candidate);
+                if ($affiliationIds === []) {
+                    return;
+                }
 
-            if ($context === null || $context['already_has_ror']) {
-                continue;
-            }
+                $affiliations = Affiliation::query()
+                    ->whereIn('id', $affiliationIds)
+                    ->where('name', $sourceContext['affiliation'])
+                    ->where('affiliatable_type', ResourceCreator::class)
+                    ->where(function ($query): void {
+                        $query->where('identifier_scheme', '!=', 'ROR')
+                            ->orWhereNull('identifier_scheme')
+                            ->orWhereNull('identifier')
+                            ->orWhere('identifier', '');
+                    })
+                    ->get()
+                    ->keyBy('id');
 
-            if (
-                $context['creator_name'] === $sourceContext['creator_name']
-                && $context['affiliation'] === $sourceContext['affiliation']
-            ) {
-                $matches[] = [
-                    'suggestion_id' => (int) $candidate->id,
-                    'affiliation_id' => (int) $context['affiliation_model']->id,
-                    'resource_id' => (int) $context['resource_id'],
-                ];
-            }
-        }
+                if ($affiliations->isEmpty()) {
+                    return;
+                }
+
+                $creatorIds = $affiliations->pluck('affiliatable_id')
+                    ->map(fn ($id): int => (int) $id)
+                    ->unique()
+                    ->values()
+                    ->all();
+
+                $creators = ResourceCreator::with('creatorable')
+                    ->whereIn('id', $creatorIds)
+                    ->whereIn('creatorable_type', [Person::class, Institution::class])
+                    ->get()
+                    ->keyBy('id');
+
+                foreach ($candidates as $candidate) {
+                    $affiliation = $affiliations->get($candidate->entity_id);
+
+                    if (! $affiliation instanceof Affiliation) {
+                        continue;
+                    }
+
+                    $creator = $creators->get($affiliation->affiliatable_id);
+
+                    if (! $creator instanceof ResourceCreator) {
+                        continue;
+                    }
+
+                    if ($this->creatorName($creator) !== $sourceContext['creator_name']) {
+                        continue;
+                    }
+
+                    $matches[] = [
+                        'suggestion_id' => (int) $candidate->id,
+                        'affiliation_id' => (int) $affiliation->id,
+                        'resource_id' => (int) $creator->resource_id,
+                    ];
+                }
+            });
 
         return $matches;
     }

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -27,6 +27,8 @@ class RorAffiliationBulkAcceptanceService
 
     private const MATCHING_SUGGESTION_BATCH_SIZE = 500;
 
+    private const DEFAULT_MAX_BULK_MATCHES_PER_TOKEN = 1000;
+
     public function __construct(
         private readonly DataCitePartyMappingService $partyMapper,
         private readonly DataCiteSyncService $dataCiteSyncService,
@@ -45,9 +47,10 @@ class RorAffiliationBulkAcceptanceService
             return null;
         }
 
-        $matchingSuggestions = $this->matchingSuggestions($sourceContext, $acceptedSuggestion->id);
+        $maxBulkMatches = $this->maxBulkMatchesPerToken();
+        $matchingSuggestions = $this->matchingSuggestions($sourceContext, $acceptedSuggestion->id, $maxBulkMatches + 1);
 
-        if ($matchingSuggestions === []) {
+        if ($matchingSuggestions === [] || count($matchingSuggestions) > $maxBulkMatches) {
             return null;
         }
 
@@ -105,14 +108,10 @@ class RorAffiliationBulkAcceptanceService
         $acceptedCount = 0;
         $skippedCount = 0;
 
-        $suggestionIds = [];
-        foreach ($matches as $match) {
-            $suggestionIds[] = $match['suggestion_id'];
-        }
+        $matchChunks = array_chunk($matches, self::MATCHING_SUGGESTION_BATCH_SIZE);
 
         DB::transaction(function () use (
-            $matches,
-            $suggestionIds,
+            $matchChunks,
             $creatorName,
             $affiliation,
             $suggestedRorId,
@@ -121,62 +120,65 @@ class RorAffiliationBulkAcceptanceService
             &$acceptedCount,
             &$skippedCount,
         ): void {
-            $suggestions = SuggestedRor::whereIn('id', $suggestionIds)
-                ->where('entity_type', 'affiliation')
-                ->where('suggested_ror_id', $suggestedRorId)
-                ->get()
-                ->keyBy('id');
+            foreach ($matchChunks as $matchChunk) {
+                $suggestionIds = array_column($matchChunk, 'suggestion_id');
+                $suggestions = SuggestedRor::whereIn('id', $suggestionIds)
+                    ->where('entity_type', 'affiliation')
+                    ->where('suggested_ror_id', $suggestedRorId)
+                    ->get()
+                    ->keyBy('id');
 
-            foreach ($matches as $match) {
-                $suggestionId = $match['suggestion_id'];
-                $suggestion = $suggestions->get($suggestionId);
+                foreach ($matchChunk as $match) {
+                    $suggestionId = $match['suggestion_id'];
+                    $suggestion = $suggestions->get($suggestionId);
 
-                if (! $suggestion instanceof SuggestedRor) {
-                    if ($this->affiliationHasExpectedRor($match['affiliation_id'], $suggestedRorId)) {
-                        $alreadyAcceptedResourceIds[] = $match['resource_id'];
-                    } else {
-                        $skippedCount++;
+                    if (! $suggestion instanceof SuggestedRor) {
+                        if ($this->affiliationHasExpectedRor($match['affiliation_id'], $suggestedRorId)) {
+                            $alreadyAcceptedResourceIds[] = $match['resource_id'];
+                        } else {
+                            $skippedCount++;
+                        }
+
+                        continue;
                     }
 
-                    continue;
-                }
+                    $context = $this->contextForSuggestion($suggestion, lockAffiliation: true);
 
-                $context = $this->contextForSuggestion($suggestion, lockAffiliation: true);
+                    if ($context === null) {
+                        $this->deleteAffiliationSuggestions($suggestion->entity_id);
+                        $skippedCount++;
 
-                if ($context === null) {
-                    $this->deleteAffiliationSuggestions($suggestion->entity_id);
-                    $skippedCount++;
+                        continue;
+                    }
 
-                    continue;
-                }
+                    if ($context['already_has_ror']) {
+                        $this->deleteAffiliationSuggestions($context['affiliation_model']->id);
+                        $skippedCount++;
 
-                if ($context['already_has_ror']) {
+                        continue;
+                    }
+
+                    if (
+                        $context['creator_name'] !== $creatorName
+                        || $context['affiliation'] !== $affiliation
+                        || $context['suggested_ror_id'] !== $suggestedRorId
+                    ) {
+                        $skippedCount++;
+
+                        continue;
+                    }
+
+                    $context['affiliation_model']->update([
+                        'identifier' => $suggestedRorId,
+                        'identifier_scheme' => 'ROR',
+                        'scheme_uri' => 'https://ror.org/',
+                    ]);
+
                     $this->deleteAffiliationSuggestions($context['affiliation_model']->id);
-                    $skippedCount++;
 
-                    continue;
+                    $acceptedResourceIds[] = $context['resource_id'];
+                    $acceptedCount++;
                 }
-
-                if (
-                    $context['creator_name'] !== $creatorName
-                    || $context['affiliation'] !== $affiliation
-                    || $context['suggested_ror_id'] !== $suggestedRorId
-                ) {
-                    $skippedCount++;
-
-                    continue;
-                }
-
-                $context['affiliation_model']->update([
-                    'identifier' => $suggestedRorId,
-                    'identifier_scheme' => 'ROR',
-                    'scheme_uri' => 'https://ror.org/',
-                ]);
-
-                $this->deleteAffiliationSuggestions($context['affiliation_model']->id);
-
-                $acceptedResourceIds[] = $context['resource_id'];
-                $acceptedCount++;
             }
         });
 
@@ -203,7 +205,7 @@ class RorAffiliationBulkAcceptanceService
 
         $message = $acceptedCount > 0
             ? sprintf('ROR-ID accepted for %d further %s.', $acceptedCount, Str::plural('creator affiliation', $acceptedCount))
-            : $this->messageForRetrySync($alreadyAcceptedResourceIds);
+            : $this->messageForRetrySync($alreadyAcceptedResourceIds, $syncResult['synced_dois']);
 
         return [
             'success' => $acceptedCount > 0 || $alreadyAcceptedResourceIds !== [],
@@ -218,7 +220,7 @@ class RorAffiliationBulkAcceptanceService
      * @param  array{creator_name: string, affiliation: string, suggested_ror_id: string}  $sourceContext
      * @return array<int, array{suggestion_id: int, affiliation_id: int, resource_id: int}>
      */
-    private function matchingSuggestions(array $sourceContext, int $acceptedSuggestionId): array
+    private function matchingSuggestions(array $sourceContext, int $acceptedSuggestionId, int $limit): array
     {
         $matches = [];
 
@@ -227,7 +229,7 @@ class RorAffiliationBulkAcceptanceService
             ->where('entity_type', 'affiliation')
             ->where('suggested_ror_id', $sourceContext['suggested_ror_id'])
             ->where('id', '!=', $acceptedSuggestionId)
-            ->chunkById(self::MATCHING_SUGGESTION_BATCH_SIZE, function ($candidates) use (&$matches, $sourceContext): void {
+            ->chunkById(self::MATCHING_SUGGESTION_BATCH_SIZE, function ($candidates) use (&$matches, $sourceContext, $limit): bool {
                 $affiliationIds = $candidates->pluck('entity_id')
                     ->map(fn ($id): int => (int) $id)
                     ->unique()
@@ -235,7 +237,7 @@ class RorAffiliationBulkAcceptanceService
                     ->all();
 
                 if ($affiliationIds === []) {
-                    return;
+                    return true;
                 }
 
                 $affiliations = Affiliation::query()
@@ -252,7 +254,7 @@ class RorAffiliationBulkAcceptanceService
                     ->keyBy('id');
 
                 if ($affiliations->isEmpty()) {
-                    return;
+                    return true;
                 }
 
                 $creatorIds = $affiliations->pluck('affiliatable_id')
@@ -289,7 +291,13 @@ class RorAffiliationBulkAcceptanceService
                         'affiliation_id' => (int) $affiliation->id,
                         'resource_id' => (int) $creator->resource_id,
                     ];
+
+                    if (count($matches) >= $limit) {
+                        return false;
+                    }
                 }
+
+                return true;
             });
 
         return $matches;
@@ -421,11 +429,20 @@ class RorAffiliationBulkAcceptanceService
 
     /**
      * @param  array<int, int>  $alreadyAcceptedResourceIds
+     * @param  array<int, string>  $syncedDois
      */
-    private function messageForRetrySync(array $alreadyAcceptedResourceIds): string
+    private function messageForRetrySync(array $alreadyAcceptedResourceIds, array $syncedDois): string
     {
         if ($alreadyAcceptedResourceIds !== []) {
             $alreadyAcceptedCount = count(array_unique($alreadyAcceptedResourceIds));
+
+            if ($syncedDois === []) {
+                return sprintf(
+                    'ROR-ID acceptance was already applied for %d further %s. No resources required DataCite sync.',
+                    $alreadyAcceptedCount,
+                    Str::plural('creator affiliation', $alreadyAcceptedCount),
+                );
+            }
 
             return sprintf(
                 'ROR-ID acceptance was already applied for %d further %s. DataCite sync has been retried.',
@@ -435,6 +452,14 @@ class RorAffiliationBulkAcceptanceService
         }
 
         return 'No further matching creator affiliations could be accepted.';
+    }
+
+    private function maxBulkMatchesPerToken(): int
+    {
+        return max(
+            1,
+            (int) config('services.ror_affiliation_bulk_accept.max_matches', self::DEFAULT_MAX_BULK_MATCHES_PER_TOKEN),
+        );
     }
 
     /**

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -169,6 +169,12 @@ class RorAffiliationBulkAcceptanceService
                         continue;
                     }
 
+                    if ($context['has_identifier']) {
+                        $skippedCount++;
+
+                        continue;
+                    }
+
                     $context['affiliation_model']->update([
                         'identifier' => $suggestedRorId,
                         'identifier_scheme' => 'ROR',
@@ -246,9 +252,7 @@ class RorAffiliationBulkAcceptanceService
                     ->where('name', $sourceContext['affiliation'])
                     ->where('affiliatable_type', ResourceCreator::class)
                     ->where(function ($query): void {
-                        $query->where('identifier_scheme', '!=', 'ROR')
-                            ->orWhereNull('identifier_scheme')
-                            ->orWhereNull('identifier')
+                        $query->whereNull('identifier')
                             ->orWhere('identifier', '');
                     })
                     ->get()
@@ -305,7 +309,7 @@ class RorAffiliationBulkAcceptanceService
     }
 
     /**
-     * @return array{creator_name: string, affiliation: string, suggested_ror_id: string, already_has_ror: bool, resource_id: int, affiliation_model: Affiliation}|null
+     * @return array{creator_name: string, affiliation: string, suggested_ror_id: string, already_has_ror: bool, has_identifier: bool, resource_id: int, affiliation_model: Affiliation}|null
      */
     private function contextForSuggestion(SuggestedRor $suggestion, bool $lockAffiliation = false): ?array
     {
@@ -342,8 +346,8 @@ class RorAffiliationBulkAcceptanceService
             'affiliation' => $affiliation->name,
             'suggested_ror_id' => $suggestion->suggested_ror_id,
             'already_has_ror' => $affiliation->identifier_scheme === 'ROR'
-                && $affiliation->identifier !== null
-                && $affiliation->identifier !== '',
+                && $this->affiliationHasIdentifier($affiliation),
+            'has_identifier' => $this->affiliationHasIdentifier($affiliation),
             'resource_id' => (int) $creator->resource_id,
             'affiliation_model' => $affiliation,
         ];
@@ -426,6 +430,11 @@ class RorAffiliationBulkAcceptanceService
             ->where('identifier_scheme', 'ROR')
             ->where('identifier', $suggestedRorId)
             ->exists();
+    }
+
+    private function affiliationHasIdentifier(Affiliation $affiliation): bool
+    {
+        return $affiliation->identifier !== null && $affiliation->identifier !== '';
     }
 
     /**

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -128,6 +128,8 @@ class RorAffiliationBulkAcceptanceService
                     ->get()
                     ->keyBy('id');
 
+                $contexts = $this->contextsForSuggestions($suggestions->values(), lockAffiliations: true);
+
                 foreach ($matchChunk as $match) {
                     $suggestionId = $match['suggestion_id'];
                     $suggestion = $suggestions->get($suggestionId);
@@ -143,7 +145,7 @@ class RorAffiliationBulkAcceptanceService
                         continue;
                     }
 
-                    $context = $this->contextForSuggestion($suggestion, lockAffiliation: true);
+                    $context = $contexts[$suggestionId] ?? null;
 
                     if ($context === null) {
                         $this->deleteAffiliationSuggestions($suggestion->entity_id);
@@ -313,34 +315,100 @@ class RorAffiliationBulkAcceptanceService
      */
     private function contextForSuggestion(SuggestedRor $suggestion, bool $lockAffiliation = false): ?array
     {
-        if ($suggestion->entity_type !== 'affiliation') {
-            return null;
+        $contexts = $this->contextsForSuggestions([$suggestion], $lockAffiliation);
+
+        return $contexts[(int) $suggestion->id] ?? null;
+    }
+
+    /**
+     * @param  iterable<int, SuggestedRor>  $suggestions
+     * @return array<int, array{creator_name: string, affiliation: string, suggested_ror_id: string, already_has_ror: bool, has_identifier: bool, resource_id: int, affiliation_model: Affiliation}>
+     */
+    private function contextsForSuggestions(iterable $suggestions, bool $lockAffiliations = false): array
+    {
+        $suggestionList = [];
+        $affiliationIds = [];
+
+        foreach ($suggestions as $suggestion) {
+            if ($suggestion->entity_type !== 'affiliation') {
+                continue;
+            }
+
+            $suggestionId = (int) $suggestion->id;
+            $suggestionList[$suggestionId] = $suggestion;
+            $affiliationIds[] = (int) $suggestion->entity_id;
         }
 
-        $affiliationQuery = Affiliation::query();
+        if ($affiliationIds === []) {
+            return [];
+        }
 
-        if ($lockAffiliation) {
+        $affiliationQuery = Affiliation::query()
+            ->whereIn('id', array_values(array_unique($affiliationIds)))
+            ->orderBy('id');
+
+        if ($lockAffiliations) {
             $affiliationQuery->lockForUpdate();
         }
 
-        /** @var Affiliation|null $affiliation */
-        $affiliation = $affiliationQuery->find($suggestion->entity_id);
+        $affiliations = $affiliationQuery->get()->keyBy('id');
 
-        if (! $affiliation instanceof Affiliation || $affiliation->affiliatable_type !== ResourceCreator::class) {
-            return null;
+        if ($affiliations->isEmpty()) {
+            return [];
         }
 
-        $creator = ResourceCreator::with('creatorable')->find($affiliation->affiliatable_id);
-
-        if (! $creator instanceof ResourceCreator) {
-            return null;
+        $creatorIds = [];
+        foreach ($affiliations as $affiliation) {
+            if ($affiliation->affiliatable_type === ResourceCreator::class) {
+                $creatorIds[] = (int) $affiliation->affiliatable_id;
+            }
         }
 
-        $creatorName = $this->creatorName($creator);
-        if ($creatorName === null) {
-            return null;
+        if ($creatorIds === []) {
+            return [];
         }
 
+        $creators = ResourceCreator::with('creatorable')
+            ->whereIn('id', array_values(array_unique($creatorIds)))
+            ->orderBy('id')
+            ->get()
+            ->keyBy('id');
+        $contexts = [];
+
+        foreach ($suggestionList as $suggestionId => $suggestion) {
+            $affiliation = $affiliations->get($suggestion->entity_id);
+
+            if (! $affiliation instanceof Affiliation || $affiliation->affiliatable_type !== ResourceCreator::class) {
+                continue;
+            }
+
+            $creator = $creators->get($affiliation->affiliatable_id);
+
+            if (! $creator instanceof ResourceCreator) {
+                continue;
+            }
+
+            $creatorName = $this->creatorName($creator);
+            if ($creatorName === null) {
+                continue;
+            }
+
+            $contexts[$suggestionId] = $this->contextFromSuggestionModels(
+                $suggestion,
+                $affiliation,
+                $creatorName,
+                (int) $creator->resource_id,
+            );
+        }
+
+        return $contexts;
+    }
+
+    /**
+     * @return array{creator_name: string, affiliation: string, suggested_ror_id: string, already_has_ror: bool, has_identifier: bool, resource_id: int, affiliation_model: Affiliation}
+     */
+    private function contextFromSuggestionModels(SuggestedRor $suggestion, Affiliation $affiliation, string $creatorName, int $resourceId): array
+    {
         return [
             'creator_name' => $creatorName,
             'affiliation' => $affiliation->name,
@@ -348,7 +416,7 @@ class RorAffiliationBulkAcceptanceService
             'already_has_ror' => $affiliation->identifier_scheme === 'ROR'
                 && $this->affiliationHasIdentifier($affiliation),
             'has_identifier' => $this->affiliationHasIdentifier($affiliation),
-            'resource_id' => (int) $creator->resource_id,
+            'resource_id' => $resourceId,
             'affiliation_model' => $affiliation,
         ];
     }

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -55,7 +55,7 @@ class RorAffiliationBulkAcceptanceService
             'creator_name' => $sourceContext['creator_name'],
             'affiliation' => $sourceContext['affiliation'],
             'suggested_ror_id' => $sourceContext['suggested_ror_id'],
-            'suggestion_ids' => array_column($matchingSuggestions, 'suggestion_id'),
+            'matches' => $matchingSuggestions,
         ], now()->addMinutes(self::CACHE_TTL_MINUTES));
 
         return [
@@ -88,8 +88,8 @@ class RorAffiliationBulkAcceptanceService
             ];
         }
 
-        /** @var array<int, int> $suggestionIds */
-        $suggestionIds = $payload['suggestion_ids'];
+        /** @var array<int, array{suggestion_id: int, affiliation_id: int, resource_id: int}> $matches */
+        $matches = $payload['matches'];
         /** @var string $creatorName */
         $creatorName = $payload['creator_name'];
         /** @var string $affiliation */
@@ -98,15 +98,23 @@ class RorAffiliationBulkAcceptanceService
         $suggestedRorId = $payload['suggested_ror_id'];
 
         $acceptedResourceIds = [];
+        $alreadyAcceptedResourceIds = [];
         $acceptedCount = 0;
         $skippedCount = 0;
 
+        $suggestionIds = [];
+        foreach ($matches as $match) {
+            $suggestionIds[] = $match['suggestion_id'];
+        }
+
         DB::transaction(function () use (
+            $matches,
             $suggestionIds,
             $creatorName,
             $affiliation,
             $suggestedRorId,
             &$acceptedResourceIds,
+            &$alreadyAcceptedResourceIds,
             &$acceptedCount,
             &$skippedCount,
         ): void {
@@ -116,11 +124,16 @@ class RorAffiliationBulkAcceptanceService
                 ->get()
                 ->keyBy('id');
 
-            foreach ($suggestionIds as $suggestionId) {
+            foreach ($matches as $match) {
+                $suggestionId = $match['suggestion_id'];
                 $suggestion = $suggestions->get($suggestionId);
 
                 if (! $suggestion instanceof SuggestedRor) {
-                    $skippedCount++;
+                    if ($this->affiliationHasExpectedRor($match['affiliation_id'], $suggestedRorId)) {
+                        $alreadyAcceptedResourceIds[] = $match['resource_id'];
+                    } else {
+                        $skippedCount++;
+                    }
 
                     continue;
                 }
@@ -164,16 +177,21 @@ class RorAffiliationBulkAcceptanceService
             }
         });
 
-        $syncedDois = $this->syncResources(array_values(array_unique($acceptedResourceIds)));
+        $syncResourceIds = array_values(array_unique([
+            ...$acceptedResourceIds,
+            ...$alreadyAcceptedResourceIds,
+        ]));
+
+        $syncedDois = $this->syncResources($syncResourceIds);
         CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT->forget();
         Cache::forget($cacheKey);
 
         $message = $acceptedCount > 0
             ? sprintf('ROR-ID accepted for %d further %s.', $acceptedCount, Str::plural('creator affiliation', $acceptedCount))
-            : 'No further matching creator affiliations could be accepted.';
+            : $this->messageForRetrySync($alreadyAcceptedResourceIds);
 
         return [
-            'success' => $acceptedCount > 0,
+            'success' => $acceptedCount > 0 || $alreadyAcceptedResourceIds !== [],
             'accepted_count' => $acceptedCount,
             'skipped_count' => $skippedCount,
             'synced_dois' => $syncedDois,
@@ -183,7 +201,7 @@ class RorAffiliationBulkAcceptanceService
 
     /**
      * @param  array{creator_name: string, affiliation: string, suggested_ror_id: string}  $sourceContext
-     * @return array<int, array{suggestion_id: int}>
+     * @return array<int, array{suggestion_id: int, affiliation_id: int, resource_id: int}>
      */
     private function matchingSuggestions(array $sourceContext, int $acceptedSuggestionId): array
     {
@@ -205,7 +223,11 @@ class RorAffiliationBulkAcceptanceService
                 $context['creator_name'] === $sourceContext['creator_name']
                 && $context['affiliation'] === $sourceContext['affiliation']
             ) {
-                $matches[] = ['suggestion_id' => $candidate->id];
+                $matches[] = [
+                    'suggestion_id' => (int) $candidate->id,
+                    'affiliation_id' => (int) $context['affiliation_model']->id,
+                    'resource_id' => (int) $context['resource_id'],
+                ];
             }
         }
 
@@ -252,7 +274,7 @@ class RorAffiliationBulkAcceptanceService
             'already_has_ror' => $affiliation->identifier_scheme === 'ROR'
                 && $affiliation->identifier !== null
                 && $affiliation->identifier !== '',
-            'resource_id' => $creator->resource_id,
+            'resource_id' => (int) $creator->resource_id,
             'affiliation_model' => $affiliation,
         ];
     }
@@ -306,8 +328,34 @@ class RorAffiliationBulkAcceptanceService
             ->delete();
     }
 
+    private function affiliationHasExpectedRor(int $affiliationId, string $suggestedRorId): bool
+    {
+        return Affiliation::whereKey($affiliationId)
+            ->where('identifier_scheme', 'ROR')
+            ->where('identifier', $suggestedRorId)
+            ->exists();
+    }
+
     /**
-     * @phpstan-assert-if-true array{creator_name: string, affiliation: string, suggested_ror_id: string, suggestion_ids: array<int, int>} $payload
+     * @param  array<int, int>  $alreadyAcceptedResourceIds
+     */
+    private function messageForRetrySync(array $alreadyAcceptedResourceIds): string
+    {
+        if ($alreadyAcceptedResourceIds !== []) {
+            $alreadyAcceptedCount = count(array_unique($alreadyAcceptedResourceIds));
+
+            return sprintf(
+                'ROR-ID acceptance was already applied for %d further %s. DataCite sync has been retried.',
+                $alreadyAcceptedCount,
+                Str::plural('creator affiliation', $alreadyAcceptedCount),
+            );
+        }
+
+        return 'No further matching creator affiliations could be accepted.';
+    }
+
+    /**
+     * @phpstan-assert-if-true array{creator_name: string, affiliation: string, suggested_ror_id: string, matches: array<int, array{suggestion_id: int, affiliation_id: int, resource_id: int}>} $payload
      */
     private function isValidPayload(mixed $payload): bool
     {
@@ -319,13 +367,18 @@ class RorAffiliationBulkAcceptanceService
             ! is_string($payload['creator_name'] ?? null)
             || ! is_string($payload['affiliation'] ?? null)
             || ! is_string($payload['suggested_ror_id'] ?? null)
-            || ! is_array($payload['suggestion_ids'] ?? null)
+            || ! is_array($payload['matches'] ?? null)
         ) {
             return false;
         }
 
-        foreach ($payload['suggestion_ids'] as $suggestionId) {
-            if (! is_int($suggestionId)) {
+        foreach ($payload['matches'] as $match) {
+            if (
+                ! is_array($match)
+                || ! is_int($match['suggestion_id'] ?? null)
+                || ! is_int($match['affiliation_id'] ?? null)
+                || ! is_int($match['resource_id'] ?? null)
+            ) {
                 return false;
             }
         }

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CacheKey;
+use App\Models\Affiliation;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\SuggestedRor;
+use App\Services\DataCite\Mapping\DataCitePartyMappingService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Handles the Issue #955 bulk accept flow for ROR suggestions on creator affiliations.
+ */
+class RorAffiliationBulkAcceptanceService
+{
+    private const CACHE_PREFIX = 'ror_affiliation_bulk_accept';
+
+    private const CACHE_TTL_MINUTES = 15;
+
+    public function __construct(
+        private readonly DataCitePartyMappingService $partyMapper,
+        private readonly DataCiteSyncService $dataCiteSyncService,
+    ) {}
+
+    /**
+     * Create a short-lived bulk accept preview for further exact creator/affiliation matches.
+     *
+     * @return array{available: bool, count: int, bulk_token: string, creator_name: string, affiliation: string, suggested_ror_id: string}|null
+     */
+    public function createPreviewForAcceptedSuggestion(SuggestedRor $acceptedSuggestion): ?array
+    {
+        $sourceContext = $this->contextForSuggestion($acceptedSuggestion);
+
+        if ($sourceContext === null) {
+            return null;
+        }
+
+        $matchingSuggestions = $this->matchingSuggestions($sourceContext, $acceptedSuggestion->id);
+
+        if ($matchingSuggestions === []) {
+            return null;
+        }
+
+        $token = (string) Str::uuid();
+
+        Cache::put($this->cacheKey($token), [
+            'creator_name' => $sourceContext['creator_name'],
+            'affiliation' => $sourceContext['affiliation'],
+            'suggested_ror_id' => $sourceContext['suggested_ror_id'],
+            'suggestion_ids' => array_column($matchingSuggestions, 'suggestion_id'),
+        ], now()->addMinutes(self::CACHE_TTL_MINUTES));
+
+        return [
+            'available' => true,
+            'count' => count($matchingSuggestions),
+            'bulk_token' => $token,
+            'creator_name' => $sourceContext['creator_name'],
+            'affiliation' => $sourceContext['affiliation'],
+            'suggested_ror_id' => $sourceContext['suggested_ror_id'],
+        ];
+    }
+
+    /**
+     * Accept all still-valid exact matches captured by a preview token.
+     *
+     * @return array{success: bool, accepted_count: int, skipped_count: int, synced_dois: array<int, string>, message: string}
+     */
+    public function acceptByToken(string $token): array
+    {
+        $payload = Cache::pull($this->cacheKey($token));
+
+        if (! is_array($payload) || ! $this->isValidPayload($payload)) {
+            return [
+                'success' => false,
+                'accepted_count' => 0,
+                'skipped_count' => 0,
+                'synced_dois' => [],
+                'message' => 'Bulk ROR acceptance token is invalid or has expired.',
+            ];
+        }
+
+        /** @var array<int, int> $suggestionIds */
+        $suggestionIds = $payload['suggestion_ids'];
+        /** @var string $creatorName */
+        $creatorName = $payload['creator_name'];
+        /** @var string $affiliation */
+        $affiliation = $payload['affiliation'];
+        /** @var string $suggestedRorId */
+        $suggestedRorId = $payload['suggested_ror_id'];
+
+        $acceptedResourceIds = [];
+        $acceptedCount = 0;
+        $skippedCount = 0;
+
+        DB::transaction(function () use (
+            $suggestionIds,
+            $creatorName,
+            $affiliation,
+            $suggestedRorId,
+            &$acceptedResourceIds,
+            &$acceptedCount,
+            &$skippedCount,
+        ): void {
+            $suggestions = SuggestedRor::whereIn('id', $suggestionIds)
+                ->where('entity_type', 'affiliation')
+                ->where('suggested_ror_id', $suggestedRorId)
+                ->get()
+                ->keyBy('id');
+
+            foreach ($suggestionIds as $suggestionId) {
+                $suggestion = $suggestions->get($suggestionId);
+
+                if (! $suggestion instanceof SuggestedRor) {
+                    $skippedCount++;
+
+                    continue;
+                }
+
+                $context = $this->contextForSuggestion($suggestion, lockAffiliation: true);
+
+                if ($context === null) {
+                    $suggestion->delete();
+                    $skippedCount++;
+
+                    continue;
+                }
+
+                if ($context['already_has_ror']) {
+                    $suggestion->delete();
+                    $skippedCount++;
+
+                    continue;
+                }
+
+                if (
+                    $context['creator_name'] !== $creatorName
+                    || $context['affiliation'] !== $affiliation
+                    || $context['suggested_ror_id'] !== $suggestedRorId
+                ) {
+                    $skippedCount++;
+
+                    continue;
+                }
+
+                $context['affiliation_model']->update([
+                    'identifier' => $suggestedRorId,
+                    'identifier_scheme' => 'ROR',
+                    'scheme_uri' => 'https://ror.org/',
+                ]);
+
+                SuggestedRor::where('entity_type', 'affiliation')
+                    ->where('entity_id', $context['affiliation_model']->id)
+                    ->delete();
+
+                $acceptedResourceIds[] = $context['resource_id'];
+                $acceptedCount++;
+            }
+        });
+
+        $syncedDois = $this->syncResources(array_values(array_unique($acceptedResourceIds)));
+        CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT->forget();
+
+        $message = $acceptedCount > 0
+            ? "ROR-ID accepted for {$acceptedCount} further creator affiliation(s)."
+            : 'No further matching creator affiliations could be accepted.';
+
+        return [
+            'success' => $acceptedCount > 0,
+            'accepted_count' => $acceptedCount,
+            'skipped_count' => $skippedCount,
+            'synced_dois' => $syncedDois,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @param  array{creator_name: string, affiliation: string, suggested_ror_id: string}  $sourceContext
+     * @return array<int, array{suggestion_id: int}>
+     */
+    private function matchingSuggestions(array $sourceContext, int $acceptedSuggestionId): array
+    {
+        $matches = [];
+
+        $candidates = SuggestedRor::where('entity_type', 'affiliation')
+            ->where('suggested_ror_id', $sourceContext['suggested_ror_id'])
+            ->where('id', '!=', $acceptedSuggestionId)
+            ->get();
+
+        foreach ($candidates as $candidate) {
+            $context = $this->contextForSuggestion($candidate);
+
+            if ($context === null || $context['already_has_ror']) {
+                continue;
+            }
+
+            if (
+                $context['creator_name'] === $sourceContext['creator_name']
+                && $context['affiliation'] === $sourceContext['affiliation']
+            ) {
+                $matches[] = ['suggestion_id' => $candidate->id];
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array{creator_name: string, affiliation: string, suggested_ror_id: string, already_has_ror: bool, resource_id: int, affiliation_model: Affiliation}|null
+     */
+    private function contextForSuggestion(SuggestedRor $suggestion, bool $lockAffiliation = false): ?array
+    {
+        if ($suggestion->entity_type !== 'affiliation') {
+            return null;
+        }
+
+        $affiliationQuery = Affiliation::query();
+
+        if ($lockAffiliation) {
+            $affiliationQuery->lockForUpdate();
+        }
+
+        /** @var Affiliation|null $affiliation */
+        $affiliation = $affiliationQuery->find($suggestion->entity_id);
+
+        if (! $affiliation instanceof Affiliation || $affiliation->affiliatable_type !== ResourceCreator::class) {
+            return null;
+        }
+
+        $creator = ResourceCreator::with('creatorable')->find($affiliation->affiliatable_id);
+
+        if (! $creator instanceof ResourceCreator) {
+            return null;
+        }
+
+        $creatorName = $this->creatorName($creator);
+
+        return [
+            'creator_name' => $creatorName,
+            'affiliation' => $affiliation->name,
+            'suggested_ror_id' => $suggestion->suggested_ror_id,
+            'already_has_ror' => $affiliation->identifier_scheme === 'ROR'
+                && $affiliation->identifier !== null
+                && $affiliation->identifier !== '',
+            'resource_id' => $creator->resource_id,
+            'affiliation_model' => $affiliation,
+        ];
+    }
+
+    private function creatorName(ResourceCreator $creator): string
+    {
+        $creatorable = $creator->creatorable;
+
+        if ($creatorable instanceof Person) {
+            return $this->partyMapper->formatPersonName($creatorable);
+        }
+
+        return $this->partyMapper->formatInstitutionName($creatorable);
+    }
+
+    /**
+     * @param  array<int, int>  $resourceIds
+     * @return array<int, string>
+     */
+    private function syncResources(array $resourceIds): array
+    {
+        if ($resourceIds === []) {
+            return [];
+        }
+
+        $syncedDois = [];
+
+        $resources = Resource::whereIn('id', $resourceIds)
+            ->whereNotNull('doi')
+            ->where('doi', '!=', '')
+            ->get();
+
+        foreach ($resources as $resource) {
+            $result = $this->dataCiteSyncService->syncIfRegistered($resource);
+            if ($result->success && $resource->doi !== null) {
+                $syncedDois[] = $resource->doi;
+            }
+        }
+
+        return $syncedDois;
+    }
+
+    /**
+     * @phpstan-assert-if-true array{creator_name: string, affiliation: string, suggested_ror_id: string, suggestion_ids: array<int, int>} $payload
+     */
+    private function isValidPayload(mixed $payload): bool
+    {
+        if (! is_array($payload)) {
+            return false;
+        }
+
+        if (
+            ! is_string($payload['creator_name'] ?? null)
+            || ! is_string($payload['affiliation'] ?? null)
+            || ! is_string($payload['suggested_ror_id'] ?? null)
+            || ! is_array($payload['suggestion_ids'] ?? null)
+        ) {
+            return false;
+        }
+
+        foreach ($payload['suggestion_ids'] as $suggestionId) {
+            if (! is_int($suggestionId)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function cacheKey(string $token): string
+    {
+        return self::CACHE_PREFIX.':'.$token;
+    }
+}

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -73,7 +73,7 @@ class RorAffiliationBulkAcceptanceService
     /**
      * Accept all still-valid exact matches captured by a preview token.
      *
-     * @return array{success: bool, accepted_count: int, skipped_count: int, synced_dois: array<int, string>, message: string}
+     * @return array{success: bool, accepted_count: int, skipped_count: int, synced_dois: array<int, string>, message: string, retryable?: bool}
      */
     public function acceptByToken(string $token): array
     {
@@ -92,6 +92,7 @@ class RorAffiliationBulkAcceptanceService
 
         /** @var array<int, array{suggestion_id: int, affiliation_id: int, resource_id: int}> $matches */
         $matches = $payload['matches'];
+        usort($matches, fn (array $a, array $b): int => [$a['affiliation_id'], $a['suggestion_id']] <=> [$b['affiliation_id'], $b['suggestion_id']]);
         /** @var string $creatorName */
         $creatorName = $payload['creator_name'];
         /** @var string $affiliation */
@@ -184,8 +185,20 @@ class RorAffiliationBulkAcceptanceService
             ...$alreadyAcceptedResourceIds,
         ]));
 
-        $syncedDois = $this->syncResources($syncResourceIds);
+        $syncResult = $this->syncResources($syncResourceIds);
         CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT->forget();
+
+        if ($syncResult['failed']) {
+            return [
+                'success' => false,
+                'accepted_count' => $acceptedCount,
+                'skipped_count' => $skippedCount,
+                'synced_dois' => $syncResult['synced_dois'],
+                'message' => $syncResult['message'],
+                'retryable' => true,
+            ];
+        }
+
         Cache::forget($cacheKey);
 
         $message = $acceptedCount > 0
@@ -196,7 +209,7 @@ class RorAffiliationBulkAcceptanceService
             'success' => $acceptedCount > 0 || $alreadyAcceptedResourceIds !== [],
             'accepted_count' => $acceptedCount,
             'skipped_count' => $skippedCount,
-            'synced_dois' => $syncedDois,
+            'synced_dois' => $syncResult['synced_dois'],
             'message' => $message,
         ];
     }
@@ -344,19 +357,25 @@ class RorAffiliationBulkAcceptanceService
 
     /**
      * @param  array<int, int>  $resourceIds
-     * @return array<int, string>
+     * @return array{synced_dois: array<int, string>, failed: bool, message: string}
      */
     private function syncResources(array $resourceIds): array
     {
         if ($resourceIds === []) {
-            return [];
+            return [
+                'synced_dois' => [],
+                'failed' => false,
+                'message' => '',
+            ];
         }
 
         $syncedDois = [];
+        $failureMessage = null;
 
         $resources = Resource::whereIn('id', $resourceIds)
             ->whereNotNull('doi')
             ->where('doi', '!=', '')
+            ->orderBy('id')
             ->get();
 
         foreach ($resources as $resource) {
@@ -364,9 +383,25 @@ class RorAffiliationBulkAcceptanceService
             if ($result->success && $resource->doi !== null) {
                 $syncedDois[] = $resource->doi;
             }
+
+            if ($result->hasFailed()) {
+                $failureMessage ??= $result->errorMessage;
+            }
         }
 
-        return $syncedDois;
+        if ($failureMessage !== null) {
+            return [
+                'synced_dois' => $syncedDois,
+                'failed' => true,
+                'message' => 'DataCite sync failed: '.$failureMessage.' Please try again.',
+            ];
+        }
+
+        return [
+            'synced_dois' => $syncedDois,
+            'failed' => false,
+            'message' => '',
+        ];
     }
 
     private function deleteAffiliationSuggestions(int $affiliationId): void

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -74,7 +74,8 @@ class RorAffiliationBulkAcceptanceService
      */
     public function acceptByToken(string $token): array
     {
-        $payload = Cache::pull($this->cacheKey($token));
+        $cacheKey = $this->cacheKey($token);
+        $payload = Cache::get($cacheKey);
 
         if (! is_array($payload) || ! $this->isValidPayload($payload)) {
             return [
@@ -166,6 +167,7 @@ class RorAffiliationBulkAcceptanceService
 
         $syncedDois = $this->syncResources(array_values(array_unique($acceptedResourceIds)));
         CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT->forget();
+        Cache::forget($cacheKey);
 
         $message = $acceptedCount > 0
             ? "ROR-ID accepted for {$acceptedCount} further creator affiliation(s)."

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -134,6 +134,7 @@ class RorAffiliationBulkAcceptanceService
 
                     if (! $suggestion instanceof SuggestedRor) {
                         if ($this->affiliationHasExpectedRor($match['affiliation_id'], $suggestedRorId)) {
+                            $this->deleteAffiliationSuggestions($match['affiliation_id']);
                             $alreadyAcceptedResourceIds[] = $match['resource_id'];
                         } else {
                             $skippedCount++;

--- a/app/Services/RorAffiliationBulkAcceptanceService.php
+++ b/app/Services/RorAffiliationBulkAcceptanceService.php
@@ -127,14 +127,14 @@ class RorAffiliationBulkAcceptanceService
                 $context = $this->contextForSuggestion($suggestion, lockAffiliation: true);
 
                 if ($context === null) {
-                    $suggestion->delete();
+                    $this->deleteAffiliationSuggestions($suggestion->entity_id);
                     $skippedCount++;
 
                     continue;
                 }
 
                 if ($context['already_has_ror']) {
-                    $suggestion->delete();
+                    $this->deleteAffiliationSuggestions($context['affiliation_model']->id);
                     $skippedCount++;
 
                     continue;
@@ -156,9 +156,7 @@ class RorAffiliationBulkAcceptanceService
                     'scheme_uri' => 'https://ror.org/',
                 ]);
 
-                SuggestedRor::where('entity_type', 'affiliation')
-                    ->where('entity_id', $context['affiliation_model']->id)
-                    ->delete();
+                $this->deleteAffiliationSuggestions($context['affiliation_model']->id);
 
                 $acceptedResourceIds[] = $context['resource_id'];
                 $acceptedCount++;
@@ -170,7 +168,7 @@ class RorAffiliationBulkAcceptanceService
         Cache::forget($cacheKey);
 
         $message = $acceptedCount > 0
-            ? "ROR-ID accepted for {$acceptedCount} further creator affiliation(s)."
+            ? sprintf('ROR-ID accepted for %d further %s.', $acceptedCount, Str::plural('creator affiliation', $acceptedCount))
             : 'No further matching creator affiliations could be accepted.';
 
         return [
@@ -291,6 +289,13 @@ class RorAffiliationBulkAcceptanceService
         }
 
         return $syncedDois;
+    }
+
+    private function deleteAffiliationSuggestions(int $affiliationId): void
+    {
+        SuggestedRor::where('entity_type', 'affiliation')
+            ->where('entity_id', $affiliationId)
+            ->delete();
     }
 
     /**

--- a/app/Services/RorDiscoveryService.php
+++ b/app/Services/RorDiscoveryService.php
@@ -15,6 +15,7 @@ use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\SuggestedRor;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -59,6 +60,7 @@ class RorDiscoveryService
 
     public function __construct(
         private readonly DataCiteSyncService $dataCiteSyncService,
+        private readonly RorAffiliationBulkAcceptanceService $affiliationBulkAcceptanceService,
     ) {}
 
     /**
@@ -121,7 +123,7 @@ class RorDiscoveryService
      * Uses a database transaction with row-level locking to prevent race conditions
      * when multiple curators accept suggestions concurrently.
      *
-     * @return array{success: bool, synced_dois: array<int, string>, message: string, replaced_identifier: string|null}
+     * @return array{success: bool, synced_dois: array<int, string>, message: string, replaced_identifier: string|null, bulk_affiliation_match?: array{available: bool, count: int, bulk_token: string, creator_name: string, affiliation: string, suggested_ror_id: string}}
      */
     public function acceptRor(SuggestedRor $suggestion): array
     {
@@ -234,6 +236,7 @@ class RorDiscoveryService
 
         // Sync affected resources with DataCite (outside transaction)
         $syncedDois = $this->syncResourcesForEntity($suggestion);
+        $bulkAffiliationMatch = $this->affiliationBulkAcceptanceService->createPreviewForAcceptedSuggestion($suggestion);
         $this->invalidateAssistanceCache();
 
         $syncCount = count($syncedDois);
@@ -241,12 +244,28 @@ class RorDiscoveryService
             ? "ROR-ID accepted. {$syncCount} resource(s) synced with DataCite."
             : 'ROR-ID accepted. No resources required DataCite sync.';
 
-        return [
+        $response = [
             'success' => true,
             'synced_dois' => $syncedDois,
             'message' => $message,
             'replaced_identifier' => $replacedIdentifier,
         ];
+
+        if ($bulkAffiliationMatch !== null) {
+            $response['bulk_affiliation_match'] = $bulkAffiliationMatch;
+        }
+
+        return $response;
+    }
+
+    /**
+     * Accept further creator-affiliation ROR matches captured by a preview token.
+     *
+     * @return array{success: bool, accepted_count: int, skipped_count: int, synced_dois: array<int, string>, message: string}
+     */
+    public function acceptMatchingAffiliationRors(string $bulkToken): array
+    {
+        return $this->affiliationBulkAcceptanceService->acceptByToken($bulkToken);
     }
 
     /**
@@ -278,9 +297,9 @@ class RorDiscoveryService
     /**
      * Build the base affiliation query for entities without a ROR identifier.
      *
-     * @return \Illuminate\Database\Eloquent\Builder<Affiliation>
+     * @return Builder<Affiliation>
      */
-    private function buildAffiliationWithoutRorQuery(): \Illuminate\Database\Eloquent\Builder
+    private function buildAffiliationWithoutRorQuery(): Builder
     {
         return Affiliation::where(function ($q): void {
             $q->whereNull('identifier_scheme')
@@ -300,9 +319,9 @@ class RorDiscoveryService
     /**
      * Build the base institution query for entities without a ROR identifier.
      *
-     * @return \Illuminate\Database\Eloquent\Builder<Institution>
+     * @return Builder<Institution>
      */
-    private function buildInstitutionWithoutRorQuery(): \Illuminate\Database\Eloquent\Builder
+    private function buildInstitutionWithoutRorQuery(): Builder
     {
         return Institution::where(function ($q): void {
             $q->whereNull('name_identifier_scheme')
@@ -344,9 +363,9 @@ class RorDiscoveryService
     /**
      * Build the base funder query for entities without a ROR identifier.
      *
-     * @return \Illuminate\Database\Eloquent\Builder<FundingReference>
+     * @return Builder<FundingReference>
      */
-    private function buildFunderWithoutRorQuery(): \Illuminate\Database\Eloquent\Builder
+    private function buildFunderWithoutRorQuery(): Builder
     {
         $hasDoi = fn ($q) => $q->whereNotNull('doi')->where('doi', '!=', '');
         $rorTypeId = FunderIdentifierType::where('slug', 'ROR')->value('id');
@@ -470,7 +489,9 @@ class RorDiscoveryService
      *
      * @param  array<int, Affiliation>  $batch
      * @param  array<int, array{entity_type: string, entity_id: int, entity_name: string, resource_id: int, existing_identifier: string|null, existing_identifier_type: string|null}>  &$pendingChunk
+     *
      * @param-out array<int, array{entity_type: string, entity_id: int, entity_name: string, resource_id: int, existing_identifier: string|null, existing_identifier_type: string|null}>  $pendingChunk
+     *
      * @return \Generator<int, array<int, array{entity_type: string, entity_id: int, entity_name: string, resource_id: int, existing_identifier: string|null, existing_identifier_type: string|null}>>
      */
     private function resolveAffiliationBatch(array $batch, array &$pendingChunk): \Generator
@@ -519,9 +540,10 @@ class RorDiscoveryService
      * Resolve a batch of institutions into entity arrays, yielding full chunks immediately.
      *
      * @param  array<int, Institution>  $batch
-     * @param  \Closure  $hasDoi
      * @param  array<int, array{entity_type: string, entity_id: int, entity_name: string, resource_id: int, existing_identifier: string|null, existing_identifier_type: string|null}>  &$pendingChunk
+     *
      * @param-out array<int, array{entity_type: string, entity_id: int, entity_name: string, resource_id: int, existing_identifier: string|null, existing_identifier_type: string|null}>  $pendingChunk
+     *
      * @return \Generator<int, array<int, array{entity_type: string, entity_id: int, entity_name: string, resource_id: int, existing_identifier: string|null, existing_identifier_type: string|null}>>
      */
     private function resolveInstitutionBatch(array $batch, \Closure $hasDoi, array &$pendingChunk): \Generator

--- a/app/Services/RorDiscoveryService.php
+++ b/app/Services/RorDiscoveryService.php
@@ -261,7 +261,7 @@ class RorDiscoveryService
     /**
      * Accept further creator-affiliation ROR matches captured by a preview token.
      *
-     * @return array{success: bool, accepted_count: int, skipped_count: int, synced_dois: array<int, string>, message: string}
+     * @return array{success: bool, accepted_count: int, skipped_count: int, synced_dois: array<int, string>, message: string, retryable?: bool}
      */
     public function acceptMatchingAffiliationRors(string $bulkToken): array
     {

--- a/composer.lock
+++ b/composer.lock
@@ -1796,16 +1796,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.35.1",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "f23af6c5aafd958a7593029a271d77baf5ed793c"
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f23af6c5aafd958a7593029a271d77baf5ed793c",
-                "reference": "f23af6c5aafd958a7593029a271d77baf5ed793c",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
                 "shasum": ""
             },
             "require": {
@@ -1873,9 +1873,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.35.1"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
             },
-            "time": "2026-06-25T06:52:23+00:00"
+            "time": "2026-07-06T14:42:07+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -6785,16 +6785,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -6853,7 +6853,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -6865,7 +6865,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -9668,16 +9668,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.7.4",
+            "version": "v4.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "ee2e97e932d158faceeaa63a4dc17324b15152cb"
+                "reference": "5dc49a71d63602a9b98fed0f2017c4679ef9f8e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/ee2e97e932d158faceeaa63a4dc17324b15152cb",
-                "reference": "ee2e97e932d158faceeaa63a4dc17324b15152cb",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/5dc49a71d63602a9b98fed0f2017c4679ef9f8e0",
+                "reference": "5dc49a71d63602a9b98fed0f2017c4679ef9f8e0",
                 "shasum": ""
             },
             "require": {
@@ -9700,11 +9700,11 @@
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
-                "mrpunyapal/peststan": "^0.2.10",
+                "mrpunyapal/peststan": "^0.2.11",
                 "pestphp/pest-dev-tools": "^4.1.0",
                 "pestphp/pest-plugin-browser": "^4.3.1",
                 "pestphp/pest-plugin-type-coverage": "^4.0.4",
-                "psy/psysh": "^0.12.23"
+                "psy/psysh": "^0.12.24"
             },
             "bin": [
                 "bin/pest"
@@ -9771,7 +9771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.7.4"
+                "source": "https://github.com/pestphp/pest/tree/v4.7.5"
             },
             "funding": [
                 {
@@ -9783,7 +9783,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-25T19:09:05+00:00"
+            "time": "2026-07-06T17:06:29+00:00"
         },
         {
             "name": "pestphp/pest-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1758,9 +1758,9 @@
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
-      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accessible-icon": {
@@ -1787,16 +1787,16 @@
       }
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.15.tgz",
-      "integrity": "sha512-24Zz/0SYx8F2bSVThBnQrdJs2VbKelyuJordcFRRdA0fRAhrq/wSegGCqaQz34VQoiWqSMGYCYXEhynLSlyQlg==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.16.tgz",
+      "integrity": "sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collapsible": "1.1.15",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collapsible": "1.1.16",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
@@ -1818,15 +1818,15 @@
       }
     },
     "node_modules/@radix-ui/react-alert-dialog": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.18.tgz",
-      "integrity": "sha512-6c2cXpNlAgHDhKguK24XcWHHayMpK+lk7/WwBXBco+ZJ4Dv7xP++GBM280KgTD/HCRu3jSdfe8WQiZssonYaIA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.19.tgz",
+      "integrity": "sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dialog": "1.1.18",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dialog": "1.1.19",
         "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
@@ -1891,12 +1891,12 @@
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.1.tgz",
-      "integrity": "sha512-+8PWoLLZv3AVb5m0pvoiOca/bQGzc9vPVb+982HB2x3Un0DpYEPM3zLMl4oqRpBsocJuNqLkiv/HXTnTrlwr4g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.2.tgz",
+      "integrity": "sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-is-hydrated": "0.1.1",
@@ -1918,15 +1918,15 @@
       }
     },
     "node_modules/@radix-ui/react-checkbox": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.6.tgz",
-      "integrity": "sha512-eUEUoGMDpfkgHWSE97ZZaUJtzR1M7EKnNIpD1Q16+8JR9NWghcaqMulx9PuCQ720w0UclfYn6FEbCdd5Hx087g==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.7.tgz",
+      "integrity": "sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
@@ -1948,16 +1948,16 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.15.tgz",
-      "integrity": "sha512-8A1zibu5skAQ+UVbaeNH5hVMibiFCRJzgMuM14LTWGttnTZKQL9jwYnhAbHRuxrtCqPXa4JvvnVUq1pTNgyZYw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.16.tgz",
+      "integrity": "sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -1978,13 +1978,13 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.11.tgz",
-      "integrity": "sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0"
       },
@@ -2019,9 +2019,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
-      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2034,14 +2034,14 @@
       }
     },
     "node_modules/@radix-ui/react-context-menu": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.2.tgz",
-      "integrity": "sha512-qzsA/ZPhF6yMxBOTIk1nlCkoy2mswSbwYL+ErBa2iP0s4WWrlxmczArYqMcpVfEjmM7KJj/ADPXky0yZfbSxtQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.3.tgz",
+      "integrity": "sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-menu": "2.1.20",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
@@ -2061,20 +2061,20 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz",
-      "integrity": "sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.11",
+        "@radix-ui/react-focus-scope": "1.1.12",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -2112,12 +2112,12 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz",
-      "integrity": "sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
@@ -2139,16 +2139,16 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.19.tgz",
-      "integrity": "sha512-HZccBkbK0LOi8nYKIp5jll/zIRW0cCOmG6WWyqsSpmXCU+ZlcBbTqIwlBvPCu886C5RVu6c/kHV7xSP8IgYNHw==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.20.tgz",
+      "integrity": "sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/react-menu": "2.1.20",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
@@ -2183,9 +2183,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz",
-      "integrity": "sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
+      "integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
@@ -2208,14 +2208,14 @@
       }
     },
     "node_modules/@radix-ui/react-form": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.11.tgz",
-      "integrity": "sha512-0mTMJHv1gQAuEQoq5VDpTD3MRgmfUFdXAVFhpqR7wBeUr+tyRsof0wv/4XdPHLwQrefhoH2FiGHCggrCJhalIw==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.12.tgz",
+      "integrity": "sha512-JTX94E4LDL91rzLg7X0mHPdxr0A8JEdVwZEmeOwZJSMDHCGW5DFtSlTSJozUyUs807IQmnvbfzKZFVCK5DmkqQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-label": "2.1.11",
         "@radix-ui/react-primitive": "2.1.7"
@@ -2236,18 +2236,18 @@
       }
     },
     "node_modules/@radix-ui/react-hover-card": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.18.tgz",
-      "integrity": "sha512-rt+Fx4HoCeEwFL2IdoV2QaPltqDLlzxN77i9nwB3Y70scFlfAHh1QCdE2TXKuFJtA1TNygb0oivnFBZifgtZOw==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.19.tgz",
+      "integrity": "sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
-        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-popper": "1.3.3",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
@@ -2308,25 +2308,25 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.19.tgz",
-      "integrity": "sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.20.tgz",
+      "integrity": "sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.11",
+        "@radix-ui/react-focus-scope": "1.1.12",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-popper": "1.3.3",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-roving-focus": "1.1.15",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "aria-hidden": "^1.2.4",
@@ -2348,20 +2348,20 @@
       }
     },
     "node_modules/@radix-ui/react-menubar": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.19.tgz",
-      "integrity": "sha512-Glt6mebxcgQvLeVkH3HiqV5bgQubE+31ELxLs7q0GlYI5k0XYkOkeuPrhXoylxK8eufvIt9CJjzY1TfFMXK3qw==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.20.tgz",
+      "integrity": "sha512-gzFZvybgmwYsFBWDqanycIoEYnhyk8MMnuLamdFVHUZYGp4COM+sqXiwbnn0VMWqGLeeU7GV7jm+dXRa+Wufag==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-menu": "2.1.19",
+        "@radix-ui/react-menu": "2.1.20",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-roving-focus": "1.1.15",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2380,19 +2380,19 @@
       }
     },
     "node_modules/@radix-ui/react-navigation-menu": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.17.tgz",
-      "integrity": "sha512-fYeYQvbeNn5AQk2RBbpO7koLm2YbS00UYxC/IL2sgLlninEH5UNIv+X3E0KJ1Vy4WIo+dhN9w8GNqSHhbHWCIg==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.18.tgz",
+      "integrity": "sha512-K9HiuxZ6xCwSaHcIuUpxyhy4w5gpwzWjh9dHTSbMN3Ix4qAyVObS9RlU3zMycb0PO3v9Tpk0BXMwWvXOUbVXew==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -2416,19 +2416,19 @@
       }
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.11.tgz",
-      "integrity": "sha512-Rsgab65u73E5kPVh8OS6PgPwJgPyf08GFfJDGAbMdF4DL7CgDhFOaDnXuk/DiMEVF6kgQwl0oJmFklvipmiOLg==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.12.tgz",
+      "integrity": "sha512-nQLu5OAcORDQp1EHAv6k3mJGV1hjMTw2NTGVAsGE1g/mWeNqAd1R5jyaAs3U+A8ZD/W8XNPY2yKT0ZdQnqo3NA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-roving-focus": "1.1.15",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-effect-event": "0.0.3",
         "@radix-ui/react-use-is-hydrated": "0.1.1",
@@ -2450,14 +2450,14 @@
       }
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.6.tgz",
-      "integrity": "sha512-pQ3xGp/uemomASPH97Eb3shfXX8QlG11bBJyEvRBV+vwtO4HvQlS06Yj9f31Ao7XepvF98SFrRgVDQ7jv+2xjQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.7.tgz",
+      "integrity": "sha512-gB1Mr8vzdv1XzDjrtJTXmL0JORRs1B4g7ngUs0F+H2VvMOwXTZMTmLCl0wZZ3m7ylX8TssI7NCvgiSHmLuTm/A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -2480,21 +2480,21 @@
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.18.tgz",
-      "integrity": "sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.19.tgz",
+      "integrity": "sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.11",
+        "@radix-ui/react-focus-scope": "1.1.12",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-popper": "1.3.3",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -2517,15 +2517,15 @@
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.2.tgz",
-      "integrity": "sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@radix-ui/react-arrow": "1.1.11",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.2",
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
-      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -2619,12 +2619,12 @@
       }
     },
     "node_modules/@radix-ui/react-progress": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.11.tgz",
-      "integrity": "sha512-KqiGJcFaZDc+BvveAgU3ZhACg2MvSUDrCBx4lRR/ZVRNal0bvt8lBpvnSkep9heeOuF8Qfw3fszLDX4OpQ2NVw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.12.tgz",
+      "integrity": "sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7"
       },
       "peerDependencies": {
@@ -2643,18 +2643,18 @@
       }
     },
     "node_modules/@radix-ui/react-radio-group": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.2.tgz",
-      "integrity": "sha512-W8Uo9riHnlzLLWy+r2mVHUyuEWqD/+be4PZzbEvaGoFSBDHkm+GYWjtcE6u3AmPKNyfanWpnVfpZ2GqPCdzzsw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.3.tgz",
+      "integrity": "sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-roving-focus": "1.1.15",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
         "@radix-ui/react-use-size": "1.1.2"
@@ -2675,20 +2675,22 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.14.tgz",
-      "integrity": "sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz",
+      "integrity": "sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
-        "@radix-ui/react-use-controllable-state": "1.2.3"
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2706,17 +2708,17 @@
       }
     },
     "node_modules/@radix-ui/react-scroll-area": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.13.tgz",
-      "integrity": "sha512-7tncSubo2G0UY1e8rk+72qe3XRzrGnOLtZQ1PL1KoBfRUNX0NrJT5akb+0kfwSCc3gVR4wdHqyhAQBDpDNOwDw==",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.14.tgz",
+      "integrity": "sha512-bBODCWZK7JTbQLHs0uIP4f73wIWatakK4OS33UzkR1x897wu0PuO658a3f+6P2GEGyDzGYMuHRatMVoAk9WZTw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -2737,24 +2739,24 @@
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.2.tgz",
-      "integrity": "sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.3.tgz",
+      "integrity": "sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.11",
+        "@radix-ui/react-focus-scope": "1.1.12",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-popper": "1.3.3",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-callback-ref": "1.1.2",
@@ -2804,16 +2806,16 @@
       }
     },
     "node_modules/@radix-ui/react-slider": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.2.tgz",
-      "integrity": "sha512-qt5C1ppJz66aUDrH1VccjPrq7aFchK0wBrn6xsxlCHNUyE57dRRQ7lp1QFpF7OscMexZF8MCGBTVBlENHPkNiA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.3.tgz",
+      "integrity": "sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.2",
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -2855,14 +2857,14 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.2.tgz",
-      "integrity": "sha512-tgRBI3DdNwAJYE4BBZyZcz/HRRCvAsPkRvG1wvKc+41tBGMxPn/a87T/wikXAvyDypNQ9kaZwHbeZe+veHCGpA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.3.tgz",
+      "integrity": "sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-previous": "1.1.2",
@@ -2884,18 +2886,18 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.16.tgz",
-      "integrity": "sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.17.tgz",
+      "integrity": "sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-roving-focus": "1.1.15",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -2914,18 +2916,18 @@
       }
     },
     "node_modules/@radix-ui/react-toast": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.18.tgz",
-      "integrity": "sha512-YNEnTHV47hPep+U0QvVM02OJNka9uygREc+k4Nh5VSZBg4MmE+myI442x3hCGfRpX7N2WSSYSJKws4gE+Z8lgg==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.19.tgz",
+      "integrity": "sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -2948,12 +2950,12 @@
       }
     },
     "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.13.tgz",
-      "integrity": "sha512-bI2ILJrzwgmAsH05TsJ9pVrzqQwAip7OM2/krqAdYn0R16bl86UPWbe5VPHsALat0EnqpV01cGtkleaUKPNdNg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.14.tgz",
+      "integrity": "sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
@@ -2973,17 +2975,17 @@
       }
     },
     "node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.14.tgz",
-      "integrity": "sha512-TK1vusNKb8IRhF23FTbRgUNZ9zfs5rGIyI7LfR3h26p9LrQ060i0uW9QWeD8baZMddaaP0DBGlIa6pbZG+mitg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.15.tgz",
+      "integrity": "sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
-        "@radix-ui/react-toggle": "1.1.13",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-toggle": "1.1.14",
         "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
@@ -3002,18 +3004,18 @@
       }
     },
     "node_modules/@radix-ui/react-toolbar": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.14.tgz",
-      "integrity": "sha512-L/EkWVqlnj3lL2toHh4C7PwH2jxfa7OCq6lGfXSCii99ve2S4Ux5rc9HnOa7LN9exHa/Nl9kmCAmP9BuDPy5UA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.15.tgz",
+      "integrity": "sha512-t/iEuVjUnXXtrsGK40AA43uIx37sn3AqZ7oAVnPICK6lFJP6dzMzWR3U9b6eCfFjb6wtSEqkJ9Rn9xDjiOx20g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-direction": "1.1.2",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-roving-focus": "1.1.15",
         "@radix-ui/react-separator": "1.1.11",
-        "@radix-ui/react-toggle-group": "1.1.14"
+        "@radix-ui/react-toggle-group": "1.1.15"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3031,19 +3033,19 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.11.tgz",
-      "integrity": "sha512-8XZ6Py3y3W2nEzAUGCN5cfVKaUi+CVApcz1d6lrNVVf2hvYEixMRkq8k9ggPKnQUpRRuOV5avt8uvxViH2jLwA==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.12.tgz",
+      "integrity": "sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-popper": "1.3.3",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-use-controllable-state": "1.2.3",
@@ -5180,17 +5182,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/type-utils": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -5203,7 +5205,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.1",
+        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -5219,16 +5221,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5244,14 +5246,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.1",
-        "@typescript-eslint/types": "^8.62.1",
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5266,14 +5268,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1"
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5284,9 +5286,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5301,15 +5303,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -5326,9 +5328,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5340,16 +5342,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.1",
-        "@typescript-eslint/tsconfig-utils": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -5381,16 +5383,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1"
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5405,13 +5407,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/types": "8.63.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5553,15 +5555,15 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.9.tgz",
-      "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -5572,18 +5574,18 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.9"
+        "vitest": "4.1.10"
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
-      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -5597,8 +5599,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.9",
-        "vitest": "4.1.9"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -5607,16 +5609,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -5625,13 +5627,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5652,9 +5654,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5665,13 +5667,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5679,14 +5681,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5695,9 +5697,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5705,13 +5707,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -6317,9 +6319,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -6337,10 +6339,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -6432,9 +6434,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001802",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
+      "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
       "dev": true,
       "funding": [
         {
@@ -7544,9 +7546,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.387",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
-      "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+      "version": "1.5.388",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
+      "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
       "dev": true,
       "license": "ISC"
     },
@@ -11448,58 +11450,58 @@
       "license": "MIT"
     },
     "node_modules/radix-ui": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.1.tgz",
-      "integrity": "sha512-QXDXJtB6sK83mLASONYUZCauatcWb+knFviFpN1EhtdbbmlsRmzCLrbZSKztnNiem2KOHIBbiDbauVB7SORXMw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.2.tgz",
+      "integrity": "sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/primitive": "1.1.5",
         "@radix-ui/react-accessible-icon": "1.1.11",
-        "@radix-ui/react-accordion": "1.2.15",
-        "@radix-ui/react-alert-dialog": "1.1.18",
+        "@radix-ui/react-accordion": "1.2.16",
+        "@radix-ui/react-alert-dialog": "1.1.19",
         "@radix-ui/react-arrow": "1.1.11",
         "@radix-ui/react-aspect-ratio": "1.1.11",
-        "@radix-ui/react-avatar": "1.2.1",
-        "@radix-ui/react-checkbox": "1.3.6",
-        "@radix-ui/react-collapsible": "1.1.15",
-        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/react-avatar": "1.2.2",
+        "@radix-ui/react-checkbox": "1.3.7",
+        "@radix-ui/react-collapsible": "1.1.16",
+        "@radix-ui/react-collection": "1.1.12",
         "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-context-menu": "2.3.2",
-        "@radix-ui/react-dialog": "1.1.18",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-context-menu": "2.3.3",
+        "@radix-ui/react-dialog": "1.1.19",
         "@radix-ui/react-direction": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.14",
-        "@radix-ui/react-dropdown-menu": "2.1.19",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-dropdown-menu": "2.1.20",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.11",
-        "@radix-ui/react-form": "0.1.11",
-        "@radix-ui/react-hover-card": "1.1.18",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-form": "0.1.12",
+        "@radix-ui/react-hover-card": "1.1.19",
         "@radix-ui/react-label": "2.1.11",
-        "@radix-ui/react-menu": "2.1.19",
-        "@radix-ui/react-menubar": "1.1.19",
-        "@radix-ui/react-navigation-menu": "1.2.17",
-        "@radix-ui/react-one-time-password-field": "0.1.11",
-        "@radix-ui/react-password-toggle-field": "0.1.6",
-        "@radix-ui/react-popover": "1.1.18",
-        "@radix-ui/react-popper": "1.3.2",
+        "@radix-ui/react-menu": "2.1.20",
+        "@radix-ui/react-menubar": "1.1.20",
+        "@radix-ui/react-navigation-menu": "1.2.18",
+        "@radix-ui/react-one-time-password-field": "0.1.12",
+        "@radix-ui/react-password-toggle-field": "0.1.7",
+        "@radix-ui/react-popover": "1.1.19",
+        "@radix-ui/react-popper": "1.3.3",
         "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-presence": "1.1.7",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-progress": "1.1.11",
-        "@radix-ui/react-radio-group": "1.4.2",
-        "@radix-ui/react-roving-focus": "1.1.14",
-        "@radix-ui/react-scroll-area": "1.2.13",
-        "@radix-ui/react-select": "2.3.2",
+        "@radix-ui/react-progress": "1.1.12",
+        "@radix-ui/react-radio-group": "1.4.3",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-scroll-area": "1.2.14",
+        "@radix-ui/react-select": "2.3.3",
         "@radix-ui/react-separator": "1.1.11",
-        "@radix-ui/react-slider": "1.4.2",
+        "@radix-ui/react-slider": "1.4.3",
         "@radix-ui/react-slot": "1.3.0",
-        "@radix-ui/react-switch": "1.3.2",
-        "@radix-ui/react-tabs": "1.1.16",
-        "@radix-ui/react-toast": "1.2.18",
-        "@radix-ui/react-toggle": "1.1.13",
-        "@radix-ui/react-toggle-group": "1.1.14",
-        "@radix-ui/react-toolbar": "1.1.14",
-        "@radix-ui/react-tooltip": "1.2.11",
+        "@radix-ui/react-switch": "1.3.3",
+        "@radix-ui/react-tabs": "1.1.17",
+        "@radix-ui/react-toast": "1.2.19",
+        "@radix-ui/react-toggle": "1.1.14",
+        "@radix-ui/react-toggle-group": "1.1.15",
+        "@radix-ui/react-toolbar": "1.1.15",
+        "@radix-ui/react-tooltip": "1.2.12",
         "@radix-ui/react-use-callback-ref": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.2.3",
         "@radix-ui/react-use-effect-event": "0.0.3",
@@ -13300,16 +13302,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.1",
-        "@typescript-eslint/parser": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1"
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -13867,19 +13869,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -13907,12 +13909,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -120,6 +120,10 @@
                 "description": "New 'Suggested ROR-IDs' card on the Assistance page for discovering missing ROR identifiers. The system searches the ROR API v2 for affiliations, institutions (as creators/contributors), and funders without a ROR-ID, ranks candidates by name similarity (minimum 50% threshold), and presents the best matches. Curators can accept (updates the entity and syncs all affected resources to DataCite) or decline (permanently dismisses that entity+ROR combination). Entities with existing non-ROR identifiers show a warning before replacement. Includes an individual 'Check' button and integration with the 'Check all' workflow."
             },
             {
+                "title": "Assistance: Bulk ROR Affiliation Acceptance",
+                "description": "When an Admin or Group Leader accepts a ROR suggestion for a creator affiliation, ERNIE now detects further pending creator-affiliation suggestions with the same exported creatorName, affiliation label, and proposed ROR identifier. A confirmation dialog lets the reviewer apply that ROR identifier to all exact matches at once while preserving affiliation labels and creator name identifiers. If processing fails before completion, the confirmation can be retried."
+            },
+            {
                 "title": "Assistance: Crossref Funder ID to ROR Suggestions",
                 "description": "The Assistance page now includes a Crossref Funder ID to ROR assistant for funding references. It uses the locally generated ROR FundRef index to propose high-confidence ROR identifiers for funding references that currently use Crossref Funder IDs, shows provenance and exact-match evidence for review, and lets curators accept or decline each suggestion while preserving award metadata."
             },

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -68,6 +68,15 @@ function resourceEditorUrl(resourceId: number): string {
     return editorRoute({ query: { resourceId } }).url;
 }
 
+function rorBulkMatchDialogDescription(count: number): string {
+    const isSingular = count === 1;
+    const noun = isSingular ? 'creator affiliation' : 'creator affiliations';
+    const verb = isSingular ? 'is' : 'are';
+    const target = isSingular ? 'this affiliation' : 'these affiliations';
+
+    return `There ${verb} ${count} further ${noun} with the same <creatorName>, <affiliation>, and ROR suggestion you have just confirmed. Would you like to accept the ROR suggestion for ${target} as well?`;
+}
+
 function normalizedResourceHeaderValue(value: string | null | undefined): string {
     return typeof value === 'string' ? value.trim() : '';
 }
@@ -1756,10 +1765,7 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                 <DialogContent showCloseButton={!isAcceptingRorBulkMatch}>
                     <DialogHeader>
                         <DialogTitle>Accept matching ROR suggestions?</DialogTitle>
-                        <DialogDescription>
-                            There are {pendingRorBulkMatch?.count ?? 0} further creators who match the resource you have just confirmed in the
-                            &lt;creatorName&gt; and &lt;affiliation&gt; elements. Would you like to accept the ROR suggestion for these as well?
-                        </DialogDescription>
+                        <DialogDescription>{rorBulkMatchDialogDescription(pendingRorBulkMatch?.count ?? 0)}</DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
                         <Button variant="outline" disabled={isAcceptingRorBulkMatch} onClick={handleDeclineRorBulkMatch}>

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -1461,10 +1461,17 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
             setPendingRorBulkMatch(null);
             reloadAssistanceSections();
         } catch (error) {
-            if (axios.isAxiosError(error) && typeof error.response?.data?.message === 'string') {
+            const isAxiosBulkAcceptError = axios.isAxiosError(error);
+
+            if (isAxiosBulkAcceptError && typeof error.response?.data?.message === 'string') {
                 toast.warning(error.response.data.message);
             } else {
                 toast.error('Failed to accept matching ROR suggestions.');
+            }
+
+            if (isAxiosBulkAcceptError && error.response?.status === 422) {
+                setPendingRorBulkMatch(null);
+                reloadAssistanceSections();
             }
         } finally {
             setIsAcceptingRorBulkMatch(false);

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -1457,6 +1457,9 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
             } else {
                 toast.warning(data.message);
             }
+
+            setPendingRorBulkMatch(null);
+            reloadAssistanceSections();
         } catch (error) {
             if (axios.isAxiosError(error) && typeof error.response?.data?.message === 'string') {
                 toast.warning(error.response.data.message);
@@ -1465,8 +1468,6 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
             }
         } finally {
             setIsAcceptingRorBulkMatch(false);
-            setPendingRorBulkMatch(null);
-            reloadAssistanceSections();
         }
     }, [pendingRorBulkMatch, reloadAssistanceSections]);
 

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Spinner } from '@/components/ui/spinner';
 import AppLayout from '@/layouts/app-layout';
 import { editor as editorRoute } from '@/routes';
@@ -16,8 +17,10 @@ import {
     type AssistancePageProps,
     type AssistantManifest,
     type BaseSuggestionItem,
+    type BulkRorAffiliationAcceptResponse,
     type CheckStatusResponse,
     type PaginatedData,
+    type RorAffiliationBulkMatch,
     type SuggestedCrossrefFunderRorItem,
     type SuggestedDescriptionSegmentationItem,
     type SuggestedOrcidItem,
@@ -1254,7 +1257,12 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
     const { states, patch, addProcessingId, removeProcessingId, pollingRefs } = useSectionState(manifests);
 
     const isAnyChecking = Object.values(states).some((s) => s.isChecking);
+    const [pendingRorBulkMatch, setPendingRorBulkMatch] = useState<RorAffiliationBulkMatch | null>(null);
+    const [isAcceptingRorBulkMatch, setIsAcceptingRorBulkMatch] = useState(false);
 
+    const reloadAssistanceSections = useCallback(() => {
+        router.reload({ only: ['sections', 'pendingAssistanceTotalCount'] });
+    }, []);
     // ── Polling logic ────────────────────────────────────────────────
 
     const stopPolling = useCallback(
@@ -1300,7 +1308,7 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                         } else {
                             toast.info(message);
                         }
-                        router.reload({ only: ['sections', 'pendingAssistanceTotalCount'] });
+                        reloadAssistanceSections();
                     } else if (status.status === 'failed') {
                         pollingRefs.current[id] = null;
                         patch(id, { isChecking: false, progress: '' });
@@ -1317,7 +1325,7 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
 
             pollingRefs.current[id] = setTimeout(pollStatus, 3000);
         },
-        [patch, pollingRefs],
+        [patch, pollingRefs, reloadAssistanceSections],
     );
 
     // ── Check one assistant ──────────────────────────────────────────
@@ -1407,15 +1415,57 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                 } else {
                     toast.warning(data.message);
                 }
-                router.reload({ only: ['sections', 'pendingAssistanceTotalCount'] });
+
+                const bulkMatch = data.bulk_affiliation_match;
+                if (data.success && manifest.id === 'ror-suggestion' && bulkMatch?.available === true && bulkMatch.count > 0) {
+                    setPendingRorBulkMatch(bulkMatch);
+                    return;
+                }
+
+                reloadAssistanceSections();
             } catch {
                 toast.error('Failed to accept suggestion.');
             } finally {
                 removeProcessingId(manifest.id, suggestionId);
             }
         },
-        [addProcessingId, removeProcessingId],
+        [addProcessingId, reloadAssistanceSections, removeProcessingId],
     );
+
+    const handleAcceptRorBulkMatch = useCallback(async () => {
+        if (pendingRorBulkMatch === null) return;
+
+        setIsAcceptingRorBulkMatch(true);
+
+        try {
+            const { data } = await axios.post<BulkRorAffiliationAcceptResponse>('/assistance/rors/bulk-affiliation-accept', {
+                bulk_token: pendingRorBulkMatch.bulk_token,
+            });
+
+            if (data.success) {
+                toast.success(data.message);
+            } else {
+                toast.warning(data.message);
+            }
+        } catch (error) {
+            if (axios.isAxiosError(error) && typeof error.response?.data?.message === 'string') {
+                toast.warning(error.response.data.message);
+            } else {
+                toast.error('Failed to accept matching ROR suggestions.');
+            }
+        } finally {
+            setIsAcceptingRorBulkMatch(false);
+            setPendingRorBulkMatch(null);
+            reloadAssistanceSections();
+        }
+    }, [pendingRorBulkMatch, reloadAssistanceSections]);
+
+    const handleDeclineRorBulkMatch = useCallback(() => {
+        if (isAcceptingRorBulkMatch) return;
+
+        setPendingRorBulkMatch(null);
+        reloadAssistanceSections();
+    }, [isAcceptingRorBulkMatch, reloadAssistanceSections]);
 
     const handleDecline = useCallback(
         async (manifest: AssistantManifest, suggestionId: number) => {
@@ -1424,14 +1474,14 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
             try {
                 await axios.post(`/assistance/${manifest.routePrefix}/${suggestionId}/decline`);
                 toast.info('Suggestion declined.');
-                router.reload({ only: ['sections', 'pendingAssistanceTotalCount'] });
+                reloadAssistanceSections();
             } catch {
                 toast.error('Failed to decline suggestion.');
             } finally {
                 removeProcessingId(manifest.id, suggestionId);
             }
         },
-        [addProcessingId, removeProcessingId],
+        [addProcessingId, reloadAssistanceSections, removeProcessingId],
     );
 
     // ── Render helpers ───────────────────────────────────────────────
@@ -1695,6 +1745,38 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                     );
                 })}
             </div>
+
+            <Dialog
+                open={pendingRorBulkMatch !== null}
+                onOpenChange={(open) => {
+                    if (!open) handleDeclineRorBulkMatch();
+                }}
+            >
+                <DialogContent showCloseButton={!isAcceptingRorBulkMatch}>
+                    <DialogHeader>
+                        <DialogTitle>Accept matching ROR suggestions?</DialogTitle>
+                        <DialogDescription>
+                            There are {pendingRorBulkMatch?.count ?? 0} further creators who match the resource you have just confirmed in the
+                            &lt;creatorName&gt; and &lt;affiliation&gt; elements. Would you like to accept the ROR suggestion for these as well?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" disabled={isAcceptingRorBulkMatch} onClick={handleDeclineRorBulkMatch}>
+                            Decline
+                        </Button>
+                        <Button disabled={isAcceptingRorBulkMatch} onClick={handleAcceptRorBulkMatch}>
+                            {isAcceptingRorBulkMatch ? (
+                                <>
+                                    <Spinner size="sm" className="mr-2" />
+                                    Accepting...
+                                </>
+                            ) : (
+                                'Accept'
+                            )}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </AppLayout>
     );
 }

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { LoadingButton } from '@/components/ui/loading-button';
 import { Spinner } from '@/components/ui/spinner';
 import AppLayout from '@/layouts/app-layout';
 import { editor as editorRoute } from '@/routes';
@@ -1764,16 +1765,9 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                         <Button variant="outline" disabled={isAcceptingRorBulkMatch} onClick={handleDeclineRorBulkMatch}>
                             Decline
                         </Button>
-                        <Button disabled={isAcceptingRorBulkMatch} onClick={handleAcceptRorBulkMatch}>
-                            {isAcceptingRorBulkMatch ? (
-                                <>
-                                    <Spinner size="sm" className="mr-2" />
-                                    Accepting...
-                                </>
-                            ) : (
-                                'Accept'
-                            )}
-                        </Button>
+                        <LoadingButton loading={isAcceptingRorBulkMatch} onClick={handleAcceptRorBulkMatch}>
+                            Accept
+                        </LoadingButton>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -589,7 +589,9 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             </li>
                             <li>
                                 <strong>Suggested ROR-IDs</strong> – Detects missing ROR identifiers for affiliations, institutions, and funders via
-                                the ROR API v2
+                                the ROR API v2. When you accept a creator-affiliation ROR suggestion, ERNIE can offer to apply the same ROR
+                                identifier to further pending creator affiliations with exactly matching <code>creatorName</code> and{' '}
+                                <code>affiliation</code> values.
                             </li>
                             <li>
                                 <strong>Crossref Funder ROR Suggestions</strong> – Reviews funding references with legacy Crossref Funder IDs and
@@ -638,6 +640,12 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                     Crossref Funder ROR suggestions compare the current Crossref Funder ID with the proposed ROR identifier,
                                     provenance, confidence evidence, and conflict warnings. Accepting updates only the funding-reference identifier,
                                     identifier type, and scheme URI; funder names and award metadata are preserved.
+                                </p>
+                                <p className="mt-2">
+                                    Suggested ROR-ID affiliation matches are exact. If a creator-affiliation suggestion has further pending matches
+                                    with the same exported <code>creatorName</code>, <code>affiliation</code>, and proposed ROR identifier, ERNIE
+                                    asks whether to accept those suggestions as well. Bulk acceptance updates only the affiliation identifier fields;
+                                    creator name identifiers and affiliation labels stay unchanged.
                                 </p>
                                 <p className="mt-2">
                                     Subject Metadata Enrichment suggestions compare the stored Subject row with proposed DataCite fields such as

--- a/resources/js/types/assistance.ts
+++ b/resources/js/types/assistance.ts
@@ -314,6 +314,24 @@ export interface AcceptResponse {
     datacite_synced?: boolean;
     synced_dois?: string[];
     replaced_identifier?: string | null;
+    bulk_affiliation_match?: RorAffiliationBulkMatch | null;
+    message: string;
+}
+
+export interface RorAffiliationBulkMatch {
+    available: boolean;
+    count: number;
+    bulk_token: string;
+    creator_name: string;
+    affiliation: string;
+    suggested_ror_id: string;
+}
+
+export interface BulkRorAffiliationAcceptResponse {
+    success: boolean;
+    accepted_count: number;
+    skipped_count: number;
+    synced_dois: string[];
     message: string;
 }
 

--- a/tests/pest/Feature/Controllers/RorAffiliationBulkAcceptanceControllerTest.php
+++ b/tests/pest/Feature/Controllers/RorAffiliationBulkAcceptanceControllerTest.php
@@ -12,6 +12,7 @@ use App\Services\RorAffiliationBulkAcceptanceService;
 use App\Services\RorDiscoveryService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 
 covers(AssistanceController::class, RorAffiliationBulkAcceptanceService::class);
 
@@ -83,11 +84,20 @@ it('accepts matching affiliation rors from a valid bulk token through the route'
         ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull();
 });
 
-it('returns a validation-style failure for expired or invalid bulk tokens', function (): void {
+it('rejects malformed bulk tokens before looking them up', function (): void {
     $user = User::factory()->admin()->create();
 
     $this->actingAs($user)
         ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => 'missing-token'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['bulk_token']);
+});
+
+it('returns a bulk failure for expired valid uuid tokens', function (): void {
+    $user = User::factory()->admin()->create();
+
+    $this->actingAs($user)
+        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => (string) Str::uuid()])
         ->assertStatus(422)
         ->assertJsonPath('success', false)
         ->assertJsonPath('accepted_count', 0);
@@ -97,6 +107,6 @@ it('requires assistance access for the bulk route', function (): void {
     $user = User::factory()->beginner()->create();
 
     $this->actingAs($user)
-        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => 'missing-token'])
+        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => (string) Str::uuid()])
         ->assertForbidden();
 });

--- a/tests/pest/Feature/Controllers/RorAffiliationBulkAcceptanceControllerTest.php
+++ b/tests/pest/Feature/Controllers/RorAffiliationBulkAcceptanceControllerTest.php
@@ -8,6 +8,9 @@ use App\Models\Resource;
 use App\Models\ResourceCreator;
 use App\Models\SuggestedRor;
 use App\Models\User;
+use App\Services\DataCiteServiceInterface;
+use App\Services\DataCiteSyncResult;
+use App\Services\DataCiteSyncService;
 use App\Services\RorAffiliationBulkAcceptanceService;
 use App\Services\RorDiscoveryService;
 use Illuminate\Support\Facades\Cache;
@@ -19,6 +22,17 @@ covers(AssistanceController::class, RorAffiliationBulkAcceptanceService::class);
 beforeEach(function (): void {
     Config::set('cache.default', 'array');
     Cache::flush();
+    app()->instance(DataCiteSyncService::class, new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            if ($resource->doi === null || $resource->doi === '') {
+                return DataCiteSyncResult::notRequired();
+            }
+
+            return DataCiteSyncResult::succeeded((string) $resource->doi);
+        }
+    });
 });
 
 function createRorBulkRouteCreatorAffiliationSuggestion(
@@ -84,6 +98,34 @@ it('accepts matching affiliation rors from a valid bulk token through the route'
         ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull();
 });
 
+it('returns a retryable server error and keeps the token when DataCite sync fails', function (): void {
+    $user = User::factory()->admin()->create();
+    $source = createRorBulkRouteCreatorAffiliationSuggestion('Bohr', 'Niels', 'Retry Route Institute');
+    $match = createRorBulkRouteCreatorAffiliationSuggestion('Bohr', 'Niels', 'Retry Route Institute');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    app()->instance(DataCiteSyncService::class, new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            return DataCiteSyncResult::failed((string) $resource->doi, 'DataCite unavailable');
+        }
+    });
+
+    $this->actingAs($user)
+        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => $bulkToken])
+        ->assertStatus(500)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('retryable', true)
+        ->assertJsonPath('accepted_count', 1);
+
+    expect(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeTrue()
+        ->and($match['affiliation']->refresh()->identifier)->toBe('https://ror.org/04z8jg394');
+
+    app()->forgetInstance(DataCiteSyncService::class);
+});
 it('rejects malformed bulk tokens before looking them up', function (): void {
     $user = User::factory()->admin()->create();
 

--- a/tests/pest/Feature/Controllers/RorAffiliationBulkAcceptanceControllerTest.php
+++ b/tests/pest/Feature/Controllers/RorAffiliationBulkAcceptanceControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\AssistanceController;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\SuggestedRor;
+use App\Models\User;
+use App\Services\RorAffiliationBulkAcceptanceService;
+use App\Services\RorDiscoveryService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+
+covers(AssistanceController::class, RorAffiliationBulkAcceptanceService::class);
+
+beforeEach(function (): void {
+    Config::set('cache.default', 'array');
+    Cache::flush();
+});
+
+function createRorBulkRouteCreatorAffiliationSuggestion(
+    string $familyName,
+    string $givenName,
+    string $affiliationName,
+    string $rorId = 'https://ror.org/04z8jg394',
+): array {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'family_name' => $familyName,
+        'given_name' => $givenName,
+    ]);
+    $creator = ResourceCreator::create([
+        'resource_id' => $resource->id,
+        'creatorable_type' => Person::class,
+        'creatorable_id' => $person->id,
+        'position' => 1,
+    ]);
+    $affiliation = $creator->affiliations()->create([
+        'name' => $affiliationName,
+        'identifier' => null,
+        'identifier_scheme' => null,
+        'scheme_uri' => null,
+    ]);
+    $suggestion = SuggestedRor::create([
+        'resource_id' => $resource->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $affiliation->id,
+        'entity_name' => $affiliationName,
+        'suggested_ror_id' => $rorId,
+        'suggested_name' => 'GFZ German Research Centre for Geosciences',
+        'similarity_score' => 0.98,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    return compact('resource', 'person', 'creator', 'affiliation', 'suggestion');
+}
+
+it('accepts matching affiliation rors from a valid bulk token through the route', function (): void {
+    $user = User::factory()->admin()->create();
+    $source = createRorBulkRouteCreatorAffiliationSuggestion('Einstein', 'Albert', 'Exact Observatory');
+    $match = createRorBulkRouteCreatorAffiliationSuggestion('Einstein', 'Albert', 'Exact Observatory');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    $this->actingAs($user)
+        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => $bulkToken])
+        ->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('accepted_count', 1)
+        ->assertJsonPath('skipped_count', 0);
+
+    expect($match['affiliation']->refresh())
+        ->identifier->toBe('https://ror.org/04z8jg394')
+        ->identifier_scheme->toBe('ROR')
+        ->scheme_uri->toBe('https://ror.org/')
+        ->name->toBe('Exact Observatory')
+        ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull();
+});
+
+it('returns a validation-style failure for expired or invalid bulk tokens', function (): void {
+    $user = User::factory()->admin()->create();
+
+    $this->actingAs($user)
+        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => 'missing-token'])
+        ->assertStatus(422)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('accepted_count', 0);
+});
+
+it('requires assistance access for the bulk route', function (): void {
+    $user = User::factory()->beginner()->create();
+
+    $this->actingAs($user)
+        ->postJson('/assistance/rors/bulk-affiliation-accept', ['bulk_token' => 'missing-token'])
+        ->assertForbidden();
+});

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Institution;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceContributor;
+use App\Models\ResourceCreator;
+use App\Models\SuggestedRor;
+use App\Services\RorAffiliationBulkAcceptanceService;
+use App\Services\RorDiscoveryService;
+use Illuminate\Support\Facades\Cache;
+
+covers(RorAffiliationBulkAcceptanceService::class, RorDiscoveryService::class);
+
+beforeEach(function (): void {
+    Cache::flush();
+});
+
+function createRorCreatorAffiliationSuggestion(
+    string $familyName,
+    string $givenName,
+    string $affiliationName,
+    string $rorId = 'https://ror.org/04z8jg394',
+): array {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'family_name' => $familyName,
+        'given_name' => $givenName,
+    ]);
+    $creator = ResourceCreator::create([
+        'resource_id' => $resource->id,
+        'creatorable_type' => Person::class,
+        'creatorable_id' => $person->id,
+        'position' => 1,
+    ]);
+    $affiliation = $creator->affiliations()->create([
+        'name' => $affiliationName,
+        'identifier' => null,
+        'identifier_scheme' => null,
+        'scheme_uri' => null,
+    ]);
+    $suggestion = SuggestedRor::create([
+        'resource_id' => $resource->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $affiliation->id,
+        'entity_name' => $affiliationName,
+        'suggested_ror_id' => $rorId,
+        'suggested_name' => 'GFZ German Research Centre for Geosciences',
+        'similarity_score' => 0.98,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    return compact('resource', 'person', 'creator', 'affiliation', 'suggestion');
+}
+
+function createRorInstitutionCreatorAffiliationSuggestion(
+    string $institutionName,
+    string $affiliationName,
+    string $rorId = 'https://ror.org/04z8jg394',
+): array {
+    $resource = Resource::factory()->create();
+    $institution = Institution::factory()->create([
+        'name' => $institutionName,
+        'name_identifier' => null,
+        'name_identifier_scheme' => null,
+        'scheme_uri' => null,
+    ]);
+    $creator = ResourceCreator::create([
+        'resource_id' => $resource->id,
+        'creatorable_type' => Institution::class,
+        'creatorable_id' => $institution->id,
+        'position' => 1,
+    ]);
+    $affiliation = $creator->affiliations()->create([
+        'name' => $affiliationName,
+        'identifier' => null,
+        'identifier_scheme' => null,
+        'scheme_uri' => null,
+    ]);
+    $suggestion = SuggestedRor::create([
+        'resource_id' => $resource->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $affiliation->id,
+        'entity_name' => $affiliationName,
+        'suggested_ror_id' => $rorId,
+        'suggested_name' => 'GFZ German Research Centre for Geosciences',
+        'similarity_score' => 0.98,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    return compact('resource', 'institution', 'creator', 'affiliation', 'suggestion');
+}
+
+function createRorContributorAffiliationSuggestion(
+    string $familyName,
+    string $givenName,
+    string $affiliationName,
+    string $rorId = 'https://ror.org/04z8jg394',
+): array {
+    $resource = Resource::factory()->create();
+    $person = Person::factory()->create([
+        'family_name' => $familyName,
+        'given_name' => $givenName,
+    ]);
+    $contributor = ResourceContributor::create([
+        'resource_id' => $resource->id,
+        'contributorable_type' => Person::class,
+        'contributorable_id' => $person->id,
+        'position' => 1,
+    ]);
+    $affiliation = $contributor->affiliations()->create([
+        'name' => $affiliationName,
+        'identifier' => null,
+        'identifier_scheme' => null,
+        'scheme_uri' => null,
+    ]);
+    $suggestion = SuggestedRor::create([
+        'resource_id' => $resource->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $affiliation->id,
+        'entity_name' => $affiliationName,
+        'suggested_ror_id' => $rorId,
+        'suggested_name' => 'GFZ German Research Centre for Geosciences',
+        'similarity_score' => 0.98,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    return compact('resource', 'person', 'contributor', 'affiliation', 'suggestion');
+}
+
+it('returns a bulk preview only for exact creator name and affiliation matches', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Doe', 'Jane', 'GFZ Potsdam');
+    createRorCreatorAffiliationSuggestion('Doe', 'Jane', 'GFZ Potsdam');
+    createRorCreatorAffiliationSuggestion('Doe', 'Janet', 'GFZ Potsdam');
+    createRorCreatorAffiliationSuggestion('Doe', 'Jane', 'GFZ Potsdam ');
+    createRorCreatorAffiliationSuggestion('Doe', 'Jane', 'GFZ Potsdam', 'https://ror.org/03yrm5c26');
+    createRorContributorAffiliationSuggestion('Doe', 'Jane', 'GFZ Potsdam');
+
+    $result = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['bulk_affiliation_match'])->toMatchArray([
+            'available' => true,
+            'count' => 1,
+            'creator_name' => 'Doe, Jane',
+            'affiliation' => 'GFZ Potsdam',
+            'suggested_ror_id' => 'https://ror.org/04z8jg394',
+        ])
+        ->and($result['bulk_affiliation_match']['bulk_token'])->toBeString()->not->toBe('');
+
+    expect($source['affiliation']->refresh())
+        ->identifier->toBe('https://ror.org/04z8jg394')
+        ->identifier_scheme->toBe('ROR')
+        ->name->toBe('GFZ Potsdam')
+        ->and($source['person']->refresh()->name_identifier)->toBeNull();
+});
+
+it('uses exact exported institution creator names without changing creator identifiers', function (): void {
+    $source = createRorInstitutionCreatorAffiliationSuggestion('GFZ Data Services', 'Shared Hosting Unit');
+    $match = createRorInstitutionCreatorAffiliationSuggestion('GFZ Data Services', 'Shared Hosting Unit');
+    createRorInstitutionCreatorAffiliationSuggestion('GFZ Data Service', 'Shared Hosting Unit');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+
+    expect($singleResult['bulk_affiliation_match'])->toMatchArray([
+        'count' => 1,
+        'creator_name' => 'GFZ Data Services',
+        'affiliation' => 'Shared Hosting Unit',
+    ]);
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($singleResult['bulk_affiliation_match']['bulk_token']);
+
+    expect($bulkResult['accepted_count'])->toBe(1)
+        ->and($match['affiliation']->refresh()->identifier)->toBe('https://ror.org/04z8jg394')
+        ->and($source['institution']->refresh()->name_identifier)->toBeNull()
+        ->and($match['institution']->refresh()->name_identifier)->toBeNull();
+});
+
+it('accepts all still-valid bulk matches and removes their suggestions', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Curie', 'Marie', 'Exact Institute');
+    $matchA = createRorCreatorAffiliationSuggestion('Curie', 'Marie', 'Exact Institute');
+    $matchB = createRorCreatorAffiliationSuggestion('Curie', 'Marie', 'Exact Institute');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($bulkResult)->toMatchArray([
+        'success' => true,
+        'accepted_count' => 2,
+        'skipped_count' => 0,
+    ]);
+
+    foreach ([$matchA['affiliation'], $matchB['affiliation']] as $affiliation) {
+        expect($affiliation->refresh())
+            ->identifier->toBe('https://ror.org/04z8jg394')
+            ->identifier_scheme->toBe('ROR')
+            ->scheme_uri->toBe('https://ror.org/')
+            ->name->toBe('Exact Institute');
+    }
+
+    expect(SuggestedRor::whereIn('id', [
+        $source['suggestion']->id,
+        $matchA['suggestion']->id,
+        $matchB['suggestion']->id,
+    ])->count())->toBe(0);
+});
+
+it('rejects expired or invalid bulk tokens without changing suggestions', function (): void {
+    $match = createRorCreatorAffiliationSuggestion('Planck', 'Max', 'Still Pending');
+
+    $result = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors('missing-token');
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['accepted_count'])->toBe(0)
+        ->and($match['affiliation']->refresh()->identifier)->toBeNull()
+        ->and(SuggestedRor::find($match['suggestion']->id))->not->toBeNull();
+});

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -15,6 +15,7 @@ use App\Services\RorAffiliationBulkAcceptanceService;
 use App\Services\RorDiscoveryService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 covers(RorAffiliationBulkAcceptanceService::class, RorDiscoveryService::class);
 
@@ -181,6 +182,18 @@ it('returns a bulk preview only for exact creator name and affiliation matches',
         ->and($source['person']->refresh()->name_identifier)->toBeNull();
 });
 
+it('does not cache a preview when exact matches exceed the bulk token limit', function (): void {
+    config(['services.ror_affiliation_bulk_accept.max_matches' => 1]);
+
+    $source = createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Tiny Limit Institute');
+    createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Tiny Limit Institute');
+    createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Tiny Limit Institute');
+
+    $result = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+
+    expect($result)->not->toHaveKey('bulk_affiliation_match');
+});
+
 it('builds bulk previews with batched candidate context queries', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Batch Institute');
 
@@ -259,6 +272,70 @@ it('accepts all still-valid bulk matches and removes their suggestions', functio
         $matchA['suggestion']->id,
         $matchB['suggestion']->id,
     ])->count())->toBe(0);
+});
+
+it('looks up cached bulk suggestions in chunks while accepting', function (): void {
+    $resource = Resource::factory()->create();
+    $now = now();
+    $rows = [];
+
+    for ($i = 1; $i <= 501; $i++) {
+        $rows[] = [
+            'resource_id' => $resource->id,
+            'entity_type' => 'affiliation',
+            'entity_id' => 1_000_000 + $i,
+            'entity_name' => 'Chunked Missing Affiliation',
+            'suggested_ror_id' => 'https://ror.org/04z8jg394',
+            'suggested_name' => 'GFZ German Research Centre for Geosciences',
+            'similarity_score' => 0.98,
+            'ror_aliases' => json_encode([]),
+            'existing_identifier' => null,
+            'existing_identifier_type' => null,
+            'discovered_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+
+    SuggestedRor::insert($rows);
+    $suggestions = SuggestedRor::where('entity_name', 'Chunked Missing Affiliation')
+        ->orderBy('id')
+        ->get(['id', 'entity_id']);
+    $matches = $suggestions
+        ->map(fn (SuggestedRor $suggestion): array => [
+            'suggestion_id' => (int) $suggestion->id,
+            'affiliation_id' => (int) $suggestion->entity_id,
+            'resource_id' => (int) $resource->id,
+        ])
+        ->all();
+    $bulkToken = (string) Str::uuid();
+
+    Cache::put('ror_affiliation_bulk_accept:'.$bulkToken, [
+        'creator_name' => 'Missing, Chunked',
+        'affiliation' => 'Chunked Missing Affiliation',
+        'suggested_ror_id' => 'https://ror.org/04z8jg394',
+        'matches' => $matches,
+    ], now()->addMinutes(15));
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $result = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    $maxBindings = collect(DB::getQueryLog())
+        ->map(fn (array $query): int => count($query['bindings'] ?? []))
+        ->max();
+
+    DB::disableQueryLog();
+    DB::flushQueryLog();
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'accepted_count' => 0,
+        'skipped_count' => 501,
+    ])
+        ->and($maxBindings)->toBeLessThanOrEqual(502)
+        ->and(SuggestedRor::whereIn('id', $suggestions->pluck('id'))->count())->toBe(0);
 });
 
 it('removes all suggestions for a bulk match whose creator morph target is missing', function (): void {
@@ -428,6 +505,34 @@ it('keeps a valid bulk token and retries sync when DataCite returns a failed res
 
     app()->forgetInstance(DataCiteSyncService::class);
 });
+it('does not claim a DataCite retry when already accepted resources have no DOI', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Lamarr', 'Hedy', 'No DOI Retry Institute');
+    $match = createRorCreatorAffiliationSuggestion('Lamarr', 'Hedy', 'No DOI Retry Institute');
+    $match['resource']->update(['doi' => null]);
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    $match['affiliation']->update([
+        'identifier' => 'https://ror.org/04z8jg394',
+        'identifier_scheme' => 'ROR',
+        'scheme_uri' => 'https://ror.org/',
+    ]);
+    $match['suggestion']->delete();
+
+    $result = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($result)->toMatchArray([
+        'success' => true,
+        'accepted_count' => 0,
+        'skipped_count' => 0,
+        'synced_dois' => [],
+    ])
+        ->and($result['message'])->toContain('No resources required DataCite sync')
+        ->and($result['message'])->not->toContain('retried')
+        ->and(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeFalse();
+});
+
 it('keeps a valid bulk token and retries sync after processing fails before completion', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
     $match = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -323,9 +323,9 @@ it('removes all suggestions for a bulk match whose affiliation already has a ROR
         ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
         ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
 });
-it('keeps a valid bulk token when processing fails before completion', function (): void {
+it('keeps a valid bulk token and retries sync after processing fails before completion', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
-    createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
+    $match = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
 
     $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
     $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
@@ -341,7 +341,35 @@ it('keeps a valid bulk token when processing fails before completion', function 
     expect(fn () => app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken))
         ->toThrow(RuntimeException::class, 'sync exploded');
 
-    expect(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeTrue();
+    expect(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeTrue()
+        ->and($match['affiliation']->refresh()->identifier)->toBe('https://ror.org/04z8jg394')
+        ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull();
+
+    $retrySyncService = new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        /** @var array<int, int> */
+        public array $syncedResourceIds = [];
+
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            $this->syncedResourceIds[] = (int) $resource->id;
+
+            return DataCiteSyncResult::succeeded((string) $resource->doi);
+        }
+    };
+
+    app()->instance(DataCiteSyncService::class, $retrySyncService);
+
+    $retryResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($retryResult)->toMatchArray([
+        'success' => true,
+        'accepted_count' => 0,
+        'skipped_count' => 0,
+        'synced_dois' => [$match['resource']->doi],
+    ])
+        ->and($retrySyncService->syncedResourceIds)->toBe([$match['resource']->id])
+        ->and(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeFalse();
 
     app()->forgetInstance(DataCiteSyncService::class);
 });

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -14,6 +14,7 @@ use App\Services\DataCiteSyncService;
 use App\Services\RorAffiliationBulkAcceptanceService;
 use App\Services\RorDiscoveryService;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 covers(RorAffiliationBulkAcceptanceService::class, RorDiscoveryService::class);
 
@@ -169,6 +170,34 @@ it('returns a bulk preview only for exact creator name and affiliation matches',
         ->and($source['person']->refresh()->name_identifier)->toBeNull();
 });
 
+it('builds bulk previews with batched candidate context queries', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Batch Institute');
+
+    for ($i = 0; $i < 8; $i++) {
+        createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Batch Institute');
+        createRorCreatorAffiliationSuggestion('Franklin', 'Rose', 'Batch Institute');
+        createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Other Institute');
+        createRorContributorAffiliationSuggestion('Franklin', 'Rosalind', 'Batch Institute');
+    }
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $preview = app(RorAffiliationBulkAcceptanceService::class)->createPreviewForAcceptedSuggestion($source['suggestion']);
+
+    $selectQueryCount = collect(DB::getQueryLog())
+        ->filter(fn (array $query): bool => str_starts_with(strtolower($query['query']), 'select'))
+        ->count();
+
+    DB::disableQueryLog();
+    DB::flushQueryLog();
+
+    expect($preview)->toMatchArray([
+        'available' => true,
+        'count' => 8,
+    ])
+        ->and($selectQueryCount)->toBeLessThanOrEqual(10);
+});
 it('uses exact exported institution creator names without changing creator identifiers', function (): void {
     $source = createRorInstitutionCreatorAffiliationSuggestion('GFZ Data Services', 'Shared Hosting Unit');
     $match = createRorInstitutionCreatorAffiliationSuggestion('GFZ Data Services', 'Shared Hosting Unit');

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -292,6 +292,36 @@ it('accepts all still-valid bulk matches and removes their suggestions', functio
     ])->count())->toBe(0);
 });
 
+it('accepts bulk matches with batched candidate context queries', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('McClintock', 'Barbara', 'Batch Accept Institute');
+
+    for ($i = 0; $i < 8; $i++) {
+        createRorCreatorAffiliationSuggestion('McClintock', 'Barbara', 'Batch Accept Institute');
+    }
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    $selectQueryCount = collect(DB::getQueryLog())
+        ->filter(fn (array $query): bool => str_starts_with(strtolower($query['query']), 'select'))
+        ->count();
+
+    DB::disableQueryLog();
+    DB::flushQueryLog();
+
+    expect($bulkResult)->toMatchArray([
+        'success' => true,
+        'accepted_count' => 8,
+        'skipped_count' => 0,
+    ])
+        ->and($selectQueryCount)->toBeLessThanOrEqual(10);
+});
+
 it('skips and keeps bulk matches that gained a non-ROR identifier after preview', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Goodall', 'Jane', 'Late Identifier Institute');
     $match = createRorCreatorAffiliationSuggestion('Goodall', 'Jane', 'Late Identifier Institute');

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -194,6 +194,24 @@ it('does not cache a preview when exact matches exceed the bulk token limit', fu
     expect($result)->not->toHaveKey('bulk_affiliation_match');
 });
 
+it('excludes bulk preview candidates that already have a non-ROR identifier value', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Fleming', 'Alexander', 'Identifier Institute');
+    $match = createRorCreatorAffiliationSuggestion('Fleming', 'Alexander', 'Identifier Institute');
+
+    $match['affiliation']->update([
+        'identifier' => 'grid.12345.6',
+        'identifier_scheme' => 'GRID',
+        'scheme_uri' => 'https://www.grid.ac/',
+    ]);
+
+    $result = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+
+    expect($result)->not->toHaveKey('bulk_affiliation_match')
+        ->and($match['affiliation']->refresh()->identifier)->toBe('grid.12345.6')
+        ->and($match['affiliation']->identifier_scheme)->toBe('GRID')
+        ->and(SuggestedRor::find($match['suggestion']->id))->not->toBeNull();
+});
+
 it('builds bulk previews with batched candidate context queries', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Franklin', 'Rosalind', 'Batch Institute');
 
@@ -272,6 +290,31 @@ it('accepts all still-valid bulk matches and removes their suggestions', functio
         $matchA['suggestion']->id,
         $matchB['suggestion']->id,
     ])->count())->toBe(0);
+});
+
+it('skips and keeps bulk matches that gained a non-ROR identifier after preview', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Goodall', 'Jane', 'Late Identifier Institute');
+    $match = createRorCreatorAffiliationSuggestion('Goodall', 'Jane', 'Late Identifier Institute');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    $match['affiliation']->update([
+        'identifier' => 'grid.65432.1',
+        'identifier_scheme' => 'GRID',
+        'scheme_uri' => 'https://www.grid.ac/',
+    ]);
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($bulkResult)->toMatchArray([
+        'success' => false,
+        'accepted_count' => 0,
+        'skipped_count' => 1,
+    ])
+        ->and($match['affiliation']->refresh()->identifier)->toBe('grid.65432.1')
+        ->and($match['affiliation']->identifier_scheme)->toBe('GRID')
+        ->and(SuggestedRor::find($match['suggestion']->id))->not->toBeNull();
 });
 
 it('looks up cached bulk suggestions in chunks while accepting', function (): void {

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -8,6 +8,9 @@ use App\Models\Resource;
 use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\SuggestedRor;
+use App\Services\DataCiteServiceInterface;
+use App\Services\DataCiteSyncResult;
+use App\Services\DataCiteSyncService;
 use App\Services\RorAffiliationBulkAcceptanceService;
 use App\Services\RorDiscoveryService;
 use Illuminate\Support\Facades\Cache;
@@ -216,6 +219,29 @@ it('accepts all still-valid bulk matches and removes their suggestions', functio
         $matchA['suggestion']->id,
         $matchB['suggestion']->id,
     ])->count())->toBe(0);
+});
+
+it('keeps a valid bulk token when processing fails before completion', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
+    createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    app()->instance(DataCiteSyncService::class, new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            throw new RuntimeException('sync exploded');
+        }
+    });
+
+    expect(fn () => app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken))
+        ->toThrow(RuntimeException::class, 'sync exploded');
+
+    expect(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeTrue();
+
+    app()->forgetInstance(DataCiteSyncService::class);
 });
 
 it('rejects expired or invalid bulk tokens without changing suggestions', function (): void {

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -221,6 +221,74 @@ it('accepts all still-valid bulk matches and removes their suggestions', functio
     ])->count())->toBe(0);
 });
 
+it('removes all suggestions for a bulk match whose creator affiliation can no longer be resolved', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Lovelace', 'Ada', 'Analytical Engine Lab');
+    $match = createRorCreatorAffiliationSuggestion('Lovelace', 'Ada', 'Analytical Engine Lab');
+    $staleAlternative = SuggestedRor::create([
+        'resource_id' => $match['resource']->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $match['affiliation']->id,
+        'entity_name' => 'Analytical Engine Lab',
+        'suggested_ror_id' => 'https://ror.org/03yrm5c26',
+        'suggested_name' => 'Alternative Research Centre',
+        'similarity_score' => 0.74,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $match['creator']->delete();
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($singleResult['bulk_affiliation_match']['bulk_token']);
+
+    expect($bulkResult)->toMatchArray([
+        'success' => false,
+        'accepted_count' => 0,
+        'skipped_count' => 1,
+    ])
+        ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull()
+        ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
+        ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
+});
+
+it('removes all suggestions for a bulk match whose affiliation already has a ROR', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Hopper', 'Grace', 'Compiler Institute');
+    $match = createRorCreatorAffiliationSuggestion('Hopper', 'Grace', 'Compiler Institute');
+    $staleAlternative = SuggestedRor::create([
+        'resource_id' => $match['resource']->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $match['affiliation']->id,
+        'entity_name' => 'Compiler Institute',
+        'suggested_ror_id' => 'https://ror.org/03yrm5c26',
+        'suggested_name' => 'Alternative Research Centre',
+        'similarity_score' => 0.74,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $match['affiliation']->update([
+        'identifier' => 'https://ror.org/03yrm5c26',
+        'identifier_scheme' => 'ROR',
+        'scheme_uri' => 'https://ror.org/',
+    ]);
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($singleResult['bulk_affiliation_match']['bulk_token']);
+
+    expect($bulkResult)->toMatchArray([
+        'success' => false,
+        'accepted_count' => 0,
+        'skipped_count' => 1,
+    ])
+        ->and($match['affiliation']->refresh()->identifier)->toBe('https://ror.org/03yrm5c26')
+        ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull()
+        ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
+        ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
+});
 it('keeps a valid bulk token when processing fails before completion', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');
     createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -20,6 +20,17 @@ covers(RorAffiliationBulkAcceptanceService::class, RorDiscoveryService::class);
 
 beforeEach(function (): void {
     Cache::flush();
+    app()->instance(DataCiteSyncService::class, new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            if ($resource->doi === null || $resource->doi === '') {
+                return DataCiteSyncResult::notRequired();
+            }
+
+            return DataCiteSyncResult::succeeded((string) $resource->doi);
+        }
+    });
 });
 
 function createRorCreatorAffiliationSuggestion(
@@ -351,6 +362,71 @@ it('removes all suggestions for a bulk match whose affiliation already has a ROR
         ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull()
         ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
         ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
+});
+it('keeps a valid bulk token and retries sync when DataCite returns a failed result', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Meitner', 'Lise', 'Retryable Sync Institute');
+    $match = createRorCreatorAffiliationSuggestion('Meitner', 'Lise', 'Retryable Sync Institute');
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    $failingSyncService = new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        /** @var array<int, int> */
+        public array $syncedResourceIds = [];
+
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            $this->syncedResourceIds[] = (int) $resource->id;
+
+            return DataCiteSyncResult::failed((string) $resource->doi, 'DataCite unavailable');
+        }
+    };
+
+    app()->instance(DataCiteSyncService::class, $failingSyncService);
+
+    $result = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'accepted_count' => 1,
+        'skipped_count' => 0,
+        'synced_dois' => [],
+        'retryable' => true,
+    ])
+        ->and($result['message'])->toContain('DataCite unavailable')
+        ->and($failingSyncService->syncedResourceIds)->toBe([$match['resource']->id])
+        ->and(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeTrue()
+        ->and($match['affiliation']->refresh()->identifier)->toBe('https://ror.org/04z8jg394')
+        ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull();
+
+    $retrySyncService = new class(app(DataCiteServiceInterface::class)) extends DataCiteSyncService
+    {
+        /** @var array<int, int> */
+        public array $syncedResourceIds = [];
+
+        public function syncIfRegistered(Resource $resource): DataCiteSyncResult
+        {
+            $this->syncedResourceIds[] = (int) $resource->id;
+
+            return DataCiteSyncResult::succeeded((string) $resource->doi);
+        }
+    };
+
+    app()->instance(DataCiteSyncService::class, $retrySyncService);
+
+    $retryResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($retryResult)->toMatchArray([
+        'success' => true,
+        'accepted_count' => 0,
+        'skipped_count' => 0,
+        'synced_dois' => [$match['resource']->doi],
+    ])
+        ->and($retrySyncService->syncedResourceIds)->toBe([$match['resource']->id])
+        ->and(Cache::has('ror_affiliation_bulk_accept:'.$bulkToken))->toBeFalse();
+
+    app()->forgetInstance(DataCiteSyncService::class);
 });
 it('keeps a valid bulk token and retries sync after processing fails before completion', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Noether', 'Emmy', 'Retry Institute');

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -440,6 +440,44 @@ it('removes all suggestions for a bulk match whose affiliation already has a ROR
         ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
         ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
 });
+it('removes stale suggestions when a cached bulk suggestion is gone but the affiliation has the expected ROR', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Keller', 'Helen', 'Resolved Institute');
+    $match = createRorCreatorAffiliationSuggestion('Keller', 'Helen', 'Resolved Institute');
+    $staleAlternative = SuggestedRor::create([
+        'resource_id' => $match['resource']->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $match['affiliation']->id,
+        'entity_name' => 'Resolved Institute',
+        'suggested_ror_id' => 'https://ror.org/03yrm5c26',
+        'suggested_name' => 'Alternative Research Centre',
+        'similarity_score' => 0.74,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $bulkToken = $singleResult['bulk_affiliation_match']['bulk_token'];
+
+    $match['affiliation']->update([
+        'identifier' => 'https://ror.org/04z8jg394',
+        'identifier_scheme' => 'ROR',
+        'scheme_uri' => 'https://ror.org/',
+    ]);
+    $match['suggestion']->delete();
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($bulkToken);
+
+    expect($bulkResult)->toMatchArray([
+        'success' => true,
+        'accepted_count' => 0,
+        'skipped_count' => 0,
+    ])
+        ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
+        ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
+});
+
 it('keeps a valid bulk token and retries sync when DataCite returns a failed result', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Meitner', 'Lise', 'Retryable Sync Institute');
     $match = createRorCreatorAffiliationSuggestion('Meitner', 'Lise', 'Retryable Sync Institute');

--- a/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
+++ b/tests/pest/Feature/Services/RorAffiliationBulkAcceptanceServiceTest.php
@@ -221,7 +221,7 @@ it('accepts all still-valid bulk matches and removes their suggestions', functio
     ])->count())->toBe(0);
 });
 
-it('removes all suggestions for a bulk match whose creator affiliation can no longer be resolved', function (): void {
+it('removes all suggestions for a bulk match whose creator morph target is missing', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Lovelace', 'Ada', 'Analytical Engine Lab');
     $match = createRorCreatorAffiliationSuggestion('Lovelace', 'Ada', 'Analytical Engine Lab');
     $staleAlternative = SuggestedRor::create([
@@ -239,7 +239,7 @@ it('removes all suggestions for a bulk match whose creator affiliation can no lo
     ]);
 
     $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
-    $match['creator']->delete();
+    $match['person']->delete();
 
     $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($singleResult['bulk_affiliation_match']['bulk_token']);
 
@@ -253,6 +253,40 @@ it('removes all suggestions for a bulk match whose creator affiliation can no lo
         ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
 });
 
+it('removes all suggestions for a bulk match whose creator morph target is unexpected', function (): void {
+    $source = createRorCreatorAffiliationSuggestion('Johnson', 'Katherine', 'Orbital Mechanics Lab');
+    $match = createRorCreatorAffiliationSuggestion('Johnson', 'Katherine', 'Orbital Mechanics Lab');
+    $staleAlternative = SuggestedRor::create([
+        'resource_id' => $match['resource']->id,
+        'entity_type' => 'affiliation',
+        'entity_id' => $match['affiliation']->id,
+        'entity_name' => 'Orbital Mechanics Lab',
+        'suggested_ror_id' => 'https://ror.org/03yrm5c26',
+        'suggested_name' => 'Alternative Research Centre',
+        'similarity_score' => 0.74,
+        'ror_aliases' => [],
+        'existing_identifier' => null,
+        'existing_identifier_type' => null,
+        'discovered_at' => now(),
+    ]);
+
+    $singleResult = app(RorDiscoveryService::class)->acceptRor($source['suggestion']);
+    $match['creator']->update([
+        'creatorable_type' => Resource::class,
+        'creatorable_id' => $match['resource']->id,
+    ]);
+
+    $bulkResult = app(RorDiscoveryService::class)->acceptMatchingAffiliationRors($singleResult['bulk_affiliation_match']['bulk_token']);
+
+    expect($bulkResult)->toMatchArray([
+        'success' => false,
+        'accepted_count' => 0,
+        'skipped_count' => 1,
+    ])
+        ->and(SuggestedRor::find($match['suggestion']->id))->toBeNull()
+        ->and(SuggestedRor::find($staleAlternative->id))->toBeNull()
+        ->and(SuggestedRor::where('entity_type', 'affiliation')->where('entity_id', $match['affiliation']->id)->count())->toBe(0);
+});
 it('removes all suggestions for a bulk match whose affiliation already has a ROR', function (): void {
     $source = createRorCreatorAffiliationSuggestion('Hopper', 'Grace', 'Compiler Institute');
     $match = createRorCreatorAffiliationSuggestion('Hopper', 'Grace', 'Compiler Institute');

--- a/tests/pest/Unit/Http/Requests/Batch/BatchAndAssistanceFormRequestsTest.php
+++ b/tests/pest/Unit/Http/Requests/Batch/BatchAndAssistanceFormRequestsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\UserRole;
+use App\Http\Requests\Assistance\AcceptRorAffiliationMatchesRequest;
 use App\Http\Requests\Assistance\DeclineSuggestionRequest;
 use App\Http\Requests\Batch\DestroyIgsnsRequest;
 use App\Http\Requests\Batch\ExportResourcesRequest;
@@ -12,10 +13,12 @@ use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
 
 covers(
+    AcceptRorAffiliationMatchesRequest::class,
     DeclineSuggestionRequest::class,
     DestroyIgsnsRequest::class,
     RegisterResourcesRequest::class,
@@ -23,6 +26,18 @@ covers(
     ExportResourcesRequest::class,
 );
 
+it('AcceptRorAffiliationMatchesRequest requires a uuid bulk token', function (): void {
+    $request = new AcceptRorAffiliationMatchesRequest;
+    expect($request->authorize())->toBeFalse();
+
+    $request->setUserResolver(fn () => User::factory()->create());
+    expect($request->authorize())->toBeTrue();
+
+    $rules = $request->rules();
+    expect(Validator::make([], $rules)->fails())->toBeTrue();
+    expect(Validator::make(['bulk_token' => 'missing-token'], $rules)->fails())->toBeTrue();
+    expect(Validator::make(['bulk_token' => (string) Str::uuid()], $rules)->fails())->toBeFalse();
+});
 it('DeclineSuggestionRequest authorizes only authenticated users', function (): void {
     $request = new DeclineSuggestionRequest;
     expect($request->authorize())->toBeFalse();

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -76,6 +76,10 @@ const SUBJECT_METADATA_ASSISTANT_NAME = 'Subject Metadata Enrichment';
 const DESCRIPTION_SEGMENTATION_ASSISTANT_ID = 'description-segmentation';
 const DESCRIPTION_SEGMENTATION_ROUTE_PREFIX = 'description-segmentation';
 const DESCRIPTION_SEGMENTATION_ASSISTANT_NAME = 'Description Segmentation Suggestions';
+const BULK_TOKEN_MATCH = '00000000-0000-4000-8000-000000000955';
+const BULK_TOKEN_SINGULAR = '00000000-0000-4000-8000-000000000958';
+const BULK_TOKEN_EXPIRED = '00000000-0000-4000-8000-000000000957';
+const BULK_TOKEN_DECLINE = '00000000-0000-4000-8000-000000000956';
 
 beforeEach(() => {
     mockedAxiosPost.mockReset();
@@ -1339,7 +1343,7 @@ describe('RorSuggestionCard – ROR link', () => {
                     bulk_affiliation_match: {
                         available: true,
                         count: 2,
-                        bulk_token: 'bulk-token-955',
+                        bulk_token: BULK_TOKEN_MATCH,
                         creator_name: 'Doe, Jane',
                         affiliation: 'GFZ Potsdam',
                         suggested_ror_id: 'https://ror.org/04t3en479',
@@ -1379,7 +1383,7 @@ describe('RorSuggestionCard – ROR link', () => {
 
         await waitFor(() => {
             expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
-                bulk_token: 'bulk-token-955',
+                bulk_token: BULK_TOKEN_MATCH,
             });
             expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
         });
@@ -1396,7 +1400,7 @@ describe('RorSuggestionCard – ROR link', () => {
                 bulk_affiliation_match: {
                     available: true,
                     count: 1,
-                    bulk_token: 'bulk-token-singular',
+                    bulk_token: BULK_TOKEN_SINGULAR,
                     creator_name: 'Doe, Jane',
                     affiliation: 'GFZ Potsdam',
                     suggested_ror_id: 'https://ror.org/04t3en479',
@@ -1430,7 +1434,7 @@ describe('RorSuggestionCard – ROR link', () => {
                     bulk_affiliation_match: {
                         available: true,
                         count: 1,
-                        bulk_token: 'expired-bulk-token',
+                        bulk_token: BULK_TOKEN_EXPIRED,
                         creator_name: 'Doe, Jane',
                         affiliation: 'GFZ Potsdam',
                         suggested_ror_id: 'https://ror.org/04t3en479',
@@ -1460,7 +1464,7 @@ describe('RorSuggestionCard – ROR link', () => {
 
         await waitFor(() => {
             expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
-                bulk_token: 'expired-bulk-token',
+                bulk_token: BULK_TOKEN_EXPIRED,
             });
             expect(mockedToastWarning).toHaveBeenCalledWith('Bulk ROR acceptance token is invalid or has expired.');
             expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
@@ -1478,7 +1482,7 @@ describe('RorSuggestionCard – ROR link', () => {
                 bulk_affiliation_match: {
                     available: true,
                     count: 1,
-                    bulk_token: 'bulk-token-decline',
+                    bulk_token: BULK_TOKEN_DECLINE,
                     creator_name: 'Doe, Jane',
                     affiliation: 'GFZ Potsdam',
                     suggested_ror_id: 'https://ror.org/04t3en479',

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -79,6 +79,7 @@ const DESCRIPTION_SEGMENTATION_ASSISTANT_NAME = 'Description Segmentation Sugges
 const BULK_TOKEN_MATCH = '00000000-0000-4000-8000-000000000955';
 const BULK_TOKEN_SINGULAR = '00000000-0000-4000-8000-000000000958';
 const BULK_TOKEN_RETRY = '00000000-0000-4000-8000-000000000957';
+const BULK_TOKEN_EXPIRED = '00000000-0000-4000-8000-000000000959';
 const BULK_TOKEN_DECLINE = '00000000-0000-4000-8000-000000000956';
 
 beforeEach(() => {
@@ -1444,6 +1445,7 @@ describe('RorSuggestionCard – ROR link', () => {
             .mockRejectedValueOnce({
                 isAxiosError: true,
                 response: {
+                    status: 500,
                     data: {
                         message: 'DataCite sync failed. Please try again.',
                     },
@@ -1495,6 +1497,56 @@ describe('RorSuggestionCard – ROR link', () => {
         });
     });
 
+    it('closes and reloads the bulk ROR dialog for non-retryable 422 responses', async () => {
+        const suggestion = makeRorSuggestion({ id: 959 });
+        const user = userEvent.setup();
+
+        mockedAxiosPost
+            .mockResolvedValueOnce({
+                data: {
+                    success: true,
+                    message: 'ROR-ID accepted. No resources required DataCite sync.',
+                    bulk_affiliation_match: {
+                        available: true,
+                        count: 1,
+                        bulk_token: BULK_TOKEN_EXPIRED,
+                        creator_name: 'Doe, Jane',
+                        affiliation: 'GFZ Potsdam',
+                        suggested_ror_id: 'https://ror.org/04t3en479',
+                    },
+                },
+            })
+            .mockRejectedValueOnce({
+                isAxiosError: true,
+                response: {
+                    status: 422,
+                    data: {
+                        message: 'Bulk ROR acceptance token is invalid or has expired.',
+                    },
+                },
+            });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
+                bulk_token: BULK_TOKEN_EXPIRED,
+            });
+            expect(mockedToastWarning).toHaveBeenCalledWith('Bulk ROR acceptance token is invalid or has expired.');
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
     it('declines the bulk ROR dialog without posting the token', async () => {
         const suggestion = makeRorSuggestion({ id: 956 });
         const user = userEvent.setup();

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -78,7 +78,7 @@ const DESCRIPTION_SEGMENTATION_ROUTE_PREFIX = 'description-segmentation';
 const DESCRIPTION_SEGMENTATION_ASSISTANT_NAME = 'Description Segmentation Suggestions';
 const BULK_TOKEN_MATCH = '00000000-0000-4000-8000-000000000955';
 const BULK_TOKEN_SINGULAR = '00000000-0000-4000-8000-000000000958';
-const BULK_TOKEN_EXPIRED = '00000000-0000-4000-8000-000000000957';
+const BULK_TOKEN_RETRY = '00000000-0000-4000-8000-000000000957';
 const BULK_TOKEN_DECLINE = '00000000-0000-4000-8000-000000000956';
 
 beforeEach(() => {
@@ -1422,7 +1422,7 @@ describe('RorSuggestionCard – ROR link', () => {
             'There is 1 further creator affiliation with the same <creatorName>, <affiliation>, and ROR suggestion you have just confirmed. Would you like to accept the ROR suggestion for this affiliation as well?',
         );
     });
-    it('warns and reloads when accepting bulk ROR matches fails with a server message', async () => {
+    it('keeps the bulk ROR dialog open so a failed request can be retried', async () => {
         const suggestion = makeRorSuggestion({ id: 957 });
         const user = userEvent.setup();
 
@@ -1434,7 +1434,7 @@ describe('RorSuggestionCard – ROR link', () => {
                     bulk_affiliation_match: {
                         available: true,
                         count: 1,
-                        bulk_token: BULK_TOKEN_EXPIRED,
+                        bulk_token: BULK_TOKEN_RETRY,
                         creator_name: 'Doe, Jane',
                         affiliation: 'GFZ Potsdam',
                         suggested_ror_id: 'https://ror.org/04t3en479',
@@ -1445,8 +1445,17 @@ describe('RorSuggestionCard – ROR link', () => {
                 isAxiosError: true,
                 response: {
                     data: {
-                        message: 'Bulk ROR acceptance token is invalid or has expired.',
+                        message: 'DataCite sync failed. Please try again.',
                     },
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    success: true,
+                    accepted_count: 0,
+                    skipped_count: 0,
+                    synced_dois: ['10.5880/test.2024.002'],
+                    message: 'ROR-ID acceptance was already applied for 1 further creator affiliation. DataCite sync has been retried.',
                 },
             });
 
@@ -1464,10 +1473,25 @@ describe('RorSuggestionCard – ROR link', () => {
 
         await waitFor(() => {
             expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
-                bulk_token: BULK_TOKEN_EXPIRED,
+                bulk_token: BULK_TOKEN_RETRY,
             });
-            expect(mockedToastWarning).toHaveBeenCalledWith('Bulk ROR acceptance token is invalid or has expired.');
+            expect(mockedToastWarning).toHaveBeenCalledWith('DataCite sync failed. Please try again.');
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+        });
+        expect(mockedRouterReload).not.toHaveBeenCalled();
+
+        await waitFor(() => {
+            expect(within(dialog).getByRole('button', { name: 'Accept' })).not.toBeDisabled();
+        });
+
+        await user.click(within(dialog).getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenNthCalledWith(3, '/assistance/rors/bulk-affiliation-accept', {
+                bulk_token: BULK_TOKEN_RETRY,
+            });
             expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -1352,7 +1352,7 @@ describe('RorSuggestionCard – ROR link', () => {
                     accepted_count: 2,
                     skipped_count: 0,
                     synced_dois: [],
-                    message: 'ROR-ID accepted for 2 further creator affiliation(s).',
+                    message: 'ROR-ID accepted for 2 further creator affiliations.',
                 },
             });
 
@@ -1371,7 +1371,7 @@ describe('RorSuggestionCard – ROR link', () => {
 
         const dialog = await screen.findByRole('dialog');
         expect(dialog).toHaveTextContent(
-            'There are 2 further creators who match the resource you have just confirmed in the <creatorName> and <affiliation> elements. Would you like to accept the ROR suggestion for these as well?',
+            'There are 2 further creator affiliations with the same <creatorName>, <affiliation>, and ROR suggestion you have just confirmed. Would you like to accept the ROR suggestion for these affiliations as well?',
         );
         expect(mockedRouterReload).not.toHaveBeenCalled();
 
@@ -1385,6 +1385,39 @@ describe('RorSuggestionCard – ROR link', () => {
         });
     });
 
+    it('uses singular copy for one matching ROR creator affiliation', async () => {
+        const suggestion = makeRorSuggestion({ id: 958 });
+        const user = userEvent.setup();
+
+        mockedAxiosPost.mockResolvedValueOnce({
+            data: {
+                success: true,
+                message: 'ROR-ID accepted. No resources required DataCite sync.',
+                bulk_affiliation_match: {
+                    available: true,
+                    count: 1,
+                    bulk_token: 'bulk-token-singular',
+                    creator_name: 'Doe, Jane',
+                    affiliation: 'GFZ Potsdam',
+                    suggested_ror_id: 'https://ror.org/04t3en479',
+                },
+            },
+        });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog).toHaveTextContent(
+            'There is 1 further creator affiliation with the same <creatorName>, <affiliation>, and ROR suggestion you have just confirmed. Would you like to accept the ROR suggestion for this affiliation as well?',
+        );
+    });
     it('warns and reloads when accepting bulk ROR matches fails with a server message', async () => {
         const suggestion = makeRorSuggestion({ id: 957 });
         const user = userEvent.setup();

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { router } from '@inertiajs/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
+import { toast } from 'sonner';
 import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -47,6 +49,8 @@ vi.mock('axios', () => {
 });
 
 const mockedAxiosPost = axios.post as Mock;
+const mockedRouterReload = router.reload as Mock;
+const mockedToastWarning = toast.warning as Mock;
 
 // ── Import component under test (after mocks) ───────────────────────
 
@@ -75,6 +79,8 @@ const DESCRIPTION_SEGMENTATION_ASSISTANT_NAME = 'Description Segmentation Sugges
 
 beforeEach(() => {
     mockedAxiosPost.mockReset();
+    mockedRouterReload.mockReset();
+    mockedToastWarning.mockReset();
 });
 
 function makeOrcidSuggestion(overrides: Partial<SuggestedOrcidItem> = {}): SuggestedOrcidItem {
@@ -1290,6 +1296,180 @@ describe('RorSuggestionCard – ROR link', () => {
 
         expect(screen.queryByRole('link', { name: 'https://ror.org/search' })).not.toBeInTheDocument();
         expect(screen.getByText(/ror\.org\/search/)).toBeInTheDocument();
+    });
+
+    it('reloads immediately after accepting a ROR suggestion without bulk matches', async () => {
+        const suggestion = makeRorSuggestion({ id: 954 });
+        const user = userEvent.setup();
+
+        mockedAxiosPost.mockResolvedValueOnce({
+            data: {
+                success: true,
+                message: 'ROR-ID accepted. No resources required DataCite sync.',
+                replaced_identifier: null,
+                synced_dois: [],
+            },
+        });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenNthCalledWith(1, '/assistance/rors/954/accept');
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('opens a bulk accept dialog after accepting a ROR affiliation suggestion with exact matches', async () => {
+        const suggestion = makeRorSuggestion({ id: 955 });
+        const user = userEvent.setup();
+
+        mockedAxiosPost
+            .mockResolvedValueOnce({
+                data: {
+                    success: true,
+                    message: 'ROR-ID accepted. No resources required DataCite sync.',
+                    bulk_affiliation_match: {
+                        available: true,
+                        count: 2,
+                        bulk_token: 'bulk-token-955',
+                        creator_name: 'Doe, Jane',
+                        affiliation: 'GFZ Potsdam',
+                        suggested_ror_id: 'https://ror.org/04t3en479',
+                    },
+                },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    success: true,
+                    accepted_count: 2,
+                    skipped_count: 0,
+                    synced_dois: [],
+                    message: 'ROR-ID accepted for 2 further creator affiliation(s).',
+                },
+            });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenNthCalledWith(1, '/assistance/rors/955/accept');
+        });
+
+        const dialog = await screen.findByRole('dialog');
+        expect(dialog).toHaveTextContent(
+            'There are 2 further creators who match the resource you have just confirmed in the <creatorName> and <affiliation> elements. Would you like to accept the ROR suggestion for these as well?',
+        );
+        expect(mockedRouterReload).not.toHaveBeenCalled();
+
+        await user.click(within(dialog).getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
+                bulk_token: 'bulk-token-955',
+            });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+        });
+    });
+
+    it('warns and reloads when accepting bulk ROR matches fails with a server message', async () => {
+        const suggestion = makeRorSuggestion({ id: 957 });
+        const user = userEvent.setup();
+
+        mockedAxiosPost
+            .mockResolvedValueOnce({
+                data: {
+                    success: true,
+                    message: 'ROR-ID accepted. No resources required DataCite sync.',
+                    bulk_affiliation_match: {
+                        available: true,
+                        count: 1,
+                        bulk_token: 'expired-bulk-token',
+                        creator_name: 'Doe, Jane',
+                        affiliation: 'GFZ Potsdam',
+                        suggested_ror_id: 'https://ror.org/04t3en479',
+                    },
+                },
+            })
+            .mockRejectedValueOnce({
+                isAxiosError: true,
+                response: {
+                    data: {
+                        message: 'Bulk ROR acceptance token is invalid or has expired.',
+                    },
+                },
+            });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
+                bulk_token: 'expired-bulk-token',
+            });
+            expect(mockedToastWarning).toHaveBeenCalledWith('Bulk ROR acceptance token is invalid or has expired.');
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+        });
+    });
+
+    it('declines the bulk ROR dialog without posting the token', async () => {
+        const suggestion = makeRorSuggestion({ id: 956 });
+        const user = userEvent.setup();
+
+        mockedAxiosPost.mockResolvedValueOnce({
+            data: {
+                success: true,
+                message: 'ROR-ID accepted. No resources required DataCite sync.',
+                bulk_affiliation_match: {
+                    available: true,
+                    count: 1,
+                    bulk_token: 'bulk-token-decline',
+                    creator_name: 'Doe, Jane',
+                    affiliation: 'GFZ Potsdam',
+                    suggested_ror_id: 'https://ror.org/04t3en479',
+                },
+            },
+        });
+
+        render(
+            <AssistancePage
+                sections={{ 'ror-suggestion': paginated([suggestion]) }}
+                manifests={[makeManifest('ror-suggestion', 'rors', 'ROR Suggestions')]}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: 'Decline' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
     });
 });
 

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -175,6 +175,25 @@ describe('Docs page', () => {
             }),
         ).toBeInTheDocument();
     });
+    it('documents exact-match bulk acceptance for ROR affiliation suggestions', () => {
+        render(<Docs userRole="group_leader" editorSettings={defaultEditorSettings} dataCite={defaultDataCite} />);
+
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return (
+                    text.includes('Suggested ROR-ID affiliation matches are exact.') &&
+                    text.includes('with the same exported creatorName, affiliation, and proposed ROR identifier') &&
+                    text.includes('creator name identifiers and affiliation labels stay unchanged.')
+                );
+            }),
+        ).toBeInTheDocument();
+    });
 
     it('hides assistance documentation for curators', () => {
         render(<Docs userRole="curator" editorSettings={defaultEditorSettings} dataCite={defaultDataCite} />);


### PR DESCRIPTION
This pull request introduces a new bulk acceptance flow for ROR (Research Organization Registry) suggestions on creator affiliations, addressing Issue #955. It enables curators to accept all exact matches of a ROR suggestion for creator affiliations in bulk, streamlining the curation process. The implementation includes a new service to handle the bulk logic, new API endpoints, request validation, and necessary controller/service wiring.

**Bulk ROR Affiliation Acceptance Feature:**

- Added `RorAffiliationBulkAcceptanceService` to encapsulate logic for previewing and accepting multiple matching ROR affiliation suggestions using a short-lived token. This service handles caching, validation, database updates, and DataCite syncs.
- Updated `RorDiscoveryService` to integrate the new bulk acceptance service, provide a preview of further matches upon single acceptance, and expose a method to accept matches by token. Also improved type annotations for Eloquent queries. [[1]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecR63) [[2]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecL124-R126) [[3]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecR239-R268) [[4]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecL281-R302) [[5]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecL303-R324) [[6]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecL347-R368) [[7]](diffhunk://#diff-d154bc533ea635448eae24d55d72c9d199963bbb37f955e50488a9d2764e3eecR18)
- Added `AcceptRorAffiliationMatchesRequest` for validating the bulk token in API requests.

**API and Controller Updates:**

- Extended `AssistanceController` to add a new endpoint for accepting bulk ROR affiliation matches, with appropriate request validation and service invocation. [[1]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062R7-R11) [[2]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062R29) [[3]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062R143-R154)
- Registered the new route for bulk affiliation acceptance under the `ror-suggestion` assistant in `AssistantServiceProvider`.
- Minor code style update in the assistant service provider for consistency.