### PR TITLE
Adds a dedicated UI card for DateType Assitant Suggestions

### DIFF
--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -1011,6 +1011,110 @@ function SizeFormatSuggestionCard({
         </div>
     );
 }
+
+function DateTypeSuggestionCard({
+    suggestion,
+    onAccept,
+    onDecline,
+    isProcessing,
+}: {
+    suggestion: BaseSuggestionItem;
+    onAccept: (id: number) => void;
+    onDecline: (id: number) => void;
+    isProcessing: boolean;
+}) {
+    const metadata = isRecord(suggestion.metadata) ? suggestion.metadata : null;
+
+    const suggestionKind = typeof metadata?.suggestion_kind === 'string' ? metadata.suggestion_kind : null;
+    const confidence = typeof metadata?.confidence === 'string' ? metadata.confidence : null;
+    const targetDateType = typeof metadata?.target_date_type === 'string' ? metadata.target_date_type : null;
+    const schemaOrgField = typeof metadata?.schema_org_field === 'string' ? metadata.schema_org_field : null;
+    const sourceUrl = typeof metadata?.source_url === 'string' ? metadata.source_url : null;
+    const evidence = typeof metadata?.evidence === 'string' ? metadata.evidence : null;
+
+    const collectedDatesCount = typeof metadata?.collected_dates_count === 'number' ? metadata.collected_dates_count : null;
+    const geoLocationsCount = typeof metadata?.geo_locations_count === 'number' ? metadata.geo_locations_count : null;
+
+    const isReview = suggestionKind === 'review';
+    const isAmbiguous = metadata?.is_ambiguous === true || isReview || confidence === 'low';
+
+    return (
+        <div
+            className={
+                isAmbiguous
+                    ? 'rounded-lg border-2 border-orange-500 bg-orange-50 p-4 shadow-sm transition-all hover:shadow-md dark:bg-orange-950/20'
+                    : 'rounded-lg border bg-card p-4 shadow-sm transition-all hover:shadow-md'
+            }
+        >
+            <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1 space-y-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline" className="text-xs">
+                            DateType
+                        </Badge>
+
+                        {targetDateType && (
+                            <Badge variant="secondary" className="text-xs">
+                                {targetDateType}
+                            </Badge>
+                        )}
+
+                        {confidence && (
+                            <Badge className={`text-xs ${confidenceBadgeColor(confidence)}`}>
+                                {confidenceLabel(confidence)}
+                            </Badge>
+                        )}
+
+                        {isAmbiguous && (
+                            <Badge className="bg-orange-600 text-xs text-white">
+                                <AlertTriangle className="mr-1 h-3 w-3" />
+                                Manual review
+                            </Badge>
+                        )}
+
+                        {collectedDatesCount !== null && geoLocationsCount !== null && (
+                            <Badge variant="secondary" className="text-xs">
+                                {collectedDatesCount}:{geoLocationsCount}
+                            </Badge>
+                        )}
+                    </div>
+
+                    <p className="text-sm font-medium">
+                        {isReview
+                            ? `Hint: ${String(suggestion.suggested_label ?? suggestion.suggested_value ?? 'DateType review')}`
+                            : String(suggestion.suggested_label ?? suggestion.suggested_value ?? 'DateType suggestion')}
+                    </p>
+
+                    {evidence && <p className="text-xs text-muted-foreground">{evidence}</p>}
+
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                        {schemaOrgField && <span>schema.org field: {schemaOrgField}</span>}
+                        {sourceUrl && (
+                            <a href={sourceUrl} target="_blank" rel="noopener noreferrer" className="break-all underline hover:text-foreground">
+                                Open source
+                            </a>
+                        )}
+                        <span>Discovered: {suggestion.discovered_at ? new Date(suggestion.discovered_at).toLocaleDateString() : '—'}</span>
+                    </div>
+                </div>
+
+                <div className="flex shrink-0 gap-2">
+                    <Button variant="outline" size="sm" disabled={isProcessing} onClick={() => onDecline(suggestion.id)}>
+                        <X className="mr-1 h-4 w-4" />
+                        {isReview ? 'Dismiss' : 'Decline'}
+                    </Button>
+
+                    {!isReview && (
+                        <Button size="sm" disabled={isProcessing} onClick={() => onAccept(suggestion.id)}>
+                            <Check className="mr-1 h-4 w-4" />
+                            Accept
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
 // ── Per-section state ────────────────────────────────────────────────
 
 
@@ -1461,6 +1565,15 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                 );
             case 'size-format-suggestion':
                 return <SizeFormatSuggestionCard suggestion={item} onAccept={onAccept} onDecline={onDecline} isProcessing={isProcessing} />;
+                case 'date-type-suggestion':
+                return (
+                    <DateTypeSuggestionCard
+                        suggestion={item}
+                        onAccept={onAccept}
+                        onDecline={onDecline}
+                        isProcessing={isProcessing}
+                    />
+                );
             case 'description-segmentation':
                 return (
                     <DescriptionSegmentationSuggestionCard


### PR DESCRIPTION
Changes
Added DateTypeSuggestionCard in assistance.tsx.
Registered it for manifest.id === "date-type-suggestion". Highlighted ambiguous/review-only suggestions in orange. Added a “Manual review” badge.
Displayed DateType metadata such as confidence, target date type, schema.org field, source URL, and evidence. Hid Accept for review-only hints and shows Dismiss instead.

Reason

DateType suggestions can be actionable additions or review-only warnings. The UI now makes ambiguous cases easier to identify for manual review.