### PR TITLE
Fix: Wrap long blocked editor link labels

### DIFF
--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -2177,9 +2177,14 @@ function ResourcesPage({
                     </DialogHeader>
                     <div className="space-y-2">
                         {blockedEditorTabs.map((tab) => (
-                            <Button key={tab.id} asChild variant="outline" className="w-full justify-between gap-2">
+                            <Button
+                                key={tab.id}
+                                asChild
+                                variant="outline"
+                                className="h-auto min-h-9 w-full items-start justify-between gap-2 py-2 text-left whitespace-normal"
+                            >
                                 <a href={tab.url} target="_blank" rel="noopener noreferrer">
-                                    <span className="truncate">{tab.label}</span>
+                                    <span className="min-w-0 flex-1 text-left wrap-break-word whitespace-normal">{tab.label}</span>
                                     <ExternalLink aria-hidden="true" className="size-4 shrink-0" />
                                 </a>
                             </Button>

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -352,6 +352,29 @@ describe('ResourcesPage - bulk selection', () => {
         expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
+    it('allows long blocked editor tab labels to wrap inside the fallback dialog', async () => {
+        openMock.mockReturnValueOnce(null);
+        const longTitle =
+            'A very long resource title with enough descriptive metadata to exceed the dialog width and aSuperLongUnbrokenSegmentThatStillNeedsToStayInsideTheFallbackLink';
+
+        render(<ResourcesPage {...buildProps([buildResource({ id: 9470, doi: '10.9999/long-title', title: longTitle })])} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-9470'));
+        await userEvent.click(screen.getByTestId('resources-action-edit'));
+
+        const fallbackLink = screen.getByRole('link', { name: new RegExp(longTitle) });
+        const label = within(fallbackLink).getByText(longTitle);
+
+        expect(fallbackLink).toHaveClass('h-auto');
+        expect(fallbackLink).toHaveClass('min-h-9');
+        expect(fallbackLink).toHaveClass('items-start');
+        expect(fallbackLink).toHaveClass('whitespace-normal');
+        expect(fallbackLink).not.toHaveClass('whitespace-nowrap');
+        expect(label).toHaveClass('whitespace-normal');
+        expect(label).toHaveClass('wrap-break-word');
+        expect(label).not.toHaveClass('truncate');
+    });
+
     it('shows fallback editor links when a row editor tab is blocked', async () => {
         openMock.mockReturnValueOnce(null);
         render(<ResourcesPage {...buildProps()} />);


### PR DESCRIPTION
This pull request improves the display of long resource tab labels in the fallback dialog on the `ResourcesPage` to ensure better readability and accessibility, and adds a test to verify this behavior.

**UI improvements for long tab labels:**

* Updated the `Button` and label rendering in the fallback dialog to allow long resource tab labels to wrap, prevent overflow, and ensure the text remains readable by adding appropriate CSS classes (`h-auto`, `min-h-9`, `whitespace-normal`, `wrap-break-word`) in `resources.tsx`.

**Testing enhancements:**

* Added a test to verify that long blocked editor tab labels correctly wrap and do not overflow or truncate in the fallback dialog, ensuring the new styling works as intended in `resources-bulk-selection.test.tsx`.