### PR TITLE
Added fixes concerning the DateTypeAssistant in the accept flow

### DIFF
--- a/app/Models/ResourceDate.php
+++ b/app/Models/ResourceDate.php
@@ -37,6 +37,9 @@ class ResourceDate extends Model
     /** @use HasFactory<\Illuminate\Database\Eloquent\Factories\Factory<static>> */
     use HasFactory;
 
+    /** @var list<string> */
+    protected $touches = ['resource'];
+
     /** @return BelongsTo<Resource, static> */
     public function resource(): BelongsTo
     {

--- a/app/Services/DateType/DateTypeAcceptanceService.php
+++ b/app/Services/DateType/DateTypeAcceptanceService.php
@@ -52,6 +52,21 @@ final class DateTypeAcceptanceService
             ];
         }
 
+        $dateTypeAlreadyExists = ResourceDate::query()
+            ->where('resource_id', $suggestion->resource_id)
+            ->whereHas('dateType', fn ($query) => $query->whereIn('slug', array_unique([
+                $targetDateType,
+                strtolower($targetDateType),
+            ])))
+            ->exists();
+
+        if ($dateTypeAlreadyExists) {
+            return [
+                'success' => false,
+                'message' => "This suggestion is stale because the resource already has a '{$targetDateType}' date.",
+            ];
+        }
+
         if (str_contains($dateValue, '/')) {
             [$startDate, $endDate] = explode('/', $dateValue, 2);
 
@@ -95,17 +110,47 @@ final class DateTypeAcceptanceService
             ];
         }
 
-        $updatedCount = ResourceDate::query()
+        $dates = ResourceDate::query()
             ->where('resource_id', $suggestion->resource_id)
             ->whereHas('dateType', fn ($query) => $query->where('slug', 'Collected'))
-            ->update(['date_type_id' => $coverageDateTypeId]);
+            ->get();
 
-        if ($updatedCount === 0) {
+        if ($dates->isEmpty()) {
             return [
                 'success' => false,
                 'message' => 'No Collected date entries were found for this resource.',
             ];
         }
+
+        $metadata = $suggestion->metadata ?? [];
+        $expectedCollectedCount = filter_var($metadata['collected_dates_count'] ?? null, FILTER_VALIDATE_INT);
+        $expectedGeoLocationCount = filter_var($metadata['geo_locations_count'] ?? null, FILTER_VALIDATE_INT);
+
+        if ($expectedCollectedCount === false || $expectedGeoLocationCount === false) {
+            preg_match('/^collected_dates:(\d+);geo_locations:(\d+)$/', $suggestion->suggested_value, $matches);
+            $expectedCollectedCount = isset($matches[1]) ? (int) $matches[1] : null;
+            $expectedGeoLocationCount = isset($matches[2]) ? (int) $matches[2] : null;
+        }
+
+        $currentCollectedCount = $dates->count();
+        $currentGeoLocationCount = $suggestion->resource()->first()?->geoLocations()->count();
+
+        if ($expectedCollectedCount === null
+            || $expectedGeoLocationCount === null
+            || $currentCollectedCount !== $expectedCollectedCount
+            || $currentGeoLocationCount !== $expectedGeoLocationCount
+            || $currentCollectedCount !== $currentGeoLocationCount) {
+            return [
+                'success' => false,
+                'message' => 'This suggestion is stale because the Collected date or geolocation counts changed.',
+            ];
+        }
+
+        $dates->each(fn (ResourceDate $date) => $date->update([
+            'date_type_id' => $coverageDateTypeId,
+        ]));
+
+        $updatedCount = $dates->count();
 
         return [
             'success' => true,

--- a/app/Services/DateType/DateTypeNormalizerService.php
+++ b/app/Services/DateType/DateTypeNormalizerService.php
@@ -61,6 +61,13 @@ final class DateTypeNormalizerService
                 return null;
             }
 
+            // Normalized DataCite dates are ordered from their most significant
+            // component (year) to their least significant component, so a lexical
+            // comparison also covers year-only and year-month ranges.
+            if ($normalizedStart > $normalizedEnd) {
+                return null;
+            }
+
             return $normalizedStart.'/'.$normalizedEnd;
         }
 

--- a/tests/pest/Feature/Services/DateTypeSuggestionAssistantTest.php
+++ b/tests/pest/Feature/Services/DateTypeSuggestionAssistantTest.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use App\Services\Assistance\AssistantManifest;
 use App\Services\DateType\DateTypeDiscoveryService;
 use App\Services\DateType\DateTypeSchemaorgExtractionService;
+use Illuminate\Support\Facades\DB;
 use Modules\Assistants\DateTypeSuggestion\Assistant;
 
 function createCollectedCoverageSuggestion(Assistant $assistant, Resource $resource): AssistantSuggestion
@@ -177,8 +178,12 @@ it('accepts a collected to coverage correction by updating only the suggested re
         'date_type_id' => $collectedType->id,
         'date_value' => '2021-01-01',
     ]);
+    GeoLocation::factory()->withPoint(13.0, 52.0)->create(['resource_id' => $resource->id]);
+    GeoLocation::factory()->withPoint(14.0, 53.0)->create(['resource_id' => $resource->id]);
 
     $suggestion = createCollectedCoverageSuggestion($assistant, $resource);
+    $staleUpdatedAt = now()->subDay();
+    DB::table('resources')->where('id', $resource->id)->update(['updated_at' => $staleUpdatedAt]);
 
     $result = $assistant->acceptSuggestion($suggestion->id);
     $firstCollectedDate->refresh();
@@ -199,7 +204,46 @@ it('accepts a collected to coverage correction by updating only the suggested re
         ->and($secondCollectedDate->start_date)->toBe('2020-01-01')
         ->and($secondCollectedDate->end_date)->toBe('2020-12-31')
         ->and($secondCollectedDate->date_information)->toBe('Collection interval from import.')
-        ->and($unrelatedCollectedDate->fresh()->date_type_id)->toBe($collectedType->id);
+        ->and($unrelatedCollectedDate->fresh()->date_type_id)->toBe($collectedType->id)
+        ->and($resource->fresh()->updated_at->greaterThan($staleUpdatedAt))->toBeTrue();
+});
+
+it('keeps a stale collected to coverage correction pending when the counts changed', function (): void {
+    $assistant = app(Assistant::class);
+    $collectedType = DateType::create(['name' => 'Collected', 'slug' => 'Collected', 'is_active' => true]);
+    DateType::create(['name' => 'Coverage', 'slug' => 'Coverage', 'is_active' => true]);
+    $resource = Resource::factory()->create();
+    $originalDate = ResourceDate::create([
+        'resource_id' => $resource->id,
+        'date_type_id' => $collectedType->id,
+        'date_value' => '2020-01-01',
+    ]);
+    GeoLocation::factory()->withPoint(13.0, 52.0)->create(['resource_id' => $resource->id]);
+    $suggestion = AssistantSuggestion::create([
+        'assistant_id' => $assistant->getId(),
+        'resource_id' => $resource->id,
+        'target_type' => DateTypeDiscoveryService::GEOLOCATION_COUNT_TARGET_TYPE,
+        'target_id' => $resource->id,
+        'suggested_value' => 'collected_dates:1;geo_locations:1',
+        'suggested_label' => 'Collected dates (1) match geolocations (1)',
+        'metadata' => ['collected_dates_count' => 1, 'geo_locations_count' => 1],
+        'discovered_at' => now(),
+    ]);
+    $newDate = ResourceDate::create([
+        'resource_id' => $resource->id,
+        'date_type_id' => $collectedType->id,
+        'date_value' => '2021-01-01',
+    ]);
+
+    $result = $assistant->acceptSuggestion($suggestion->id);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'message' => 'This suggestion is stale because the Collected date or geolocation counts changed.',
+    ])
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
+        ->and($originalDate->fresh()->date_type_id)->toBe($collectedType->id)
+        ->and($newDate->fresh()->date_type_id)->toBe($collectedType->id);
 });
 
 it('keeps a collected to coverage correction pending when no collected dates exist', function (): void {
@@ -233,6 +277,8 @@ it('accepts a date type suggestion by creating a single date and deleting the su
     $suggestion = createDateTypeSuggestion($assistant, $resource, '2024-03-15', [
         'target_date_type' => 'Created',
     ]);
+    $staleUpdatedAt = now()->subDay();
+    DB::table('resources')->where('id', $resource->id)->update(['updated_at' => $staleUpdatedAt]);
 
     $result = $assistant->acceptSuggestion($suggestion->id);
     $date = ResourceDate::where('resource_id', $resource->id)->sole();
@@ -245,7 +291,8 @@ it('accepts a date type suggestion by creating a single date and deleting the su
         ->and($date->date_type_id)->toBe($createdType->id)
         ->and($date->date_value)->toBe('2024-03-15')
         ->and($date->start_date)->toBeNull()
-        ->and($date->end_date)->toBeNull();
+        ->and($date->end_date)->toBeNull()
+        ->and($resource->fresh()->updated_at->greaterThan($staleUpdatedAt))->toBeTrue();
 });
 
 it('normalizes accepted date type suggestion values before storing them', function (): void {
@@ -266,6 +313,30 @@ it('normalizes accepted date type suggestion values before storing them', functi
         ->and(AssistantSuggestion::find($suggestion->id))->toBeNull()
         ->and($date->date_type_id)->toBe($createdType->id)
         ->and($date->date_value)->toBe('2024-03-15');
+});
+
+it('keeps a stale date type suggestion pending when that date type was added after discovery', function (): void {
+    $assistant = app(Assistant::class);
+    $createdType = DateType::create(['name' => 'Created', 'slug' => 'Created', 'is_active' => true]);
+    $resource = Resource::factory()->create();
+    $suggestion = createDateTypeSuggestion($assistant, $resource, '2024-03-15', [
+        'target_date_type' => 'Created',
+    ]);
+    $currentDate = ResourceDate::create([
+        'resource_id' => $resource->id,
+        'date_type_id' => $createdType->id,
+        'date_value' => '2024-04-01',
+    ]);
+
+    $result = $assistant->acceptSuggestion($suggestion->id);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'message' => "This suggestion is stale because the resource already has a 'Created' date.",
+    ])
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
+        ->and(ResourceDate::where('resource_id', $resource->id)->count())->toBe(1)
+        ->and($currentDate->fresh()->date_value)->toBe('2024-04-01');
 });
 
 it('accepts a discovered date type addition with a date-type-specific target type', function (): void {
@@ -385,6 +456,27 @@ it('keeps date type suggestions pending when the suggested date value is invalid
         ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
         ->and(ResourceDate::where('resource_id', $resource->id)->exists())->toBeFalse();
 });
+
+it('keeps reversed date range suggestions pending without writing dates', function (string $suggestedValue): void {
+    $assistant = app(Assistant::class);
+    DateType::create(['name' => 'Valid', 'slug' => 'Valid', 'is_active' => true]);
+    $resource = Resource::factory()->create();
+    $suggestion = createDateTypeSuggestion($assistant, $resource, $suggestedValue, [
+        'target_date_type' => 'Valid',
+    ]);
+
+    $result = $assistant->acceptSuggestion($suggestion->id);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'message' => 'Suggested date value is invalid.',
+    ])
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
+        ->and(ResourceDate::where('resource_id', $resource->id)->exists())->toBeFalse();
+})->with([
+    'reversed years' => '2025/2024',
+    'reversed full dates' => '2025-12-31/2025-01-01',
+]);
 
 it('keeps collected to coverage corrections pending when the Coverage DateType is missing', function (): void {
     $assistant = app(Assistant::class);

--- a/tests/pest/Unit/Services/DateType/DateTypeNormalizerServiceTest.php
+++ b/tests/pest/Unit/Services/DateType/DateTypeNormalizerServiceTest.php
@@ -43,6 +43,13 @@ it('normalizes complete date ranges', function () {
         ->and(DateTypeNormalizerService::normalize('2010-01-22T12:30:00Z/2016-07-04T15:30:00Z'))->toBe('2010-01-22T12:30:00Z/2016-07-04T15:30:00Z');
 });
 
+it('rejects reversed date ranges', function (string $value) {
+    expect(DateTypeNormalizerService::normalize($value))->toBeNull();
+})->with([
+    'reversed years' => '2025/2024',
+    'reversed full dates' => '2025-12-31/2025-01-01',
+]);
+
 it('rejects invalid or unsupported date values', function () {
     expect(DateTypeNormalizerService::normalize(null))->toBeNull()
         ->and(DateTypeNormalizerService::normalize(''))->toBeNull()
@@ -61,4 +68,3 @@ it('rejects invalid or unsupported date values', function () {
         ->and(DateTypeNormalizerService::normalize('/2'))->toBeNull()
         ->and(DateTypeNormalizerService::normalize('Before 2016-12-12'))->toBeNull();
 });
-


### PR DESCRIPTION
Added fixes and implementations for the following issues:

Accepted date sugestions are not propagated to the parent resource or external systems maybe because ResourceDate does not touch its parent Resource, so resources.updated_at stays unchanged and ResourceObserver is not called.

Stale suggestions can create conflicts or rewrite unrelated current dates. Example 1: a Created suggestion is discovered, then a curator adds another Created date. Accepting the old suggestion still adds a second, conflicting milestone because firstOrCreate() checks only the exact type/value combination. Example 2: a 1:1 Collected suggestion is discovered. The counts later change, but Accept still changes every current Collected row to Coverage.

Reversed ranges are accepted: 2025/2024 and 2025-12-31/2025-01-01 pass and can be stored, bypassing the editor's end-before-start guard.

The Tests for this fix were written by me while the code was written mainly in support with AI.