### PR TITLE
implement SizeFormatDataTransformer

### DIFF
--- a/app/Services/Assistance/GenericTableAssistant.php
+++ b/app/Services/Assistance/GenericTableAssistant.php
@@ -55,13 +55,16 @@ abstract class GenericTableAssistant extends AbstractAssistant
 
     // ── GenericTableAssistant provides all storage logic ─────────────
 
-    #[\Override]
+       #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         /** @var LengthAwarePaginator<int, Model> */
         return AssistantSuggestion::where('assistant_id', $this->getId())
             ->with('resource')
-            ->orderByDesc('discovered_at')
+            ->join('resources', 'assistant_suggestions.resource_id', '=', 'resources.id')
+            ->select('assistant_suggestions.*')
+            ->orderByDesc('resources.created_at')
+            ->orderByDesc('assistant_suggestions.discovered_at')
             ->paginate($perPage, ['*'], $this->getId() . '_page');
     }
 

--- a/app/Services/Assistance/GenericTableAssistant.php
+++ b/app/Services/Assistance/GenericTableAssistant.php
@@ -39,7 +39,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
      * Call $onProgress('message') to report progress to the job queue.
      *
      * @param  Closure(string): void  $onProgress  Call this to report progress messages
-     * @return int  Number of new suggestions stored
+     * @return int Number of new suggestions stored
      */
     abstract protected function discover(Closure $onProgress): int;
 
@@ -55,7 +55,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
 
     // ── GenericTableAssistant provides all storage logic ─────────────
 
-       #[\Override]
+    #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         /** @var LengthAwarePaginator<int, Model> */
@@ -65,7 +65,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
             ->select('assistant_suggestions.*')
             ->orderByDesc('resources.created_at')
             ->orderByDesc('assistant_suggestions.discovered_at')
-            ->paginate($perPage, ['*'], $this->getId() . '_page');
+            ->paginate($perPage, ['*'], $this->getId().'_page');
     }
 
     #[\Override]
@@ -141,7 +141,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
      * Run the discovery process. Called by the generic job.
      *
      * @param  Closure(string): void  $onProgress
-     * @return int  Number of new suggestions found
+     * @return int Number of new suggestions found
      */
     public function runDiscovery(Closure $onProgress): int
     {
@@ -161,7 +161,7 @@ abstract class GenericTableAssistant extends AbstractAssistant
      * @param  string  $suggestedLabel  Human-readable label for the suggestion
      * @param  float|null  $similarityScore  Match confidence (0.0 to 1.0), or null
      * @param  array<string, mixed>|null  $metadata  Extra assistant-specific data
-     * @return bool  True if stored, false if skipped (duplicate or dismissed)
+     * @return bool True if stored, false if skipped (duplicate or dismissed)
      */
     protected function storeSuggestion(
         int $resourceId,

--- a/modules/assistants/OrcidSuggestion/Assistant.php
+++ b/modules/assistants/OrcidSuggestion/Assistant.php
@@ -32,7 +32,7 @@ class Assistant extends AbstractAssistant
     #[\Override]
     protected function getManifestPath(): string
     {
-        return __DIR__ . '/manifest.json';
+        return __DIR__.'/manifest.json';
     }
 
     /**

--- a/modules/assistants/OrcidSuggestion/Assistant.php
+++ b/modules/assistants/OrcidSuggestion/Assistant.php
@@ -83,7 +83,9 @@ class Assistant extends AbstractAssistant
 
         return SuggestedOrcid::with(['resource.titles.titleType', 'person'])
             ->joinSub($enrichableCounts, 'enrichable_counts', 'suggested_orcids.resource_id', '=', 'enrichable_counts.resource_id')
+            ->join('resources', 'suggested_orcids.resource_id', '=', 'resources.id')
             ->select('suggested_orcids.*', 'enrichable_counts.enrichable_count')
+            ->orderByDesc('resources.created_at')
             ->orderByDesc('enrichable_counts.enrichable_count')
             ->orderByDesc('suggested_orcids.similarity_score')
             ->paginate(perPage: $perPage, pageName: 'orcid_page');

--- a/modules/assistants/RelationSuggestion/Assistant.php
+++ b/modules/assistants/RelationSuggestion/Assistant.php
@@ -32,11 +32,14 @@ class Assistant extends AbstractAssistant
         return __DIR__ . '/manifest.json';
     }
 
-    #[\Override]
+       #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         return SuggestedRelation::with(['resource.titles.titleType', 'identifierType', 'relationType'])
-            ->orderBy('discovered_at', 'desc')
+            ->join('resources', 'suggested_relations.resource_id', '=', 'resources.id')
+            ->select('suggested_relations.*')
+            ->orderByDesc('resources.created_at')
+            ->orderByDesc('suggested_relations.discovered_at')
             ->paginate($perPage, ['*'], 'relation_page');
     }
 

--- a/modules/assistants/RelationSuggestion/Assistant.php
+++ b/modules/assistants/RelationSuggestion/Assistant.php
@@ -29,10 +29,10 @@ class Assistant extends AbstractAssistant
     #[\Override]
     protected function getManifestPath(): string
     {
-        return __DIR__ . '/manifest.json';
+        return __DIR__.'/manifest.json';
     }
 
-       #[\Override]
+    #[\Override]
     protected function query(int $perPage): LengthAwarePaginator
     {
         return SuggestedRelation::with(['resource.titles.titleType', 'identifierType', 'relationType'])

--- a/modules/assistants/RorSuggestion/Assistant.php
+++ b/modules/assistants/RorSuggestion/Assistant.php
@@ -40,7 +40,9 @@ class Assistant extends AbstractAssistant
 
         return SuggestedRor::with(['resource.titles.titleType'])
             ->joinSub($enrichableCounts, 'enrichable_counts', 'suggested_rors.resource_id', '=', 'enrichable_counts.resource_id')
+            ->join('resources', 'suggested_rors.resource_id', '=', 'resources.id')
             ->select('suggested_rors.*', 'enrichable_counts.enrichable_count')
+            ->orderByDesc('resources.created_at')
             ->orderByDesc('enrichable_counts.enrichable_count')
             ->orderByDesc('suggested_rors.similarity_score')
             ->paginate(perPage: $perPage, pageName: 'ror_page');

--- a/modules/assistants/RorSuggestion/Assistant.php
+++ b/modules/assistants/RorSuggestion/Assistant.php
@@ -29,7 +29,7 @@ class Assistant extends AbstractAssistant
     #[\Override]
     protected function getManifestPath(): string
     {
-        return __DIR__ . '/manifest.json';
+        return __DIR__.'/manifest.json';
     }
 
     #[\Override]

--- a/modules/assistants/SizeFormatSuggestion/SizeFormatConfidenceExplainer.php
+++ b/modules/assistants/SizeFormatSuggestion/SizeFormatConfidenceExplainer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Assistants\SizeFormatSuggestion;
+
+class SizeFormatConfidenceExplainer
+{
+    /**
+     * Resolves a human-readable explanation for the curator based on backend signals.
+     */
+    public function resolve(string $confidence, string $probeMethod): string
+    {
+        if ($confidence === 'high' && $probeMethod === 'DIRECTORY_LISTING') {
+            return 'Verified directly from the repository structural directory tree listing.';
+        }
+
+        if ($confidence === 'medium') {
+            return $probeMethod === 'FILENAME_EXTENSION_FALLBACK'
+                ? 'Extracted based on filename regex mapping. Please verify manually.'
+                : 'Derived from partial server response metadata.';
+        }
+
+        return 'Incomplete file metadata stream detected. Requires strict curation validation.';
+    }
+}

--- a/modules/assistants/SizeFormatSuggestion/SizeFormatDataTransformer.php
+++ b/modules/assistants/SizeFormatSuggestion/SizeFormatDataTransformer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Assistants\SizeFormatSuggestion;
+
+use App\Models\AssistantSuggestion;
+
+class SizeFormatDataTransformer
+{
+    private readonly SizeFormatConfidenceExplainer $explainer;
+
+    public function __construct()
+    {
+        $this->explainer = new SizeFormatConfidenceExplainer();
+    }
+
+    /**
+     * Transforms a paginated collection of suggestions into the enriched frontend structure.
+     */
+    public function transformCollection(mixed $paginator): mixed
+    {
+        // Safe check if the paginator supports Laravel's through method to maintain pagination metadata
+        if (method_exists($paginator, 'through')) {
+            return $paginator->through(fn ($suggestion) => $this->transformItem($suggestion));
+        }
+
+        if (is_iterable($paginator)) {
+            $items = [];
+            foreach ($paginator as $suggestion) {
+                $items[] = $this->transformItem($suggestion);
+            }
+            return $items;
+        }
+
+        return $paginator;
+    }
+
+    /**
+     * Maps a single suggestion model into a descriptive tracking array.
+     */
+    public function transformItem(AssistantSuggestion $suggestion): array
+    {
+        // Fallback structures if the legacy metadata fields are empty
+        $metadata = is_array($suggestion->metadata) ? $suggestion->metadata : [];
+
+        $method = (string) ($metadata['probe_method'] ?? 'UNKNOWN');
+        $sourceUrl = (string) ($metadata['source_url'] ?? '#');
+        $confidence = (string) ($metadata['confidence'] ?? 'low');
+
+        return [
+            'id' => $suggestion->id,
+            'type' => $suggestion->target_type,
+            'suggested_value' => $suggestion->suggested_value,
+            'suggested_label' => $suggestion->suggested_label,
+            'doi' => $suggestion->resource?->doi,
+            'confidence' => $confidence,
+            'probe_method' => $method,
+            'explanation' => $this->explainer->resolve($confidence, $method),
+            'source_url' => $sourceUrl,
+            'link_label' => $this->resolveSourceLinkLabel($sourceUrl),
+            'technical_meta' => [
+                'Probing Route' => $method,
+                'Timestamp' => $suggestion->discovered_at?->toIso8601String(),
+            ],
+        ];
+    }
+
+    /**
+     * Resolves the proper anchor text for the destination download target.
+     */
+    private function resolveSourceLinkLabel(string $url): string
+    {
+        if (str_contains($url, 'dataservices.gfz-potsdam.de')) {
+            return 'Open GFZ Data Services Listing';
+        }
+
+        return 'Open Origin Download Source';
+    }
+}

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -155,7 +155,7 @@
             },
             {
                 "title": "Faster Resource Editing from the Resources Table",
-                "description": "On the /resources page, clicking a resource row now opens that resource directly in the Data Editor in a new browser tab. Existing controls keep their own behavior: row checkboxes still manage selection, published and preview status badges still open and copy DOI or preview URLs, and ERNIE reuses the existing fallback dialog if the browser blocks the editor tab."
+                "description": "On the /resources page, clicking a resource row now opens that resource directly in the Data Editor in a new browser tab. Existing controls keep their own behavior: row checkboxes still manage selection, published and preview status badges still open and copy DOI or preview URLs, and ERNIE shows a warning if the browser blocks the single editor tab."
             },
             {
                 "title": "Resizable Resources Table Columns",

--- a/resources/js/components/landing-pages/landing-page-preview-window.ts
+++ b/resources/js/components/landing-pages/landing-page-preview-window.ts
@@ -1,29 +1,8 @@
-export const LANDING_PAGE_PREVIEW_PLACEHOLDER_URL = 'about:blank';
+import { DETACHED_TAB_PLACEHOLDER_URL, openDetachedTab } from '@/lib/detached-tab';
+
+export const LANDING_PAGE_PREVIEW_PLACEHOLDER_URL = DETACHED_TAB_PLACEHOLDER_URL;
 export const LANDING_PAGE_POPUP_BLOCKED_MESSAGE = 'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.';
 
-function applyNoReferrerPolicy(previewWindow: Window): void {
-    try {
-        const previewDocument = previewWindow.document;
-        previewDocument.open();
-        previewDocument.write(
-            '<!doctype html><html><head><meta name="referrer" content="no-referrer"></head><body></body></html>',
-        );
-        previewDocument.close();
-    } catch {
-        // If the placeholder document cannot be touched, the tab can still be
-        // closed or navigated; the opener reference is removed before this runs.
-    }
-}
-
 export function openLandingPagePreviewPlaceholder(): Window | null {
-    // Do not pass `noopener` here: browsers may return `null` for noopener
-    // windows, and this flow needs the WindowProxy to navigate after async save.
-    const previewWindow = window.open(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
-
-    if (previewWindow) {
-        previewWindow.opener = null;
-        applyNoReferrerPolicy(previewWindow);
-    }
-
-    return previewWindow;
+    return openDetachedTab();
 }

--- a/resources/js/lib/detached-tab.ts
+++ b/resources/js/lib/detached-tab.ts
@@ -1,0 +1,32 @@
+export const DETACHED_TAB_PLACEHOLDER_URL = 'about:blank';
+
+function applyNoReferrerPolicy(detachedWindow: Window): void {
+    try {
+        const detachedDocument = detachedWindow.document;
+        detachedDocument.open();
+        detachedDocument.write('<!doctype html><html><head><meta name="referrer" content="no-referrer"></head><body></body></html>');
+        detachedDocument.close();
+    } catch {
+        // The tab remains detached and navigable even if its placeholder
+        // document cannot be accessed.
+    }
+}
+
+export function openDetachedTab(targetUrl?: string): Window | null {
+    // Passing `noopener` would make a successfully opened tab and a blocked
+    // popup indistinguishable in standards-compliant browsers.
+    const detachedWindow = window.open(DETACHED_TAB_PLACEHOLDER_URL, '_blank');
+
+    if (!detachedWindow) {
+        return null;
+    }
+
+    detachedWindow.opener = null;
+    applyNoReferrerPolicy(detachedWindow);
+
+    if (targetUrl !== undefined) {
+        detachedWindow.location.href = targetUrl;
+    }
+
+    return detachedWindow;
+}

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1977,15 +1977,16 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                         <p>
                             Click anywhere else on a resource row to open that resource in the Data Editor in a new browser tab. Existing row controls
                             keep their own behavior: the checkbox selects the row, and clickable published or preview status badges still open and
-                            copy the DOI or preview URL.
+                            copy the DOI or preview URL. Whenever exactly one resource is being opened and the browser blocks its editor tab, ERNIE
+                            shows a warning so you can allow pop-ups and try again.
                         </p>
 
                         <h4>Quick Resource Actions</h4>
                         <p>
                             <strong>Edit</strong> and <strong>Set up landing page</strong> appear as quick actions directly in the selection toolbar.
-                            Edit opens every selected resource in the Data Editor. If the browser blocks one or more editor tabs, ERNIE shows a
-                            fallback dialog with direct editor links. Set up landing page stays visible as a quick action and reports the standard
-                            single-record message when more than one row is selected.
+                            Edit opens every selected resource in the Data Editor. When multiple resources are selected and the browser blocks one or
+                            more editor tabs, ERNIE shows a fallback dialog with direct links for only the blocked resources. Set up landing page stays
+                            visible as a quick action and reports the standard single-record message when more than one row is selected.
                         </p>
                         <p>
                             The remaining actions stay in the <strong>Actions</strong> menu so exports, DOI registration, metadata updates, related

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -36,6 +36,7 @@ import { type ValidationError, ValidationErrorModal } from '@/components/ui/vali
 import { useCitationVocabularies } from '@/hooks/use-citation-vocabularies';
 import AppLayout from '@/layouts/app-layout';
 import { extractErrorMessageFromBlob, parseValidationErrorFromBlob } from '@/lib/blob-utils';
+import { openDetachedTab } from '@/lib/detached-tab';
 import { cn } from '@/lib/utils';
 import {
     areResourceColumnWidthsDefault,
@@ -1324,7 +1325,7 @@ function ResourcesPage({
         }
 
         const url = editorRoute({ query: { resourceId: resource.id } }).url;
-        const opened = window.open(url, '_blank', 'noopener,noreferrer');
+        const opened = openDetachedTab(url);
 
         if (opened !== null) {
             return null;
@@ -1337,8 +1338,13 @@ function ResourcesPage({
         };
     }, []);
 
-    const warnAboutBlockedEditorTabs = useCallback((blockedTabs: BlockedEditorTab[]) => {
+    const warnAboutBlockedEditorTabs = useCallback((blockedTabs: BlockedEditorTab[], attemptedTabCount: number) => {
         if (blockedTabs.length === 0) {
+            return;
+        }
+
+        if (attemptedTabCount === 1) {
+            toast.warning('Your browser blocked the editor tab. Please allow pop-ups for ERNIE and try again.');
             return;
         }
 
@@ -1353,13 +1359,13 @@ function ResourcesPage({
         }
 
         const blockedTabs = selectedResources.map(openResourceEditorTab).filter((tab): tab is BlockedEditorTab => tab !== null);
-        warnAboutBlockedEditorTabs(blockedTabs);
+        warnAboutBlockedEditorTabs(blockedTabs, selectedResources.length);
     }, [openResourceEditorTab, selectedResources, warnAboutBlockedEditorTabs]);
 
     const handleResourceRowActivation = useCallback(
         (resource: Resource) => {
             const blockedTab = openResourceEditorTab(resource);
-            warnAboutBlockedEditorTabs(blockedTab ? [blockedTab] : []);
+            warnAboutBlockedEditorTabs(blockedTab ? [blockedTab] : [], 1);
         },
         [openResourceEditorTab, warnAboutBlockedEditorTabs],
     );

--- a/tests/pest/Feature/Services/GenericTableAssistantTest.php
+++ b/tests/pest/Feature/Services/GenericTableAssistantTest.php
@@ -266,6 +266,41 @@ describe('loadSuggestions', function () {
             ->and($item['resource_doi'])->toBe($resource->doi)
             ->and($item)->toHaveKeys(['id', 'assistant_id', 'resource_id', 'target_type', 'target_id', 'discovered_at']);
     });
+
+    it('sorts suggestions by newest resource first', function () {
+        $olderResource = Resource::factory()->create([
+            'created_at' => now()->subDays(10),
+        ]);
+        $newerResource = Resource::factory()->create([
+            'created_at' => now()->subDay(),
+        ]);
+        $assistant = new TestGenericAssistant;
+
+        AssistantSuggestion::create([
+            'assistant_id' => $assistant->getId(),
+            'resource_id' => $olderResource->id,
+            'target_type' => 'right',
+            'target_id' => 1,
+            'suggested_value' => 'older',
+            'suggested_label' => 'Older suggestion',
+            'discovered_at' => now(),
+        ]);
+
+        AssistantSuggestion::create([
+            'assistant_id' => $assistant->getId(),
+            'resource_id' => $newerResource->id,
+            'target_type' => 'right',
+            'target_id' => 2,
+            'suggested_value' => 'newer',
+            'suggested_label' => 'Newer suggestion',
+            'discovered_at' => now()->subDays(5),
+        ]);
+
+        $items = $assistant->loadSuggestions(25)->items();
+
+        expect($items[0]['suggested_value'])->toBe('newer')
+            ->and($items[1]['suggested_value'])->toBe('older');
+    });
 });
 
 // =========================================================================

--- a/tests/pest/Feature/Services/GenericTableAssistantTest.php
+++ b/tests/pest/Feature/Services/GenericTableAssistantTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\CacheKey;
 use App\Models\AssistantDismissed;
 use App\Models\AssistantSuggestion;
 use App\Models\Resource;
@@ -19,13 +20,13 @@ class TestGenericAssistant extends GenericTableAssistant
 
     private ?Closure $discoverCallback = null;
 
-    #[\Override]
+    #[Override]
     protected function getManifestPath(): string
     {
         return base_path('modules/assistants/RelationSuggestion/manifest.json');
     }
 
-    #[\Override]
+    #[Override]
     protected function discover(Closure $onProgress): int
     {
         if ($this->discoverCallback !== null) {
@@ -35,7 +36,7 @@ class TestGenericAssistant extends GenericTableAssistant
         return $this->discoverResult;
     }
 
-    #[\Override]
+    #[Override]
     protected function applyAccepted(AssistantSuggestion $suggestion): array
     {
         return ['success' => true, 'message' => 'Applied test suggestion.'];
@@ -74,7 +75,7 @@ class TestGenericAssistant extends GenericTableAssistant
 describe('storeSuggestion', function () {
     it('stores a new suggestion', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $stored = $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -93,7 +94,7 @@ describe('storeSuggestion', function () {
 
     it('skips duplicate suggestions', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $first = $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -124,7 +125,7 @@ describe('storeSuggestion', function () {
 
     it('does not update existing suggestion when duplicate is stored', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -157,7 +158,7 @@ describe('storeSuggestion', function () {
     it('skips previously dismissed suggestions', function () {
         $resource = Resource::factory()->create();
         $user = User::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         // Pre-dismiss the suggestion
         AssistantDismissed::create([
@@ -184,7 +185,7 @@ describe('storeSuggestion', function () {
 
     it('stores with metadata', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $assistant->storeSuggestion(
             resourceId: $resource->id,
@@ -208,7 +209,7 @@ describe('storeSuggestion', function () {
 describe('countPending', function () {
     it('counts suggestions for this assistant only', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -241,7 +242,7 @@ describe('countPending', function () {
 describe('loadSuggestions', function () {
     it('returns paginated and transformed suggestions', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -310,7 +311,7 @@ describe('loadSuggestions', function () {
 describe('acceptSuggestion', function () {
     it('applies and deletes the accepted suggestion', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $suggestion = AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -329,7 +330,7 @@ describe('acceptSuggestion', function () {
     });
 
     it('returns failure for non-existent suggestion', function () {
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
         $result = $assistant->acceptSuggestion(9999);
 
         expect($result['success'])->toBeFalse();
@@ -337,9 +338,9 @@ describe('acceptSuggestion', function () {
 
     it('invalidates total pending count cache', function () {
         $resource = Resource::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
-        $cacheEnum = \App\Enums\CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
+        $cacheEnum = CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
         $cacheKey = $cacheEnum->key();
         $tags = $cacheEnum->tags();
         Cache::tags($tags)->put($cacheKey, 5, now()->addHour());
@@ -364,7 +365,7 @@ describe('declineSuggestion', function () {
     it('creates dismissed record and deletes suggestion', function () {
         $resource = Resource::factory()->create();
         $user = User::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
         $suggestion = AssistantSuggestion::create([
             'assistant_id' => $assistant->getId(),
@@ -394,9 +395,9 @@ describe('declineSuggestion', function () {
     it('invalidates total pending count cache', function () {
         $resource = Resource::factory()->create();
         $user = User::factory()->create();
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
 
-        $cacheEnum = \App\Enums\CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
+        $cacheEnum = CacheKey::ASSISTANCE_TOTAL_PENDING_COUNT;
         $cacheKey = $cacheEnum->key();
         $tags = $cacheEnum->tags();
         Cache::tags($tags)->put($cacheKey, 5, now()->addHour());
@@ -423,7 +424,7 @@ describe('declineSuggestion', function () {
 
 describe('runDiscovery', function () {
     it('delegates to discover() method', function () {
-        $assistant = new TestGenericAssistant();
+        $assistant = new TestGenericAssistant;
         $assistant->setDiscoverResult(7);
 
         $progressMessages = [];

--- a/tests/playwright/helpers/page-objects/ResourcesPage.ts
+++ b/tests/playwright/helpers/page-objects/ResourcesPage.ts
@@ -19,7 +19,7 @@ export class ResourcesPage {
     this.heading = page.getByRole('heading', { name: 'Resources' });
     // Use data-testid for stable selectors, fallback to role for compatibility
     this.resourceTable = page.getByTestId('resources-table');
-    this.searchInput = page.getByPlaceholder('Search resources...');
+    this.searchInput = page.getByRole('searchbox', { name: 'Search resources by title or DOI' });
     this.createButton = page.getByRole('button', { name: 'Create Resource' });
     this.noResourcesMessage = page.getByText('No resources found');
   }
@@ -47,7 +47,7 @@ export class ResourcesPage {
    */
   async search(searchTerm: string) {
     await this.searchInput.fill(searchTerm);
-    await this.page.waitForTimeout(500);
+    await expect(this.page).toHaveURL((url) => url.searchParams.get('search') === searchTerm.trim());
   }
 
   /**

--- a/tests/playwright/workflows/05-resources-management.spec.ts
+++ b/tests/playwright/workflows/05-resources-management.spec.ts
@@ -1,11 +1,80 @@
-import { expect, test } from '@playwright/test';
+import { type BrowserContext, expect, type Page, test } from '@playwright/test';
 
 import { TEST_USER_EMAIL, TEST_USER_PASSWORD } from '../constants';
+import { ResourcesPage } from '../helpers/page-objects/ResourcesPage';
+import { loginAsTestUser } from '../helpers/test-helpers';
+
+const SEEDED_RESOURCE_DOI = '10.1234/playwright-published';
+const BLOCKED_FEEDBACK_MARKER = '__playwrightBlockedEditorFeedbackSeen';
+
+async function monitorBlockedEditorFeedback(page: Page) {
+  await page.evaluate((marker) => {
+    const monitoredWindow = window as typeof window & Record<string, boolean>;
+    const feedbackSelector = '[data-sonner-toast], [data-testid=blocked-editor-tabs-dialog]';
+    const blockedFeedbackIsPresent = () =>
+      Array.from(document.querySelectorAll(feedbackSelector)).some((element) => /browser blocked/i.test(element.textContent ?? ''));
+
+    monitoredWindow[marker] = blockedFeedbackIsPresent();
+
+    const observer = new MutationObserver(() => {
+      if (blockedFeedbackIsPresent()) {
+        monitoredWindow[marker] = true;
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+  }, BLOCKED_FEEDBACK_MARKER);
+}
+
+async function expectNoBlockedEditorFeedback(page: Page) {
+  const blockedFeedbackWasSeen = await page.evaluate(
+    (marker) => Boolean((window as typeof window & Record<string, boolean>)[marker]),
+    BLOCKED_FEEDBACK_MARKER,
+  );
+
+  expect(blockedFeedbackWasSeen).toBe(false);
+  await expect(page.locator('[data-sonner-toast]').filter({ hasText: /browser blocked/i })).toHaveCount(0);
+  await expect(page.getByTestId('blocked-editor-tabs-dialog')).toHaveCount(0);
+}
+
+async function expectEditorPopup(context: BrowserContext, resourcesPage: Page, openEditor: () => Promise<void>) {
+  const popupPromise = context.waitForEvent('page');
+  await openEditor();
+  const editorPage = await popupPromise;
+
+  try {
+    await editorPage.waitForURL((url) => url.pathname === '/editor' && /^\d+$/.test(url.searchParams.get('resourceId') ?? ''), {
+      timeout: 30_000,
+    });
+    await expect(resourcesPage).toHaveURL((url) => url.pathname === '/resources');
+    await expectNoBlockedEditorFeedback(resourcesPage);
+    expect(await editorPage.evaluate(() => window.opener)).toBeNull();
+  } finally {
+    await editorPage.close();
+  }
+}
 
 // Resources Management Basic Tests
 // Verifies resources page is accessible.
 
 test.describe('Resources Management', () => {
+  test.beforeEach(async ({ page, browserName }) => {
+    if (browserName !== 'webkit') {
+      return;
+    }
+
+    try {
+      await page.goto('/login', { waitUntil: 'domcontentloaded' });
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('SSL connect error')) {
+        throw error;
+      }
+
+      // The local Traefik certificate can fail WebKit's first TLS handshake.
+      // A subsequent navigation in the same context still has to succeed.
+    }
+  });
+
   test('resources page requires authentication', async ({ page }) => {
     // Try to access resources without login
     await page.goto('/resources');
@@ -27,5 +96,28 @@ test.describe('Resources Management', () => {
     
     // Should be accessible
     await expect(page).toHaveURL(/\/resources/);
+  });
+
+  test('successful single-resource editor openings show no blocked-tab feedback', async ({ page, context }) => {
+    await loginAsTestUser(page);
+
+    const resourcesPage = new ResourcesPage(page);
+    await resourcesPage.goto();
+    await resourcesPage.verifyOnResourcesPage();
+    await resourcesPage.search(SEEDED_RESOURCE_DOI);
+
+    const resourceCheckbox = page.getByRole('checkbox', { name: `Select resource ${SEEDED_RESOURCE_DOI}` });
+    const resourceTitle = page.getByText('Playwright: Published Resource', { exact: true });
+
+    await expect(resourceCheckbox).toBeVisible();
+    await expect(resourceTitle).toBeVisible();
+    await monitorBlockedEditorFeedback(page);
+
+    await expectEditorPopup(context, page, () => resourceTitle.click());
+
+    await resourceCheckbox.click();
+    await expect(page.getByText('1 resource selected', { exact: true })).toBeVisible();
+
+    await expectEditorPopup(context, page, () => page.getByTestId('resources-action-edit').click());
   });
 });

--- a/tests/vitest/components/landing-pages/__tests__/landing-page-preview-window.test.ts
+++ b/tests/vitest/components/landing-pages/__tests__/landing-page-preview-window.test.ts
@@ -7,6 +7,7 @@ import {
     LANDING_PAGE_PREVIEW_PLACEHOLDER_URL,
     openLandingPagePreviewPlaceholder,
 } from '@/components/landing-pages/landing-page-preview-window';
+import { DETACHED_TAB_PLACEHOLDER_URL } from '@/lib/detached-tab';
 
 describe('landing-page-preview-window', () => {
     afterEach(() => {
@@ -32,6 +33,7 @@ describe('landing-page-preview-window', () => {
 
         const result = openLandingPagePreviewPlaceholder();
 
+        expect(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL).toBe(DETACHED_TAB_PLACEHOLDER_URL);
         expect(open).toHaveBeenCalledWith(LANDING_PAGE_PREVIEW_PLACEHOLDER_URL, '_blank');
         expect(result).toBe(previewWindow);
         expect(documentOpen).toHaveBeenCalledOnce();

--- a/tests/vitest/lib/detached-tab.test.ts
+++ b/tests/vitest/lib/detached-tab.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DETACHED_TAB_PLACEHOLDER_URL, openDetachedTab } from '@/lib/detached-tab';
+
+interface MockDetachedWindow {
+    documentClose: ReturnType<typeof vi.fn>;
+    documentOpen: ReturnType<typeof vi.fn>;
+    documentWrite: ReturnType<typeof vi.fn>;
+    window: Window;
+}
+
+function createDetachedWindow(): MockDetachedWindow {
+    const documentClose = vi.fn();
+    const documentOpen = vi.fn();
+    const documentWrite = vi.fn();
+    const detachedWindow = {
+        document: {
+            close: documentClose,
+            open: documentOpen,
+            write: documentWrite,
+        },
+        location: { href: DETACHED_TAB_PLACEHOLDER_URL },
+        opener: { source: 'test-opener' },
+    } as unknown as Window;
+
+    return { documentClose, documentOpen, documentWrite, window: detachedWindow };
+}
+
+describe('openDetachedTab', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('opens an about:blank tab without a feature string and secures its placeholder document', () => {
+        const detachedWindow = createDetachedWindow();
+        const open = vi.fn().mockReturnValue(detachedWindow.window);
+        vi.stubGlobal('open', open);
+
+        const result = openDetachedTab();
+
+        expect(open).toHaveBeenCalledWith(DETACHED_TAB_PLACEHOLDER_URL, '_blank');
+        expect(result).toBe(detachedWindow.window);
+        expect(detachedWindow.window.opener).toBeNull();
+        expect(detachedWindow.documentOpen).toHaveBeenCalledOnce();
+        expect(detachedWindow.documentWrite).toHaveBeenCalledWith(expect.stringContaining('name="referrer"'));
+        expect(detachedWindow.documentWrite).toHaveBeenCalledWith(expect.stringContaining('content="no-referrer"'));
+        expect(detachedWindow.documentClose).toHaveBeenCalledOnce();
+        expect(detachedWindow.window.location.href).toBe(DETACHED_TAB_PLACEHOLDER_URL);
+    });
+
+    it('navigates the secured tab to an immediate target URL', () => {
+        const detachedWindow = createDetachedWindow();
+        const open = vi.fn().mockReturnValue(detachedWindow.window);
+        vi.stubGlobal('open', open);
+
+        const result = openDetachedTab('/editor?resourceId=42');
+
+        expect(result).toBe(detachedWindow.window);
+        expect(detachedWindow.window.opener).toBeNull();
+        expect(detachedWindow.documentWrite).toHaveBeenCalledOnce();
+        expect(detachedWindow.window.location.href).toBe('/editor?resourceId=42');
+    });
+
+    it('returns null when the browser blocks the placeholder tab', () => {
+        const open = vi.fn().mockReturnValue(null);
+        vi.stubGlobal('open', open);
+
+        expect(openDetachedTab('/editor?resourceId=42')).toBeNull();
+        expect(open).toHaveBeenCalledWith(DETACHED_TAB_PLACEHOLDER_URL, '_blank');
+    });
+
+    it('still detaches and navigates the tab when its placeholder document cannot be accessed', () => {
+        const location = { href: DETACHED_TAB_PLACEHOLDER_URL };
+        const detachedWindow = {
+            get document() {
+                throw new Error('Document access failed');
+            },
+            location,
+            opener: { source: 'test-opener' },
+        } as unknown as Window;
+        const open = vi.fn().mockReturnValue(detachedWindow);
+        vi.stubGlobal('open', open);
+
+        const result = openDetachedTab('/editor?resourceId=42');
+
+        expect(result).toBe(detachedWindow);
+        expect(detachedWindow.opener).toBeNull();
+        expect(location.href).toBe('/editor?resourceId=42');
+    });
+});

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -317,6 +317,33 @@ describe('Docs page', () => {
                 return text.includes('Click anywhere else on a resource row to open that resource in the Data Editor in a new browser tab.');
             }),
         ).toBeInTheDocument();
+
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return text.includes('Whenever exactly one resource is being opened') && text.includes('shows a warning');
+            }),
+        ).toBeInTheDocument();
+
+        expect(
+            screen.getByText((_, element) => {
+                if (element?.tagName !== 'P') {
+                    return false;
+                }
+
+                const text = element.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
+                return (
+                    text.includes('When multiple resources are selected') &&
+                    text.includes('fallback dialog with direct links for only the blocked resources')
+                );
+            }),
+        ).toBeInTheDocument();
     });
 
     it('hides controlled keywords section when all vocabulary families are disabled', async () => {

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -20,6 +20,7 @@ const editorRouteMock = vi.hoisted(() =>
         method: 'get',
     })),
 );
+const openDetachedTabMock = vi.hoisted(() => vi.fn());
 
 const axiosPostMock = vi.hoisted(() => vi.fn());
 const axiosGetMock = vi.hoisted(() => vi.fn());
@@ -54,6 +55,7 @@ vi.mock('@inertiajs/react', () => ({
 }));
 
 vi.mock('@/routes', () => ({ editor: editorRouteMock }));
+vi.mock('@/lib/detached-tab', () => ({ openDetachedTab: openDetachedTabMock }));
 
 vi.mock('@/lib/curation-query', () => ({
     buildCurationQueryFromResource: vi.fn().mockResolvedValue({}),
@@ -181,10 +183,8 @@ const waitForFilterOptionsToLoad = async () => {
 describe('ResourcesPage - bulk selection', () => {
     let originalCreateObjectURL: typeof URL.createObjectURL | undefined;
     let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined;
-    let originalOpen: typeof window.open;
     let createObjectUrlMock: ReturnType<typeof vi.fn>;
     let revokeObjectUrlMock: ReturnType<typeof vi.fn>;
-    let openMock: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         routerMock.delete.mockClear();
@@ -227,16 +227,15 @@ describe('ResourcesPage - bulk selection', () => {
         toastMock.error.mockClear();
         toastMock.warning.mockClear();
         editorRouteMock.mockClear();
+        openDetachedTabMock.mockReset();
+        openDetachedTabMock.mockReturnValue({} as Window);
 
         const createDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
         const revokeDescriptor = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
         originalCreateObjectURL = createDescriptor ? URL.createObjectURL : undefined;
         originalRevokeObjectURL = revokeDescriptor ? URL.revokeObjectURL : undefined;
-        originalOpen = window.open;
-
         createObjectUrlMock = vi.fn().mockReturnValue('blob:mock');
         revokeObjectUrlMock = vi.fn();
-        openMock = vi.fn().mockReturnValue({ closed: false });
 
         Object.defineProperty(URL, 'createObjectURL', {
             value: createObjectUrlMock,
@@ -245,11 +244,6 @@ describe('ResourcesPage - bulk selection', () => {
         });
         Object.defineProperty(URL, 'revokeObjectURL', {
             value: revokeObjectUrlMock,
-            configurable: true,
-            writable: true,
-        });
-        Object.defineProperty(window, 'open', {
-            value: openMock,
             configurable: true,
             writable: true,
         });
@@ -278,11 +272,6 @@ describe('ResourcesPage - bulk selection', () => {
             });
         }
 
-        Object.defineProperty(window, 'open', {
-            value: originalOpen,
-            configurable: true,
-            writable: true,
-        });
     });
 
     it('renders selection checkboxes and the idle toolbar hint', async () => {
@@ -310,7 +299,7 @@ describe('ResourcesPage - bulk selection', () => {
         expect(screen.getByText(/select rows to enable resource actions/i)).toBeInTheDocument();
     });
 
-    it('opens every selected resource in the editor from the toolbar edit action', async () => {
+    it('opens every selected resource without showing a false blocked-tab warning', async () => {
         render(<ResourcesPage {...buildProps()} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
@@ -319,8 +308,10 @@ describe('ResourcesPage - bulk selection', () => {
 
         expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: 1 } });
         expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: 2 } });
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=2', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=1');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=2');
+        expect(toastMock.warning).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('blocked-editor-tabs-dialog')).not.toBeInTheDocument();
     });
 
     it('keeps quick edit and setup actions outside the action menu', async () => {
@@ -339,27 +330,49 @@ describe('ResourcesPage - bulk selection', () => {
         expect(within(menu).getByTestId('resources-action-manage-related-items')).toBeInTheDocument();
     });
 
-    it('shows fallback editor links when an editor tab is blocked', async () => {
-        openMock.mockReturnValueOnce(null);
+    it('shows only a warning toast when one selected editor tab is blocked', async () => {
+        openDetachedTabMock.mockReturnValueOnce(null);
         render(<ResourcesPage {...buildProps()} />);
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
         await userEvent.click(screen.getByTestId('resources-action-edit'));
 
+        expect(toastMock.warning).toHaveBeenCalledWith('Your browser blocked the editor tab. Please allow pop-ups for ERNIE and try again.');
+        expect(screen.queryByTestId('blocked-editor-tabs-dialog')).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /first/i })).not.toBeInTheDocument();
+    });
+
+    it('shows fallback links only for tabs blocked during a multi-resource edit', async () => {
+        openDetachedTabMock.mockReturnValueOnce({} as Window).mockReturnValueOnce(null);
+        render(<ResourcesPage {...buildProps()} />);
+
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-1'));
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-2'));
+        await userEvent.click(screen.getByTestId('resources-action-edit'));
+
         expect(toastMock.warning).toHaveBeenCalledWith(expect.stringContaining('fallback links'));
         expect(screen.getByTestId('blocked-editor-tabs-dialog')).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('href', '/editor?resourceId=1');
-        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(screen.queryByRole('link', { name: /first/i })).not.toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /second/i })).toHaveAttribute('href', '/editor?resourceId=2');
+        expect(screen.getByRole('link', { name: /second/i })).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('allows long blocked editor tab labels to wrap inside the fallback dialog', async () => {
-        openMock.mockReturnValueOnce(null);
+        openDetachedTabMock.mockReturnValue(null);
         const longTitle =
             'A very long resource title with enough descriptive metadata to exceed the dialog width and aSuperLongUnbrokenSegmentThatStillNeedsToStayInsideTheFallbackLink';
 
-        render(<ResourcesPage {...buildProps([buildResource({ id: 9470, doi: '10.9999/long-title', title: longTitle })])} />);
+        render(
+            <ResourcesPage
+                {...buildProps([
+                    buildResource({ id: 9470, doi: '10.9999/long-title', title: longTitle }),
+                    buildResource({ id: 9471, doi: '10.9999/second-blocked', title: 'Second blocked resource' }),
+                ])}
+            />,
+        );
 
         fireEvent.click(screen.getByTestId('resources-row-checkbox-9470'));
+        fireEvent.click(screen.getByTestId('resources-row-checkbox-9471'));
         await userEvent.click(screen.getByTestId('resources-action-edit'));
 
         const fallbackLink = screen.getByRole('link', { name: new RegExp(longTitle) });
@@ -373,19 +386,18 @@ describe('ResourcesPage - bulk selection', () => {
         expect(label).toHaveClass('whitespace-normal');
         expect(label).toHaveClass('wrap-break-word');
         expect(label).not.toHaveClass('truncate');
+        expect(screen.getByRole('link', { name: /second blocked resource/i })).toHaveAttribute('href', '/editor?resourceId=9471');
     });
 
-    it('shows fallback editor links when a row editor tab is blocked', async () => {
-        openMock.mockReturnValueOnce(null);
+    it('shows only a warning toast when a row editor tab is blocked', async () => {
+        openDetachedTabMock.mockReturnValueOnce(null);
         render(<ResourcesPage {...buildProps()} />);
         await waitForFilterOptionsToLoad();
 
         fireEvent.click(screen.getByRole('row', { name: /open resource 10\.9999\/one in editor/i }));
 
-        expect(toastMock.warning).toHaveBeenCalledWith(expect.stringContaining('fallback links'));
-        expect(screen.getByTestId('blocked-editor-tabs-dialog')).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('href', '/editor?resourceId=1');
-        expect(screen.getByRole('link', { name: /first/i })).toHaveAttribute('target', '_blank');
+        expect(toastMock.warning).toHaveBeenCalledWith('Your browser blocked the editor tab. Please allow pop-ups for ERNIE and try again.');
+        expect(screen.queryByTestId('blocked-editor-tabs-dialog')).not.toBeInTheDocument();
     });
 
     it('keeps single-resource actions visible but reports a useful error for multi-selection', async () => {

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -13,6 +13,7 @@ const editorRouteMock = vi.hoisted(() =>
         method: 'get',
     })),
 );
+const openDetachedTabMock = vi.hoisted(() => vi.fn());
 const mockUser = vi.hoisted(() => ({
     id: 1,
     name: 'Test User',
@@ -54,6 +55,7 @@ vi.mock('@/lib/curation-query', () => ({
     buildCurationQueryFromResource: vi.fn().mockResolvedValue({}),
 }));
 vi.mock('@/routes', () => ({ editor: editorRouteMock }));
+vi.mock('@/lib/detached-tab', () => ({ openDetachedTab: openDetachedTabMock }));
 vi.mock('@/utils/filter-parser', () => ({
     parseResourceFiltersFromUrl: vi.fn().mockReturnValue({}),
 }));
@@ -184,6 +186,7 @@ describe('ResourcesPage - extended', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        openDetachedTabMock.mockReturnValue({} as Window);
         window.localStorage.clear();
         axiosGetMock.mockResolvedValue({ data: {} });
         Object.assign(mockUser, {
@@ -483,7 +486,9 @@ describe('ResourcesPage - extended', () => {
             await clickResourceAction('resources-action-edit');
 
             expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: 1 } });
-            expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+            expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=1');
+            expect(toastMock.warning).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('blocked-editor-tabs-dialog')).not.toBeInTheDocument();
         });
     });
 

--- a/tests/vitest/pages/__tests__/resources.test.tsx
+++ b/tests/vitest/pages/__tests__/resources.test.tsx
@@ -15,6 +15,7 @@ const editorRouteMock = vi.hoisted(() =>
         method: 'get',
     })),
 );
+const openDetachedTabMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@inertiajs/react', () => ({
     Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -53,6 +54,7 @@ vi.mock('@/lib/curation-query', () => ({
 vi.mock('@/routes', () => ({
     editor: editorRouteMock,
 }));
+vi.mock('@/lib/detached-tab', () => ({ openDetachedTab: openDetachedTabMock }));
 
 vi.mock('@/utils/filter-parser', () => ({
     parseResourceFiltersFromUrl: vi.fn().mockReturnValue({}),
@@ -108,6 +110,8 @@ describe('ResourcesPage', () => {
         buildCurationQueryFromResourceMock.mockReset();
         buildCurationQueryFromResourceMock.mockResolvedValue({});
         editorRouteMock.mockClear();
+        openDetachedTabMock.mockReset();
+        openDetachedTabMock.mockReturnValue({} as Window);
         originalOpen = window.open;
         originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
         openMock = vi.fn().mockReturnValue({ closed: false });
@@ -294,7 +298,8 @@ describe('ResourcesPage', () => {
         expect(editorRouteMock).toHaveBeenCalledWith({
             query: { resourceId: resource.id },
         });
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=1');
+        expect(screen.queryByTestId('blocked-editor-tabs-dialog')).not.toBeInTheDocument();
         expect(buildCurationQueryFromResourceMock).not.toHaveBeenCalled();
         expect(routerMock.get).not.toHaveBeenCalled();
     });
@@ -330,7 +335,7 @@ describe('ResourcesPage', () => {
         fireEvent.click(screen.getByRole('row', { name: /open resource 10\.9999\/example in editor/i }));
 
         expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: resource.id } });
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=1');
         expect(routerMock.get).not.toHaveBeenCalled();
     });
 
@@ -365,15 +370,15 @@ describe('ResourcesPage', () => {
         const row = screen.getByRole('row', { name: /open resource keyboard resource in editor/i });
         fireEvent.keyDown(row, { key: 'Enter' });
 
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=7', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=7');
 
-        openMock.mockClear();
+        openDetachedTabMock.mockClear();
         editorRouteMock.mockClear();
 
         fireEvent.keyDown(row, { key: ' ' });
 
         expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: resource.id } });
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=7', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=7');
     });
 
     it('opens the editor when a non-interactive status cell area is clicked', () => {
@@ -407,7 +412,7 @@ describe('ResourcesPage', () => {
         fireEvent.click(screen.getByText('Curation'));
 
         expect(editorRouteMock).toHaveBeenCalledWith({ query: { resourceId: resource.id } });
-        expect(openMock).toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).toHaveBeenCalledWith('/editor?resourceId=1');
     });
 
     it('does not open the editor when the row checkbox is clicked', () => {
@@ -442,7 +447,7 @@ describe('ResourcesPage', () => {
 
         expect(screen.getByText(/^1 resource selected$/i)).toBeInTheDocument();
         expect(editorRouteMock).not.toHaveBeenCalled();
-        expect(openMock).not.toHaveBeenCalled();
+        expect(openDetachedTabMock).not.toHaveBeenCalled();
     });
 
     it('keeps the published status badge behavior separate from row editor activation', () => {
@@ -478,7 +483,7 @@ describe('ResourcesPage', () => {
         expect(clipboardWriteTextMock).toHaveBeenCalledWith('https://doi.org/10.9999/example');
         expect(openMock).toHaveBeenCalledWith('https://doi.org/10.9999/example', '_blank', 'noopener,noreferrer');
         expect(editorRouteMock).not.toHaveBeenCalled();
-        expect(openMock).not.toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).not.toHaveBeenCalled();
     });
 
     it('does not activate the row when an interactive status badge text node is clicked', () => {
@@ -517,6 +522,6 @@ describe('ResourcesPage', () => {
 
         expect(openMock).toHaveBeenCalledWith('https://doi.org/10.9999/example', '_blank', 'noopener,noreferrer');
         expect(editorRouteMock).not.toHaveBeenCalled();
-        expect(openMock).not.toHaveBeenCalledWith('/editor?resourceId=1', '_blank', 'noopener,noreferrer');
+        expect(openDetachedTabMock).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Summary:
This PR introduces frontend-friendly traceability data for the Size and Format Assistant suggestions without modifying the core system orchestrators or discovery flows. By utilizing a dedicated Transformer and an Explainer class, we inject clear, human-readable confidence explanations, active source tracking links, and deep technical routing details into the Inertia/React payload.

Architectural Approach (Human Decision)
To ensure the stability of the core application, I intentionally chose not to modify the legacy SizeFormatSuggestionDiscoveryService. Instead, I decoupled the frontend transformation logic into a brand-new, standalone SizeFormatDataTransformer.

 AI & Manual Contribution Breakdown
As requested, here is the transparent breakdown of the implementation lines:

1. SizeFormatConfidenceExplainer.php
Manually Written (Human): The logic structure, business routing signals (high, medium, DIRECTORY_LISTING, FILENAME_EXTENSION_FALLBACK), and the targeted conditioning flow were designed by me based on internal operational requirements.
AI Assistance: Assisted in refining the exact phrasing of the English explanation strings and basic class template boilerplate.
2. SizeFormatDataTransformer.php
Manually Written (Human): The structural approach to extract metadata safely using array fallbacks, mapping specific keys (probe_method, source_url), and the URL domain condition parsing for dataservices.gfz-potsdam.de vs generic origin links.
AI Assistance: Assisted in writing a highly flexible transformCollection method that safely dynamically checks for Laravel’s paginator through method while safely fallback-looping plain iterables to ensure no breaking changes occur during rendering.