### PR TITLE
Added a fix for stale suggestions in the collected to coverage flow

### DIFF
--- a/app/Services/DateType/DateTypeAcceptanceService.php
+++ b/app/Services/DateType/DateTypeAcceptanceService.php
@@ -7,6 +7,7 @@ namespace App\Services\DateType;
 use App\Models\AssistantSuggestion;
 use App\Models\DateType;
 use App\Models\ResourceDate;
+use Illuminate\Support\Facades\DB;
 
 final class DateTypeAcceptanceService
 {
@@ -24,7 +25,7 @@ final class DateTypeAcceptanceService
             ];
         }
 
-        $dateValue = DateTypeNormalizerService::normalize( $suggestion->metadata['normalized_value'] ?? $suggestion->suggested_value);
+        $dateValue = DateTypeNormalizerService::normalize($suggestion->metadata['normalized_value'] ?? $suggestion->suggested_value);
 
         if (! is_string($dateValue) || $dateValue === '') {
             return [
@@ -110,18 +111,6 @@ final class DateTypeAcceptanceService
             ];
         }
 
-        $dates = ResourceDate::query()
-            ->where('resource_id', $suggestion->resource_id)
-            ->whereHas('dateType', fn ($query) => $query->where('slug', 'Collected'))
-            ->get();
-
-        if ($dates->isEmpty()) {
-            return [
-                'success' => false,
-                'message' => 'No Collected date entries were found for this resource.',
-            ];
-        }
-
         $metadata = $suggestion->metadata ?? [];
         $expectedCollectedCount = filter_var($metadata['collected_dates_count'] ?? null, FILTER_VALIDATE_INT);
         $expectedGeoLocationCount = filter_var($metadata['geo_locations_count'] ?? null, FILTER_VALIDATE_INT);
@@ -132,29 +121,116 @@ final class DateTypeAcceptanceService
             $expectedGeoLocationCount = isset($matches[2]) ? (int) $matches[2] : null;
         }
 
-        $currentCollectedCount = $dates->count();
-        $currentGeoLocationCount = $suggestion->resource()->first()?->geoLocations()->count();
+        $expectedCollectedDateIds = $this->snapshotIds($metadata['collected_date_ids'] ?? null);
+        $expectedCollectedDatesSnapshot = $metadata['collected_dates_snapshot'] ?? null;
+        $expectedGeoLocationIds = $this->snapshotIds($metadata['geo_location_ids'] ?? null);
 
-        if ($expectedCollectedCount === null
-            || $expectedGeoLocationCount === null
-            || $currentCollectedCount !== $expectedCollectedCount
-            || $currentGeoLocationCount !== $expectedGeoLocationCount
-            || $currentCollectedCount !== $currentGeoLocationCount) {
+        return DB::transaction(function () use (
+            $suggestion,
+            $coverageDateTypeId,
+            $expectedCollectedCount,
+            $expectedGeoLocationCount,
+            $expectedCollectedDateIds,
+            $expectedCollectedDatesSnapshot,
+            $expectedGeoLocationIds,
+        ): array {
+            $dates = ResourceDate::query()
+                ->where('resource_id', $suggestion->resource_id)
+                ->whereHas('dateType', fn ($query) => $query->where('slug', 'Collected'))
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+
+            if ($dates->isEmpty()) {
+                return [
+                    'success' => false,
+                    'message' => 'No Collected date entries were found for this resource.',
+                ];
+            }
+
+            if ($expectedCollectedDateIds === null
+                || ! is_array($expectedCollectedDatesSnapshot)
+                || ! array_is_list($expectedCollectedDatesSnapshot)
+                || $expectedGeoLocationIds === null) {
+                return [
+                    'success' => false,
+                    'message' => 'This suggestion is stale because it does not identify the reviewed Collected dates and geolocations.',
+                ];
+            }
+
+            $currentCollectedDateIds = $dates->pluck('id')->map(fn (mixed $id): int => (int) $id)->all();
+            $currentCollectedDatesSnapshot = $dates
+                ->map(fn (ResourceDate $date): array => [
+                    'id' => (int) $date->id,
+                    'date_value' => $date->date_value,
+                    'start_date' => $date->start_date,
+                    'end_date' => $date->end_date,
+                    'date_information' => $date->date_information,
+                ])
+                ->all();
+            $currentGeoLocationIds = $suggestion->resource()
+                ->firstOrFail()
+                ->geoLocations()
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->pluck('id')
+                ->map(fn (mixed $id): int => (int) $id)
+                ->all();
+
+            if (count($currentCollectedDateIds) !== $expectedCollectedCount
+                || count($currentGeoLocationIds) !== $expectedGeoLocationCount
+                || count($currentCollectedDateIds) !== count($currentGeoLocationIds)) {
+                return [
+                    'success' => false,
+                    'message' => 'This suggestion is stale because the Collected date or geolocation counts changed.',
+                ];
+            }
+
+            if ($currentCollectedDateIds !== $expectedCollectedDateIds
+                || $currentCollectedDatesSnapshot !== $expectedCollectedDatesSnapshot
+                || $currentGeoLocationIds !== $expectedGeoLocationIds) {
+                return [
+                    'success' => false,
+                    'message' => 'This suggestion is stale because the reviewed Collected dates or geolocations changed.',
+                ];
+            }
+
+            // Update the locked, reviewed rows rather than a newly evaluated
+            // open-ended set of all current Collected dates.
+            $dates->each(fn (ResourceDate $date) => $date->update([
+                'date_type_id' => $coverageDateTypeId,
+            ]));
+
+            $updatedCount = $dates->count();
+
             return [
-                'success' => false,
-                'message' => 'This suggestion is stale because the Collected date or geolocation counts changed.',
+                'success' => true,
+                'message' => "Changed {$updatedCount} Collected date entr".($updatedCount === 1 ? 'y' : 'ies').' to Coverage.',
             ];
+        });
+    }
+
+    /** @return list<int>|null */
+    private function snapshotIds(mixed $value): ?array
+    {
+        if (! is_array($value) || ! array_is_list($value) || $value === []) {
+            return null;
         }
 
-        $dates->each(fn (ResourceDate $date) => $date->update([
-            'date_type_id' => $coverageDateTypeId,
-        ]));
+        $ids = [];
 
-        $updatedCount = $dates->count();
+        foreach ($value as $id) {
+            $validatedId = filter_var($id, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
 
-        return [
-            'success' => true,
-            'message' => "Changed {$updatedCount} Collected date entr".($updatedCount === 1 ? 'y' : 'ies').' to Coverage.',
-        ];
+            if ($validatedId === false) {
+                return null;
+            }
+
+            $ids[] = $validatedId;
+        }
+
+        sort($ids);
+
+        return count($ids) === count(array_unique($ids)) ? $ids : null;
     }
 }

--- a/app/Services/DateType/DateTypeDiscoveryService.php
+++ b/app/Services/DateType/DateTypeDiscoveryService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\DateType;
 
 use App\Models\Resource;
+use App\Models\ResourceDate;
 use Illuminate\Database\Eloquent\Builder;
 use App\Services\DateType\DateTypeSchemaorgExtractionService;
 use Closure;
@@ -234,6 +235,39 @@ final class DateTypeDiscoveryService
             return false;
         }
 
+        $collectedDates = $resource->dates()
+            ->whereHas('dateType', fn (Builder $query): Builder => $query
+                ->whereIn('slug', self::COLLECTED_DATE_TYPES))
+            ->orderBy('id')
+            ->get(['dates.id', 'date_value', 'start_date', 'end_date', 'date_information']);
+        $collectedDateIds = $collectedDates
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+        $collectedDatesSnapshot = $collectedDates
+            ->map(fn (ResourceDate $date): array => [
+                'id' => (int) $date->id,
+                'date_value' => $date->date_value,
+                'start_date' => $date->start_date,
+                'end_date' => $date->end_date,
+                'date_information' => $date->date_information,
+            ])
+            ->all();
+        $geoLocationIds = $resource->geoLocations()
+            ->orderBy('id')
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+
+        // Counts may have changed since the candidate query was loaded. Only
+        // persist a suggestion when its row snapshots still support the match.
+        $collectedDatesCount = count($collectedDateIds);
+        $geoLocationsCount = count($geoLocationIds);
+
+        if ($collectedDatesCount === 0 || $collectedDatesCount !== $geoLocationsCount) {
+            return false;
+        }
+
         $suggestedValue = "collected_dates:{$collectedDatesCount};geo_locations:{$geoLocationsCount}";
         $suggestedLabel = "Collected dates ({$collectedDatesCount}) match geolocations ({$geoLocationsCount})";
 
@@ -255,6 +289,9 @@ final class DateTypeDiscoveryService
                 'source_url' => 'https://doi.org/'.$resource->doi,
                 'collected_dates_count' => $collectedDatesCount,
                 'geo_locations_count' => $geoLocationsCount,
+                'collected_date_ids' => $collectedDateIds,
+                'collected_dates_snapshot' => $collectedDatesSnapshot,
+                'geo_location_ids' => $geoLocationIds,
                 'evidence' => 'The resource has a DOI and the same number of Collected date entries as geolocation entries.',
             ],
         );

--- a/tests/pest/Feature/Services/DateTypeSuggestionAssistantTest.php
+++ b/tests/pest/Feature/Services/DateTypeSuggestionAssistantTest.php
@@ -17,6 +17,24 @@ use Modules\Assistants\DateTypeSuggestion\Assistant;
 
 function createCollectedCoverageSuggestion(Assistant $assistant, Resource $resource): AssistantSuggestion
 {
+    $collectedDates = $resource->dates()
+        ->whereHas('dateType', fn ($query) => $query->where('slug', 'Collected'))
+        ->orderBy('id')
+        ->get();
+    $collectedDateIds = $collectedDates
+        ->pluck('id')
+        ->all();
+    $collectedDatesSnapshot = $collectedDates
+        ->map(fn (ResourceDate $date): array => [
+            'id' => (int) $date->id,
+            'date_value' => $date->date_value,
+            'start_date' => $date->start_date,
+            'end_date' => $date->end_date,
+            'date_information' => $date->date_information,
+        ])
+        ->all();
+    $geoLocationIds = $resource->geoLocations()->orderBy('id')->pluck('id')->all();
+
     return AssistantSuggestion::create([
         'assistant_id' => $assistant->getId(),
         'resource_id' => $resource->id,
@@ -27,6 +45,11 @@ function createCollectedCoverageSuggestion(Assistant $assistant, Resource $resou
         'metadata' => [
             'source' => 'database',
             'check' => 'collected_dates_vs_geolocations',
+            'collected_dates_count' => count($collectedDateIds),
+            'geo_locations_count' => count($geoLocationIds),
+            'collected_date_ids' => $collectedDateIds,
+            'collected_dates_snapshot' => $collectedDatesSnapshot,
+            'geo_location_ids' => $geoLocationIds,
         ],
         'discovered_at' => now(),
     ]);
@@ -226,7 +249,19 @@ it('keeps a stale collected to coverage correction pending when the counts chang
         'target_id' => $resource->id,
         'suggested_value' => 'collected_dates:1;geo_locations:1',
         'suggested_label' => 'Collected dates (1) match geolocations (1)',
-        'metadata' => ['collected_dates_count' => 1, 'geo_locations_count' => 1],
+        'metadata' => [
+            'collected_dates_count' => 1,
+            'geo_locations_count' => 1,
+            'collected_date_ids' => [$originalDate->id],
+            'collected_dates_snapshot' => [[
+                'id' => $originalDate->id,
+                'date_value' => $originalDate->date_value,
+                'start_date' => null,
+                'end_date' => null,
+                'date_information' => null,
+            ]],
+            'geo_location_ids' => $resource->geoLocations()->pluck('id')->all(),
+        ],
         'discovered_at' => now(),
     ]);
     $newDate = ResourceDate::create([
@@ -244,6 +279,62 @@ it('keeps a stale collected to coverage correction pending when the counts chang
         ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
         ->and($originalDate->fresh()->date_type_id)->toBe($collectedType->id)
         ->and($newDate->fresh()->date_type_id)->toBe($collectedType->id);
+});
+
+it('keeps a stale collected to coverage correction pending when a reviewed date was edited in place', function (): void {
+    $assistant = app(Assistant::class);
+    $collectedType = DateType::create(['name' => 'Collected', 'slug' => 'Collected', 'is_active' => true]);
+    DateType::create(['name' => 'Coverage', 'slug' => 'Coverage', 'is_active' => true]);
+    $resource = Resource::factory()->create();
+    $reviewedDate = ResourceDate::create([
+        'resource_id' => $resource->id,
+        'date_type_id' => $collectedType->id,
+        'date_value' => '2020-01-01',
+    ]);
+    GeoLocation::factory()->withPoint(13.0, 52.0)->create(['resource_id' => $resource->id]);
+    $suggestion = createCollectedCoverageSuggestion($assistant, $resource);
+
+    $reviewedDate->update(['date_value' => '2021-01-01']);
+
+    $result = $assistant->acceptSuggestion($suggestion->id);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'message' => 'This suggestion is stale because the reviewed Collected dates or geolocations changed.',
+    ])
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
+        ->and($reviewedDate->fresh()->date_type_id)->toBe($collectedType->id)
+        ->and($reviewedDate->fresh()->date_value)->toBe('2021-01-01');
+});
+
+it('keeps a stale collected to coverage correction pending when the collected rows changed but the count stayed the same', function (): void {
+    $assistant = app(Assistant::class);
+    $collectedType = DateType::create(['name' => 'Collected', 'slug' => 'Collected', 'is_active' => true]);
+    DateType::create(['name' => 'Coverage', 'slug' => 'Coverage', 'is_active' => true]);
+    $resource = Resource::factory()->create();
+    $reviewedDate = ResourceDate::create([
+        'resource_id' => $resource->id,
+        'date_type_id' => $collectedType->id,
+        'date_value' => '2020-01-01',
+    ]);
+    GeoLocation::factory()->withPoint(13.0, 52.0)->create(['resource_id' => $resource->id]);
+    $suggestion = createCollectedCoverageSuggestion($assistant, $resource);
+
+    $reviewedDate->delete();
+    $unreviewedDate = ResourceDate::create([
+        'resource_id' => $resource->id,
+        'date_type_id' => $collectedType->id,
+        'date_value' => '2021-01-01',
+    ]);
+
+    $result = $assistant->acceptSuggestion($suggestion->id);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'message' => 'This suggestion is stale because the reviewed Collected dates or geolocations changed.',
+    ])
+        ->and(AssistantSuggestion::find($suggestion->id))->not->toBeNull()
+        ->and($unreviewedDate->fresh()->date_type_id)->toBe($collectedType->id);
 });
 
 it('keeps a collected to coverage correction pending when no collected dates exist', function (): void {
@@ -854,7 +945,10 @@ it('discovers collected to coverage correction when collected date and geolocati
         ->and($suggestion->metadata['from_date_type'])->toBe('Collected')
         ->and($suggestion->metadata['target_date_type'])->toBe('Coverage')
         ->and($suggestion->metadata['collected_dates_count'])->toBe(1)
-        ->and($suggestion->metadata['geo_locations_count'])->toBe(1);
+        ->and($suggestion->metadata['geo_locations_count'])->toBe(1)
+        ->and($suggestion->metadata['collected_date_ids'])->toHaveCount(1)
+        ->and($suggestion->metadata['collected_dates_snapshot'])->toHaveCount(1)
+        ->and($suggestion->metadata['geo_location_ids'])->toHaveCount(1);
 });
 
 it('stores plausibility hint suggestions', function (): void {
@@ -953,4 +1047,3 @@ it('stores multiple plausibility hint suggestions for the same date type', funct
         ->and($suggestion[1]->metadata['is_ambiguous'])->toBeTrue()
         ->and($suggestion[1]->metadata['source_url'])->toBe('https://doi.org/10.5880/pik.2023.001');
 });
-


### PR DESCRIPTION
This branch fixes the issue of this comment:

I would still request changes before merge. The biggest remaining issue is the Collected-to-Coverage accept path: it only rechecks counts and then updates all current Collected rows. If the rows changed but the count stayed the same, an old suggestion can still rewrite unreviewed current data.

I added and edited Tests which should cover the issues described in the comment and then wrote code with the help of ai to fix these Issues.