### PR TITLE
Documentation: Improve Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,11 +2,16 @@ name: Bug Report
 description: Report a bug or unexpected behavior in ERNIE
 title: "[BUG] "
 labels: ["bug"]
+projects: ["McNamara84/14"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for taking the time to report a bug! Please fill out the sections below.
+
+        ## Use ERNIE terms
+
+        Please write terms out and use the words shown in ERNIE. For example a digital dataset is named **Resource**, a physical sample is **IGSN**. There is a **Data Editor** and not an **Editor**. The form group **Spatial and Temporal Coverage** is not called **STC**.
 
   - type: textarea
     id: description
@@ -22,11 +27,9 @@ body:
     attributes:
       label: Steps to Reproduce
       description: Step-by-step instructions to reproduce the behavior.
-      placeholder: |
-        1. Go to '...'
-        2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
+      value: |
+        1. Open ERNIE
+        2. Navigate to page ... with route /...
     validations:
       required: true
 
@@ -74,6 +77,20 @@ body:
     validations:
       required: false
 
+  - type: checkboxes
+    id: definition-of-ready
+    attributes:
+      label: Definition of Ready
+      description: Check every item that is already true for this bug report.
+      options:
+        - label: The affected ERNIE page, route, or workflow is named.
+        - label: If the bug is reported from stakeholders, the bug was reproduced by at least one team member.
+        - label: The affected Resource, DOI, IGSN, or sample data is named/linked when relevant.
+        - label: The user role, browser, ERNIE version or branch, and environment are added when relevant.
+        - label: The current behavior and expected behavior are clear.
+        - label: The steps to reproduce are testable.
+        - label: Screenshots, logs, or error messages are attached when they could be helpful.
+
   - type: textarea
     id: additional-context
     attributes:
@@ -81,3 +98,8 @@ body:
       description: Any other context about the problem.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        **Draft or missing info?** Add the `DoR not met` label if this issue is still a draft or important details are missing. Developer will ignore the issue until the label is removed or there is a question and they are mentioned.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior in ERNIE
 title: "[BUG] "
-labels: ["bug"]
+labels: ["bug", "DoR not met"]
 projects: ["McNamara84/14"]
 body:
   - type: markdown
@@ -85,7 +85,7 @@ body:
       options:
         - label: The affected ERNIE page, route, or workflow is named.
         - label: If the bug is reported from stakeholders, the bug was reproduced by at least one team member.
-        - label: The affected Resource, DOI, IGSN, or sample data is named/linked when relevant.
+        - label: The affected Resource or Sample is named/linked when relevant.
         - label: The user role, browser, ERNIE version or branch, and environment are added when relevant.
         - label: The current behavior and expected behavior are clear.
         - label: The steps to reproduce are testable.
@@ -102,4 +102,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Draft or missing info?** Add the `DoR not met` label if this issue is still a draft or important details are missing. Developer will ignore the issue until the label is removed or there is a question and they are mentioned.
+        **Ready for work?** This issue is created with the `DoR not met` label by default. Remove it only when the Definition of Ready is met or when a developer is mentioned for a question.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
 
         ## Use ERNIE terms
 
-        Please write terms out and use the words shown in ERNIE. For example a digital dataset is named **Resource**, a physical sample is **IGSN**. There is a **Data Editor** and not an **Editor**. The form group **Spatial and Temporal Coverage** is not called **STC**.
+        Please use the exact terms shown in ERNIE. Do not use abbreviations. For example, a digital dataset is named **Resource**, and a physical sample is named **IGSN**.
 
   - type: textarea
     id: description
@@ -102,4 +102,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Ready for work?** This issue is created with the `DoR not met` label by default. Remove it only when the Definition of Ready is met or when a developer is mentioned for a question.
+        **Ready for work?** This issue is created with the `DoR not met` label by default. Remove it only when the Definition of Ready is met.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,11 +2,16 @@ name: Feature Request
 description: Suggest a new feature or improvement for ERNIE
 title: "[FEATURE] "
 labels: ["enhancement"]
+projects: ["McNamara84/14"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for suggesting a feature! Please describe your idea below.
+
+        ## Use ERNIE terms
+
+         Please write terms out and use the words shown in ERNIE. For example a digital dataset is named **Resource**, a physical sample is **IGSN**. There is a **Data Editor** and not an **Editor**. The form group **Spatial and Temporal Coverage** is not called **STC**.
 
   - type: textarea
     id: user-story
@@ -14,7 +19,7 @@ body:
       label: User Story
       description: Describe the feature from a user's perspective.
       value: |
-        As a **…**, I want **…**, so that **…**.
+        As a **...**, I want **...**, so that **...**.
     validations:
       required: true
 
@@ -46,6 +51,21 @@ body:
     validations:
       required: false
 
+  - type: checkboxes
+    id: definition-of-ready
+    attributes:
+      label: Definition of Ready
+      description: Check every item that is already true for this feature request.
+      options:
+        - label: The user role or target user (not Product Owner, not Scrum Master) is named at least in the user story.
+        - label: The user story follows the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable).
+        - label: The affected ERNIE page, route, workflow, or data type is named.
+        - label: The problem or user need is clear.
+        - label: The acceptance criteria follow the Given-When-Then format.
+        - label: Acceptance criteria are testable.
+        - label: Relevant Resource, DOI, IGSN, or sample data is included/linked.
+        - label: Sketches, mockups, or wireframes are attached when they could be helpful.
+
   - type: textarea
     id: additional-context
     attributes:
@@ -53,3 +73,8 @@ body:
       description: Any mockups, references, or further information.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        **Draft or missing info?** Add the `DoR not met` label if this issue is still a draft or important details are missing. Developer will ignore the issue until the label is removed or there is a question and they are mentioned.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
 
         ## Use ERNIE terms
 
-         Please write terms out and use the words shown in ERNIE. For example a digital dataset is named **Resource**, a physical sample is **IGSN**. There is a **Data Editor** and not an **Editor**. The form group **Spatial and Temporal Coverage** is not called **STC**.
+        Please use the exact terms shown in ERNIE. Do not use abbreviations. For example, a digital dataset is named **Resource**, and a physical sample is named **IGSN**.
 
   - type: textarea
     id: user-story
@@ -77,4 +77,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Ready for work?** This issue is created with the `DoR not met` label by default. Remove it only when the Definition of Ready is met or when a developer is mentioned for a question.
+        **Ready for work?** This issue is created with the `DoR not met` label by default. Remove it only when the Definition of Ready is met.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement for ERNIE
 title: "[FEATURE] "
-labels: ["enhancement"]
+labels: ["enhancement", "DoR not met"]
 projects: ["McNamara84/14"]
 body:
   - type: markdown
@@ -63,7 +63,7 @@ body:
         - label: The problem or user need is clear.
         - label: The acceptance criteria follow the Given-When-Then format.
         - label: Acceptance criteria are testable.
-        - label: Relevant Resource, DOI, IGSN, or sample data is included/linked.
+        - label: Relevant Resource or Sample is included/linked when relevant.
         - label: Sketches, mockups, or wireframes are attached when they could be helpful.
 
   - type: textarea
@@ -77,4 +77,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Draft or missing info?** Add the `DoR not met` label if this issue is still a draft or important details are missing. Developer will ignore the issue until the label is removed or there is a question and they are mentioned.
+        **Ready for work?** This issue is created with the `DoR not met` label by default. Remove it only when the Definition of Ready is met or when a developer is mentioned for a question.


### PR DESCRIPTION
This pull request updates the GitHub issue templates for bug reports and feature requests to improve clarity, enforce consistent terminology, and introduce a "Definition of Ready" (DoR) checklist. These changes are designed to ensure that issues are well-defined and actionable before work begins.

**Enhancements to issue templates:**

*Improved workflow and readiness:*
- Added a "Definition of Ready" checklist to both the bug report and feature request templates, helping reporters ensure all necessary information is provided before work starts. [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR80-R105) [[2]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR54-R80)
- Automatically apply the `DoR not met` label and project assignment to new issues, with instructions to remove the label only when the DoR is satisfied or a developer is consulted. [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL4-R15) [[2]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL4-R22) [[3]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR80-R105) [[4]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR54-R80)

*Terminology and clarity:*
- Added reminders to use ERNIE-specific terms (e.g., "Resource" instead of "digital dataset") in both templates, promoting consistent language. [[1]](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL4-R15) [[2]](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL4-R22)
- Updated the "Steps to Reproduce" section in the bug report template to reference ERNIE-specific navigation and routes, making reports more actionable.

These changes help ensure that new issues are clear, use the correct terminology, and are ready for development work.