### PR TITLE
Documentation: Toast Feedback for Copy Endpoints in  API Documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "react-resizable-panels": "^4.11.1",
         "recharts": "^3.8.0",
         "sonner": "^2.0.7",
-        "swagger-ui-react": "^5.32.6",
+        "swagger-ui-react": "^5.32.8",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.3.1",
         "tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "react-resizable-panels": "^4.11.1",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7",
-    "swagger-ui-react": "^5.32.6",
+    "swagger-ui-react": "^5.32.8",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^4.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/resources/css/swagger-overrides.css
+++ b/resources/css/swagger-overrides.css
@@ -3,6 +3,13 @@
     margin: 0 5px;
 }
 
+.swagger-ui .opblock .opblock-summary .view-line-link.copy-to-clipboard button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image: none;
+}
+
 .swagger-ui .opblock .opblock-summary .view-line-link.copy-to-clipboard button:focus-visible {
     border-radius: 2px;
     outline: 2px solid #2563eb;

--- a/resources/css/swagger-overrides.css
+++ b/resources/css/swagger-overrides.css
@@ -12,6 +12,6 @@
 
 .swagger-ui .opblock .opblock-summary .view-line-link.copy-to-clipboard button:focus-visible {
     border-radius: 2px;
-    outline: 2px solid #2563eb;
+    outline: 2px solid var(--ring);
     outline-offset: 2px;
 }

--- a/resources/css/swagger-overrides.css
+++ b/resources/css/swagger-overrides.css
@@ -1,0 +1,10 @@
+.swagger-ui .opblock .opblock-summary .view-line-link.copy-to-clipboard:focus-within {
+    width: 24px;
+    margin: 0 5px;
+}
+
+.swagger-ui .opblock .opblock-summary .view-line-link.copy-to-clipboard button:focus-visible {
+    border-radius: 2px;
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}

--- a/resources/js/components/api-doc/endpoint-copy-button.tsx
+++ b/resources/js/components/api-doc/endpoint-copy-button.tsx
@@ -1,0 +1,42 @@
+import { toast } from 'sonner';
+
+export interface EndpointCopyButtonProps {
+    textToCopy: string;
+}
+
+interface EndpointCopyFeedbackPlugin {
+    wrapComponents: {
+        CopyToClipboardBtn: () => typeof EndpointCopyButton;
+    };
+}
+
+export function EndpointCopyButton({ textToCopy }: EndpointCopyButtonProps) {
+    const copyEndpointPath = async () => {
+        if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+            toast.error('Could not copy endpoint to clipboard');
+
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(textToCopy);
+            toast.success('Copied to clipboard');
+        } catch {
+            toast.error('Could not copy endpoint to clipboard');
+        }
+    };
+
+    return (
+        <div className="view-line-link copy-to-clipboard" title="Copy to clipboard">
+            <button type="button" aria-label="Copy endpoint path to clipboard" onClick={copyEndpointPath} />
+        </div>
+    );
+}
+
+export function endpointCopyFeedbackPlugin(): EndpointCopyFeedbackPlugin {
+    return {
+        wrapComponents: {
+            CopyToClipboardBtn: () => EndpointCopyButton,
+        },
+    };
+}

--- a/resources/js/components/api-doc/endpoint-copy-button.tsx
+++ b/resources/js/components/api-doc/endpoint-copy-button.tsx
@@ -33,7 +33,7 @@ export function EndpointCopyButton({ getComponent, textToCopy }: EndpointCopyBut
     return (
         <div className="view-line-link copy-to-clipboard" title="Copy to clipboard">
             <button type="button" aria-label="Copy endpoint path to clipboard" onClick={copyEndpointPath}>
-                <CopyIcon />
+                <CopyIcon aria-hidden="true" focusable="false" />
             </button>
         </div>
     );

--- a/resources/js/components/api-doc/endpoint-copy-button.tsx
+++ b/resources/js/components/api-doc/endpoint-copy-button.tsx
@@ -1,6 +1,8 @@
+import type { ComponentType, SVGProps } from 'react';
 import { toast } from 'sonner';
 
 export interface EndpointCopyButtonProps {
+    getComponent: (name: 'CopyIcon') => ComponentType<SVGProps<SVGSVGElement>>;
     textToCopy: string;
 }
 
@@ -10,7 +12,9 @@ interface EndpointCopyFeedbackPlugin {
     };
 }
 
-export function EndpointCopyButton({ textToCopy }: EndpointCopyButtonProps) {
+export function EndpointCopyButton({ getComponent, textToCopy }: EndpointCopyButtonProps) {
+    const CopyIcon = getComponent('CopyIcon');
+
     const copyEndpointPath = async () => {
         if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
             toast.error('Could not copy endpoint to clipboard');
@@ -28,7 +32,9 @@ export function EndpointCopyButton({ textToCopy }: EndpointCopyButtonProps) {
 
     return (
         <div className="view-line-link copy-to-clipboard" title="Copy to clipboard">
-            <button type="button" aria-label="Copy endpoint path to clipboard" onClick={copyEndpointPath} />
+            <button type="button" aria-label="Copy endpoint path to clipboard" onClick={copyEndpointPath}>
+                <CopyIcon />
+            </button>
         </div>
     );
 }

--- a/resources/js/swagger.tsx
+++ b/resources/js/swagger.tsx
@@ -1,7 +1,11 @@
 import 'swagger-ui-react/swagger-ui.css';
+import '../css/swagger-overrides.css';
 
 import { createRoot } from 'react-dom/client';
 import SwaggerUI from 'swagger-ui-react';
+
+import { endpointCopyFeedbackPlugin } from '@/components/api-doc/endpoint-copy-button';
+import { Toaster } from '@/components/ui/sonner';
 
 declare global {
     interface Window {
@@ -10,7 +14,12 @@ declare global {
 }
 
 export function renderSwagger(spec: object, element: HTMLElement) {
-    createRoot(element).render(<SwaggerUI spec={spec} />);
+    createRoot(element).render(
+        <>
+            <SwaggerUI spec={spec} plugins={[endpointCopyFeedbackPlugin]} />
+            <Toaster position="bottom-right" richColors />
+        </>,
+    );
 }
 
 window.addEventListener('load', () => {

--- a/resources/js/swagger.tsx
+++ b/resources/js/swagger.tsx
@@ -14,12 +14,16 @@ declare global {
 }
 
 export function renderSwagger(spec: object, element: HTMLElement) {
-    createRoot(element).render(
+    const root = createRoot(element);
+
+    root.render(
         <>
             <SwaggerUI spec={spec} plugins={[endpointCopyFeedbackPlugin]} />
             <Toaster position="bottom-right" richColors />
         </>,
     );
+
+    return root;
 }
 
 window.addEventListener('load', () => {

--- a/tests/vitest/__tests__/swagger.test.tsx
+++ b/tests/vitest/__tests__/swagger.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import { act } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import type { Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 interface SwaggerMockProps {
     spec: { info: { title: string } };
@@ -27,9 +28,23 @@ import { endpointCopyFeedbackPlugin } from '@/components/api-doc/endpoint-copy-b
 import { renderSwagger } from '@/swagger';
 
 describe('renderSwagger', () => {
+    let container: HTMLDivElement | undefined;
+    let root: Root | undefined;
+
+    afterEach(async () => {
+        await act(async () => {
+            root?.unmount();
+        });
+        container?.remove();
+        swaggerMockState.current = undefined;
+        root = undefined;
+        container = undefined;
+    });
+
     it('renders the API title with endpoint copy feedback and the configured toaster', async () => {
         const el = document.createElement('div');
         document.body.appendChild(el);
+        container = el;
         const spec = {
             openapi: '3.2.0',
             info: { title: 'Example API', summary: 'OpenAPI 3.2 test document', version: '1.0.0' },
@@ -37,7 +52,7 @@ describe('renderSwagger', () => {
         };
 
         await act(async () => {
-            renderSwagger(spec, el);
+            root = renderSwagger(spec, el);
         });
 
         expect(screen.getByText('Example API')).toBeInTheDocument();

--- a/tests/vitest/__tests__/swagger.test.tsx
+++ b/tests/vitest/__tests__/swagger.test.tsx
@@ -1,30 +1,49 @@
 import { screen } from '@testing-library/react';
-import React from 'react';
 import { act } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+interface SwaggerMockProps {
+    spec: { info: { title: string } };
+    plugins?: unknown[];
+}
+
+const swaggerMockState = vi.hoisted(() => ({ current: undefined as SwaggerMockProps | undefined }));
+
 vi.mock('swagger-ui-react', () => ({
-  default: ({ spec }: { spec: { info: { title: string } } }) => (
-    <div>{spec.info.title}</div>
-  ),
+    default: (props: SwaggerMockProps) => {
+        swaggerMockState.current = props;
+
+        return <div>{props.spec.info.title}</div>;
+    },
 }));
 
+vi.mock('@/components/ui/sonner', () => ({
+    Toaster: ({ position, richColors }: { position?: string; richColors?: boolean }) => (
+        <div data-testid="swagger-toaster" data-position={position} data-rich-colors={richColors ? 'true' : 'false'} />
+    ),
+}));
+
+import { endpointCopyFeedbackPlugin } from '@/components/api-doc/endpoint-copy-button';
 import { renderSwagger } from '@/swagger';
 
 describe('renderSwagger', () => {
-  it('renders the API title', async () => {
-    const el = document.createElement('div');
-    document.body.appendChild(el);
-    const spec = {
-      openapi: '3.2.0',
-      info: { title: 'Example API', summary: 'OpenAPI 3.2 test document', version: '1.0.0' },
-      security: [],
-    };
+    it('renders the API title with endpoint copy feedback and the configured toaster', async () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        const spec = {
+            openapi: '3.2.0',
+            info: { title: 'Example API', summary: 'OpenAPI 3.2 test document', version: '1.0.0' },
+            security: [],
+        };
 
-    await act(async () => {
-      renderSwagger(spec, el);
+        await act(async () => {
+            renderSwagger(spec, el);
+        });
+
+        expect(screen.getByText('Example API')).toBeInTheDocument();
+        expect(swaggerMockState.current?.spec).toBe(spec);
+        expect(swaggerMockState.current?.plugins).toEqual([endpointCopyFeedbackPlugin]);
+        expect(screen.getByTestId('swagger-toaster')).toHaveAttribute('data-position', 'bottom-right');
+        expect(screen.getByTestId('swagger-toaster')).toHaveAttribute('data-rich-colors', 'true');
     });
-
-    expect(screen.getByText('Example API')).toBeInTheDocument();
-  });
 });

--- a/tests/vitest/components/api-doc/endpoint-copy-button.test.tsx
+++ b/tests/vitest/components/api-doc/endpoint-copy-button.test.tsx
@@ -12,12 +12,18 @@ vi.mock('sonner', () => ({
 }));
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+const CopyIcon = () => <svg aria-hidden="true" data-testid="swagger-copy-icon" />;
+const getComponent = vi.fn(() => CopyIcon);
 
 function setClipboard(writeText: ReturnType<typeof vi.fn>) {
     Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
         value: { writeText },
     });
+}
+
+function renderEndpointCopyButton(textToCopy: string) {
+    return render(<EndpointCopyButton getComponent={getComponent} textToCopy={textToCopy} />);
 }
 
 describe('EndpointCopyButton', () => {
@@ -33,21 +39,23 @@ describe('EndpointCopyButton', () => {
         }
     });
 
-    it('renders an accessible button with the Swagger UI style hooks', () => {
-        render(<EndpointCopyButton textToCopy="/api/v1/licenses" />);
+    it('renders an accessible button with Swagger UI style hooks and its visible copy icon', () => {
+        renderEndpointCopyButton('/api/v1/licenses');
 
         const button = screen.getByRole('button', { name: 'Copy endpoint path to clipboard' });
 
         expect(button).toHaveAttribute('type', 'button');
+        expect(button).toContainElement(screen.getByTestId('swagger-copy-icon'));
         expect(button.parentElement).toHaveClass('view-line-link', 'copy-to-clipboard');
         expect(button.parentElement).toHaveAttribute('title', 'Copy to clipboard');
+        expect(getComponent).toHaveBeenCalledWith('CopyIcon');
     });
 
     it('copies the exact endpoint path and reports success after the write resolves', async () => {
         const writeText = vi.fn().mockResolvedValue(undefined);
         setClipboard(writeText);
 
-        render(<EndpointCopyButton textToCopy="/api/v1/resource-types/{type}" />);
+        renderEndpointCopyButton('/api/v1/resource-types/{type}');
         fireEvent.click(screen.getByRole('button', { name: 'Copy endpoint path to clipboard' }));
 
         await waitFor(() => {
@@ -61,7 +69,7 @@ describe('EndpointCopyButton', () => {
         const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'));
         setClipboard(writeText);
 
-        render(<EndpointCopyButton textToCopy="/api/v1/licenses" />);
+        renderEndpointCopyButton('/api/v1/licenses');
         fireEvent.click(screen.getByRole('button', { name: 'Copy endpoint path to clipboard' }));
 
         await waitFor(() => {
@@ -73,7 +81,7 @@ describe('EndpointCopyButton', () => {
     it('reports an unavailable Clipboard API without throwing or showing success', async () => {
         Reflect.deleteProperty(navigator, 'clipboard');
 
-        render(<EndpointCopyButton textToCopy="/api/v1/languages" />);
+        renderEndpointCopyButton('/api/v1/languages');
         fireEvent.click(screen.getByRole('button', { name: 'Copy endpoint path to clipboard' }));
 
         expect(toast.error).toHaveBeenCalledWith('Could not copy endpoint to clipboard');

--- a/tests/vitest/components/api-doc/endpoint-copy-button.test.tsx
+++ b/tests/vitest/components/api-doc/endpoint-copy-button.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EndpointCopyButton, endpointCopyFeedbackPlugin } from '@/components/api-doc/endpoint-copy-button';
+
+vi.mock('sonner', () => ({
+    toast: {
+        error: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+function setClipboard(writeText: ReturnType<typeof vi.fn>) {
+    Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+    });
+}
+
+describe('EndpointCopyButton', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        if (originalClipboardDescriptor) {
+            Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+        } else {
+            Reflect.deleteProperty(navigator, 'clipboard');
+        }
+    });
+
+    it('renders an accessible button with the Swagger UI style hooks', () => {
+        render(<EndpointCopyButton textToCopy="/api/v1/licenses" />);
+
+        const button = screen.getByRole('button', { name: 'Copy endpoint path to clipboard' });
+
+        expect(button).toHaveAttribute('type', 'button');
+        expect(button.parentElement).toHaveClass('view-line-link', 'copy-to-clipboard');
+        expect(button.parentElement).toHaveAttribute('title', 'Copy to clipboard');
+    });
+
+    it('copies the exact endpoint path and reports success after the write resolves', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        setClipboard(writeText);
+
+        render(<EndpointCopyButton textToCopy="/api/v1/resource-types/{type}" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Copy endpoint path to clipboard' }));
+
+        await waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith('/api/v1/resource-types/{type}');
+            expect(toast.success).toHaveBeenCalledWith('Copied to clipboard');
+        });
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed clipboard write without showing false success', async () => {
+        const writeText = vi.fn().mockRejectedValue(new Error('Clipboard permission denied'));
+        setClipboard(writeText);
+
+        render(<EndpointCopyButton textToCopy="/api/v1/licenses" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Copy endpoint path to clipboard' }));
+
+        await waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith('Could not copy endpoint to clipboard');
+        });
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('reports an unavailable Clipboard API without throwing or showing success', async () => {
+        Reflect.deleteProperty(navigator, 'clipboard');
+
+        render(<EndpointCopyButton textToCopy="/api/v1/languages" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Copy endpoint path to clipboard' }));
+
+        expect(toast.error).toHaveBeenCalledWith('Could not copy endpoint to clipboard');
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it("only replaces Swagger UI's endpoint copy component plug point", () => {
+        const plugin = endpointCopyFeedbackPlugin();
+
+        expect(Object.keys(plugin.wrapComponents)).toEqual(['CopyToClipboardBtn']);
+        expect(plugin.wrapComponents.CopyToClipboardBtn()).toBe(EndpointCopyButton);
+    });
+});

--- a/tests/vitest/components/api-doc/endpoint-copy-button.test.tsx
+++ b/tests/vitest/components/api-doc/endpoint-copy-button.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { SVGProps } from 'react';
 import { toast } from 'sonner';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -12,7 +13,7 @@ vi.mock('sonner', () => ({
 }));
 
 const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
-const CopyIcon = () => <svg aria-hidden="true" data-testid="swagger-copy-icon" />;
+const CopyIcon = (props: SVGProps<SVGSVGElement>) => <svg data-testid="swagger-copy-icon" {...props} />;
 const getComponent = vi.fn(() => CopyIcon);
 
 function setClipboard(writeText: ReturnType<typeof vi.fn>) {
@@ -46,6 +47,8 @@ describe('EndpointCopyButton', () => {
 
         expect(button).toHaveAttribute('type', 'button');
         expect(button).toContainElement(screen.getByTestId('swagger-copy-icon'));
+        expect(screen.getByTestId('swagger-copy-icon')).toHaveAttribute('aria-hidden', 'true');
+        expect(screen.getByTestId('swagger-copy-icon')).toHaveAttribute('focusable', 'false');
         expect(button.parentElement).toHaveClass('view-line-link', 'copy-to-clipboard');
         expect(button.parentElement).toHaveAttribute('title', 'Copy to clipboard');
         expect(getComponent).toHaveBeenCalledWith('CopyIcon');


### PR DESCRIPTION
This pull request enhances the API documentation experience by improving the "copy endpoint" functionality in Swagger UI. It introduces a custom copy-to-clipboard button with user feedback, updates related styling, and adds comprehensive tests to ensure robust behavior. Additionally, it updates the Swagger UI dependency and ensures the new functionality is properly integrated and tested.

**Swagger UI copy-to-clipboard improvements:**

* Added a new `EndpointCopyButton` React component that replaces the default Swagger UI copy button, providing clipboard support and user feedback via toast notifications.
* Introduced a plugin (`endpointCopyFeedbackPlugin`) to integrate the custom copy button into Swagger UI.
* Updated the API docs entry point (`swagger.tsx`) to use the new plugin and display the toast notification component.

**Styling enhancements:**

* Added custom CSS in `swagger-overrides.css` to style the new copy-to-clipboard button for accessibility and visual consistency.

**Testing improvements:**

* Added unit tests for the new copy button component, covering successful copy, error handling, and plugin integration.
* Updated Swagger UI rendering tests to verify plugin and toaster integration. [[1]](diffhunk://#diff-138ee61a8dca9b90b04c086163e2e920712070ad2864be4f004b27caa21dc53eL2-R30) [[2]](diffhunk://#diff-138ee61a8dca9b90b04c086163e2e920712070ad2864be4f004b27caa21dc53eR44-R47)

**Dependency updates:**

* Upgraded `swagger-ui-react` from version 5.32.6 to 5.32.8 to ensure compatibility and receive the latest fixes.