### PR TITLE
fix: show resource types for relation suggestions

### DIFF
--- a/app/Services/RelationDiscoveryService.php
+++ b/app/Services/RelationDiscoveryService.php
@@ -12,6 +12,7 @@ use App\Models\RelationType;
 use App\Models\Resource;
 use App\Models\SuggestedRelation;
 use App\Models\User;
+use App\Services\Citations\CitationLookupService;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -28,6 +29,7 @@ class RelationDiscoveryService
     public function __construct(
         private readonly ScholExplorerService $scholExplorerService,
         private readonly DataCiteEventDataService $dataCiteEventDataService,
+        private readonly CitationLookupService $citationLookupService,
         private readonly DataCiteSyncService $dataCiteSyncService,
         private readonly RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService,
     ) {}
@@ -46,6 +48,7 @@ class RelationDiscoveryService
 
         $processed = 0;
         $newCount = 0;
+        $updatedCount = 0;
 
         // Pre-fetch lookups
         $identifierTypeLookup = IdentifierType::pluck('id', 'slug')->all();
@@ -60,6 +63,7 @@ class RelationDiscoveryService
                 $total,
                 &$processed,
                 &$newCount,
+                &$updatedCount,
                 $progressCallback,
             ) {
                 $resourceIds = $resources->pluck('id')->all();
@@ -68,19 +72,21 @@ class RelationDiscoveryService
                 $existingKeys = RelatedIdentifier::whereIn('resource_id', $resourceIds)
                     ->get(['resource_id', 'identifier', 'relation_type_id'])
                     ->groupBy('resource_id')
-                    ->map(fn ($items) => $items->map(fn (RelatedIdentifier $ri) => mb_strtolower($ri->identifier) . '|' . $ri->relation_type_id)->all())
+                    ->map(fn ($items) => $items->map(fn (RelatedIdentifier $ri) => mb_strtolower($ri->identifier).'|'.$ri->relation_type_id)->all())
                     ->all();
 
                 $dismissedKeys = DismissedRelation::whereIn('resource_id', $resourceIds)
                     ->get(['resource_id', 'identifier', 'relation_type_id'])
                     ->groupBy('resource_id')
-                    ->map(fn ($items) => $items->map(fn (DismissedRelation $dr) => mb_strtolower($dr->identifier) . '|' . $dr->relation_type_id)->all())
+                    ->map(fn ($items) => $items->map(fn (DismissedRelation $dr) => mb_strtolower($dr->identifier).'|'.$dr->relation_type_id)->all())
                     ->all();
 
-                $suggestedKeys = SuggestedRelation::whereIn('resource_id', $resourceIds)
-                    ->get(['resource_id', 'identifier', 'relation_type_id'])
+                $pendingSuggestions = SuggestedRelation::whereIn('resource_id', $resourceIds)
+                    ->get(['id', 'resource_id', 'identifier', 'relation_type_id', 'source_type'])
                     ->groupBy('resource_id')
-                    ->map(fn ($items) => $items->map(fn (SuggestedRelation $sr) => mb_strtolower($sr->identifier) . '|' . $sr->relation_type_id)->all())
+                    ->map(fn ($items) => $items->mapWithKeys(fn (SuggestedRelation $sr) => [
+                        mb_strtolower($sr->identifier).'|'.$sr->relation_type_id => $sr,
+                    ])->all())
                     ->all();
 
                 foreach ($resources as $resource) {
@@ -91,17 +97,20 @@ class RelationDiscoveryService
                     $knownSet = array_flip(array_merge(
                         $existingKeys[$resourceId] ?? [],
                         $dismissedKeys[$resourceId] ?? [],
-                        $suggestedKeys[$resourceId] ?? [],
+                        array_keys($pendingSuggestions[$resourceId] ?? []),
                     ));
 
                     $relations = $this->discoverForDoi($doi);
-                    $newCount += $this->storeNewSuggestions(
+                    $counts = $this->storeNewSuggestions(
                         $resourceId,
                         $relations,
                         $identifierTypeLookup,
                         $relationTypeLookup,
                         $knownSet,
+                        $pendingSuggestions[$resourceId] ?? [],
                     );
+                    $newCount += $counts['created'];
+                    $updatedCount += $counts['updated'];
 
                     $processed++;
                     if ($progressCallback !== null) {
@@ -113,9 +122,10 @@ class RelationDiscoveryService
         Log::info('Relation discovery completed', [
             'total_dois' => $total,
             'new_suggestions' => $newCount,
+            'updated_suggestions' => $updatedCount,
         ]);
 
-        if ($newCount > 0) {
+        if ($newCount > 0 || $updatedCount > 0) {
             $this->invalidateAssistanceCache();
         }
 
@@ -135,7 +145,7 @@ class RelationDiscoveryService
         // Primary source: ScholExplorer
         $scholexResults = $this->scholExplorerService->findRelationsForDoi($doi);
         foreach ($scholexResults as $relation) {
-            $key = mb_strtolower($relation['identifier']) . '|' . $relation['relation_type'];
+            $key = mb_strtolower($relation['identifier']).'|'.$relation['relation_type'];
             if (! isset($seen[$key])) {
                 $seen[$key] = true;
                 $allRelations[] = [
@@ -148,7 +158,7 @@ class RelationDiscoveryService
         // Supplementary source: DataCite Event Data
         $dataciteResults = $this->dataCiteEventDataService->findRelationsForDoi($doi);
         foreach ($dataciteResults as $relation) {
-            $key = mb_strtolower($relation['identifier']) . '|' . $relation['relation_type'];
+            $key = mb_strtolower($relation['identifier']).'|'.$relation['relation_type'];
             if (! isset($seen[$key])) {
                 $seen[$key] = true;
                 $allRelations[] = [
@@ -162,14 +172,50 @@ class RelationDiscoveryService
     }
 
     /**
+     * @param  array{identifier: string, identifier_type: string, relation_type: string, source: string, source_title: string|null, source_type: string|null, source_publisher: string|null, source_publication_date: string|null}  $relation
+     * @return array{identifier: string, identifier_type: string, relation_type: string, source: string, source_title: string|null, source_type: string|null, source_publisher: string|null, source_publication_date: string|null}
+     */
+    private function enrichDataCiteEventRelationSourceType(array $relation): array
+    {
+        if ($relation['identifier_type'] !== 'DOI') {
+            return $relation;
+        }
+
+        $existingSourceType = $relation['source_type'] ?? null;
+        if (is_string($existingSourceType) && trim($existingSourceType) !== '') {
+            return $relation;
+        }
+
+        $result = $this->citationLookupService->lookup($relation['identifier']);
+
+        if (! $result->found || ! is_array($result->data)) {
+            return $relation;
+        }
+
+        $relatedItemType = $result->data['relatedItemType'] ?? null;
+        if (! is_string($relatedItemType)) {
+            return $relation;
+        }
+
+        $relatedItemType = trim($relatedItemType);
+        if ($relatedItemType === '') {
+            return $relation;
+        }
+
+        $relation['source_type'] = $relatedItemType;
+
+        return $relation;
+    }
+
+    /**
      * Store new suggestions, filtering out known relations using pre-loaded set.
      *
-     * @param  int  $resourceId
-     * @param  array<int, array<string, mixed>>  $relations
+     * @param  array<int, array{identifier: string, identifier_type: string, relation_type: string, source: string, source_title: string|null, source_type: string|null, source_publisher: string|null, source_publication_date: string|null}>  $relations
      * @param  array<string, int>  $identifierTypeLookup
      * @param  array<string, int>  $relationTypeLookup
      * @param  array<string, true|int>  $knownSet  Pre-loaded set of known relation keys
-     * @return int Number of newly stored suggestions
+     * @param  array<string, SuggestedRelation>  $pendingSuggestions
+     * @return array{created: int, updated: int}
      */
     private function storeNewSuggestions(
         int $resourceId,
@@ -177,12 +223,14 @@ class RelationDiscoveryService
         array $identifierTypeLookup,
         array $relationTypeLookup,
         array $knownSet,
-    ): int {
+        array $pendingSuggestions,
+    ): array {
         if (empty($relations)) {
-            return 0;
+            return ['created' => 0, 'updated' => 0];
         }
 
         $newCount = 0;
+        $updatedCount = 0;
 
         foreach ($relations as $relation) {
             $relationTypeId = $relationTypeLookup[$relation['relation_type']] ?? null;
@@ -198,7 +246,36 @@ class RelationDiscoveryService
                 continue;
             }
 
-            $key = mb_strtolower((string) $relation['identifier']) . '|' . $relationTypeId;
+            $key = mb_strtolower((string) $relation['identifier']).'|'.$relationTypeId;
+            $existingPendingSuggestion = $pendingSuggestions[$key] ?? null;
+            $pendingSourceType = $existingPendingSuggestion?->source_type;
+            $pendingHasSourceType = is_string($pendingSourceType) && trim($pendingSourceType) !== '';
+            $shouldEnrichPendingSuggestion = $existingPendingSuggestion !== null && ! $pendingHasSourceType;
+            $shouldEnrichNewSuggestion = $existingPendingSuggestion === null && ! isset($knownSet[$key]);
+
+            if (($shouldEnrichNewSuggestion || $shouldEnrichPendingSuggestion) && $relation['source'] === 'datacite_event_data') {
+                $relation = $this->enrichDataCiteEventRelationSourceType($relation);
+            }
+
+            $sourceType = $relation['source_type'] ?? null;
+            if (is_string($sourceType)) {
+                $sourceType = trim($sourceType);
+                if ($sourceType === '') {
+                    $sourceType = null;
+                }
+            } else {
+                $sourceType = null;
+            }
+
+            if ($existingPendingSuggestion !== null) {
+                if (! $pendingHasSourceType && $sourceType !== null) {
+                    $existingPendingSuggestion->source_type = $sourceType;
+                    $existingPendingSuggestion->save();
+                    $updatedCount++;
+                }
+
+                continue;
+            }
 
             if (isset($knownSet[$key])) {
                 continue;
@@ -214,7 +291,7 @@ class RelationDiscoveryService
                     'identifier_type_id' => $identifierTypeId,
                     'source' => $relation['source'],
                     'source_title' => $relation['source_title'] ?? null,
-                    'source_type' => $relation['source_type'] ?? null,
+                    'source_type' => $sourceType,
                     'source_publisher' => $relation['source_publisher'] ?? null,
                     'source_publication_date' => $relation['source_publication_date'] ?? null,
                     'discovered_at' => now(),
@@ -230,14 +307,14 @@ class RelationDiscoveryService
             }
         }
 
-        return $newCount;
+        return ['created' => $newCount, 'updated' => $updatedCount];
     }
 
     /**
      * Accept a suggested relation: creates a RelatedIdentifier and syncs to DataCite.
      *
-    * Uses a DB transaction for atomicity and re-checks duplicates under a
-    * resource-level lock before assigning the next position.
+     * Uses a DB transaction for atomicity and re-checks duplicates under a
+     * resource-level lock before assigning the next position.
      *
      * @return array{success: bool, datacite_synced: bool, message: string}
      */
@@ -314,7 +391,7 @@ class RelationDiscoveryService
         return [
             'success' => true,
             'datacite_synced' => false,
-            'message' => 'Relation accepted but DataCite sync failed: ' . ($syncResult->errorMessage ?? 'Unknown error'),
+            'message' => 'Relation accepted but DataCite sync failed: '.($syncResult->errorMessage ?? 'Unknown error'),
         ];
     }
 
@@ -354,7 +431,7 @@ class RelationDiscoveryService
             $label .= ". {$publisher}";
         }
 
-        return rtrim($label, ". ") . '.';
+        return rtrim($label, '. ').'.';
     }
 
     private function extractPublicationYear(?string $publicationDate): ?string

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -1,6 +1,6 @@
 import { Head, Link, router } from '@inertiajs/react';
 import axios from 'axios';
-import { AlertTriangle, Building2, Check, Plus,RefreshCw, User, X } from 'lucide-react';
+import { AlertTriangle, Building2, Check, Plus, RefreshCw, User, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -96,6 +96,8 @@ function SuggestionCard({
     onDecline: (id: number) => void;
     isProcessing: boolean;
 }) {
+    const sourceType = suggestion.source_type?.trim() ?? '';
+
     return (
         <div className="rounded-lg border bg-card p-4 shadow-sm transition-all hover:shadow-md">
             <div className="flex items-start justify-between gap-4">
@@ -114,11 +116,16 @@ function SuggestionCard({
 
                     <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
                         {suggestion.source_publisher && <span>Publisher: {suggestion.source_publisher}</span>}
-                        {suggestion.source_type && <span>Type: {suggestion.source_type}</span>}
                         <span>Source: {sourceLabel(suggestion.source)}</span>
                         <span>Discovered: {new Date(suggestion.discovered_at).toLocaleDateString()}</span>
                     </div>
                 </div>
+
+                {sourceType !== '' && (
+                    <Badge variant="outline" className="min-w-24 justify-center self-center">
+                        {sourceType}
+                    </Badge>
+                )}
 
                 <div className="flex shrink-0 gap-2">
                     <Button variant="outline" size="sm" disabled={isProcessing} onClick={() => onDecline(suggestion.id)}>
@@ -1072,13 +1079,15 @@ function DateTypeSuggestionCard({
     const isAmbiguous = metadata?.is_ambiguous === true || isHint || confidence === 'low';
     const evidenceUrl = typeof metadata?.evidence_url === 'string' ? metadata.evidence_url : null;
     const hintLabel = String(suggestion.suggested_label ?? suggestion.suggested_value ?? 'DateType hint').replace(/^Hint:\s*/i, '');
-    const displayLabel = isHint ? hintLabel : suggestionKind === 'correction'
-        ? String(suggestion.suggested_label ?? 'DateType correction')
-        : dateTypeDisplayLabel(
-              targetDateType,
-              String(suggestion.suggested_value ?? ''),
-              String(suggestion.suggested_label ?? 'DateType suggestion'),
-          );
+    const displayLabel = isHint
+        ? hintLabel
+        : suggestionKind === 'correction'
+          ? String(suggestion.suggested_label ?? 'DateType correction')
+          : dateTypeDisplayLabel(
+                targetDateType,
+                String(suggestion.suggested_value ?? ''),
+                String(suggestion.suggested_label ?? 'DateType suggestion'),
+            );
 
     return (
         <div
@@ -1091,22 +1100,22 @@ function DateTypeSuggestionCard({
             <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0 flex-1 space-y-3">
                     <div className="flex flex-wrap items-center gap-2">
-                            {isHint ? (
-                                <Badge className="bg-orange-600 text-white">
-                                    <AlertTriangle className="mr-1 h-3 w-3" />
-                                    Hint
-                                </Badge>
-                            ) : suggestionKind === 'correction' ? (
-                                <Badge className="bg-black text-white">
-                                    <RefreshCw className="mr-1 h-3 w-3" />
-                                    Correction
-                                </Badge>
-                            ) : (
-                                <Badge className="bg-black text-white">
-                                    <Plus className="mr-1 h-3 w-3" />
-                                    Addition
-                                </Badge>
-                            )}
+                        {isHint ? (
+                            <Badge className="bg-orange-600 text-white">
+                                <AlertTriangle className="mr-1 h-3 w-3" />
+                                Hint
+                            </Badge>
+                        ) : suggestionKind === 'correction' ? (
+                            <Badge className="bg-black text-white">
+                                <RefreshCw className="mr-1 h-3 w-3" />
+                                Correction
+                            </Badge>
+                        ) : (
+                            <Badge className="bg-black text-white">
+                                <Plus className="mr-1 h-3 w-3" />
+                                Addition
+                            </Badge>
+                        )}
 
                         {targetDateType && (
                             <Badge variant="secondary" className="text-xs">
@@ -1114,16 +1123,10 @@ function DateTypeSuggestionCard({
                             </Badge>
                         )}
 
-                        {confidence && (
-                            <Badge className={`text-xs ${confidenceBadgeColor(confidence)}`}>
-                                {confidenceLabel(confidence)}
-                            </Badge>
-                        )}
+                        {confidence && <Badge className={`text-xs ${confidenceBadgeColor(confidence)}`}>{confidenceLabel(confidence)}</Badge>}
 
                         {isAmbiguous && (
-                            <Badge className="bg-orange-50 text-orange-600 dark:border-orange-400 dark:text-orange-400">
-                                Manual review
-                            </Badge>
+                            <Badge className="bg-orange-50 text-orange-600 dark:border-orange-400 dark:text-orange-400">Manual review</Badge>
                         )}
 
                         {collectedDatesCount !== null && geoLocationsCount !== null && (
@@ -1133,9 +1136,7 @@ function DateTypeSuggestionCard({
                         )}
                     </div>
 
-                    <p className="text-sm font-medium">
-                        {displayLabel}
-                    </p>
+                    <p className="text-sm font-medium">{displayLabel}</p>
 
                     {evidence && <p className="text-xs text-muted-foreground">{evidence}</p>}
                     {(sourceUrl || evidenceUrl || schemaOrgField) && (
@@ -1155,7 +1156,6 @@ function DateTypeSuggestionCard({
                     )}
                     <p className="text-xs text-muted-foreground">
                         Discovered: {suggestion.discovered_at ? new Date(suggestion.discovered_at).toLocaleDateString() : '—'}
-
                     </p>
                 </div>
 
@@ -1176,8 +1176,7 @@ function DateTypeSuggestionCard({
         </div>
     );
 }
-function dateTypeDisplayLabel(targetType: unknown, value: string, fallbackLabel: string,): string 
-{
+function dateTypeDisplayLabel(targetType: unknown, value: string, fallbackLabel: string): string {
     if (typeof targetType !== 'string') {
         return fallbackLabel;
     }
@@ -1688,15 +1687,8 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                 );
             case 'size-format-suggestion':
                 return <SizeFormatSuggestionCard suggestion={item} onAccept={onAccept} onDecline={onDecline} isProcessing={isProcessing} />;
-                case 'date-type-suggestion':
-                return (
-                    <DateTypeSuggestionCard
-                        suggestion={item}
-                        onAccept={onAccept}
-                        onDecline={onDecline}
-                        isProcessing={isProcessing}
-                    />
-                );
+            case 'date-type-suggestion':
+                return <DateTypeSuggestionCard suggestion={item} onAccept={onAccept} onDecline={onDecline} isProcessing={isProcessing} />;
             case 'description-segmentation':
                 return (
                     <DescriptionSegmentationSuggestionCard
@@ -1733,7 +1725,7 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                         isProcessing={isProcessing}
                     />
                 );
-            default: 
+            default:
                 // Generic card for future student modules
                 return (
                     <div className="rounded-lg border bg-card p-4 shadow-sm">
@@ -1757,7 +1749,6 @@ export default function AssistancePage({ sections, manifests }: AssistancePagePr
                         </div>
                     </div>
                 );
-            
         }
     }
 

--- a/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
@@ -7,6 +7,8 @@ use App\Models\RelatedIdentifier;
 use App\Models\RelationType;
 use App\Models\Resource;
 use App\Models\SuggestedRelation;
+use App\Services\Citations\CitationLookupResult;
+use App\Services\Citations\CitationLookupService;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\DataCiteEventDataService;
 use App\Services\DataCiteSyncResult;
@@ -16,6 +18,7 @@ use App\Services\ScholExplorerService;
 use Database\Seeders\IdentifierTypeSeeder;
 use Database\Seeders\RelationTypeSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 
 uses(RefreshDatabase::class);
 
@@ -64,6 +67,7 @@ describe('RelationDiscoveryService', function (): void {
         $service = new RelationDiscoveryService(
             Mockery::mock(ScholExplorerService::class),
             Mockery::mock(DataCiteEventDataService::class),
+            Mockery::mock(CitationLookupService::class),
             $syncService,
             $citationLabelService,
         );
@@ -115,6 +119,7 @@ describe('RelationDiscoveryService', function (): void {
         $service = new RelationDiscoveryService(
             Mockery::mock(ScholExplorerService::class),
             Mockery::mock(DataCiteEventDataService::class),
+            Mockery::mock(CitationLookupService::class),
             $syncService,
             $citationLabelService,
         );
@@ -168,6 +173,7 @@ describe('RelationDiscoveryService', function (): void {
         $service = new RelationDiscoveryService(
             Mockery::mock(ScholExplorerService::class),
             Mockery::mock(DataCiteEventDataService::class),
+            Mockery::mock(CitationLookupService::class),
             $syncService,
             $citationLabelService,
         );
@@ -179,5 +185,194 @@ describe('RelationDiscoveryService', function (): void {
         expect($relatedIdentifiers)->toHaveCount(1)
             ->and($relatedIdentifiers->first()?->citation_label)->toBe('Manual curated citation label')
             ->and(SuggestedRelation::query()->find($suggestion->id))->toBeNull();
+    });
+
+    it('stores the related resource type from CitationLookupService for Crossref DOI relations discovered from DataCite Event Data', function (): void {
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/source.2026.001',
+        ]);
+
+        $relatedDoi = '10.1016/j.cageo.2026.106001';
+
+        $scholExplorerService = Mockery::mock(ScholExplorerService::class);
+        $scholExplorerService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([]);
+
+        $dataCiteEventDataService = Mockery::mock(DataCiteEventDataService::class);
+        $dataCiteEventDataService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([
+                [
+                    'identifier' => $relatedDoi,
+                    'identifier_type' => 'DOI',
+                    'relation_type' => 'Cites',
+                    'source_title' => null,
+                    'source_type' => null,
+                    'source_publisher' => null,
+                    'source_publication_date' => null,
+                ],
+            ]);
+
+        $citationLookupService = Mockery::mock(CitationLookupService::class);
+        $citationLookupService->shouldReceive('lookup')
+            ->once()
+            ->with($relatedDoi)
+            ->andReturn(CitationLookupResult::hit('crossref', [
+                'relatedItemType' => 'JournalArticle',
+            ]));
+
+        app()->instance(ScholExplorerService::class, $scholExplorerService);
+        app()->instance(DataCiteEventDataService::class, $dataCiteEventDataService);
+        app()->instance(CitationLookupService::class, $citationLookupService);
+        app()->instance(DataCiteSyncService::class, Mockery::mock(DataCiteSyncService::class));
+        app()->instance(RelatedIdentifierCitationLabelService::class, Mockery::mock(RelatedIdentifierCitationLabelService::class));
+
+        app(RelationDiscoveryService::class)->discoverAll();
+
+        $suggestion = SuggestedRelation::query()->first();
+
+        expect(SuggestedRelation::query()->count())->toBe(1)
+            ->and($suggestion)->not->toBeNull()
+            ->and($suggestion?->source_type)->toBe('JournalArticle');
+    });
+
+    it('backfills the related resource type for an existing pending suggestion', function (): void {
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/source.2026.002',
+        ]);
+
+        $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+        $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+        expect($identifierTypeId)->toBeInt()
+            ->and($relationTypeId)->toBeInt();
+
+        $relatedDoi = '10.5880/related.2026.002';
+        $originalDiscoveredAt = Carbon::parse('2026-02-03 04:05:06');
+
+        $existingSuggestion = SuggestedRelation::query()->create([
+            'resource_id' => $resource->id,
+            'identifier' => $relatedDoi,
+            'identifier_type_id' => $identifierTypeId,
+            'relation_type_id' => $relationTypeId,
+            'source' => 'datacite_event_data',
+            'source_title' => null,
+            'source_type' => null,
+            'source_publisher' => null,
+            'source_publication_date' => null,
+            'discovered_at' => $originalDiscoveredAt,
+        ]);
+
+        $scholExplorerService = Mockery::mock(ScholExplorerService::class);
+        $scholExplorerService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([]);
+
+        $dataCiteEventDataService = Mockery::mock(DataCiteEventDataService::class);
+        $dataCiteEventDataService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([
+                [
+                    'identifier' => $relatedDoi,
+                    'identifier_type' => 'DOI',
+                    'relation_type' => 'Cites',
+                    'source_title' => null,
+                    'source_type' => null,
+                    'source_publisher' => null,
+                    'source_publication_date' => null,
+                ],
+            ]);
+
+        $citationLookupService = Mockery::mock(CitationLookupService::class);
+        $citationLookupService->shouldReceive('lookup')
+            ->once()
+            ->with($relatedDoi)
+            ->andReturn(CitationLookupResult::hit('datacite', [
+                'relatedItemType' => 'Dataset',
+            ]));
+
+        app()->instance(ScholExplorerService::class, $scholExplorerService);
+        app()->instance(DataCiteEventDataService::class, $dataCiteEventDataService);
+        app()->instance(CitationLookupService::class, $citationLookupService);
+        app()->instance(DataCiteSyncService::class, Mockery::mock(DataCiteSyncService::class));
+        app()->instance(RelatedIdentifierCitationLabelService::class, Mockery::mock(RelatedIdentifierCitationLabelService::class));
+
+        $newCount = app(RelationDiscoveryService::class)->discoverAll();
+
+        $refreshedSuggestion = $existingSuggestion->fresh();
+
+        expect($newCount)->toBe(0)
+            ->and(SuggestedRelation::query()->count())->toBe(1)
+            ->and($refreshedSuggestion)->not->toBeNull()
+            ->and($refreshedSuggestion?->id)->toBe($existingSuggestion->id)
+            ->and($refreshedSuggestion?->source_type)->toBe('Dataset')
+            ->and($refreshedSuggestion?->discovered_at?->equalTo($originalDiscoveredAt))->toBeTrue();
+    });
+
+    it('keeps the related resource type empty when it cannot be resolved', function (): void {
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/source.2026.003',
+        ]);
+
+        $relatedUrl = 'https://example.org/related-resource';
+        $relatedDoi = '10.5880/related.2026.003';
+
+        $scholExplorerService = Mockery::mock(ScholExplorerService::class);
+        $scholExplorerService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([]);
+
+        $dataCiteEventDataService = Mockery::mock(DataCiteEventDataService::class);
+        $dataCiteEventDataService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([
+                [
+                    'identifier' => $relatedUrl,
+                    'identifier_type' => 'URL',
+                    'relation_type' => 'References',
+                    'source_title' => null,
+                    'source_type' => null,
+                    'source_publisher' => null,
+                    'source_publication_date' => null,
+                ],
+                [
+                    'identifier' => $relatedDoi,
+                    'identifier_type' => 'DOI',
+                    'relation_type' => 'Cites',
+                    'source_title' => null,
+                    'source_type' => null,
+                    'source_publisher' => null,
+                    'source_publication_date' => null,
+                ],
+            ]);
+
+        $citationLookupService = Mockery::mock(CitationLookupService::class);
+        $citationLookupService->shouldReceive('lookup')
+            ->once()
+            ->with($relatedDoi)
+            ->andReturn(CitationLookupResult::notFound('datacite'));
+
+        app()->instance(ScholExplorerService::class, $scholExplorerService);
+        app()->instance(DataCiteEventDataService::class, $dataCiteEventDataService);
+        app()->instance(CitationLookupService::class, $citationLookupService);
+        app()->instance(DataCiteSyncService::class, Mockery::mock(DataCiteSyncService::class));
+        app()->instance(RelatedIdentifierCitationLabelService::class, Mockery::mock(RelatedIdentifierCitationLabelService::class));
+
+        $newCount = app(RelationDiscoveryService::class)->discoverAll();
+
+        $suggestions = SuggestedRelation::query()
+            ->orderBy('identifier')
+            ->get();
+
+        expect($newCount)->toBe(2)
+            ->and($suggestions)->toHaveCount(2)
+            ->and($suggestions->pluck('source_type')->all())->toBe([null, null]);
     });
 });

--- a/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
+++ b/tests/pest/Feature/Services/RelationDiscoveryServiceTest.php
@@ -375,4 +375,106 @@ describe('RelationDiscoveryService', function (): void {
             ->and($suggestions)->toHaveCount(2)
             ->and($suggestions->pluck('source_type')->all())->toBe([null, null]);
     });
+
+    it('keeps an existing related resource type from DataCite Event Data without calling CitationLookupService', function (): void {
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/source.2026.004',
+        ]);
+
+        $relatedDoi = '10.5880/related.2026.004';
+
+        $scholExplorerService = Mockery::mock(ScholExplorerService::class);
+        $scholExplorerService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([]);
+
+        $dataCiteEventDataService = Mockery::mock(DataCiteEventDataService::class);
+        $dataCiteEventDataService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([
+                [
+                    'identifier' => $relatedDoi,
+                    'identifier_type' => 'DOI',
+                    'relation_type' => 'Cites',
+                    'source_title' => null,
+                    'source_type' => 'Dataset',
+                    'source_publisher' => null,
+                    'source_publication_date' => null,
+                ],
+            ]);
+
+        $citationLookupService = Mockery::mock(CitationLookupService::class);
+        $citationLookupService->shouldNotReceive('lookup');
+
+        app()->instance(ScholExplorerService::class, $scholExplorerService);
+        app()->instance(DataCiteEventDataService::class, $dataCiteEventDataService);
+        app()->instance(CitationLookupService::class, $citationLookupService);
+        app()->instance(DataCiteSyncService::class, Mockery::mock(DataCiteSyncService::class));
+        app()->instance(RelatedIdentifierCitationLabelService::class, Mockery::mock(RelatedIdentifierCitationLabelService::class));
+
+        app(RelationDiscoveryService::class)->discoverAll();
+
+        $suggestion = SuggestedRelation::query()->first();
+
+        expect(SuggestedRelation::query()->count())->toBe(1)
+            ->and($suggestion)->not->toBeNull()
+            ->and($suggestion?->source_type)->toBe('Dataset');
+    });
+
+    it('keeps the related resource type empty when CitationLookupService returns an invalid related item type', function (mixed $relatedItemType): void {
+        $resource = Resource::factory()->create([
+            'doi' => '10.5880/source.2026.005',
+        ]);
+
+        $relatedDoi = '10.5880/related.2026.005';
+
+        $scholExplorerService = Mockery::mock(ScholExplorerService::class);
+        $scholExplorerService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([]);
+
+        $dataCiteEventDataService = Mockery::mock(DataCiteEventDataService::class);
+        $dataCiteEventDataService->shouldReceive('findRelationsForDoi')
+            ->once()
+            ->with($resource->doi)
+            ->andReturn([
+                [
+                    'identifier' => $relatedDoi,
+                    'identifier_type' => 'DOI',
+                    'relation_type' => 'Cites',
+                    'source_title' => null,
+                    'source_type' => null,
+                    'source_publisher' => null,
+                    'source_publication_date' => null,
+                ],
+            ]);
+
+        $citationLookupService = Mockery::mock(CitationLookupService::class);
+        $citationLookupService->shouldReceive('lookup')
+            ->once()
+            ->with($relatedDoi)
+            ->andReturn(CitationLookupResult::hit('datacite', [
+                'relatedItemType' => $relatedItemType,
+            ]));
+
+        app()->instance(ScholExplorerService::class, $scholExplorerService);
+        app()->instance(DataCiteEventDataService::class, $dataCiteEventDataService);
+        app()->instance(CitationLookupService::class, $citationLookupService);
+        app()->instance(DataCiteSyncService::class, Mockery::mock(DataCiteSyncService::class));
+        app()->instance(RelatedIdentifierCitationLabelService::class, Mockery::mock(RelatedIdentifierCitationLabelService::class));
+
+        app(RelationDiscoveryService::class)->discoverAll();
+
+        $suggestion = SuggestedRelation::query()->first();
+
+        expect(SuggestedRelation::query()->count())->toBe(1)
+            ->and($suggestion)->not->toBeNull()
+            ->and($suggestion?->source_type)->toBeNull();
+    })->with([
+        'non-string related item type' => [123],
+        'whitespace-only related item type' => ['   '],
+    ]);
 });

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -692,6 +692,23 @@ describe('RelationSuggestionCard - resource type', () => {
         expect(badge).toHaveAttribute('data-slot', 'badge');
         expect(badge).toHaveAttribute('data-variant', 'outline');
     });
+
+    it('does not render a resource type badge when the relation suggestion has no source type', () => {
+        const suggestion = makeRelationSuggestion({ source_type: null });
+
+        const { container } = render(
+            <AssistancePage
+                sections={{ [RELATION_ASSISTANT_ID]: paginated([suggestion]) }}
+                manifests={[makeManifest(RELATION_ASSISTANT_ID, RELATION_ROUTE_PREFIX, RELATION_ASSISTANT_NAME)]}
+            />,
+        );
+
+        const outlineBadges = container.querySelectorAll('[data-slot="badge"][data-variant="outline"]');
+
+        expect(screen.queryByText('Dataset')).not.toBeInTheDocument();
+        expect(outlineBadges).toHaveLength(1);
+        expect(outlineBadges[0]).toHaveTextContent('Cites');
+    });
 });
 
 describe('OrcidSuggestionCard – ORCID link', () => {

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -12,6 +12,7 @@ import type {
     SuggestedCrossrefFunderRorItem,
     SuggestedDescriptionSegmentationItem,
     SuggestedOrcidItem,
+    SuggestedRelationItem,
     SuggestedRorItem,
     SuggestedSpdxRightsItem,
     SuggestedSubjectMetadataEnrichmentItem,
@@ -76,6 +77,9 @@ const SUBJECT_METADATA_ASSISTANT_NAME = 'Subject Metadata Enrichment';
 const DESCRIPTION_SEGMENTATION_ASSISTANT_ID = 'description-segmentation';
 const DESCRIPTION_SEGMENTATION_ROUTE_PREFIX = 'description-segmentation';
 const DESCRIPTION_SEGMENTATION_ASSISTANT_NAME = 'Description Segmentation Suggestions';
+const RELATION_ASSISTANT_ID = 'relation-suggestion';
+const RELATION_ROUTE_PREFIX = 'relations';
+const RELATION_ASSISTANT_NAME = 'Relation Suggestions';
 const BULK_TOKEN_MATCH = '00000000-0000-4000-8000-000000000955';
 const BULK_TOKEN_SINGULAR = '00000000-0000-4000-8000-000000000958';
 const BULK_TOKEN_RETRY = '00000000-0000-4000-8000-000000000957';
@@ -198,6 +202,27 @@ function makeDateTypeSuggestion(overrides: Partial<BaseSuggestionItem> = {}): Ba
             target_date_type: 'Issued',
             confidence: 'high',
         },
+        discovered_at: '2026-07-05T10:00:00+00:00',
+        ...overrides,
+    };
+}
+
+function makeRelationSuggestion(overrides: Partial<SuggestedRelationItem> = {}): SuggestedRelationItem {
+    return {
+        id: 89,
+        resource_id: 89,
+        resource_doi: '10.5880/test.2026.089',
+        resource_title: 'Related resource type example',
+        identifier: '10.5880/related.2026.089',
+        identifier_type: 'DOI',
+        identifier_type_name: 'DOI',
+        relation_type: 'Cites',
+        relation_type_name: 'Cites',
+        source: 'datacite_event_data',
+        source_title: null,
+        source_type: 'Dataset',
+        source_publisher: null,
+        source_publication_date: null,
         discovered_at: '2026-07-05T10:00:00+00:00',
         ...overrides,
     };
@@ -612,6 +637,25 @@ describe('Assistance resource header links', () => {
         expect(screen.getByText(/Original grouped title/)).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: '10.5880/conflict.2026.201' })).not.toBeInTheDocument();
         expect(screen.queryByText(/Conflicting grouped title/)).not.toBeInTheDocument();
+    });
+});
+
+describe('RelationSuggestionCard - resource type', () => {
+    it('renders the related resource type for relation suggestions', () => {
+        const suggestion = makeRelationSuggestion();
+
+        render(
+            <AssistancePage
+                sections={{ [RELATION_ASSISTANT_ID]: paginated([suggestion]) }}
+                manifests={[makeManifest(RELATION_ASSISTANT_ID, RELATION_ROUTE_PREFIX, RELATION_ASSISTANT_NAME)]}
+            />,
+        );
+
+        const badge = screen.getByText('Dataset');
+
+        expect(badge).toBeVisible();
+        expect(badge).toHaveAttribute('data-slot', 'badge');
+        expect(badge).toHaveAttribute('data-variant', 'outline');
     });
 });
 
@@ -1789,9 +1833,11 @@ describe('DateTypeSuggestionCard - DateType preview', () => {
         expect(screen.getByText('Manual review')).toBeInTheDocument();
         expect(screen.getByText('Medium confidence')).toBeInTheDocument();
 
-        expect(screen.getByText(
-            'Created (2023-02-22) occurs after Issued (2018). Please check whether the date values or date types are assigned correctly.',
-        )).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Created (2023-02-22) occurs after Issued (2018). Please check whether the date values or date types are assigned correctly.',
+            ),
+        ).toBeInTheDocument();
 
         expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
@@ -1824,10 +1870,7 @@ describe('DateTypeSuggestionCard - DateType preview', () => {
         expect(screen.getByText('High confidence')).toBeInTheDocument();
         expect(screen.getByText('schema.org field: datePublished')).toBeInTheDocument();
 
-        expect(screen.getByRole('link', { name: 'Open source' })).toHaveAttribute(
-            'href',
-            'https://dataservices.gfz.de/example-dataset',
-        );
+        expect(screen.getByRole('link', { name: 'Open source' })).toHaveAttribute('href', 'https://dataservices.gfz.de/example-dataset');
 
         expect(screen.getByRole('link', { name: 'Open schema.org' })).toHaveAttribute(
             'href',
@@ -1847,7 +1890,7 @@ describe('DateTypeSuggestionCard - DateType preview', () => {
                 target_date_type: 'Coverage',
                 confidence: 'medium',
                 collected_dates_count: 1,
-                source_url : 'https://doi.org/10.5880/test.001',
+                source_url: 'https://doi.org/10.5880/test.001',
                 geo_locations_count: 1,
                 evidence: 'The resource has a DOI and the same number of Collected date entries as geolocation entries.',
             },
@@ -1873,4 +1916,3 @@ describe('DateTypeSuggestionCard - DateType preview', () => {
         expect(screen.getByRole('button', { name: 'Decline' })).toBeInTheDocument();
     });
 });
-


### PR DESCRIPTION
## Summary

* Enriches relation suggestions with canonical DataCite resource types through the existing citation lookup flow.
* Uses Crossref first and DataCite as fallback.
* Backfills missing resource types for existing pending suggestions without overwriting populated values or changing `discovered_at`.
* Displays the resource type as an outline badge on the Assistance page.

## Validation

* RelationDiscoveryService tests: 6 passed
* Assistance page tests: 58 passed
* PHPStan: passed
* TypeScript checks: passed
* ESLint: passed
* Pint and Prettier: passed
* Manual UI verification completed
* Verified that all 88 DataCite Event Data suggestions received a resource type

## Known unrelated test failures

The full frontend suite reports accessibility-role expectation failures in untouched DataCiteForm and DateField tests. These failures reproduce independently without the Assistance tests.

## AI Assistance

OpenAI Codex was used to assist with code analysis, implementation, test preparation, and review. All changes were manually reviewed, and the relevant tests, static analysis, formatting checks, and UI behavior were verified by the author.

Closes #1025
