### PR TITLE
Feature: Import legacy Resources by Datacenter

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -132,6 +132,12 @@ DATACITE_TEST_ENDPOINT=https://api.test.datacite.org
 DATACITE_USERNAME=
 DATACITE_PASSWORD=
 DATACITE_ENDPOINT=https://api.datacite.org
+GFZ_DATA_SERVICES_PORTAL_PROXY_URL=https://dataservices.gfz-potsdam.de/portal/proxy/proxy.php
+GFZ_DATA_SERVICES_PORTAL_TIMEOUT=30
+GFZ_DATA_SERVICES_PORTAL_RETRY_TIMES=3
+GFZ_DATA_SERVICES_PORTAL_RETRY_SLEEP_MS=500
+GFZ_DATA_SERVICES_PORTAL_PAGE_SIZE=500
+GFZ_DATA_SERVICES_PORTAL_CACHE_TTL=600
 
 # =============================================================================
 # Sanctum Configuration

--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,12 @@ DATACITE_TEST_ENDPOINT=https://api.test.datacite.org
 DATACITE_USERNAME=
 DATACITE_PASSWORD=
 DATACITE_ENDPOINT=https://api.datacite.org
+GFZ_DATA_SERVICES_PORTAL_PROXY_URL=https://dataservices.gfz-potsdam.de/portal/proxy/proxy.php
+GFZ_DATA_SERVICES_PORTAL_TIMEOUT=30
+GFZ_DATA_SERVICES_PORTAL_RETRY_TIMES=3
+GFZ_DATA_SERVICES_PORTAL_RETRY_SLEEP_MS=500
+GFZ_DATA_SERVICES_PORTAL_PAGE_SIZE=500
+GFZ_DATA_SERVICES_PORTAL_CACHE_TTL=600
 
 # Crossref API Configuration (Citation Manager)
 # Used by the Citation Manager to look up bibliographic metadata by DOI.

--- a/app/Http/Controllers/DataCiteImportController.php
+++ b/app/Http/Controllers/DataCiteImportController.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StartDatacenterOldResourceImportRequest;
 use App\Http\Requests\StartSingleOldResourceImportRequest;
 use App\Jobs\ImportFromDataCiteJob;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\DoiImportEligibilityService;
+use App\Services\GfzDataServicesPortalService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -50,6 +52,74 @@ class DataCiteImportController extends Controller
         return response()->json([
             'import_id' => $importId,
             'message' => 'Import started successfully',
+        ]);
+    }
+
+    /**
+     * List datacenters exposed by the legacy GFZ Data Services portal.
+     */
+    public function datacenters(
+        Request $request,
+        GfzDataServicesPortalService $portalService,
+    ): JsonResponse {
+        $this->authorize('importFromDataCite', Resource::class);
+
+        try {
+            return response()->json([
+                'datacenters' => $portalService->listDatacenters(),
+            ]);
+        } catch (\Throwable $exception) {
+            Log::warning('GFZ Data Services datacenter lookup failed', [
+                'user_id' => $request->user()?->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return response()->json([
+                'message' => 'The GFZ Data Services datacenter list is currently unavailable. Please try again later.',
+            ], 503);
+        }
+    }
+
+    /**
+     * Start an import limited to one GFZ Data Services datacenter.
+     */
+    public function startDatacenter(
+        StartDatacenterOldResourceImportRequest $request,
+        GfzDataServicesPortalService $portalService,
+    ): JsonResponse {
+        $this->authorize('importFromDataCite', Resource::class);
+
+        try {
+            $datacenter = $portalService->findDatacenter($request->getDatacenterId());
+        } catch (\Throwable $exception) {
+            Log::warning('GFZ Data Services datacenter validation failed', [
+                'user_id' => $request->user()?->id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return response()->json([
+                'message' => 'The GFZ Data Services datacenter list is currently unavailable. Please try again later.',
+            ], 503);
+        }
+
+        if ($datacenter === null) {
+            throw ValidationException::withMessages([
+                'datacenter_id' => 'The selected datacenter is no longer available. Reload the list and try again.',
+            ]);
+        }
+
+        $importId = Str::uuid()->toString();
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $this->initializeProgress(importId: $importId, total: 0);
+
+        ImportFromDataCiteJob::dispatch($user->id, $importId, null, $datacenter['id']);
+
+        return response()->json([
+            'import_id' => $importId,
+            'message' => 'Datacenter import started successfully',
         ]);
     }
 

--- a/app/Http/Requests/StartDatacenterOldResourceImportRequest.php
+++ b/app/Http/Requests/StartDatacenterOldResourceImportRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StartDatacenterOldResourceImportRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'datacenter_id' => ['required', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'datacenter_id.required' => 'Select a datacenter to start the import.',
+            'datacenter_id.string' => 'The selected datacenter is invalid.',
+            'datacenter_id.max' => 'The selected datacenter is invalid.',
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $value = $this->input('datacenter_id');
+
+        if (is_string($value)) {
+            $value = trim($value);
+        }
+
+        $this->merge(['datacenter_id' => $value]);
+    }
+
+    public function getDatacenterId(): string
+    {
+        return (string) $this->input('datacenter_id');
+    }
+}

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Models\Datacenter;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteImportService;
@@ -11,6 +12,7 @@ use App\Services\DataCiteLandingPageImportService;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
+use App\Services\GfzDataServicesPortalService;
 use App\Services\LegacyLandingPageDecisionService;
 use App\Services\LegacyLandingPageImportService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
@@ -63,6 +65,7 @@ class ImportFromDataCiteJob implements ShouldQueue
         private int $userId,
         private string $importId,
         private ?string $singleDoi = null,
+        private ?string $datacenterId = null,
     ) {
         // Validate UUID format to prevent cache key collisions or unexpected behavior.
         // The importId is used as part of the cache key and must be unique.
@@ -78,6 +81,10 @@ class ImportFromDataCiteJob implements ShouldQueue
                 );
             }
         }
+
+        if ($this->singleDoi !== null && $this->datacenterId !== null) {
+            throw new \InvalidArgumentException('Single DOI and datacenter imports cannot be combined.');
+        }
     }
 
     /**
@@ -92,6 +99,7 @@ class ImportFromDataCiteJob implements ShouldQueue
             'import_id' => $this->importId,
             'user_id' => $this->userId,
             'single_doi' => $this->singleDoi,
+            'datacenter_id' => $this->datacenterId,
         ]);
 
         $startTime = now();
@@ -99,6 +107,17 @@ class ImportFromDataCiteJob implements ShouldQueue
         try {
             if ($this->singleDoi !== null) {
                 $this->handleSingleImport($importService, $transformer, $metaworksService, $startTime->toIso8601String());
+
+                return;
+            }
+
+            if ($this->datacenterId !== null) {
+                $this->handleDatacenterImport(
+                    $importService,
+                    $transformer,
+                    $metaworksService,
+                    $startTime->toIso8601String(),
+                );
 
                 return;
             }
@@ -325,6 +344,358 @@ class ImportFromDataCiteJob implements ShouldQueue
         }
     }
 
+    private function handleDatacenterImport(
+        DataCiteImportService $importService,
+        DataCiteToResourceTransformer $transformer,
+        MetaworksDownloadUrlService $metaworksService,
+        string $startedAt,
+    ): void {
+        $datacenterId = $this->datacenterId;
+
+        if ($datacenterId === null) {
+            throw new \RuntimeException('Datacenter import requested without a datacenter.');
+        }
+
+        $portalSelection = app(GfzDataServicesPortalService::class)
+            ->resourcesForDatacenter($datacenterId);
+        $datacenter = $portalSelection['datacenter'];
+        /** @var array<string, list<string>> $targets */
+        $targets = $portalSelection['resources'];
+        $pendingImportService = app(SumarioPendingResourceImportService::class);
+        $warnings = [];
+
+        try {
+            $pendingDois = $pendingImportService
+                ->importablePendingDoisForDatacenter($datacenter['name']);
+        } catch (\Throwable $exception) {
+            $pendingDois = [];
+            $warnings[] = 'Matching SUMARIO pending resources could not be loaded.';
+
+            Log::warning('SUMARIO pending datacenter lookup failed; importing portal resources only', [
+                'import_id' => $this->importId,
+                'datacenter_id' => $datacenter['id'],
+                'error' => $exception->getMessage(),
+            ]);
+        }
+
+        foreach ($pendingDois as $pendingDoi) {
+            $normalizedDoi = $this->normalizeDoi($pendingDoi);
+
+            if ($normalizedDoi !== '' && ! array_key_exists($normalizedDoi, $targets)) {
+                $targets[$normalizedDoi] = [];
+            }
+        }
+
+        ksort($targets);
+
+        $total = count($targets);
+        $processed = 0;
+        $imported = 0;
+        $skipped = 0;
+        $failed = 0;
+        $enriched = 0;
+        /** @var list<string> $skippedDois */
+        $skippedDois = [];
+        /** @var list<string> $enrichedDois */
+        $enrichedDois = [];
+        /** @var list<array{doi: string, error: string}> $failedDois */
+        $failedDois = [];
+        $maxStoredDois = 100;
+        $metaworksUnavailable = false;
+        $remainingTargets = $targets;
+
+        $this->updateProgress([
+            'status' => 'running',
+            'total' => $total,
+            'processed' => 0,
+            'imported' => 0,
+            'skipped' => 0,
+            'failed' => 0,
+            'enriched' => 0,
+            'skipped_dois' => [],
+            'enriched_dois' => [],
+            'failed_dois' => [],
+            'warnings' => $warnings,
+            'datacenter' => $datacenter,
+            'started_at' => $startedAt,
+            'completed_at' => null,
+            'current_prefix' => null,
+        ]);
+
+        /**
+         * @param array{
+         *     status: 'imported'|'skipped'|'failed',
+         *     enriched: bool,
+         *     metaworks_unavailable: bool,
+         *     error: string|null
+         * } $outcome
+         */
+        $recordOutcome = function (string $doi, array $outcome) use (
+            &$imported,
+            &$skipped,
+            &$failed,
+            &$enriched,
+            &$skippedDois,
+            &$enrichedDois,
+            &$failedDois,
+            $maxStoredDois,
+        ): void {
+            if ($outcome['enriched']) {
+                $enriched++;
+
+                if (count($enrichedDois) < $maxStoredDois) {
+                    $enrichedDois[] = $doi;
+                }
+            }
+
+            if ($outcome['status'] === 'imported') {
+                $imported++;
+
+                return;
+            }
+
+            if ($outcome['status'] === 'skipped') {
+                $skipped++;
+
+                if (count($skippedDois) < $maxStoredDois) {
+                    $skippedDois[] = $doi;
+                }
+
+                return;
+            }
+
+            $failed++;
+
+            if (count($failedDois) < $maxStoredDois) {
+                $failedDois[] = [
+                    'doi' => $doi,
+                    'error' => $outcome['error'] ?? 'Import failed.',
+                ];
+            }
+        };
+
+        $scannedDataCiteRecords = 0;
+
+        foreach ($importService->fetchAllDois() as $doiRecord) {
+            $scannedDataCiteRecords++;
+
+            if (($scannedDataCiteRecords === 1 || $scannedDataCiteRecords % 50 === 0) && $this->isCancelled()) {
+                break;
+            }
+
+            $rawDoi = $doiRecord['attributes']['doi'] ?? $doiRecord['id'] ?? null;
+
+            if (! is_string($rawDoi)) {
+                continue;
+            }
+
+            ['doi' => $doi, 'doiRecord' => $normalizedRecord] = $this->normalizeDoiRecord(
+                $rawDoi,
+                $doiRecord,
+            );
+
+            if (! array_key_exists($doi, $remainingTargets)) {
+                continue;
+            }
+
+            $processed++;
+            $portalDatacenterNames = $remainingTargets[$doi];
+            unset($remainingTargets[$doi]);
+
+            $outcome = $this->processDatacenterDataCiteRecord(
+                doi: $doi,
+                doiRecord: $normalizedRecord,
+                portalDatacenterNames: $portalDatacenterNames,
+                transformer: $transformer,
+                metaworksService: $metaworksService,
+                shouldLookupMetaworks: ! $metaworksUnavailable,
+            );
+            $metaworksUnavailable = $metaworksUnavailable || $outcome['metaworks_unavailable'];
+            $recordOutcome($doi, $outcome);
+
+            $this->updateProgressCounts(
+                $processed,
+                $imported,
+                $skipped,
+                $failed,
+                $enriched,
+                $skippedDois,
+                $enrichedDois,
+                $failedDois,
+                $total,
+            );
+        }
+
+        foreach ($remainingTargets as $doi => $portalDatacenterNames) {
+            if ($this->isCancelled()) {
+                break;
+            }
+
+            $processed++;
+            $doiRecord = $importService->fetchSingleDoi($doi);
+
+            if ($doiRecord !== null) {
+                ['doi' => $normalizedDoi, 'doiRecord' => $normalizedRecord] = $this->normalizeDoiRecord(
+                    $doi,
+                    $doiRecord,
+                );
+                $outcome = $this->processDatacenterDataCiteRecord(
+                    doi: $normalizedDoi,
+                    doiRecord: $normalizedRecord,
+                    portalDatacenterNames: $portalDatacenterNames,
+                    transformer: $transformer,
+                    metaworksService: $metaworksService,
+                    shouldLookupMetaworks: ! $metaworksUnavailable,
+                );
+                $metaworksUnavailable = $metaworksUnavailable || $outcome['metaworks_unavailable'];
+                $recordOutcome($normalizedDoi, $outcome);
+            } else {
+                try {
+                    $pendingResult = $pendingImportService->importPendingByDoi($doi, $this->userId);
+
+                    if ($pendingResult['status'] === 'imported') {
+                        if ($portalDatacenterNames !== [] && $pendingResult['resource'] !== null) {
+                            $this->syncPortalDatacenters(
+                                $pendingResult['resource'],
+                                $portalDatacenterNames,
+                            );
+                        }
+
+                        $recordOutcome($doi, [
+                            'status' => 'imported',
+                            'enriched' => false,
+                            'metaworks_unavailable' => false,
+                            'error' => null,
+                        ]);
+                    } elseif ($pendingResult['status'] === 'skipped') {
+                        $recordOutcome($doi, [
+                            'status' => 'skipped',
+                            'enriched' => false,
+                            'metaworks_unavailable' => false,
+                            'error' => null,
+                        ]);
+                    } else {
+                        $recordOutcome($doi, [
+                            'status' => 'failed',
+                            'enriched' => false,
+                            'metaworks_unavailable' => false,
+                            'error' => $pendingResult['error']
+                                ?? 'The DOI was not found in DataCite or SUMARIO pending resources.',
+                        ]);
+                    }
+                } catch (\Throwable $exception) {
+                    Log::warning('Datacenter import fallback failed', [
+                        'doi' => $doi,
+                        'datacenter_id' => $datacenter['id'],
+                        'error' => $exception->getMessage(),
+                    ]);
+
+                    $recordOutcome($doi, [
+                        'status' => 'failed',
+                        'enriched' => false,
+                        'metaworks_unavailable' => false,
+                        'error' => 'SUMARIO pending lookup is unavailable.',
+                    ]);
+                }
+            }
+
+            $this->updateProgressCounts(
+                $processed,
+                $imported,
+                $skipped,
+                $failed,
+                $enriched,
+                $skippedDois,
+                $enrichedDois,
+                $failedDois,
+                $total,
+            );
+        }
+
+        $finalStatus = $this->determineFinalStatus();
+
+        $this->updateProgress([
+            'status' => $finalStatus,
+            'total' => $total,
+            'processed' => $processed,
+            'imported' => $imported,
+            'skipped' => $skipped,
+            'failed' => $failed,
+            'enriched' => $enriched,
+            'skipped_dois' => $skippedDois,
+            'enriched_dois' => $enrichedDois,
+            'failed_dois' => $failedDois,
+            'warnings' => $warnings,
+            'datacenter' => $datacenter,
+            'started_at' => $startedAt,
+            'completed_at' => now()->toIso8601String(),
+            'current_prefix' => null,
+        ]);
+
+        Log::info('Datacenter DataCite import completed', [
+            'import_id' => $this->importId,
+            'datacenter_id' => $datacenter['id'],
+            'datacenter_name' => $datacenter['name'],
+            'total' => $total,
+            'imported' => $imported,
+            'skipped' => $skipped,
+            'failed' => $failed,
+            'enriched' => $enriched,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $doiRecord
+     * @param  list<string>  $portalDatacenterNames
+     * @return array{
+     *     status: 'imported'|'skipped'|'failed',
+     *     enriched: bool,
+     *     metaworks_unavailable: bool,
+     *     error: string|null
+     * }
+     */
+    private function processDatacenterDataCiteRecord(
+        string $doi,
+        array $doiRecord,
+        array $portalDatacenterNames,
+        DataCiteToResourceTransformer $transformer,
+        MetaworksDownloadUrlService $metaworksService,
+        bool $shouldLookupMetaworks,
+    ): array {
+        try {
+            $result = $this->processDoiRecord(
+                doi: $doi,
+                doiRecord: $doiRecord,
+                transformer: $transformer,
+                metaworksService: $metaworksService,
+                shouldLookupMetaworks: $shouldLookupMetaworks,
+                portalDatacenterNames: $portalDatacenterNames !== []
+                    ? $portalDatacenterNames
+                    : null,
+            );
+
+            return [
+                'status' => $result['status'],
+                'enriched' => $result['enriched'],
+                'metaworks_unavailable' => $result['metaworks_unavailable'],
+                'error' => null,
+            ];
+        } catch (\Throwable $exception) {
+            Log::warning('Failed to import datacenter DOI', [
+                'doi' => $doi,
+                'datacenter_id' => $this->datacenterId,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [
+                'status' => 'failed',
+                'enriched' => false,
+                'metaworks_unavailable' => false,
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
     private function handleSingleImport(
         DataCiteImportService $importService,
         DataCiteToResourceTransformer $transformer,
@@ -492,6 +863,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
     /**
      * @param  array<string, mixed>  $doiRecord
+     * @param  list<string>|null  $portalDatacenterNames
      * @return array{status: 'imported'|'skipped', metaworks_unavailable: bool, enriched: bool}
      */
     private function processDoiRecord(
@@ -500,6 +872,7 @@ class ImportFromDataCiteJob implements ShouldQueue
         DataCiteToResourceTransformer $transformer,
         MetaworksDownloadUrlService $metaworksService,
         bool $shouldLookupMetaworks = true,
+        ?array $portalDatacenterNames = null,
     ): array {
         if ($this->shouldSkipLegacyDoi($doi)) {
             Log::info('Skipping legacy DOI marked as test/delete', ['doi' => $doi]);
@@ -573,7 +946,11 @@ class ImportFromDataCiteJob implements ShouldQueue
             /** @var Resource $importedResource */
             $importedResource = $result['resource'];
 
-            $this->enrichImportedResourceFromLegacyDatabases($importedResource, $doi);
+            $this->enrichImportedResourceFromLegacyDatabases(
+                $importedResource,
+                $doi,
+                $portalDatacenterNames,
+            );
 
             $this->syncDataCiteLandingPageIfAllowed($importedResource, $doi, $preparedDoiRecord);
 
@@ -723,14 +1100,52 @@ class ImportFromDataCiteJob implements ShouldQueue
         ];
     }
 
-    private function enrichImportedResourceFromLegacyDatabases(Resource $resource, string $doi): void
-    {
+    /**
+     * @param  list<string>|null  $portalDatacenterNames
+     */
+    private function enrichImportedResourceFromLegacyDatabases(
+        Resource $resource,
+        string $doi,
+        ?array $portalDatacenterNames = null,
+    ): void {
         if (! $resource->exists) {
             return;
         }
 
         app(SumarioPmdContactEnrichmentService::class)->enrich($resource, $doi);
+
+        if ($portalDatacenterNames !== null && $portalDatacenterNames !== []) {
+            $this->syncPortalDatacenters($resource, $portalDatacenterNames);
+
+            return;
+        }
+
         app(LegacyMetaworksDatacenterLookupService::class)->syncDatacenters($resource, $doi);
+    }
+
+    /**
+     * @param  list<string>  $datacenterNames
+     */
+    private function syncPortalDatacenters(Resource $resource, array $datacenterNames): void
+    {
+        $names = array_values(array_unique(array_filter(
+            array_map(static fn (string $name): string => trim($name), $datacenterNames),
+            static fn (string $name): bool => $name !== '',
+        )));
+
+        if ($names === []) {
+            return;
+        }
+
+        $datacenterIds = array_map(
+            static fn (string $name): int => (int) Datacenter::firstOrCreate(['name' => $name])->id,
+            $names,
+        );
+        $changes = $resource->datacenters()->sync($datacenterIds);
+
+        if (array_filter($changes)) {
+            $resource->touch();
+        }
     }
 
     private function syncDataCiteMetadataIfAllowed(Resource $resource): void
@@ -876,6 +1291,13 @@ class ImportFromDataCiteJob implements ShouldQueue
             : 'completed';
     }
 
+    private function isCancelled(): bool
+    {
+        $currentStatus = Cache::get($this->getCacheKey());
+
+        return isset($currentStatus['status']) && $currentStatus['status'] === 'cancelled';
+    }
+
     /**
      * Handle a job failure.
      */
@@ -904,5 +1326,10 @@ class ImportFromDataCiteJob implements ShouldQueue
     public function getSingleDoi(): ?string
     {
         return $this->singleDoi;
+    }
+
+    public function getDatacenterId(): ?string
+    {
+        return $this->datacenterId;
     }
 }

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -53,6 +53,9 @@ class ImportFromDataCiteJob implements ShouldQueue
      */
     public int $tries = 1;
 
+    /** @var array<string, int> */
+    private array $portalDatacenterIds = [];
+
     /**
      * Create a new job instance.
      *
@@ -388,6 +391,8 @@ class ImportFromDataCiteJob implements ShouldQueue
 
         ksort($targets);
 
+        $this->cacheExistingPortalDatacenterIds($targets);
+
         $total = count($targets);
         $processed = 0;
         $imported = 0;
@@ -476,7 +481,11 @@ class ImportFromDataCiteJob implements ShouldQueue
 
         $scannedDataCiteRecords = 0;
 
-        foreach ($importService->fetchAllDois() as $doiRecord) {
+        $dataCiteRecords = $remainingTargets === []
+            ? []
+            : $importService->fetchAllDois();
+
+        foreach ($dataCiteRecords as $doiRecord) {
             $scannedDataCiteRecords++;
 
             if (($scannedDataCiteRecords === 1 || $scannedDataCiteRecords % 50 === 0) && $this->isCancelled()) {
@@ -524,6 +533,10 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $failedDois,
                 $total,
             );
+
+            if ($remainingTargets === []) {
+                break;
+            }
         }
 
         foreach ($remainingTargets as $doi => $portalDatacenterNames) {
@@ -1128,17 +1141,23 @@ class ImportFromDataCiteJob implements ShouldQueue
      */
     private function syncPortalDatacenters(Resource $resource, array $datacenterNames): void
     {
-        $names = array_values(array_unique(array_filter(
-            array_map(static fn (string $name): string => trim($name), $datacenterNames),
-            static fn (string $name): bool => $name !== '',
-        )));
+        $names = $this->normalizePortalDatacenterNames($datacenterNames);
 
         if ($names === []) {
             return;
         }
 
         $datacenterIds = array_map(
-            static fn (string $name): int => (int) Datacenter::firstOrCreate(['name' => $name])->id,
+            function (string $name): int {
+                if (isset($this->portalDatacenterIds[$name])) {
+                    return $this->portalDatacenterIds[$name];
+                }
+
+                $datacenterId = (int) Datacenter::firstOrCreate(['name' => $name])->id;
+                $this->portalDatacenterIds[$name] = $datacenterId;
+
+                return $datacenterId;
+            },
             $names,
         );
         $changes = $resource->datacenters()->sync($datacenterIds);
@@ -1146,6 +1165,42 @@ class ImportFromDataCiteJob implements ShouldQueue
         if (array_filter($changes)) {
             $resource->touch();
         }
+    }
+
+    /**
+     * @param  array<string, list<string>>  $targets
+     */
+    private function cacheExistingPortalDatacenterIds(array $targets): void
+    {
+        $targetDatacenterNames = [];
+
+        foreach ($targets as $datacenterNames) {
+            foreach ($datacenterNames as $datacenterName) {
+                $targetDatacenterNames[] = $datacenterName;
+            }
+        }
+
+        $names = $this->normalizePortalDatacenterNames($targetDatacenterNames);
+
+        if ($names === []) {
+            return;
+        }
+
+        foreach (Datacenter::query()->whereIn('name', $names)->get(['id', 'name']) as $datacenter) {
+            $this->portalDatacenterIds[$datacenter->name] = (int) $datacenter->id;
+        }
+    }
+
+    /**
+     * @param  list<string>  $datacenterNames
+     * @return list<string>
+     */
+    private function normalizePortalDatacenterNames(array $datacenterNames): array
+    {
+        return array_values(array_unique(array_filter(
+            array_map(static fn (string $name): string => trim($name), $datacenterNames),
+            static fn (string $name): bool => $name !== '',
+        )));
     }
 
     private function syncDataCiteMetadataIfAllowed(Resource $resource): void

--- a/app/Services/GfzDataServicesPortalService.php
+++ b/app/Services/GfzDataServicesPortalService.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+class GfzDataServicesPortalService
+{
+    private const DATACENTER_CACHE_KEY = 'gfz_data_services_portal:datacenters';
+
+    public function __construct(
+        private readonly DoiSuggestionService $doiSuggestionService,
+    ) {}
+
+    /**
+     * @return list<array{id: string, name: string, resource_count: int}>
+     */
+    public function listDatacenters(): array
+    {
+        $ttl = max(0, (int) config('datacite.legacy_portal.datacenter_cache_ttl_seconds', 600));
+
+        if ($ttl === 0) {
+            return $this->fetchDatacenters();
+        }
+
+        /** @var list<array{id: string, name: string, resource_count: int}> $datacenters */
+        $datacenters = Cache::remember(
+            self::DATACENTER_CACHE_KEY,
+            now()->addSeconds($ttl),
+            fn (): array => $this->fetchDatacenters(),
+        );
+
+        return $datacenters;
+    }
+
+    /**
+     * @return array{id: string, name: string, resource_count: int}|null
+     */
+    public function findDatacenter(string $id): ?array
+    {
+        $id = trim($id);
+
+        foreach ($this->listDatacenters() as $datacenter) {
+            if (hash_equals($datacenter['id'], $id)) {
+                return $datacenter;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{
+     *     datacenter: array{id: string, name: string, resource_count: int},
+     *     resources: array<string, list<string>>
+     * }
+     */
+    public function resourcesForDatacenter(string $id): array
+    {
+        $datacenter = $this->findDatacenter($id);
+
+        if ($datacenter === null) {
+            throw new RuntimeException('The selected GFZ Data Services datacenter is no longer available.');
+        }
+
+        $pageSize = max(1, min(
+            1000,
+            (int) config('datacite.legacy_portal.page_size', 500),
+        ));
+        $start = 0;
+        $total = null;
+        /** @var array<string, list<string>> $resources */
+        $resources = [];
+
+        do {
+            $response = $this->postQuery([
+                'q' => '*:*',
+                'rows' => $pageSize,
+                'start' => $start,
+                'fl' => 'doi,datacentre_facet',
+                'sort' => 'doi asc',
+                'json.nl' => 'map',
+                'fq' => sprintf(
+                    'datacentre_facet:"%s" AND -type:text',
+                    $this->escapeSolrQuotedValue($this->facetValue($datacenter)),
+                ),
+            ]);
+            $payload = $this->jsonPayload($response);
+            $responseData = $payload['response'] ?? null;
+
+            if (! is_array($responseData)) {
+                throw new RuntimeException('The GFZ Data Services portal returned an invalid resource response.');
+            }
+
+            $pageTotal = $responseData['numFound'] ?? null;
+            $documents = $responseData['docs'] ?? null;
+
+            if (! is_numeric($pageTotal) || ! is_array($documents)) {
+                throw new RuntimeException('The GFZ Data Services portal resource response is incomplete.');
+            }
+
+            $total ??= max(0, (int) $pageTotal);
+
+            foreach ($documents as $document) {
+                if (! is_array($document) || ! is_string($document['doi'] ?? null)) {
+                    Log::warning('Skipping malformed GFZ Data Services portal resource', [
+                        'datacenter_id' => $datacenter['id'],
+                    ]);
+
+                    continue;
+                }
+
+                $doi = $this->doiSuggestionService->normalizeDoi($document['doi']);
+
+                if ($doi === '' || ! $this->doiSuggestionService->isValidDoiFormat($doi)) {
+                    Log::warning('Skipping invalid DOI from GFZ Data Services portal', [
+                        'datacenter_id' => $datacenter['id'],
+                    ]);
+
+                    continue;
+                }
+
+                $names = $this->datacenterNamesFromDocument($document);
+
+                if ($names === []) {
+                    $names = [$datacenter['name']];
+                }
+
+                $resources[$doi] = array_values(array_unique(array_merge(
+                    $resources[$doi] ?? [],
+                    $names,
+                )));
+            }
+
+            $documentCount = count($documents);
+            $start += $documentCount;
+
+            if ($documentCount === 0 && $start < $total) {
+                throw new RuntimeException('The GFZ Data Services portal pagination ended unexpectedly.');
+            }
+        } while ($start < $total);
+
+        ksort($resources);
+
+        return [
+            'datacenter' => $datacenter,
+            'resources' => $resources,
+        ];
+    }
+
+    public function clearDatacenterCache(): void
+    {
+        Cache::forget(self::DATACENTER_CACHE_KEY);
+    }
+
+    /**
+     * @return list<array{id: string, name: string, resource_count: int}>
+     */
+    private function fetchDatacenters(): array
+    {
+        $response = $this->postQuery([
+            'q' => '*:*',
+            'facet' => 'true',
+            'facet.field' => 'datacentre_facet',
+            'facet.limit' => 196,
+            'facet.mincount' => 1,
+            'rows' => 0,
+            'json.nl' => 'map',
+            'fq' => '-type:text',
+        ]);
+        $payload = $this->jsonPayload($response);
+        $facets = $payload['facet_counts']['facet_fields']['datacentre_facet'] ?? null;
+
+        if (! is_array($facets)) {
+            throw new RuntimeException('The GFZ Data Services portal returned an invalid datacenter response.');
+        }
+
+        $datacenters = [];
+
+        foreach ($facets as $facetValue => $count) {
+            if (! is_string($facetValue) || ! is_numeric($count)) {
+                continue;
+            }
+
+            $parsed = $this->parseFacetValue($facetValue);
+
+            if ($parsed === null) {
+                Log::warning('Skipping malformed GFZ Data Services datacenter facet');
+
+                continue;
+            }
+
+            $datacenters[$parsed['id']] = [
+                'id' => $parsed['id'],
+                'name' => $parsed['name'],
+                'resource_count' => max(0, (int) $count),
+            ];
+        }
+
+        $datacenters = array_values($datacenters);
+
+        usort(
+            $datacenters,
+            static fn (array $left, array $right): int => strcasecmp($left['name'], $right['name']),
+        );
+
+        return $datacenters;
+    }
+
+    /**
+     * @param  array<string, scalar>  $parameters
+     */
+    private function postQuery(array $parameters): Response
+    {
+        $url = trim((string) config('datacite.legacy_portal.proxy_url'));
+
+        if ($url === '' || ! str_starts_with($url, 'https://')) {
+            throw new RuntimeException('The GFZ Data Services portal proxy URL must use HTTPS.');
+        }
+
+        try {
+            $response = Http::asForm()
+                ->acceptJson()
+                ->timeout(max(1, (int) config('datacite.legacy_portal.timeout_seconds', 30)))
+                ->retry(
+                    max(1, (int) config('datacite.legacy_portal.retry_times', 3)),
+                    max(0, (int) config('datacite.legacy_portal.retry_sleep_ms', 500)),
+                    throw: false,
+                )
+                ->post($url, [
+                    'query' => http_build_query($parameters, '', '&', PHP_QUERY_RFC3986),
+                ]);
+        } catch (ConnectionException $exception) {
+            throw new RuntimeException(
+                'The GFZ Data Services portal could not be reached.',
+                previous: $exception,
+            );
+        }
+
+        if (! $response->successful()) {
+            throw new RuntimeException(sprintf(
+                'The GFZ Data Services portal request failed with HTTP %d.',
+                $response->status(),
+            ));
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonPayload(Response $response): array
+    {
+        $payload = $response->json();
+
+        if (! is_array($payload)) {
+            throw new RuntimeException('The GFZ Data Services portal returned invalid JSON.');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array{id: string, name: string}|null
+     */
+    private function parseFacetValue(string $value): ?array
+    {
+        $parts = explode(' - ', trim($value), 2);
+
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        $id = trim($parts[0]);
+        $name = trim($parts[1]);
+
+        if ($id === '' || $name === '') {
+            return null;
+        }
+
+        return [
+            'id' => $id,
+            'name' => $name,
+        ];
+    }
+
+    /**
+     * @param  array{id: string, name: string, resource_count: int}  $datacenter
+     */
+    private function facetValue(array $datacenter): string
+    {
+        return "{$datacenter['id']} - {$datacenter['name']}";
+    }
+
+    private function escapeSolrQuotedValue(string $value): string
+    {
+        return str_replace(
+            ['\\', '"'],
+            ['\\\\', '\\"'],
+            $value,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return list<string>
+     */
+    private function datacenterNamesFromDocument(array $document): array
+    {
+        $rawFacets = $document['datacentre_facet'] ?? [];
+        $facetValues = is_array($rawFacets) ? $rawFacets : [$rawFacets];
+        $names = [];
+
+        foreach ($facetValues as $facetValue) {
+            if (! is_string($facetValue)) {
+                continue;
+            }
+
+            $parsed = $this->parseFacetValue($facetValue);
+
+            if ($parsed !== null) {
+                $names[] = $parsed['name'];
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+}

--- a/app/Services/SumarioPendingResourceImportService.php
+++ b/app/Services/SumarioPendingResourceImportService.php
@@ -91,6 +91,50 @@ class SumarioPendingResourceImportService
     }
 
     /**
+     * @return list<string>
+     */
+    public function importablePendingDoisForDatacenter(string $datacenterName): array
+    {
+        $datacenterName = trim($datacenterName);
+
+        if ($datacenterName === '') {
+            return [];
+        }
+
+        /** @var iterable<int, OldDataset> $pendingDatasets */
+        $pendingDatasets = OldDataset::query()
+            ->where('publicstatus', 'pending')
+            ->whereNotNull('identifier')
+            ->where('identifier', '!=', '')
+            ->orderBy('id')
+            ->cursor();
+
+        $dois = [];
+        $seenDois = [];
+
+        foreach ($pendingDatasets as $oldDataset) {
+            $doi = $this->normaliseDoi((string) $oldDataset->identifier);
+
+            if ($doi === '' || isset($seenDois[$doi]) || $this->shouldSkipLegacyDoi($doi)) {
+                continue;
+            }
+
+            $seenDois[$doi] = true;
+
+            if (! in_array($datacenterName, $this->datacenterLookup->resolveDatacenterNames($doi), true)) {
+                continue;
+            }
+
+            $dois[$doi] = true;
+        }
+
+        $dois = array_keys($dois);
+        sort($dois);
+
+        return $dois;
+    }
+
+    /**
      * @return array{processed: int, imported: int, skipped: int, failed: int, skipped_dois: list<string>, failed_dois: list<array{doi: string, error: string}>}
      */
     public function importAllPending(int $userId, int $maxStoredDois = 100): array

--- a/config/datacite.php
+++ b/config/datacite.php
@@ -50,6 +50,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | GFZ Data Services Legacy Portal
+    |--------------------------------------------------------------------------
+    |
+    | The legacy portal exposes the authoritative datacentre_facet values used
+    | to group published GFZ resources. ERNIE accesses the proxy server-side;
+    | browsers never receive raw Solr query access.
+    |
+    */
+    'legacy_portal' => [
+        'proxy_url' => env(
+            'GFZ_DATA_SERVICES_PORTAL_PROXY_URL',
+            'https://dataservices.gfz-potsdam.de/portal/proxy/proxy.php'
+        ),
+        'timeout_seconds' => (int) env('GFZ_DATA_SERVICES_PORTAL_TIMEOUT', 30),
+        'retry_times' => (int) env('GFZ_DATA_SERVICES_PORTAL_RETRY_TIMES', 3),
+        'retry_sleep_ms' => (int) env('GFZ_DATA_SERVICES_PORTAL_RETRY_SLEEP_MS', 500),
+        'page_size' => (int) env('GFZ_DATA_SERVICES_PORTAL_PAGE_SIZE', 500),
+        'datacenter_cache_ttl_seconds' => (int) env('GFZ_DATA_SERVICES_PORTAL_CACHE_TTL', 600),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | DataCite Test API Configuration
     |--------------------------------------------------------------------------
     |

--- a/config/datacite.php
+++ b/config/datacite.php
@@ -61,7 +61,7 @@ return [
     'legacy_portal' => [
         'proxy_url' => env(
             'GFZ_DATA_SERVICES_PORTAL_PROXY_URL',
-            'https://dataservices.gfz-potsdam.de/portal/proxy/proxy.php'
+            'https://dataservices.gfz-potsdam.de/portal/proxy/proxy.php',
         ),
         'timeout_seconds' => (int) env('GFZ_DATA_SERVICES_PORTAL_TIMEOUT', 30),
         'retry_times' => (int) env('GFZ_DATA_SERVICES_PORTAL_RETRY_TIMES', 3),

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -5,7 +5,7 @@
         "features": [
             {
                 "title": "Legacy Resource Import by Datacenter",
-                "description": "Admins and Group Leaders can now import legacy resources for one current GFZ Data Services portal datacenter from the Resources page. Published assignments come from the portal facet, while matching pending SUMARIO resources continue to use the legacy databases, DOI rules, and the established general-GFZ fallback. Portal assignments are applied to newly imported resources only; existing ERNIE resources and their datacenter assignments remain unchanged."
+                "description": "Admins and Group Leaders can now import legacy resources for one current GFZ Data Services portal datacenter from the Resources page. Published assignments come from the portal facet, while matching pending SUMARIO resources continue to use the legacy databases, DOI rules, and the established general-GFZ fallback. Portal assignments are applied to newly imported resources only. Existing ERNIE resources are not overwritten and retain their datacenter assignments, but they may still be enriched with missing legacy download links or an external landing page URL from DataCite."
             },
             {
                 "title": "Admin Database Dump Exports",

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-07-13",
         "features": [
             {
+                "title": "Legacy Resource Import by Datacenter",
+                "description": "Admins and Group Leaders can now import legacy resources for one current GFZ Data Services portal datacenter from the Resources page. Published assignments come from the portal facet, while matching pending SUMARIO resources continue to use the legacy databases, DOI rules, and the established general-GFZ fallback. Portal assignments are applied to newly imported resources only; existing ERNIE resources and their datacenter assignments remain unchanged."
+            },
+            {
                 "title": "Admin Database Dump Exports",
                 "description": "Admins can now open the new /database page from the Administration workspace to queue downloadable compressed database dumps for the ERNIE application database and configured legacy metadata databases. Exports are audited, expire automatically, and the scheduled cleanup command removes expired dump files so private exports are not kept indefinitely."
             },

--- a/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
+++ b/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
@@ -8,7 +8,9 @@ import { DataCiteIcon } from '@/components/icons/datacite-icon';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Combobox } from '@/components/ui/combobox';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { Spinner } from '@/components/ui/spinner';
 import { buildCsrfHeaders } from '@/lib/csrf-token';
@@ -27,25 +29,58 @@ interface ImportProgress {
     started_at?: string;
     completed_at?: string;
     error?: string;
+    warnings?: string[];
+    datacenter?: PortalDatacenter;
+}
+
+interface PortalDatacenter {
+    id: string;
+    name: string;
+    resource_count: number;
 }
 
 interface ImportFromDataCiteModalProps {
     isOpen: boolean;
     onClose: () => void;
     onSuccess?: () => void;
+    mode?: 'all' | 'datacenter';
 }
 
 type ModalState = 'confirm' | 'running' | 'completed' | 'failed';
 
-export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: ImportFromDataCiteModalProps) {
+export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess, mode = 'all' }: ImportFromDataCiteModalProps) {
+    const isDatacenterMode = mode === 'datacenter';
     const [modalState, setModalState] = useState<ModalState>('confirm');
     const [importId, setImportId] = useState<string | null>(null);
     const [progress, setProgress] = useState<ImportProgress | null>(null);
     const [isStarting, setIsStarting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [datacenters, setDatacenters] = useState<PortalDatacenter[]>([]);
+    const [selectedDatacenterId, setSelectedDatacenterId] = useState('');
+    const [isLoadingDatacenters, setIsLoadingDatacenters] = useState(false);
+    const [datacenterLoadError, setDatacenterLoadError] = useState<string | null>(null);
     const [showSkippedDois, setShowSkippedDois] = useState(false);
     const [showFailedDois, setShowFailedDois] = useState(false);
     const hasNotifiedSuccessRef = useRef(false);
+
+    const loadDatacenters = useCallback(async () => {
+        setIsLoadingDatacenters(true);
+        setDatacenterLoadError(null);
+
+        try {
+            const response = await axios.get<{ datacenters: PortalDatacenter[] }>('/datacite/import/datacenters');
+            setDatacenters(response.data.datacenters);
+        } catch (err) {
+            const message =
+                isAxiosError(err) && typeof err.response?.data?.message === 'string'
+                    ? err.response.data.message
+                    : 'The datacenter list could not be loaded. Please try again.';
+            setDatacenters([]);
+            setDatacenterLoadError(message);
+        } finally {
+            setIsLoadingDatacenters(false);
+        }
+    }, []);
 
     useEffect(() => {
         if (!isOpen) {
@@ -54,11 +89,21 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
             setProgress(null);
             setIsStarting(false);
             setError(null);
+            setDatacenters([]);
+            setSelectedDatacenterId('');
+            setIsLoadingDatacenters(false);
+            setDatacenterLoadError(null);
             setShowSkippedDois(false);
             setShowFailedDois(false);
             hasNotifiedSuccessRef.current = false;
         }
     }, [isOpen]);
+
+    useEffect(() => {
+        if (isOpen && isDatacenterMode && modalState === 'confirm') {
+            void loadDatacenters();
+        }
+    }, [isDatacenterMode, isOpen, loadDatacenters, modalState]);
 
     useEffect(() => {
         const changedCount = (progress?.imported ?? 0) + (progress?.enriched ?? 0);
@@ -127,12 +172,22 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
     }, [importId, modalState]);
 
     const startImport = useCallback(async () => {
+        if (isDatacenterMode && selectedDatacenterId === '') {
+            setError('Select a datacenter before starting the import.');
+
+            return;
+        }
+
         setIsStarting(true);
         setError(null);
         hasNotifiedSuccessRef.current = false;
 
         try {
-            const response = await axios.post<{ import_id: string; message: string }>('/datacite/import/start', {}, { headers: buildCsrfHeaders() });
+            const endpoint = isDatacenterMode ? '/datacite/import/start-datacenter' : '/datacite/import/start';
+            const payload = isDatacenterMode ? { datacenter_id: selectedDatacenterId } : {};
+            const response = await axios.post<{ import_id: string; message: string }>(endpoint, payload, {
+                headers: buildCsrfHeaders(),
+            });
 
             setImportId(response.data.import_id);
             setModalState('running');
@@ -149,8 +204,9 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
                 failed_dois: [],
             });
 
+            const selectedDatacenter = datacenters.find((datacenter) => datacenter.id === selectedDatacenterId);
             toast.info('Import started', {
-                description: 'Fetching DOIs from DataCite...',
+                description: selectedDatacenter ? `Fetching resources for ${selectedDatacenter.name}...` : 'Fetching DOIs from DataCite...',
             });
         } catch (err) {
             console.error('Failed to start import:', err);
@@ -177,7 +233,7 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
         } finally {
             setIsStarting(false);
         }
-    }, []);
+    }, [datacenters, isDatacenterMode, selectedDatacenterId]);
 
     const handleClose = useCallback(() => {
         onClose();
@@ -277,16 +333,21 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
         </div>
     ) : null;
 
+    const selectedDatacenter = datacenters.find((datacenter) => datacenter.id === selectedDatacenterId);
+
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
             <DialogContent className="max-w-lg">
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
                         <DataCiteIcon className="size-5" />
-                        Import all old Resources
+                        {isDatacenterMode ? 'Import all Resources from a Datacenter' : 'Import all old Resources'}
                     </DialogTitle>
                     <DialogDescription>
-                        {modalState === 'confirm' && 'Import all registered GFZ legacy resources from the DataCite production API into ERNIE.'}
+                        {modalState === 'confirm' &&
+                            (isDatacenterMode
+                                ? 'Import legacy resources for one GFZ Data Services datacenter into ERNIE.'
+                                : 'Import all registered GFZ legacy resources from the DataCite production API into ERNIE.')}
                         {modalState === 'running' && 'Import is in progress...'}
                         {modalState === 'completed' && 'Import completed successfully.'}
                         {modalState === 'failed' && 'Import failed.'}
@@ -296,15 +357,67 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
                 <div className="py-4">
                     {modalState === 'confirm' && (
                         <div className="space-y-4">
+                            {isDatacenterMode && (
+                                <div className="space-y-2">
+                                    <Label htmlFor="legacy-datacenter">Datacenter</Label>
+                                    <Combobox
+                                        id="legacy-datacenter"
+                                        value={selectedDatacenterId || undefined}
+                                        onChange={(value) => setSelectedDatacenterId(value ?? '')}
+                                        options={datacenters.map((datacenter) => ({
+                                            value: datacenter.id,
+                                            label: `${datacenter.name} (${datacenter.resource_count.toLocaleString()} visible)`,
+                                        }))}
+                                        placeholder={isLoadingDatacenters ? 'Loading datacenters...' : 'Select a datacenter'}
+                                        searchPlaceholder="Search datacenters..."
+                                        emptyMessage="No matching datacenter found."
+                                        disabled={isLoadingDatacenters || datacenters.length === 0}
+                                        clearable={false}
+                                    />
+
+                                    {selectedDatacenter && (
+                                        <p className="text-xs text-muted-foreground">
+                                            {selectedDatacenter.resource_count.toLocaleString()} visible portal resources; matching pending resources
+                                            are included from the legacy databases.
+                                        </p>
+                                    )}
+
+                                    {!isLoadingDatacenters && !datacenterLoadError && datacenters.length === 0 && (
+                                        <p className="text-sm text-muted-foreground">No current portal datacenters are available.</p>
+                                    )}
+
+                                    {datacenterLoadError && (
+                                        <Alert variant="destructive">
+                                            <AlertCircle className="size-4" />
+                                            <AlertTitle>Datacenter list unavailable</AlertTitle>
+                                            <AlertDescription className="space-y-3">
+                                                <p>{datacenterLoadError}</p>
+                                                <Button type="button" variant="outline" size="sm" onClick={() => void loadDatacenters()}>
+                                                    Try again
+                                                </Button>
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+                                </div>
+                            )}
+
                             <Alert>
                                 <Download className="size-4" />
                                 <AlertTitle>What will happen?</AlertTitle>
                                 <AlertDescription>
                                     <ul className="mt-2 list-inside list-disc space-y-1 text-sm">
-                                        <li>All DOIs registered with your GFZ DataCite credentials will be fetched</li>
+                                        <li>
+                                            {isDatacenterMode
+                                                ? 'Visible resources are selected through the GFZ Data Services portal'
+                                                : 'All DOIs registered with your GFZ DataCite credentials will be fetched'}
+                                        </li>
+                                        {isDatacenterMode && (
+                                            <li>Matching pending SUMARIO resources are selected through the legacy databases and DOI rules</li>
+                                        )}
                                         <li>DOIs already in ERNIE will not be overwritten</li>
                                         <li>Missing legacy download links can be added to existing Resources</li>
                                         <li>New legacy DOIs will be imported as Resources</li>
+                                        {isDatacenterMode && <li>Portal datacenter assignments are applied only to newly imported Resources</li>}
                                         <li>You will see a summary of imported, links added, skipped, and failed DOIs after completion</li>
                                     </ul>
                                 </AlertDescription>
@@ -319,6 +432,15 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
                             )}
                         </div>
                     )}
+
+                    {modalState !== 'confirm' &&
+                        progress?.warnings?.map((warning) => (
+                            <Alert key={warning} className="mb-4">
+                                <AlertCircle className="size-4" />
+                                <AlertTitle>Import warning</AlertTitle>
+                                <AlertDescription>{warning}</AlertDescription>
+                            </Alert>
+                        ))}
 
                     {modalState === 'running' && progress && (
                         <div className="space-y-4">
@@ -420,7 +542,10 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess }: 
                             <Button variant="outline" onClick={handleClose}>
                                 Cancel
                             </Button>
-                            <Button onClick={startImport} disabled={isStarting}>
+                            <Button
+                                onClick={startImport}
+                                disabled={isStarting || (isDatacenterMode && (selectedDatacenterId === '' || isLoadingDatacenters))}
+                            >
                                 {isStarting ? (
                                     <>
                                         <Spinner size="sm" className="mr-2" />

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -2085,16 +2085,29 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <h4>Import Existing GFZ Legacy Resources</h4>
                         <p>
-                            Admins and Group Leaders see two import actions to the right of the bulk toolbar on the <code>/resources</code> page:
+                            Admins and Group Leaders see three import actions to the right of the bulk toolbar on the <code>/resources</code> page:
                         </p>
                         <ul className="list-inside list-disc space-y-1">
                             <li>
                                 <strong>Import all old Resources</strong> starts the existing background import of all GFZ DataCite resources.
                             </li>
                             <li>
+                                <strong>Import all Resources from a Datacenter</strong> loads the current datacenter list from the GFZ Data Services
+                                portal and imports resources for one selected datacenter.
+                            </li>
+                            <li>
                                 <strong>Import old single Resource</strong> opens a dialog for a single DOI.
                             </li>
                         </ul>
+                        <p>
+                            The datacenter import uses the portal assignment for visible resources. It also includes matching pending SUMARIO
+                            resources, whose datacenter is determined from the legacy databases and the established DOI rules. Pending resources
+                            without a more specific assignment remain part of the general GFZ datacenter through the existing fallback.
+                        </p>
+                        <p>
+                            Datacenter assignments from the portal are applied only to newly imported resources. Resources that already exist in
+                            ERNIE are skipped without changing their metadata or current datacenter assignments.
+                        </p>
                         <p>
                             The single-resource dialog accepts either a bare DOI such as <code>10.5880/GFZ.OJSJ.2026.001</code> or a DOI URL such as{' '}
                             <code>https://doi.org/10.5880/GFZ.OJSJ.2026.001</code>. The DOI must also exist in the GFZ legacy database before the

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -2105,8 +2105,9 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             without a more specific assignment remain part of the general GFZ datacenter through the existing fallback.
                         </p>
                         <p>
-                            Datacenter assignments from the portal are applied only to newly imported resources. Resources that already exist in
-                            ERNIE are skipped without changing their metadata or current datacenter assignments.
+                            Datacenter assignments from the portal are applied only to newly imported resources. Resources that already exist in ERNIE
+                            are not re-imported or overwritten, and their current datacenter assignments are preserved. Where applicable, the job may
+                            still enrich them with missing legacy download links or an external landing page URL from DataCite.
                         </p>
                         <p>
                             The single-resource dialog accepts either a bare DOI such as <code>10.5880/GFZ.OJSJ.2026.001</code> or a DOI URL such as{' '}

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -648,6 +648,7 @@ function ResourcesPage({
     const [loading, setLoading] = useState(false);
     const [loadingError, setLoadingError] = useState<string | null>(null);
     const [showImportModal, setShowImportModal] = useState(false);
+    const [showDatacenterImportModal, setShowDatacenterImportModal] = useState(false);
     const [showSingleImportModal, setShowSingleImportModal] = useState(false);
     const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
     const [isBulkRegistering, setIsBulkRegistering] = useState(false);
@@ -1936,6 +1937,15 @@ function ResourcesPage({
                                     <Button
                                         variant="outline"
                                         size="default"
+                                        onClick={() => setShowDatacenterImportModal(true)}
+                                        className="flex items-center gap-2"
+                                    >
+                                        <DataCiteIcon className="size-4" aria-hidden="true" />
+                                        Import all Resources from a Datacenter
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        size="default"
                                         onClick={() => setShowSingleImportModal(true)}
                                         className="flex items-center gap-2"
                                     >
@@ -2158,6 +2168,14 @@ function ResourcesPage({
 
             {/* Import from DataCite Modal */}
             <ImportFromDataCiteModal isOpen={showImportModal} onClose={() => setShowImportModal(false)} onSuccess={handleImportSuccess} />
+
+            {/* Import old resources for one portal datacenter */}
+            <ImportFromDataCiteModal
+                isOpen={showDatacenterImportModal}
+                onClose={() => setShowDatacenterImportModal(false)}
+                onSuccess={handleImportSuccess}
+                mode="datacenter"
+            />
 
             {/* Import Single Old Resource Modal */}
             <ImportSingleOldResourceModal

--- a/routes/web.php
+++ b/routes/web.php
@@ -420,11 +420,17 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('resources.destroy');
 
     // DataCite Import (Admin/Group Leader only)
+    Route::get('datacite/import/datacenters', [DataCiteImportController::class, 'datacenters'])
+        ->name('datacite.import.datacenters');
+
     Route::post('datacite/import/start', [DataCiteImportController::class, 'start'])
         ->name('datacite.import.start');
 
     Route::post('datacite/import/start-single', [DataCiteImportController::class, 'startSingle'])
         ->name('datacite.import.start-single');
+
+    Route::post('datacite/import/start-datacenter', [DataCiteImportController::class, 'startDatacenter'])
+        ->name('datacite.import.start-datacenter');
 
     Route::get('datacite/import/{importId}/status', [DataCiteImportController::class, 'status'])
         ->name('datacite.import.status');

--- a/tests/pest/Feature/DataCiteImport/DataCiteDatacenterImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteDatacenterImportControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Jobs\ImportFromDataCiteJob;
+use App\Models\User;
+use App\Services\GfzDataServicesPortalService;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    Bus::fake();
+
+    $this->admin = User::factory()->create(['role' => UserRole::ADMIN]);
+    $this->groupLeader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
+    $this->curator = User::factory()->create(['role' => UserRole::CURATOR]);
+    $this->beginner = User::factory()->create(['role' => UserRole::BEGINNER]);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+function mockPortalDatacenters(array $datacenters): GfzDataServicesPortalService
+{
+    $portalService = Mockery::mock(GfzDataServicesPortalService::class);
+    $portalService
+        ->shouldReceive('listDatacenters')
+        ->zeroOrMoreTimes()
+        ->andReturn($datacenters);
+
+    app()->instance(GfzDataServicesPortalService::class, $portalService);
+
+    return $portalService;
+}
+
+describe('datacenter import endpoints', function () {
+    it('returns the portal datacenters to authorized users', function () {
+        mockPortalDatacenters([
+            ['id' => 'GFZ', 'name' => 'GFZ Data Services', 'resource_count' => 1200],
+            ['id' => 'ArboDat', 'name' => 'ArboDat 2016', 'resource_count' => 172],
+        ]);
+
+        $response = $this->actingAs($this->groupLeader)
+            ->getJson('/datacite/import/datacenters');
+
+        $response
+            ->assertOk()
+            ->assertExactJson([
+                'datacenters' => [
+                    ['id' => 'GFZ', 'name' => 'GFZ Data Services', 'resource_count' => 1200],
+                    ['id' => 'ArboDat', 'name' => 'ArboDat 2016', 'resource_count' => 172],
+                ],
+            ]);
+    });
+
+    it('rejects users without DataCite import permission', function () {
+        mockPortalDatacenters([]);
+
+        $this->actingAs($this->curator)
+            ->getJson('/datacite/import/datacenters')
+            ->assertForbidden();
+
+        $this->actingAs($this->curator)
+            ->postJson('/datacite/import/start-datacenter', ['datacenter_id' => 'GFZ'])
+            ->assertForbidden();
+
+        $this->actingAs($this->beginner)
+            ->getJson('/datacite/import/datacenters')
+            ->assertForbidden();
+
+        Bus::assertNothingDispatched();
+    });
+
+    it('requires authentication for both datacenter endpoints', function () {
+        $this->getJson('/datacite/import/datacenters')->assertUnauthorized();
+        $this->postJson('/datacite/import/start-datacenter', ['datacenter_id' => 'GFZ'])
+            ->assertUnauthorized();
+    });
+
+    it('returns a safe service-unavailable response when the portal list fails', function () {
+        $portalService = Mockery::mock(GfzDataServicesPortalService::class);
+        $portalService
+            ->shouldReceive('listDatacenters')
+            ->once()
+            ->andThrow(new RuntimeException('Internal upstream details'));
+        app()->instance(GfzDataServicesPortalService::class, $portalService);
+
+        $this->actingAs($this->admin)
+            ->getJson('/datacite/import/datacenters')
+            ->assertStatus(503)
+            ->assertExactJson([
+                'message' => 'The GFZ Data Services datacenter list is currently unavailable. Please try again later.',
+            ])
+            ->assertDontSee('Internal upstream details');
+    });
+
+    it('validates that a datacenter was selected', function () {
+        mockPortalDatacenters([]);
+
+        $this->actingAs($this->admin)
+            ->postJson('/datacite/import/start-datacenter')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('datacenter_id');
+
+        Bus::assertNothingDispatched();
+    });
+
+    it('rejects a datacenter that disappeared from the current portal facets', function () {
+        $portalService = mockPortalDatacenters([]);
+        $portalService
+            ->shouldReceive('findDatacenter')
+            ->once()
+            ->with('retired')
+            ->andReturnNull();
+
+        $this->actingAs($this->admin)
+            ->postJson('/datacite/import/start-datacenter', ['datacenter_id' => 'retired'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('datacenter_id');
+
+        Bus::assertNothingDispatched();
+    });
+
+    it('starts a datacenter job and initializes progress', function () {
+        $portalService = mockPortalDatacenters([]);
+        $portalService
+            ->shouldReceive('findDatacenter')
+            ->once()
+            ->with('ArboDat')
+            ->andReturn([
+                'id' => 'ArboDat',
+                'name' => 'ArboDat 2016',
+                'resource_count' => 172,
+            ]);
+
+        $response = $this->actingAs($this->groupLeader)
+            ->postJson('/datacite/import/start-datacenter', ['datacenter_id' => ' ArboDat ']);
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'message' => 'Datacenter import started successfully',
+            ]);
+
+        $importId = $response->json('import_id');
+
+        expect($importId)->toBeString()
+            ->and(Cache::get("datacite_import:{$importId}"))
+            ->toMatchArray([
+                'status' => 'pending',
+                'total' => 0,
+                'processed' => 0,
+            ]);
+
+        Bus::assertDispatched(
+            ImportFromDataCiteJob::class,
+            fn (ImportFromDataCiteJob $job): bool => $job->getDatacenterId() === 'ArboDat'
+                && $job->getSingleDoi() === null,
+        );
+    });
+
+    it('does not dispatch when current datacenter validation is unavailable', function () {
+        $portalService = mockPortalDatacenters([]);
+        $portalService
+            ->shouldReceive('findDatacenter')
+            ->once()
+            ->andThrow(new RuntimeException('portal timeout'));
+
+        $this->actingAs($this->admin)
+            ->postJson('/datacite/import/start-datacenter', ['datacenter_id' => 'GFZ'])
+            ->assertStatus(503);
+
+        Bus::assertNothingDispatched();
+    });
+});

--- a/tests/pest/Feature/DataCiteImport/DataCiteDatacenterImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteDatacenterImportControllerTest.php
@@ -118,7 +118,12 @@ describe('datacenter import endpoints', function () {
         $this->actingAs($this->admin)
             ->postJson('/datacite/import/start-datacenter', ['datacenter_id' => 'retired'])
             ->assertUnprocessable()
-            ->assertJsonValidationErrors('datacenter_id');
+            ->assertJsonPath('message', 'The selected datacenter is no longer available. Reload the list and try again.')
+            ->assertJsonValidationErrors('datacenter_id')
+            ->assertJsonPath(
+                'errors.datacenter_id.0',
+                'The selected datacenter is no longer available. Reload the list and try again.',
+            );
 
         Bus::assertNothingDispatched();
     });

--- a/tests/pest/Feature/DataCiteImport/ImportDatacenterFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportDatacenterFromDataCiteJobTest.php
@@ -15,6 +15,7 @@ use App\Services\MetaworksDownloadUrlService;
 use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 beforeEach(function () {
@@ -100,12 +101,15 @@ describe('datacenter-scoped DataCite import job', function () {
             ->once()
             ->with('ArboDat 2016')
             ->andReturn([]);
+        $streamAdvancedAfterFinalTarget = false;
         $this->importService
             ->shouldReceive('fetchAllDois')
             ->once()
-            ->andReturn((function () {
+            ->andReturn((function () use (&$streamAdvancedAfterFinalTarget) {
                 yield datacenterDoiRecord('10.5880/not-selected');
                 yield datacenterDoiRecord('10.5880/selected');
+                $streamAdvancedAfterFinalTarget = true;
+                yield datacenterDoiRecord('10.5880/after-final-target');
             })());
         $this->transformer
             ->shouldReceive('transform')
@@ -138,7 +142,141 @@ describe('datacenter-scoped DataCite import job', function () {
             ->and($resource->datacenters()->pluck('name')->sort()->values()->all())
             ->toBe(['ArboDat 2016', 'GFZ Data Services'])
             ->and(Resource::query()->where('doi', '10.5880/not-selected')->exists())
+            ->toBeFalse()
+            ->and($streamAdvancedAfterFinalTarget)
+            ->toBeFalse()
+            ->and(Resource::query()->where('doi', '10.5880/after-final-target')->exists())
             ->toBeFalse();
+    });
+
+    it('does not start the DataCite bulk stream when there are no targets', function () {
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->with('ArboDat')
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'ArboDat',
+                    'name' => 'ArboDat 2016',
+                    'resource_count' => 0,
+                ],
+                'resources' => [],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('ArboDat 2016')
+            ->andReturn([]);
+        $this->importService->shouldReceive('fetchAllDois')->never();
+        $this->importService->shouldReceive('fetchSingleDoi')->never();
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'ArboDat'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}"))
+            ->toMatchArray([
+                'status' => 'completed',
+                'total' => 0,
+                'processed' => 0,
+                'imported' => 0,
+                'skipped' => 0,
+                'failed' => 0,
+            ]);
+    });
+
+    it('bulk-loads existing datacenter ids and caches newly resolved ids across resources', function () {
+        Datacenter::query()->create(['name' => 'Existing portal datacenter']);
+
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->with('Existing')
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'Existing',
+                    'name' => 'Existing portal datacenter',
+                    'resource_count' => 2,
+                ],
+                'resources' => [
+                    '10.5880/cache-one' => [
+                        'Existing portal datacenter',
+                        'New shared datacenter',
+                    ],
+                    '10.5880/cache-two' => [
+                        'Existing portal datacenter',
+                        'New shared datacenter',
+                    ],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('Existing portal datacenter')
+            ->andReturn([]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield datacenterDoiRecord('10.5880/cache-one');
+                yield datacenterDoiRecord('10.5880/cache-two');
+            })());
+        $this->transformer
+            ->shouldReceive('transform')
+            ->twice()
+            ->andReturnUsing(
+                fn (array $doiRecord): Resource => Resource::factory()->create([
+                    'doi' => $doiRecord['attributes']['doi'],
+                ]),
+            );
+
+        $queries = [];
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        try {
+            $importId = Str::uuid()->toString();
+            (new ImportFromDataCiteJob($this->user->id, $importId, null, 'Existing'))
+                ->handle($this->importService, $this->transformer, $this->metaworksService);
+        } finally {
+            $queries = DB::getQueryLog();
+            DB::disableQueryLog();
+        }
+
+        $datacenterQueries = array_values(array_filter(
+            $queries,
+            static fn (array $query): bool => preg_match(
+                '/\b(?:from|into)\s+["`\[]?datacenters["`\]]?/i',
+                $query['query'],
+            ) === 1,
+        ));
+
+        $firstResourceDatacenters = Resource::query()
+            ->where('doi', '10.5880/cache-one')
+            ->firstOrFail()
+            ->datacenters()
+            ->pluck('name')
+            ->sort()
+            ->values()
+            ->all();
+        $secondResourceDatacenters = Resource::query()
+            ->where('doi', '10.5880/cache-two')
+            ->firstOrFail()
+            ->datacenters()
+            ->pluck('name')
+            ->sort()
+            ->values()
+            ->all();
+
+        expect($datacenterQueries)
+            ->toHaveCount(3)
+            ->and(Datacenter::query()->where('name', 'New shared datacenter')->count())
+            ->toBe(1)
+            ->and($firstResourceDatacenters)
+            ->toBe(['Existing portal datacenter', 'New shared datacenter'])
+            ->and($secondResourceDatacenters)
+            ->toBe(['Existing portal datacenter', 'New shared datacenter']);
     });
 
     it('does not change datacenters on resources that already exist in ERNIE', function () {

--- a/tests/pest/Feature/DataCiteImport/ImportDatacenterFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportDatacenterFromDataCiteJobTest.php
@@ -1,0 +1,552 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\UserRole;
+use App\Jobs\ImportFromDataCiteJob;
+use App\Models\Datacenter;
+use App\Models\Resource;
+use App\Models\User;
+use App\Services\DataCiteImportService;
+use App\Services\DataCiteToResourceTransformer;
+use App\Services\GfzDataServicesPortalService;
+use App\Services\LegacyMetaworksDatacenterLookupService;
+use App\Services\MetaworksDownloadUrlService;
+use App\Services\SumarioPendingResourceImportService;
+use App\Services\SumarioPmdContactEnrichmentService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    $this->user = User::factory()->create(['role' => UserRole::ADMIN]);
+
+    $this->importService = Mockery::mock(DataCiteImportService::class);
+    $this->app->instance(DataCiteImportService::class, $this->importService);
+
+    $this->transformer = Mockery::mock(DataCiteToResourceTransformer::class);
+    $this->transformer
+        ->shouldReceive('prepareDoiData')
+        ->zeroOrMoreTimes()
+        ->andReturnUsing(fn (array $doiRecord): array => $doiRecord)
+        ->byDefault();
+    $this->app->instance(DataCiteToResourceTransformer::class, $this->transformer);
+
+    $this->metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+    $this->metaworksService
+        ->shouldReceive('lookupFileEntries')
+        ->zeroOrMoreTimes()
+        ->andReturn(['files' => [], 'allPublic' => false, 'resourceFound' => false])
+        ->byDefault();
+    $this->app->instance(MetaworksDownloadUrlService::class, $this->metaworksService);
+
+    $this->pendingImportService = Mockery::mock(SumarioPendingResourceImportService::class);
+    $this->app->instance(SumarioPendingResourceImportService::class, $this->pendingImportService);
+
+    $this->contactEnrichmentService = Mockery::mock(SumarioPmdContactEnrichmentService::class);
+    $this->contactEnrichmentService
+        ->shouldReceive('enrich')
+        ->zeroOrMoreTimes()
+        ->andReturnFalse()
+        ->byDefault();
+    $this->app->instance(SumarioPmdContactEnrichmentService::class, $this->contactEnrichmentService);
+
+    $this->datacenterLookupService = Mockery::mock(LegacyMetaworksDatacenterLookupService::class);
+    $this->datacenterLookupService
+        ->shouldReceive('syncDatacenters')
+        ->zeroOrMoreTimes()
+        ->andReturnNull()
+        ->byDefault();
+    $this->app->instance(LegacyMetaworksDatacenterLookupService::class, $this->datacenterLookupService);
+
+    $this->portalService = Mockery::mock(GfzDataServicesPortalService::class);
+    $this->app->instance(GfzDataServicesPortalService::class, $this->portalService);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+function datacenterDoiRecord(string $doi): array
+{
+    return [
+        'id' => $doi,
+        'attributes' => [
+            'doi' => $doi,
+            'titles' => [['title' => "Resource {$doi}"]],
+            'publicationYear' => 2024,
+            'types' => ['resourceTypeGeneral' => 'Dataset'],
+        ],
+    ];
+}
+
+describe('datacenter-scoped DataCite import job', function () {
+    it('imports only portal targets and assigns every portal facet to new resources', function () {
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->with('ArboDat')
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'ArboDat',
+                    'name' => 'ArboDat 2016',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/selected' => ['ArboDat 2016', 'GFZ Data Services'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('ArboDat 2016')
+            ->andReturn([]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield datacenterDoiRecord('10.5880/not-selected');
+                yield datacenterDoiRecord('10.5880/selected');
+            })());
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(
+                fn (): Resource => Resource::factory()->create(['doi' => '10.5880/selected']),
+            );
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'ArboDat'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $resource = Resource::query()->where('doi', '10.5880/selected')->firstOrFail();
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'completed',
+                'total' => 1,
+                'processed' => 1,
+                'imported' => 1,
+                'skipped' => 0,
+                'failed' => 0,
+                'datacenter' => [
+                    'id' => 'ArboDat',
+                    'name' => 'ArboDat 2016',
+                    'resource_count' => 1,
+                ],
+            ])
+            ->and($resource->datacenters()->pluck('name')->sort()->values()->all())
+            ->toBe(['ArboDat 2016', 'GFZ Data Services'])
+            ->and(Resource::query()->where('doi', '10.5880/not-selected')->exists())
+            ->toBeFalse();
+    });
+
+    it('does not change datacenters on resources that already exist in ERNIE', function () {
+        $legacyDatacenter = Datacenter::query()->create(['name' => 'Legacy assignment']);
+        $existingResource = Resource::factory()->create(['doi' => '10.5880/existing']);
+        $existingResource->datacenters()->attach($legacyDatacenter);
+
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'ArboDat',
+                    'name' => 'ArboDat 2016',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/existing' => ['ArboDat 2016'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('ArboDat 2016')
+            ->andReturn([]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield datacenterDoiRecord('10.5880/existing');
+            })());
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'ArboDat'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'completed',
+                'processed' => 1,
+                'imported' => 0,
+                'skipped' => 1,
+            ])
+            ->and($existingResource->fresh()->datacenters()->pluck('name')->all())
+            ->toBe(['Legacy assignment'])
+            ->and(Datacenter::query()->where('name', 'ArboDat 2016')->exists())
+            ->toBeFalse();
+    });
+
+    it('includes pending-only resources selected from the legacy database mapping', function () {
+        $gfz = Datacenter::query()->create([
+            'name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+        ]);
+        $pendingResource = Resource::factory()->create(['doi' => '10.5880/pending-gfz']);
+        $pendingResource->datacenters()->attach($gfz);
+
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->with('GFZ')
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'GFZ',
+                    'name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+                    'resource_count' => 0,
+                ],
+                'resources' => [],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with(LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER)
+            ->andReturn(['10.5880/pending-gfz']);
+        $this->pendingImportService
+            ->shouldReceive('importPendingByDoi')
+            ->once()
+            ->with('10.5880/pending-gfz', $this->user->id)
+            ->andReturn([
+                'status' => 'imported',
+                'resource' => $pendingResource,
+                'doi' => '10.5880/pending-gfz',
+                'error' => null,
+            ]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                if (false) {
+                    yield [];
+                }
+            })());
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/pending-gfz')
+            ->andReturnNull();
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'GFZ'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'completed',
+                'total' => 1,
+                'processed' => 1,
+                'imported' => 1,
+                'failed' => 0,
+            ])
+            ->and($pendingResource->fresh()->datacenters()->pluck('name')->all())
+            ->toBe([LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
+    });
+
+    it('deduplicates portal and pending targets and gives the portal assignment precedence', function () {
+        $gfz = Datacenter::query()->create([
+            'name' => LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+        ]);
+        $pendingResource = Resource::factory()->create(['doi' => '10.5880/shared']);
+        $pendingResource->datacenters()->attach($gfz);
+
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'ArboDat',
+                    'name' => 'ArboDat 2016',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/shared' => ['ArboDat 2016'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('ArboDat 2016')
+            ->andReturn(['10.5880/shared']);
+        $this->pendingImportService
+            ->shouldReceive('importPendingByDoi')
+            ->once()
+            ->with('10.5880/shared', $this->user->id)
+            ->andReturn([
+                'status' => 'imported',
+                'resource' => $pendingResource,
+                'doi' => '10.5880/shared',
+                'error' => null,
+            ]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                if (false) {
+                    yield [];
+                }
+            })());
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/shared')
+            ->andReturnNull();
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'ArboDat'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status['total'])->toBe(1)
+            ->and($status['processed'])->toBe(1)
+            ->and($status['imported'])->toBe(1)
+            ->and($pendingResource->fresh()->datacenters()->pluck('name')->all())
+            ->toBe(['ArboDat 2016']);
+    });
+
+    it('continues with portal resources and reports a warning when pending selection fails', function () {
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'Riesgos',
+                    'name' => 'Riesgos',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/riesgos' => ['Riesgos'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->andThrow(new RuntimeException('legacy database unavailable'));
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield datacenterDoiRecord('10.5880/riesgos');
+            })());
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(
+                fn (): Resource => Resource::factory()->create(['doi' => '10.5880/riesgos']),
+            );
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'Riesgos'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'completed',
+                'imported' => 1,
+                'warnings' => ['Matching SUMARIO pending resources could not be loaded.'],
+            ]);
+    });
+
+    it('uses the targeted DataCite lookup for portal resources missing from the bulk stream', function () {
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'Riesgos',
+                    'name' => 'Riesgos',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/riesgos-targeted' => ['Riesgos'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('Riesgos')
+            ->andReturn([]);
+        $this->pendingImportService->shouldNotReceive('importPendingByDoi');
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                if (false) {
+                    yield [];
+                }
+            })());
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/riesgos-targeted')
+            ->andReturn(datacenterDoiRecord('10.5880/riesgos-targeted'));
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(
+                fn (): Resource => Resource::factory()->create(['doi' => '10.5880/riesgos-targeted']),
+            );
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'Riesgos'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $resource = Resource::query()->where('doi', '10.5880/riesgos-targeted')->firstOrFail();
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'completed',
+                'total' => 1,
+                'processed' => 1,
+                'imported' => 1,
+                'failed' => 0,
+            ])
+            ->and($resource->datacenters()->pluck('name')->all())
+            ->toBe(['Riesgos']);
+    });
+
+    it('records a failure when a portal DOI exists in neither DataCite nor pending SUMARIO data', function () {
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'Riesgos',
+                    'name' => 'Riesgos',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/missing-everywhere' => ['Riesgos'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('Riesgos')
+            ->andReturn([]);
+        $this->pendingImportService
+            ->shouldReceive('importPendingByDoi')
+            ->once()
+            ->with('10.5880/missing-everywhere', $this->user->id)
+            ->andReturn([
+                'status' => 'missing',
+                'resource' => null,
+                'doi' => '10.5880/missing-everywhere',
+                'error' => null,
+            ]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                if (false) {
+                    yield [];
+                }
+            })());
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with('10.5880/missing-everywhere')
+            ->andReturnNull();
+        $this->transformer->shouldReceive('transform')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, null, 'Riesgos'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'completed',
+                'total' => 1,
+                'processed' => 1,
+                'imported' => 0,
+                'failed' => 1,
+                'failed_dois' => [[
+                    'doi' => '10.5880/missing-everywhere',
+                    'error' => 'The DOI was not found in DataCite or SUMARIO pending resources.',
+                ]],
+            ]);
+    });
+
+    it('stops scanning unrelated DataCite records after cancellation', function () {
+        $this->portalService
+            ->shouldReceive('resourcesForDatacenter')
+            ->once()
+            ->andReturn([
+                'datacenter' => [
+                    'id' => 'Riesgos',
+                    'name' => 'Riesgos',
+                    'resource_count' => 1,
+                ],
+                'resources' => [
+                    '10.5880/riesgos-target' => ['Riesgos'],
+                ],
+            ]);
+        $this->pendingImportService
+            ->shouldReceive('importablePendingDoisForDatacenter')
+            ->once()
+            ->with('Riesgos')
+            ->andReturn([]);
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturnUsing(function () {
+                Cache::put("datacite_import:{$this->importId}", ['status' => 'cancelled']);
+
+                yield datacenterDoiRecord('10.5880/unrelated');
+                yield datacenterDoiRecord('10.5880/riesgos-target');
+            });
+        $this->importService->shouldNotReceive('fetchSingleDoi');
+        $this->pendingImportService->shouldNotReceive('importPendingByDoi');
+        $this->transformer->shouldReceive('transform')->never();
+
+        $this->importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $this->importId, null, 'Riesgos'))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$this->importId}");
+
+        expect($status)
+            ->toMatchArray([
+                'status' => 'cancelled',
+                'total' => 1,
+                'processed' => 0,
+                'imported' => 0,
+                'skipped' => 0,
+                'failed' => 0,
+            ]);
+    });
+
+    it('rejects combining single-resource and datacenter modes', function () {
+        expect(fn () => new ImportFromDataCiteJob(
+            $this->user->id,
+            Str::uuid()->toString(),
+            '10.5880/single',
+            'GFZ',
+        ))->toThrow(
+            InvalidArgumentException::class,
+            'Single DOI and datacenter imports cannot be combined.',
+        );
+    });
+});

--- a/tests/pest/Unit/Http/Requests/Doi/StartDatacenterOldResourceImportRequestTest.php
+++ b/tests/pest/Unit/Http/Requests/Doi/StartDatacenterOldResourceImportRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Requests\StartDatacenterOldResourceImportRequest;
+
+describe('StartDatacenterOldResourceImportRequest', function (): void {
+    it('authorizes the request and defines the expected rules', function (): void {
+        $request = StartDatacenterOldResourceImportRequest::create(
+            '/datacite/import/start-datacenter',
+            'POST',
+        );
+
+        expect($request->authorize())->toBeTrue()
+            ->and($request->rules())->toBe([
+                'datacenter_id' => ['required', 'string', 'max:255'],
+            ]);
+    });
+
+    it('trims the selected datacenter id before validation', function (): void {
+        $request = StartDatacenterOldResourceImportRequest::create(
+            '/datacite/import/start-datacenter',
+            'POST',
+            ['datacenter_id' => '  DOIDB.RIESGOS  '],
+        );
+        $method = new ReflectionMethod($request, 'prepareForValidation');
+        $method->setAccessible(true);
+        $method->invoke($request);
+
+        expect($request->getDatacenterId())->toBe('DOIDB.RIESGOS');
+    });
+
+    it('returns specific validation messages', function (): void {
+        $request = StartDatacenterOldResourceImportRequest::create(
+            '/datacite/import/start-datacenter',
+            'POST',
+        );
+
+        expect($request->messages())->toBe([
+            'datacenter_id.required' => 'Select a datacenter to start the import.',
+            'datacenter_id.string' => 'The selected datacenter is invalid.',
+            'datacenter_id.max' => 'The selected datacenter is invalid.',
+        ]);
+    });
+});

--- a/tests/pest/Unit/Services/GfzDataServicesPortalServiceTest.php
+++ b/tests/pest/Unit/Services/GfzDataServicesPortalServiceTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\GfzDataServicesPortalService;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+covers(GfzDataServicesPortalService::class);
+
+beforeEach(function (): void {
+    Cache::flush();
+    Config::set('datacite.legacy_portal', [
+        'proxy_url' => 'https://portal.example.test/proxy.php',
+        'timeout_seconds' => 5,
+        'retry_times' => 1,
+        'retry_sleep_ms' => 0,
+        'page_size' => 2,
+        'datacenter_cache_ttl_seconds' => 600,
+    ]);
+});
+
+function portalFacetResponse(array $facets): array
+{
+    return [
+        'facet_counts' => [
+            'facet_fields' => [
+                'datacentre_facet' => $facets,
+            ],
+        ],
+    ];
+}
+
+it('loads sorts and caches datacenters from portal facets', function (): void {
+    Http::fake([
+        'portal.example.test/*' => Http::response(portalFacetResponse([
+            'DOIDB.RIESGOS - Riesgos' => 15,
+            'invalid-facet' => 99,
+            'DOIDB.ARBODAT - ArboDat 2016' => 172,
+        ])),
+    ]);
+
+    $service = app(GfzDataServicesPortalService::class);
+
+    expect($service->listDatacenters())->toBe([
+        [
+            'id' => 'DOIDB.ARBODAT',
+            'name' => 'ArboDat 2016',
+            'resource_count' => 172,
+        ],
+        [
+            'id' => 'DOIDB.RIESGOS',
+            'name' => 'Riesgos',
+            'resource_count' => 15,
+        ],
+    ])->and($service->listDatacenters())->toHaveCount(2);
+
+    Http::assertSentCount(1);
+    Http::assertSent(function (Request $request): bool {
+        parse_str((string) $request->data()['query'], $query);
+
+        return $request->method() === 'POST'
+            && $request->url() === 'https://portal.example.test/proxy.php'
+            && $query['facet_field'] === 'datacentre_facet'
+            && $query['rows'] === '0';
+    });
+});
+
+it('paginates resources and keeps all portal datacenter assignments', function (): void {
+    Http::fakeSequence('portal.example.test/*')
+        ->push(portalFacetResponse([
+            'DOIDB.RIESGOS - Riesgos' => 3,
+            'DOIDB.GFZ - GFZ German Research Centre for Geosciences' => 755,
+        ]))
+        ->push([
+            'response' => [
+                'numFound' => 3,
+                'docs' => [
+                    [
+                        'doi' => '10.5880/RIESGOS.2021.001',
+                        'datacentre_facet' => 'DOIDB.RIESGOS - Riesgos',
+                    ],
+                    [
+                        'doi' => 'https://doi.org/10.5880/RIESGOS.2021.002',
+                        'datacentre_facet' => [
+                            'DOIDB.RIESGOS - Riesgos',
+                            'DOIDB.GFZ - GFZ German Research Centre for Geosciences',
+                        ],
+                    ],
+                ],
+            ],
+        ])
+        ->push([
+            'response' => [
+                'numFound' => 3,
+                'docs' => [
+                    [
+                        'doi' => '10.5880/riesgos.2021.001',
+                        'datacentre_facet' => 'DOIDB.RIESGOS - Riesgos',
+                    ],
+                    [
+                        'doi' => '10.5880/RIESGOS.2021.003',
+                    ],
+                ],
+            ],
+        ]);
+
+    $result = app(GfzDataServicesPortalService::class)
+        ->resourcesForDatacenter('DOIDB.RIESGOS');
+
+    expect($result['datacenter']['name'])->toBe('Riesgos')
+        ->and($result['resources'])->toBe([
+            '10.5880/riesgos.2021.001' => ['Riesgos'],
+            '10.5880/riesgos.2021.002' => [
+                'Riesgos',
+                'GFZ German Research Centre for Geosciences',
+            ],
+            '10.5880/riesgos.2021.003' => ['Riesgos'],
+        ]);
+
+    Http::assertSentCount(3);
+    Http::assertSent(function (Request $request): bool {
+        parse_str((string) $request->data()['query'], $query);
+
+        return isset($query['fq'])
+            && $query['fq'] === 'datacentre_facet:"DOIDB.RIESGOS - Riesgos" AND -type:text'
+            && $query['sort'] === 'doi asc';
+    });
+});
+
+it('rejects a datacenter id that is not in the portal list', function (): void {
+    Http::fake([
+        'portal.example.test/*' => Http::response(portalFacetResponse([
+            'DOIDB.RIESGOS - Riesgos' => 15,
+        ])),
+    ]);
+
+    expect(fn () => app(GfzDataServicesPortalService::class)
+        ->resourcesForDatacenter('DOIDB.UNKNOWN'))
+        ->toThrow(RuntimeException::class, 'no longer available');
+
+    Http::assertSentCount(1);
+});
+
+it('fails safely for an insecure proxy url', function (): void {
+    Config::set('datacite.legacy_portal.proxy_url', 'http://portal.example.test/proxy.php');
+    Config::set('datacite.legacy_portal.datacenter_cache_ttl_seconds', 0);
+
+    expect(fn () => app(GfzDataServicesPortalService::class)->listDatacenters())
+        ->toThrow(RuntimeException::class, 'must use HTTPS');
+
+    Http::assertNothingSent();
+});
+
+it('fails safely for unsuccessful and malformed portal responses', function (): void {
+    Config::set('datacite.legacy_portal.datacenter_cache_ttl_seconds', 0);
+
+    Http::fakeSequence('portal.example.test/*')
+        ->push(['message' => 'unavailable'], 503)
+        ->push(['facet_counts' => []]);
+
+    expect(fn () => app(GfzDataServicesPortalService::class)->listDatacenters())
+        ->toThrow(RuntimeException::class, 'HTTP 503');
+
+    expect(fn () => app(GfzDataServicesPortalService::class)->listDatacenters())
+        ->toThrow(RuntimeException::class, 'invalid datacenter response');
+});
+
+it('converts connection failures into a stable portal error', function (): void {
+    Config::set('datacite.legacy_portal.datacenter_cache_ttl_seconds', 0);
+
+    Http::fake(function (): never {
+        throw new ConnectionException('cURL error containing upstream details');
+    });
+
+    expect(fn () => app(GfzDataServicesPortalService::class)->listDatacenters())
+        ->toThrow(
+            RuntimeException::class,
+            'The GFZ Data Services portal could not be reached.',
+        );
+});

--- a/tests/pest/Unit/Services/SumarioPendingDatacenterSelectionTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingDatacenterSelectionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DoiSuggestionService;
+use App\Services\LegacyLandingPageImportService;
+use App\Services\LegacyMetaworksDatacenterLookupService;
+use App\Services\MetaworksDownloadUrlService;
+use App\Services\OldDatasetEditorLoader;
+use App\Services\ResourceStorageService;
+use App\Services\SumarioPendingResourceImportService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    Config::set('database.connections.metaworks', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => false,
+    ]);
+    DB::purge('metaworks');
+
+    Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+        $table->id();
+        $table->string('publicstatus')->nullable();
+        $table->string('identifier')->nullable()->collation('NOCASE');
+        $table->integer('publicationyear')->nullable();
+        $table->string('title')->nullable();
+    });
+});
+
+afterEach(function () {
+    DB::disconnect('metaworks');
+    Mockery::close();
+});
+
+function pendingDatacenterSelectionService(
+    LegacyMetaworksDatacenterLookupService $lookup,
+): SumarioPendingResourceImportService {
+    return new SumarioPendingResourceImportService(
+        editorLoader: Mockery::mock(OldDatasetEditorLoader::class),
+        resourceStorage: Mockery::mock(ResourceStorageService::class),
+        datacenterLookup: $lookup,
+        downloadUrlService: Mockery::mock(MetaworksDownloadUrlService::class),
+        landingPageImport: new LegacyLandingPageImportService,
+        doiSuggestionService: app(DoiSuggestionService::class),
+    );
+}
+
+it('selects pending DOIs using legacy database and DOI-rule datacenter resolution', function () {
+    DB::connection('metaworks')->table('resource')->insert([
+        [
+            'id' => 1,
+            'publicstatus' => 'pending',
+            'identifier' => 'https://doi.org/10.5880/HA-ARBODAT_AK1',
+        ],
+        [
+            'id' => 2,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/GFZ.FALLBACK',
+        ],
+        [
+            'id' => 3,
+            'publicstatus' => 'published',
+            'identifier' => '10.5880/not.pending',
+        ],
+        [
+            'id' => 4,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/DELETE-ME',
+        ],
+        [
+            'id' => 5,
+            'publicstatus' => 'pending',
+            'identifier' => '10.5880/ha-arbodat_ak1',
+        ],
+    ]);
+
+    $lookup = Mockery::mock(LegacyMetaworksDatacenterLookupService::class);
+    $lookup
+        ->shouldReceive('resolveDatacenterNames')
+        ->twice()
+        ->with('10.5880/ha-arbodat_ak1')
+        ->andReturn(['ArboDat 2016']);
+    $lookup
+        ->shouldReceive('resolveDatacenterNames')
+        ->twice()
+        ->with('10.5880/gfz.fallback')
+        ->andReturn([LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
+
+    $service = pendingDatacenterSelectionService($lookup);
+
+    expect($service->importablePendingDoisForDatacenter('ArboDat 2016'))
+        ->toBe(['10.5880/ha-arbodat_ak1'])
+        ->and($service->importablePendingDoisForDatacenter(
+            LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+        ))
+        ->toBe(['10.5880/gfz.fallback']);
+});
+
+it('returns no pending resources for an empty datacenter name', function () {
+    $lookup = Mockery::mock(LegacyMetaworksDatacenterLookupService::class);
+    $lookup->shouldNotReceive('resolveDatacenterNames');
+
+    expect(pendingDatacenterSelectionService($lookup)
+        ->importablePendingDoisForDatacenter('  '))
+        ->toBe([]);
+});

--- a/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@tests/vitest/utils/render';
 import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 

--- a/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
@@ -152,6 +152,8 @@ describe('ImportFromDataCiteModal datacenter mode', () => {
         expect(await screen.findByText('Import warning')).toBeInTheDocument();
         expect(screen.getByText('Matching SUMARIO pending resources could not be loaded.')).toBeInTheDocument();
         expect(screen.getByText('Import Complete')).toBeInTheDocument();
-        expect(onSuccess).toHaveBeenCalledOnce();
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalledOnce();
+        });
     });
 });

--- a/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
@@ -102,6 +102,33 @@ describe('ImportFromDataCiteModal datacenter mode', () => {
         });
     });
 
+    it('shows the actionable validation message when the selected datacenter is no longer available', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        const message = 'The selected datacenter is no longer available. Reload the list and try again.';
+        (axios.get as Mock).mockResolvedValueOnce({ data: { datacenters } });
+        (axios.post as Mock).mockRejectedValueOnce({
+            isAxiosError: true,
+            message: 'Request failed with status code 422',
+            response: {
+                status: 422,
+                data: {
+                    message,
+                    errors: {
+                        datacenter_id: [message],
+                    },
+                },
+            },
+        });
+
+        render(<ImportFromDataCiteModal isOpen={true} onClose={onClose} mode="datacenter" />);
+
+        await user.click(await screen.findByRole('combobox', { name: 'Datacenter' }));
+        await user.click(await screen.findByRole('option', { name: /ArboDat 2016/ }));
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(await screen.findByText(message)).toBeInTheDocument();
+    });
+
     it('shows the upstream error and retries loading the datacenter list', async () => {
         const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
         (axios.get as Mock)

--- a/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
+++ b/tests/vitest/components/resources/modals/ImportDatacenterFromDataCiteModal.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+
+import ImportFromDataCiteModal from '@/components/resources/modals/ImportFromDataCiteModal';
+
+vi.mock('axios', () => ({
+    default: {
+        post: vi.fn(),
+        get: vi.fn(),
+    },
+    isAxiosError: vi.fn((error) => error?.isAxiosError === true),
+}));
+
+vi.mock('@/lib/csrf-token', () => ({
+    buildCsrfHeaders: () => ({ 'X-CSRF-TOKEN': 'test-token' }),
+}));
+
+vi.mock('@inertiajs/react', () => ({
+    router: {
+        reload: vi.fn(),
+    },
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        info: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const datacenters = [
+    { id: 'ArboDat', name: 'ArboDat 2016', resource_count: 172 },
+    { id: 'GFZ', name: 'GFZ Data Services', resource_count: 1200 },
+];
+
+describe('ImportFromDataCiteModal datacenter mode', () => {
+    const onClose = vi.fn();
+    const onSuccess = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('loads datacenters when opened and describes the hybrid selection', async () => {
+        (axios.get as Mock).mockResolvedValueOnce({ data: { datacenters } });
+
+        render(<ImportFromDataCiteModal isOpen={true} onClose={onClose} mode="datacenter" />);
+
+        expect(screen.getByText('Import all Resources from a Datacenter')).toBeInTheDocument();
+        expect(screen.getByText(/Visible resources are selected through the GFZ Data Services portal/)).toBeInTheDocument();
+        expect(screen.getByText(/Matching pending SUMARIO resources are selected through the legacy databases and DOI rules/)).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(axios.get).toHaveBeenCalledWith('/datacite/import/datacenters');
+        });
+
+        expect(screen.getByRole('combobox', { name: 'Datacenter' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: /start import/i })).toBeDisabled();
+    });
+
+    it('starts the import with the selected datacenter id', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        (axios.get as Mock).mockResolvedValueOnce({ data: { datacenters } }).mockResolvedValue({
+            data: {
+                status: 'running',
+                total: 172,
+                processed: 0,
+                imported: 0,
+                skipped: 0,
+                failed: 0,
+                skipped_dois: [],
+                failed_dois: [],
+            },
+        });
+        (axios.post as Mock).mockResolvedValueOnce({
+            data: { import_id: 'datacenter-import-123', message: 'Datacenter import started successfully' },
+        });
+
+        render(<ImportFromDataCiteModal isOpen={true} onClose={onClose} mode="datacenter" />);
+
+        const select = await screen.findByRole('combobox', { name: 'Datacenter' });
+        await user.click(select);
+        await user.click(await screen.findByRole('option', { name: /ArboDat 2016/ }));
+
+        expect(screen.getByText(/172 visible portal resources; matching pending resources are included/)).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        await waitFor(() => {
+            expect(axios.post).toHaveBeenCalledWith(
+                '/datacite/import/start-datacenter',
+                { datacenter_id: 'ArboDat' },
+                { headers: { 'X-CSRF-TOKEN': 'test-token' } },
+            );
+        });
+    });
+
+    it('shows the upstream error and retries loading the datacenter list', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        (axios.get as Mock)
+            .mockRejectedValueOnce({
+                isAxiosError: true,
+                response: { data: { message: 'Portal is temporarily unavailable.' } },
+            })
+            .mockResolvedValueOnce({ data: { datacenters } });
+
+        render(<ImportFromDataCiteModal isOpen={true} onClose={onClose} mode="datacenter" />);
+
+        expect(await screen.findByText('Portal is temporarily unavailable.')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: 'Datacenter' })).toBeDisabled();
+
+        await user.click(screen.getByRole('button', { name: /try again/i }));
+
+        await waitFor(() => {
+            expect(axios.get).toHaveBeenCalledTimes(2);
+            expect(screen.getByRole('combobox', { name: 'Datacenter' })).toBeEnabled();
+        });
+    });
+
+    it('shows a non-fatal pending-resource warning returned by the job', async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        (axios.get as Mock).mockResolvedValueOnce({ data: { datacenters } }).mockResolvedValueOnce({
+            data: {
+                status: 'completed',
+                total: 1,
+                processed: 1,
+                imported: 1,
+                skipped: 0,
+                failed: 0,
+                skipped_dois: [],
+                failed_dois: [],
+                warnings: ['Matching SUMARIO pending resources could not be loaded.'],
+            },
+        });
+        (axios.post as Mock).mockResolvedValueOnce({
+            data: { import_id: 'datacenter-import-123', message: 'Datacenter import started successfully' },
+        });
+
+        render(<ImportFromDataCiteModal isOpen={true} onClose={onClose} onSuccess={onSuccess} mode="datacenter" />);
+
+        await user.click(await screen.findByRole('combobox', { name: 'Datacenter' }));
+        await user.click(await screen.findByRole('option', { name: /GFZ Data Services/ }));
+        await user.click(screen.getByRole('button', { name: /start import/i }));
+
+        expect(await screen.findByText('Import warning')).toBeInTheDocument();
+        expect(screen.getByText('Matching SUMARIO pending resources could not be loaded.')).toBeInTheDocument();
+        expect(screen.getByText('Import Complete')).toBeInTheDocument();
+        expect(onSuccess).toHaveBeenCalledOnce();
+    });
+});

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -465,6 +465,17 @@ describe('Docs page', () => {
         expect(screen.getByText('Importing from Old Datasets')).toBeInTheDocument();
     });
 
+    it('documents the portal and legacy sources used by datacenter imports', async () => {
+        const user = userEvent.setup();
+        render(<Docs userRole="admin" editorSettings={defaultEditorSettings} dataCite={defaultDataCite} />);
+
+        await user.click(screen.getByRole('tab', { name: /Datasets/i }));
+
+        expect(screen.getByText('Import all Resources from a Datacenter')).toBeInTheDocument();
+        expect(screen.getByText(/uses the portal assignment for visible resources/i)).toBeInTheDocument();
+        expect(screen.getByText(/determined from the legacy databases and the established DOI rules/i)).toBeInTheDocument();
+    });
+
     it('shows landing pages documentation for beginner training', async () => {
         const user = userEvent.setup();
         render(<Docs userRole="beginner" editorSettings={defaultEditorSettings} dataCite={defaultDataCite} />);

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -474,6 +474,11 @@ describe('Docs page', () => {
         expect(screen.getByText('Import all Resources from a Datacenter')).toBeInTheDocument();
         expect(screen.getByText(/uses the portal assignment for visible resources/i)).toBeInTheDocument();
         expect(screen.getByText(/determined from the legacy databases and the established DOI rules/i)).toBeInTheDocument();
+        expect(screen.getByText(/not re-imported or overwritten/i)).toBeInTheDocument();
+        expect(screen.getByText(/current datacenter assignments are preserved/i)).toBeInTheDocument();
+        expect(
+            screen.getByText(/may still enrich them with missing legacy download links or an external landing page URL from DataCite/i),
+        ).toBeInTheDocument();
     });
 
     it('shows landing pages documentation for beginner training', async () => {

--- a/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-bulk-selection.test.tsx
@@ -974,6 +974,7 @@ describe('ResourcesPage - bulk selection', () => {
         await waitForFilterOptionsToLoad();
 
         expect(within(screen.getByTestId('app-layout')).getByRole('button', { name: /import all old resources/i })).toBeInTheDocument();
+        expect(within(screen.getByTestId('app-layout')).getByRole('button', { name: /import all resources from a datacenter/i })).toBeInTheDocument();
         expect(within(screen.getByTestId('app-layout')).getByRole('button', { name: /import old single resource/i })).toBeInTheDocument();
     });
 });

--- a/tests/vitest/pages/__tests__/resources-extended.test.tsx
+++ b/tests/vitest/pages/__tests__/resources-extended.test.tsx
@@ -363,12 +363,14 @@ describe('ResourcesPage - extended', () => {
         it('shows import buttons when canImportFromDataCite is true', () => {
             renderPage({ canImportFromDataCite: true });
             expect(screen.getByRole('button', { name: /import all old resources/i })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /import all resources from a datacenter/i })).toBeInTheDocument();
             expect(screen.getByRole('button', { name: /import old single resource/i })).toBeInTheDocument();
         });
 
         it('hides import buttons when canImportFromDataCite is false', () => {
             renderPage({ canImportFromDataCite: false });
             expect(screen.queryByRole('button', { name: /import all old resources/i })).not.toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: /import all resources from a datacenter/i })).not.toBeInTheDocument();
             expect(screen.queryByRole('button', { name: /import old single resource/i })).not.toBeInTheDocument();
         });
 


### PR DESCRIPTION
This pull request introduces a new feature allowing admins and group leaders to import legacy resources by datacenter from the current GFZ Data Services portal. It includes backend and frontend changes to support listing datacenters, validating selection, and starting imports scoped to a single datacenter. Additionally, new configuration options for the legacy portal have been added, and the changelog has been updated.

**Legacy Resource Import by Datacenter**

* Added a new service `GfzDataServicesPortalService` to interact with the GFZ Data Services portal, supporting listing datacenters, validating a datacenter, and fetching resources for a given datacenter. This service handles caching, pagination, and error handling for the portal API.
* Extended `DataCiteImportController` with endpoints to list datacenters and start an import for a selected datacenter, using the new service and request validation. [[1]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6R58-R125) [[2]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6R7-R13) [[3]](diffhunk://#diff-7b72d577fcc851a9d975f614a25149fee171c89158da2b832a4a11cabfe3ff63R1-R53)

**Frontend Support**

* Updated the import modal (`ImportFromDataCiteModal.tsx`) to support a new "datacenter" mode, including UI for selecting a datacenter, loading the list from the backend, and handling errors. [[1]](diffhunk://#diff-acda986becf8e7f7ab246831bba2de3a63f59f3e990a401d738c598e78058014R32-R107) [[2]](diffhunk://#diff-acda986becf8e7f7ab246831bba2de3a63f59f3e990a401d738c598e78058014R11-R13)

**Configuration**

* Added new environment variables and configuration entries for the GFZ Data Services portal proxy URL, timeouts, retries, page size, and cache TTL in `.env.example`, `.env.docker.example`, and `config/datacite.php`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR101-R106) [[2]](diffhunk://#diff-2f1bab5147b0fd2b6e6ff8dc6163c62e9c706f1539229e8d4e88358db076bc9dR135-R140) [[3]](diffhunk://#diff-3fb734d353c148cc1ae2802234a373074bbb3dd813335df0df9721239db9cf40R51-R72)

**Changelog**

* Documented the new feature in `changelog.json` under "Legacy Resource Import by Datacenter," clarifying its scope and behavior.

**Pending Resource Import**

* Added a method to `SumarioPendingResourceImportService` to list importable pending DOIs for a given datacenter, improving integration between portal assignments and pending legacy resources.