### PR TITLE
Feature: Relation Type Override when accepting Suggestions in Assistant

### DIFF
--- a/app/Http/Controllers/AssistanceController.php
+++ b/app/Http/Controllers/AssistanceController.php
@@ -6,8 +6,10 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\BatchSuggestionValidationException;
 use App\Http\Requests\Assistance\AcceptRorAffiliationMatchesRequest;
+use App\Http\Requests\Assistance\AcceptSuggestionRequest;
 use App\Http\Requests\Assistance\BatchSuggestionsRequest;
 use App\Http\Requests\Assistance\DeclineSuggestionRequest;
+use App\Models\RelationType;
 use App\Models\User;
 use App\Services\Assistance\AssistanceReviewService;
 use App\Services\Assistance\AssistantRegistrar;
@@ -52,7 +54,40 @@ class AssistanceController extends Controller
         return Inertia::render('assistance', [
             ...$review,
             'manifests' => $manifests,
+            'relationTypes' => $this->relationTypeOptions(),
         ]);
+    }
+
+    /**
+     * @return list<array{id: int, name: string, slug: string, usage_count: int, is_most_used: bool}>
+     */
+    private function relationTypeOptions(): array
+    {
+        $ranked = RelationType::query()
+            ->select(['relation_types.id', 'relation_types.name', 'relation_types.slug'])
+            ->active()
+            ->withCount('relatedIdentifiers')
+            ->orderByDesc('related_identifiers_count')
+            ->orderBy('name')
+            ->get();
+
+        $mostUsed = $ranked->take(5);
+        $mostUsedIds = array_fill_keys($mostUsed->pluck('id')->all(), true);
+        $remaining = $ranked->skip(5)
+            ->sortBy(fn (RelationType $type): string => mb_strtolower($type->name))
+            ->values();
+
+        return array_values($mostUsed
+            ->concat($remaining)
+            ->map(fn (RelationType $type): array => [
+                'id' => $type->id,
+                'name' => $type->name,
+                'slug' => $type->slug,
+                'usage_count' => (int) $type->getAttribute('related_identifiers_count'),
+                'is_most_used' => isset($mostUsedIds[$type->id]),
+            ])
+            ->values()
+            ->all());
     }
 
     /**
@@ -129,7 +164,7 @@ class AssistanceController extends Controller
     /**
      * Accept a suggestion from any assistant.
      */
-    public function accept(Request $request, int $suggestion): JsonResponse
+    public function accept(AcceptSuggestionRequest $request, int $suggestion): JsonResponse
     {
         $assistantId = $request->route('assistantId');
         $assistant = $this->registrar->get((string) $assistantId);
@@ -138,7 +173,7 @@ class AssistanceController extends Controller
             return response()->json(['error' => 'Unknown assistant.'], 404);
         }
 
-        $result = $assistant->acceptSuggestion($suggestion);
+        $result = $assistant->acceptSuggestion($suggestion, $request->validated());
 
         return response()->json($result);
     }

--- a/app/Http/Requests/Assistance/AcceptSuggestionRequest.php
+++ b/app/Http/Requests/Assistance/AcceptSuggestionRequest.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-final class BatchSuggestionsRequest extends FormRequest
+final class AcceptSuggestionRequest extends FormRequest
 {
     public function authorize(): bool
     {
@@ -21,18 +21,13 @@ final class BatchSuggestionsRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'resource_id' => ['required', 'integer', 'min:1'],
-            'suggestions' => ['required', 'array', 'min:1', 'max:250'],
-            'suggestions.*.assistant_id' => ['required', 'string', 'max:64'],
-            'suggestions.*.suggestion_id' => ['required', 'integer', 'min:1'],
-            'suggestions.*.relation_type_id' => [
+            'relation_type_id' => [
                 'sometimes',
                 'integer',
                 Rule::exists('relation_types', 'id')->where(
                     fn (Builder $query): Builder => $query->where('is_active', true),
                 ),
             ],
-            'reason' => ['nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Services/Assistance/AbstractAssistant.php
+++ b/app/Services/Assistance/AbstractAssistant.php
@@ -63,6 +63,17 @@ abstract class AbstractAssistant implements AssistantContract
     abstract protected function accept(Model $suggestion): array;
 
     /**
+     * Apply assistant-specific acceptance input before accepting a suggestion.
+     *
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    protected function acceptWithInput(Model $suggestion, array $input): array
+    {
+        return $this->accept($suggestion);
+    }
+
+    /**
      * Record a declined suggestion so it won't be suggested again.
      */
     abstract protected function decline(Model $suggestion, User $user, ?string $reason): void;
@@ -178,7 +189,7 @@ abstract class AbstractAssistant implements AssistantContract
         return $suggestion === null ? null : $this->present($suggestion);
     }
 
-    public function acceptSuggestion(int $id): array
+    public function acceptSuggestion(int $id, array $input = []): array
     {
         $suggestion = $this->findById($id);
 
@@ -186,7 +197,7 @@ abstract class AbstractAssistant implements AssistantContract
             return ['success' => false, 'message' => 'Suggestion not found.'];
         }
 
-        $result = $this->accept($suggestion);
+        $result = $this->acceptWithInput($suggestion, $input);
 
         $this->forgetTotalPendingCount();
 

--- a/app/Services/Assistance/AssistantContract.php
+++ b/app/Services/Assistance/AssistantContract.php
@@ -99,9 +99,10 @@ interface AssistantContract
     /**
      * Accept a suggestion by its ID and apply the enrichment.
      *
+     * @param  array<string, mixed>  $input  Optional assistant-specific acceptance input
      * @return array<string, mixed> Result data (e.g. success status, message)
      */
-    public function acceptSuggestion(int $id): array;
+    public function acceptSuggestion(int $id, array $input = []): array;
 
     /**
      * Decline a suggestion by its ID, recording who declined and why.

--- a/app/Services/Assistance/BatchSuggestionActionService.php
+++ b/app/Services/Assistance/BatchSuggestionActionService.php
@@ -21,7 +21,7 @@ final class BatchSuggestionActionService
     ) {}
 
     /**
-     * @param  list<array{assistant_id: string, suggestion_id: int}>  $selections
+     * @param  list<array{assistant_id: string, suggestion_id: int, relation_type_id?: int}>  $selections
      * @return array<string, mixed>
      */
     public function execute(
@@ -44,10 +44,13 @@ final class BatchSuggestionActionService
             $assistant = $selection['assistant'];
             $suggestion = $selection['suggestion'];
             $suggestionId = $selection['suggestion_id'];
+            $acceptanceInput = $selection['acceptance_input'];
 
             try {
                 $result = $action === 'accept'
-                    ? $assistant->acceptSuggestion($suggestionId)
+                    ? ($acceptanceInput === []
+                        ? $assistant->acceptSuggestion($suggestionId)
+                        : $assistant->acceptSuggestion($suggestionId, $acceptanceInput))
                     : $assistant->declineSuggestion($suggestionId, $user, $reason);
             } catch (Throwable $exception) {
                 report($exception);
@@ -116,8 +119,8 @@ final class BatchSuggestionActionService
      * leave a partially processed selection behind.
      *
      * @param  'accept'|'decline'  $action
-     * @param  list<array{assistant_id: string, suggestion_id: int}>  $selections
-     * @return list<array{assistant: AssistantContract, suggestion: array<string, mixed>, suggestion_id: int}>
+     * @param  list<array{assistant_id: string, suggestion_id: int, relation_type_id?: int}>  $selections
+     * @return list<array{assistant: AssistantContract, suggestion: array<string, mixed>, suggestion_id: int, acceptance_input: array<string, mixed>}>
      */
     private function resolveSelection(string $action, int $resourceId, array $selections): array
     {
@@ -176,6 +179,9 @@ final class BatchSuggestionActionService
                 'assistant' => $assistant,
                 'suggestion' => $suggestion,
                 'suggestion_id' => $suggestionId,
+                'acceptance_input' => isset($selection['relation_type_id'])
+                    ? ['relation_type_id' => $selection['relation_type_id']]
+                    : [],
             ];
         }
 
@@ -183,7 +189,7 @@ final class BatchSuggestionActionService
     }
 
     /**
-     * @param  list<array{assistant: AssistantContract, suggestion: array<string, mixed>, suggestion_id: int}>  $resolved
+     * @param  list<array{assistant: AssistantContract, suggestion: array<string, mixed>, suggestion_id: int, acceptance_input: array<string, mixed>}>  $resolved
      */
     private function resourceLabel(array $resolved, int $resourceId): string
     {

--- a/app/Services/RelationDiscoveryService.php
+++ b/app/Services/RelationDiscoveryService.php
@@ -241,19 +241,28 @@ class RelationDiscoveryService
      *
      * @return array{success: bool, datacite_synced: bool, message: string}
      */
-    public function acceptRelation(SuggestedRelation $suggestion): array
+    public function acceptRelation(SuggestedRelation $suggestion, ?int $relationTypeId = null): array
     {
+        if ($relationTypeId !== null && ! RelationType::query()->active()->whereKey($relationTypeId)->exists()) {
+            return [
+                'success' => false,
+                'datacite_synced' => false,
+                'message' => 'The selected relation type is not available.',
+            ];
+        }
+
+        $effectiveRelationTypeId = $relationTypeId ?? $suggestion->relation_type_id;
         $resource = $suggestion->resource;
         $alreadyExists = RelatedIdentifier::where('resource_id', $resource->id)
             ->where('identifier', $suggestion->identifier)
-            ->where('relation_type_id', $suggestion->relation_type_id)
+            ->where('relation_type_id', $effectiveRelationTypeId)
             ->exists();
 
         $citationLabel = $alreadyExists
             ? null
             : $this->resolveAcceptedSuggestionCitationLabel($suggestion);
 
-        DB::transaction(function () use ($suggestion, $resource, $citationLabel) {
+        DB::transaction(function () use ($suggestion, $resource, $citationLabel, $effectiveRelationTypeId) {
             Resource::query()
                 ->whereKey($resource->getKey())
                 ->lockForUpdate()
@@ -261,7 +270,7 @@ class RelationDiscoveryService
 
             $existingRelation = RelatedIdentifier::where('resource_id', $resource->id)
                 ->where('identifier', $suggestion->identifier)
-                ->where('relation_type_id', $suggestion->relation_type_id)
+                ->where('relation_type_id', $effectiveRelationTypeId)
                 ->lockForUpdate()
                 ->first();
 
@@ -279,7 +288,7 @@ class RelationDiscoveryService
                 'resource_id' => $resource->id,
                 'identifier' => $suggestion->identifier,
                 'identifier_type_id' => $suggestion->identifier_type_id,
-                'relation_type_id' => $suggestion->relation_type_id,
+                'relation_type_id' => $effectiveRelationTypeId,
                 'citation_label' => $citationLabel,
                 'source' => RelatedIdentifier::SOURCE_RELATION_SUGGESTION_ASSISTANT,
                 'position' => $maxPosition + 1,

--- a/modules/assistants/DEVELOPER_GUIDE.md
+++ b/modules/assistants/DEVELOPER_GUIDE.md
@@ -390,7 +390,7 @@ classDiagram
         +dispatchDiscovery(jobId, lockOwner) void
         +getJobStatusCacheKey(jobId) string
         +getLockKey() string
-        +acceptSuggestion(id) array
+        +acceptSuggestion(id, input = []) array
         +declineSuggestion(id, user, reason) void
     }
 
@@ -402,9 +402,10 @@ classDiagram
         #transform(model)* array
         #findById(id)* Model
         #accept(model)* array
+        #acceptWithInput(model, input) array
         #decline(model, user, reason)* void
         +loadSuggestions(perPage) LengthAwarePaginator
-        +acceptSuggestion(id) array
+        +acceptSuggestion(id, input = []) array
         +declineSuggestion(id, user, reason) void
     }
 
@@ -528,7 +529,7 @@ sequenceDiagram
     Page->>Ctrl: POST /assistance/{prefix}/{id}/accept
     Ctrl->>Reg: get(assistantId)
     Reg-->>Ctrl: Assistant instance
-    Ctrl->>Asst: acceptSuggestion(id)
+    Ctrl->>Asst: acceptSuggestion(id, optional input)
     Asst->>DB: Update entity + delete suggestion
     Asst-->>Ctrl: { success: true, message: "..." }
     Ctrl-->>Page: JSON response

--- a/modules/assistants/RelationSuggestion/Assistant.php
+++ b/modules/assistants/RelationSuggestion/Assistant.php
@@ -141,6 +141,10 @@ class Assistant extends AbstractAssistant
         /** @var SuggestedRelation $suggestion */
         $relationTypeId = $input['relation_type_id'] ?? null;
 
+        if (is_string($relationTypeId)) {
+            $relationTypeId = filter_var($relationTypeId, FILTER_VALIDATE_INT);
+        }
+
         if ($relationTypeId !== null && ! is_int($relationTypeId)) {
             return [
                 'success' => false,

--- a/modules/assistants/RelationSuggestion/Assistant.php
+++ b/modules/assistants/RelationSuggestion/Assistant.php
@@ -95,6 +95,7 @@ class Assistant extends AbstractAssistant
             'identifier' => $suggestion->identifier,
             'identifier_type' => $suggestion->identifierType->slug ?? '',
             'identifier_type_name' => $suggestion->identifierType->name ?? '',
+            'relation_type_id' => $suggestion->relation_type_id,
             'relation_type' => $suggestion->relationType->slug ?? '',
             'relation_type_name' => $suggestion->relationType->name ?? '',
             'source' => $suggestion->source,
@@ -129,6 +130,26 @@ class Assistant extends AbstractAssistant
     {
         /** @var SuggestedRelation $suggestion */
         return $this->service->acceptRelation($suggestion);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    #[\Override]
+    protected function acceptWithInput(Model $suggestion, array $input): array
+    {
+        /** @var SuggestedRelation $suggestion */
+        $relationTypeId = $input['relation_type_id'] ?? null;
+
+        if ($relationTypeId !== null && ! is_int($relationTypeId)) {
+            return [
+                'success' => false,
+                'datacite_synced' => false,
+                'message' => 'The selected relation type is invalid.',
+            ];
+        }
+
+        return $this->service->acceptRelation($suggestion, $relationTypeId);
     }
 
     #[\Override]

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -76,6 +76,10 @@
                 "description": "A new Related Item Manager allows curators to add detailed inline metadata for related works directly to a resource, using DataCite Metadata Schema 4.7 relatedItem. A new Quote icon on the /resources page opens a modal to create, edit, reorder, and delete related items per resource. Each related item captures full bibliographic metadata: resource type, relation type, titles (with MainTitle/Subtitle/TranslatedTitle/AlternativeTitle), creators and contributors with ORCID/ROR affiliations, publication year, volume, issue, pages, publisher, edition, identifier (DOI, ISBN, URL, etc.). DOIs can be auto-filled via a Crossref lookup (30 requests/minute), and related items can be previewed as APA or IEEE citations with one-click copy. Related items are included in DataCite XML, JSON, JSON-LD, and Schema.org exports; imported from DataCite JSON; parsed from XML uploads; and displayed on the public landing page next to plain related identifiers with an 'Inline metadata' badge. Administrators can inspect and curate related items via the curation form's new Related Items accordion."
             },
             {
+                "title": "Selectable Relation Types for Assistance Suggestions",
+                "description": "Group Leaders reviewing Relation Suggestions can now change the proposed DataCite relation type before accepting it. The selector highlights the five relation types currently used most often in ERNIE, keeps all other active types available alphabetically, and applies the chosen type consistently for individual and resource-batch acceptance."
+            },
+            {
                 "title": "Repository-Curated Related Identifiers",
                 "description": "Related identifiers accepted through the Relation Suggestions assistance tool now keep their repository-curation provenance. The Data Editor highlights these entries with a clear assistance-tool note, while landing pages display them in a separate 'Added by repository curation' section below the initially supplied related identifiers."
             },

--- a/resources/js/components/assistance/relation-type-select.tsx
+++ b/resources/js/components/assistance/relation-type-select.tsx
@@ -1,0 +1,92 @@
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { RELATION_TYPE_DESCRIPTIONS } from '@/lib/related-identifiers';
+import type { AssistanceRelationTypeOption, SuggestedRelationItem } from '@/types/assistance';
+
+interface RelationTypeSelectProps {
+    suggestion: SuggestedRelationItem;
+    options: AssistanceRelationTypeOption[];
+    value: number;
+    disabled: boolean;
+    onValueChange: (relationTypeId: number) => void;
+}
+
+function optionDescription(slug: string): string | null {
+    return (RELATION_TYPE_DESCRIPTIONS as Record<string, string>)[slug] ?? null;
+}
+
+function RelationTypeOptionLabel({ option, inactive = false }: { option: AssistanceRelationTypeOption; inactive?: boolean }) {
+    const description = optionDescription(option.slug);
+
+    return (
+        <div className="flex min-w-0 flex-col items-start">
+            <span>{inactive ? `${option.name} (inactive)` : option.name}</span>
+            {description && <span className="max-w-96 truncate text-xs text-muted-foreground">{description}</span>}
+        </div>
+    );
+}
+
+export function RelationTypeSelect({ suggestion, options, value, disabled, onValueChange }: RelationTypeSelectProps) {
+    const selectId = `relation-type-${suggestion.id}`;
+    const originalOption = options.find((option) => option.id === suggestion.relation_type_id);
+    const inactiveOriginal: AssistanceRelationTypeOption | null = originalOption
+        ? null
+        : {
+              id: suggestion.relation_type_id,
+              name: suggestion.relation_type_name || suggestion.relation_type,
+              slug: suggestion.relation_type,
+              usage_count: 0,
+              is_most_used: false,
+          };
+    const mostUsed = options.filter((option) => option.is_most_used);
+    const remaining = options.filter((option) => !option.is_most_used);
+
+    return (
+        <div className="min-w-56 space-y-1">
+            <Label htmlFor={selectId} className="text-xs text-muted-foreground">
+                Relation Type
+            </Label>
+            <Select value={String(value)} disabled={disabled} onValueChange={(nextValue) => onValueChange(Number(nextValue))}>
+                <SelectTrigger
+                    id={selectId}
+                    size="sm"
+                    className="w-full"
+                    aria-label={`Relation type for ${suggestion.identifier}`}
+                    data-testid={`relation-type-select-${suggestion.id}`}
+                >
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="max-w-lg">
+                    {inactiveOriginal && (
+                        <SelectGroup>
+                            <SelectLabel className="font-semibold">Suggested Type</SelectLabel>
+                            <SelectItem value={String(inactiveOriginal.id)}>
+                                <RelationTypeOptionLabel option={inactiveOriginal} inactive />
+                            </SelectItem>
+                        </SelectGroup>
+                    )}
+                    {mostUsed.length > 0 && (
+                        <SelectGroup>
+                            <SelectLabel className="font-semibold">Most Used</SelectLabel>
+                            {mostUsed.map((option) => (
+                                <SelectItem key={option.id} value={String(option.id)}>
+                                    <RelationTypeOptionLabel option={option} />
+                                </SelectItem>
+                            ))}
+                        </SelectGroup>
+                    )}
+                    {remaining.length > 0 && (
+                        <SelectGroup>
+                            <SelectLabel className="font-semibold">All Relation Types</SelectLabel>
+                            {remaining.map((option) => (
+                                <SelectItem key={option.id} value={String(option.id)}>
+                                    <RelationTypeOptionLabel option={option} />
+                                </SelectItem>
+                            ))}
+                        </SelectGroup>
+                    )}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}

--- a/resources/js/components/assistance/resource-review.tsx
+++ b/resources/js/components/assistance/resource-review.tsx
@@ -18,6 +18,7 @@ import {
     type BatchSuggestionResponse,
     type PaginatedData,
     type RorAffiliationBulkMatch,
+    type SuggestionAcceptanceInput,
     type SuggestionReviewMetadata,
 } from '@/types/assistance';
 
@@ -45,6 +46,7 @@ interface ResourceReviewProps {
     onReload: () => void;
     onRorFollowUps: (matches: RorAffiliationBulkMatch[]) => void;
     renderSuggestion: (manifest: AssistantManifest, item: BaseSuggestionItem, processing: boolean) => ReactNode;
+    acceptanceInputs?: Record<string, SuggestionAcceptanceInput>;
 }
 
 function fallbackReview(item: BaseSuggestionItem, manifest: AssistantManifest): SuggestionReviewMetadata {
@@ -127,6 +129,7 @@ export function ResourceReview({
     onReload,
     onRorFollowUps,
     renderSuggestion,
+    acceptanceInputs = {},
 }: ResourceReviewProps) {
     const manifestsById = useMemo(() => new Map(manifests.map((manifest) => [manifest.id, manifest])), [manifests]);
     const [activeView, setActiveView] = useState<'all' | 'assistant'>(initialReviewView);
@@ -199,10 +202,15 @@ export function ResourceReview({
         try {
             const { data } = await axios.post<BatchSuggestionResponse>(`/assistance/suggestions/batch/${action}`, {
                 resource_id: group.resource_id,
-                suggestions: items.map((item) => ({
-                    assistant_id: item.review?.assistant_id ?? item.assistant_id,
-                    suggestion_id: item.id,
-                })),
+                suggestions: items.map((item) => {
+                    const acceptanceInput = action === 'accept' ? acceptanceInputs[identity(item)] : undefined;
+
+                    return {
+                        assistant_id: item.review?.assistant_id ?? item.assistant_id,
+                        suggestion_id: item.id,
+                        ...(acceptanceInput ?? {}),
+                    };
+                }),
             });
             const details = data.results.map((result) => `${result.assistant_name}: ${result.label} — ${result.message}`).join('\n');
 

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Building2, Check, Plus, RefreshCw, User, X } from 'lucid
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { RelationTypeSelect } from '@/components/assistance/relation-type-select';
 import { ResourceReview } from '@/components/assistance/resource-review';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -18,6 +19,7 @@ import { type BreadcrumbItem } from '@/types';
 import {
     type AcceptResponse,
     type AssistancePageProps,
+    type AssistanceResourceGroup,
     type AssistantManifest,
     type BaseSuggestionItem,
     type BulkRorAffiliationAcceptResponse,
@@ -32,6 +34,7 @@ import {
     type SuggestedRorItem,
     type SuggestedSpdxRightsItem,
     type SuggestedSubjectMetadataEnrichmentItem,
+    type SuggestionAcceptanceInput,
 } from '@/types/assistance';
 import { validateORCID } from '@/utils/validation-rules';
 
@@ -93,22 +96,35 @@ function SuggestionCard({
     onAccept,
     onDecline,
     isProcessing,
+    relationTypes,
+    acceptanceInput,
+    onAcceptanceInputChange,
 }: {
     suggestion: SuggestedRelationItem;
-    onAccept: (id: number) => void;
+    onAccept: (id: number, input?: SuggestionAcceptanceInput) => void;
     onDecline: (id: number) => void;
     isProcessing: boolean;
+    relationTypes: NonNullable<AssistancePageProps['relationTypes']>;
+    acceptanceInput: SuggestionAcceptanceInput;
+    onAcceptanceInputChange: (input: SuggestionAcceptanceInput) => void;
 }) {
     const identifierUrl = suggestion.identifier_type === 'DOI' ? resolveIdentifierUrl(suggestion.identifier, 'DOI') : null;
+    const selectedRelationTypeId = acceptanceInput.relation_type_id ?? suggestion.relation_type_id;
 
     return (
         <div className="bg-card p-2 sm:p-3">
             <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
-                        <Badge variant="outline" className="font-mono text-xs">
-                            {suggestion.relation_type_name}
-                        </Badge>
+                        <RelationTypeSelect
+                            suggestion={suggestion}
+                            options={relationTypes}
+                            value={selectedRelationTypeId}
+                            disabled={isProcessing}
+                            onValueChange={(relationTypeId) =>
+                                onAcceptanceInputChange(relationTypeId === suggestion.relation_type_id ? {} : { relation_type_id: relationTypeId })
+                            }
+                        />
                         <Badge variant="secondary" className="text-xs">
                             {suggestion.identifier_type}
                         </Badge>
@@ -141,7 +157,7 @@ function SuggestionCard({
                         <X className="mr-1 h-4 w-4" />
                         Decline
                     </Button>
-                    <Button size="sm" disabled={isProcessing} onClick={() => onAccept(suggestion.id)}>
+                    <Button size="sm" disabled={isProcessing} onClick={() => onAccept(suggestion.id, acceptanceInput)}>
                         <Check className="mr-1 h-4 w-4" />
                         Accept
                     </Button>
@@ -1470,8 +1486,48 @@ function useSectionState(manifests: AssistantManifest[]) {
 
 // ── Main page component ──────────────────────────────────────────────
 
-export default function AssistancePage({ sections, manifests, allAssistantResources, pendingCounts }: AssistancePageProps) {
+export default function AssistancePage({ sections, manifests, allAssistantResources, pendingCounts, relationTypes = [] }: AssistancePageProps) {
     const { states, patch, addProcessingId, removeProcessingId, pollingRefs } = useSectionState(manifests);
+    const [acceptanceInputs, setAcceptanceInputs] = useState<Record<string, SuggestionAcceptanceInput>>({});
+
+    useEffect(() => {
+        const available = new Set<string>();
+
+        for (const manifest of manifests) {
+            const section = sections[manifest.id];
+
+            for (const entry of section?.data ?? []) {
+                const group = entry as AssistanceResourceGroup;
+                const items =
+                    Array.isArray(group.suggestions) && typeof group.suggestion_count === 'number'
+                        ? group.suggestions
+                        : [entry as BaseSuggestionItem];
+
+                for (const item of items) {
+                    available.add(`${item.review?.assistant_id ?? item.assistant_id ?? manifest.id}:${item.id}`);
+                }
+            }
+        }
+
+        setAcceptanceInputs((current) => {
+            const next = Object.fromEntries(Object.entries(current).filter(([key]) => available.has(key)));
+
+            return Object.keys(next).length === Object.keys(current).length ? current : next;
+        });
+    }, [manifests, sections]);
+
+    const changeAcceptanceInput = useCallback((identity: string, input: SuggestionAcceptanceInput) => {
+        setAcceptanceInputs((current) => {
+            if (Object.keys(input).length === 0) {
+                if (!(identity in current)) return current;
+                const next = { ...current };
+                delete next[identity];
+                return next;
+            }
+
+            return { ...current, [identity]: input };
+        });
+    }, []);
 
     const isAnyChecking = Object.values(states).some((s) => s.isChecking);
     const [rorBulkMatchQueue, setRorBulkMatchQueue] = useState<RorAffiliationBulkMatch[]>([]);
@@ -1481,8 +1537,8 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
     const reloadAssistanceSections = useCallback(() => {
         router.reload({
             only: allAssistantResources
-                ? ['sections', 'allAssistantResources', 'pendingCounts', 'pendingAssistanceTotalCount']
-                : ['sections', 'pendingAssistanceTotalCount'],
+                ? ['sections', 'allAssistantResources', 'pendingCounts', 'relationTypes', 'pendingAssistanceTotalCount']
+                : ['sections', 'relationTypes', 'pendingAssistanceTotalCount'],
         });
     }, [allAssistantResources]);
 
@@ -1652,11 +1708,13 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
     // ── Accept / Decline ─────────────────────────────────────────────
 
     const handleAccept = useCallback(
-        async (manifest: AssistantManifest, suggestionId: number) => {
+        async (manifest: AssistantManifest, suggestionId: number, input: SuggestionAcceptanceInput = {}) => {
             addProcessingId(manifest.id, suggestionId);
 
             try {
-                const { data } = await axios.post<AcceptResponse>(`/assistance/${manifest.routePrefix}/${suggestionId}/accept`);
+                const url = `/assistance/${manifest.routePrefix}/${suggestionId}/accept`;
+                const response = Object.keys(input).length > 0 ? await axios.post<AcceptResponse>(url, input) : await axios.post<AcceptResponse>(url);
+                const { data } = response;
 
                 if (data.success) {
                     toast.success(data.message);
@@ -1751,6 +1809,8 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
     function renderSuggestionActions(manifest: AssistantManifest, item: BaseSuggestionItem, isProcessing: boolean) {
         const isDateTypeHint = manifest.id === 'date-type-suggestion' && isRecord(item.metadata) && item.metadata.suggestion_kind === 'hint';
         const descriptionSegmentationTestId = manifest.id === 'description-segmentation' ? 'description-segmentation' : null;
+        const suggestionIdentity = `${item.review?.assistant_id ?? item.assistant_id ?? manifest.id}:${item.id}`;
+        const acceptanceInput = acceptanceInputs[suggestionIdentity] ?? {};
 
         return (
             <div className="flex flex-wrap justify-end gap-2">
@@ -1769,7 +1829,7 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
                         size="sm"
                         disabled={isProcessing}
                         data-testid={descriptionSegmentationTestId ? `${descriptionSegmentationTestId}-accept-${item.id}` : undefined}
-                        onClick={() => handleAccept(manifest, item.id)}
+                        onClick={() => handleAccept(manifest, item.id, acceptanceInput)}
                     >
                         <Check className="mr-1 h-4 w-4" />
                         Accept
@@ -1780,8 +1840,11 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
     }
 
     function renderCard(manifest: AssistantManifest, item: BaseSuggestionItem, isProcessing: boolean) {
-        const onAccept = (id: number) => handleAccept(manifest, id);
+        const suggestionIdentity = `${item.review?.assistant_id ?? item.assistant_id ?? manifest.id}:${item.id}`;
+        const acceptanceInput = acceptanceInputs[suggestionIdentity] ?? {};
+        const onAccept = (id: number, input: SuggestionAcceptanceInput = {}) => handleAccept(manifest, id, input);
         const onDecline = (id: number) => handleDecline(manifest, id);
+        const onAcceptanceInputChange = (input: SuggestionAcceptanceInput) => changeAcceptanceInput(suggestionIdentity, input);
 
         switch (manifest.id) {
             case 'relation-suggestion':
@@ -1791,6 +1854,9 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
                         onAccept={onAccept}
                         onDecline={onDecline}
                         isProcessing={isProcessing}
+                        relationTypes={relationTypes}
+                        acceptanceInput={acceptanceInput}
+                        onAcceptanceInputChange={onAcceptanceInputChange}
                     />
                 );
             case 'orcid-suggestion':
@@ -1930,6 +1996,7 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
                         onReload={reloadAssistanceSections}
                         onRorFollowUps={enqueueRorBulkMatches}
                         renderSuggestion={renderCard}
+                        acceptanceInputs={acceptanceInputs}
                     />
                 )}
 

--- a/resources/js/types/assistance.ts
+++ b/resources/js/types/assistance.ts
@@ -6,6 +6,7 @@ export interface SuggestedRelationItem {
     identifier: string;
     identifier_type: string;
     identifier_type_name: string;
+    relation_type_id: number;
     relation_type: string;
     relation_type_name: string;
     source: 'scholexplorer' | 'datacite_event_data';
@@ -14,6 +15,18 @@ export interface SuggestedRelationItem {
     source_publisher: string | null;
     source_publication_date: string | null;
     discovered_at: string;
+}
+
+export interface AssistanceRelationTypeOption {
+    id: number;
+    name: string;
+    slug: string;
+    usage_count: number;
+    is_most_used: boolean;
+}
+
+export interface SuggestionAcceptanceInput {
+    relation_type_id?: number;
 }
 
 export interface PaginatedData<T> {
@@ -303,6 +316,7 @@ export interface AssistancePageProps {
     allAssistantResources?: PaginatedData<AssistanceResourceGroup>;
     pendingCounts?: Record<string, number>;
     manifests: AssistantManifest[];
+    relationTypes?: AssistanceRelationTypeOption[];
 }
 
 export interface BatchSuggestionResult {

--- a/tests/pest/Feature/Controllers/AssistanceControllerTest.php
+++ b/tests/pest/Feature/Controllers/AssistanceControllerTest.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 use App\Http\Controllers\AssistanceController;
 use App\Models\AssistantSuggestion;
+use App\Models\DismissedRelation;
+use App\Models\IdentifierType;
 use App\Models\Person;
+use App\Models\RelatedIdentifier;
+use App\Models\RelatedItem;
+use App\Models\RelationType;
 use App\Models\Resource;
 use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\SuggestedOrcid;
+use App\Models\SuggestedRelation;
 use App\Models\SuggestedRor;
 use App\Models\User;
+use App\Services\Assistance\AssistantContract;
 use App\Services\Assistance\AssistantRegistrar;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
@@ -47,6 +54,106 @@ describe('index', function () {
                 ->has('allAssistantResources')
                 ->has('pendingCounts')
                 ->has('manifests')
+            );
+    });
+
+    it('orders active relation type options by related identifier usage and exposes relation type IDs on suggestions', function () {
+        $user = User::factory()->create(['role' => 'admin']);
+        $resource = Resource::factory()->create();
+        $identifierType = IdentifierType::create([
+            'name' => 'DOI',
+            'slug' => 'DOI',
+            'is_active' => true,
+        ]);
+        $relationTypes = collect([
+            ['name' => 'Zulu Unused', 'slug' => 'ZuluUnused', 'count' => 0],
+            ['name' => 'Has Part', 'slug' => 'HasPart', 'count' => 2],
+            ['name' => 'Cites', 'slug' => 'Cites', 'count' => 5],
+            ['name' => 'Alpha Unused', 'slug' => 'AlphaUnused', 'count' => 0],
+            ['name' => 'Documents', 'slug' => 'Documents', 'count' => 3],
+            ['name' => 'Compiles', 'slug' => 'Compiles', 'count' => 1],
+            ['name' => 'References', 'slug' => 'References', 'count' => 4],
+        ])->mapWithKeys(function (array $definition) use ($resource, $identifierType): array {
+            $type = RelationType::create([
+                'name' => $definition['name'],
+                'slug' => $definition['slug'],
+                'is_active' => true,
+            ]);
+
+            for ($position = 1; $position <= $definition['count']; $position++) {
+                RelatedIdentifier::create([
+                    'resource_id' => $resource->id,
+                    'identifier' => "10.1234/{$definition['slug']}.{$position}",
+                    'identifier_type_id' => $identifierType->id,
+                    'relation_type_id' => $type->id,
+                    'position' => $position,
+                ]);
+            }
+
+            return [$definition['slug'] => $type];
+        });
+
+        $inactive = RelationType::create([
+            'name' => 'Inactive Popular',
+            'slug' => 'InactivePopular',
+            'is_active' => false,
+        ]);
+        foreach (range(1, 8) as $position) {
+            RelatedIdentifier::create([
+                'resource_id' => $resource->id,
+                'identifier' => "10.1234/inactive.{$position}",
+                'identifier_type_id' => $identifierType->id,
+                'relation_type_id' => $inactive->id,
+                'position' => $position + 20,
+            ]);
+            RelatedItem::create([
+                'resource_id' => $resource->id,
+                'related_item_type' => 'Dataset',
+                'relation_type_id' => $relationTypes['ZuluUnused']->id,
+                'position' => $position,
+            ]);
+            SuggestedRelation::create([
+                'resource_id' => $resource->id,
+                'identifier' => "10.1234/open-suggestion.{$position}",
+                'identifier_type_id' => $identifierType->id,
+                'relation_type_id' => $relationTypes['ZuluUnused']->id,
+                'source' => 'scholexplorer',
+                'discovered_at' => now(),
+            ]);
+            DismissedRelation::create([
+                'resource_id' => $resource->id,
+                'identifier' => "10.1234/dismissed.{$position}",
+                'relation_type_id' => $relationTypes['ZuluUnused']->id,
+                'dismissed_by' => $user->id,
+            ]);
+        }
+
+        $suggestion = SuggestedRelation::create([
+            'resource_id' => $resource->id,
+            'identifier' => '10.1234/suggested',
+            'identifier_type_id' => $identifierType->id,
+            'relation_type_id' => $relationTypes['Cites']->id,
+            'source' => 'scholexplorer',
+            'discovered_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get('/assistance')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->has('relationTypes', 7)
+                ->where('relationTypes.0.slug', 'Cites')
+                ->where('relationTypes.0.usage_count', 5)
+                ->where('relationTypes.0.is_most_used', true)
+                ->where('relationTypes.1.slug', 'References')
+                ->where('relationTypes.2.slug', 'Documents')
+                ->where('relationTypes.3.slug', 'HasPart')
+                ->where('relationTypes.4.slug', 'Compiles')
+                ->where('relationTypes.5.slug', 'AlphaUnused')
+                ->where('relationTypes.5.is_most_used', false)
+                ->where('relationTypes.6.slug', 'ZuluUnused')
+                ->where('sections.relation-suggestion.data.0.suggestions.0.id', $suggestion->id)
+                ->where('sections.relation-suggestion.data.0.suggestions.0.relation_type_id', $relationTypes['Cites']->id)
             );
     });
 
@@ -284,6 +391,30 @@ describe('accept', function () {
             ->post('/assistance/relations/99999/accept')
             ->assertOk()
             ->assertJson(['success' => false]);
+    });
+
+    it('forwards a validated active relation type override to the assistant', function () {
+        $user = User::factory()->create(['role' => 'admin']);
+        $relationType = RelationType::create([
+            'name' => 'References',
+            'slug' => 'References',
+            'is_active' => true,
+        ]);
+        $registrar = new AssistantRegistrar;
+        $assistant = Mockery::mock(AssistantContract::class);
+        $assistant->shouldReceive('getId')->once()->andReturn('relation-suggestion');
+        $assistant->shouldReceive('countPending')->andReturn(0);
+        $assistant->shouldReceive('acceptSuggestion')
+            ->once()
+            ->with(123, ['relation_type_id' => $relationType->id])
+            ->andReturn(['success' => true, 'message' => 'Accepted with override.']);
+        $registrar->register($assistant);
+        app()->instance(AssistantRegistrar::class, $registrar);
+
+        $this->actingAs($user)
+            ->postJson('/assistance/relations/123/accept', ['relation_type_id' => $relationType->id])
+            ->assertOk()
+            ->assertJson(['success' => true, 'message' => 'Accepted with override.']);
     });
 });
 

--- a/tests/pest/Feature/Services/RelationSuggestionAcceptanceOverrideTest.php
+++ b/tests/pest/Feature/Services/RelationSuggestionAcceptanceOverrideTest.php
@@ -15,6 +15,7 @@ use App\Services\RelationDiscoveryService;
 use App\Services\ScholExplorerService;
 use Database\Seeders\IdentifierTypeSeeder;
 use Database\Seeders\RelationTypeSeeder;
+use Modules\Assistants\RelationSuggestion\Assistant as RelationSuggestionAssistant;
 
 beforeEach(function (): void {
     test()->seed(IdentifierTypeSeeder::class);
@@ -71,6 +72,51 @@ it('stores an active override instead of the suggested relation type', function 
         ->and($stored->relation_type_id)->toBe($overrideType->id)
         ->and($stored->relation_type_id)->not->toBe($suggestedType->id)
         ->and(SuggestedRelation::find($suggestion->id))->toBeNull();
+});
+
+it('normalizes a validated numeric-string override before accepting', function (): void {
+    $resource = Resource::factory()->create();
+    $suggestedType = RelationType::query()->where('slug', 'Cites')->firstOrFail();
+    $overrideType = RelationType::query()->where('slug', 'References')->firstOrFail();
+    $suggestion = relationAcceptanceSuggestion($resource, $suggestedType, '10.5880/override.2026.string');
+    $service = Mockery::mock(RelationDiscoveryService::class);
+    $service->shouldReceive('acceptRelation')
+        ->once()
+        ->with(
+            Mockery::on(fn (SuggestedRelation $candidate): bool => $candidate->is($suggestion)),
+            $overrideType->id,
+        )
+        ->andReturn([
+            'success' => true,
+            'datacite_synced' => false,
+            'message' => 'Accepted with override.',
+        ]);
+
+    $result = (new RelationSuggestionAssistant($service))->acceptSuggestion(
+        $suggestion->id,
+        ['relation_type_id' => (string) $overrideType->id],
+    );
+
+    expect($result['success'])->toBeTrue();
+});
+
+it('still rejects a non-integer string override before calling the service', function (): void {
+    $resource = Resource::factory()->create();
+    $suggestedType = RelationType::query()->where('slug', 'Cites')->firstOrFail();
+    $suggestion = relationAcceptanceSuggestion($resource, $suggestedType, '10.5880/override.2026.invalid-string');
+    $service = Mockery::mock(RelationDiscoveryService::class);
+    $service->shouldNotReceive('acceptRelation');
+
+    $result = (new RelationSuggestionAssistant($service))->acceptSuggestion(
+        $suggestion->id,
+        ['relation_type_id' => '42.5'],
+    );
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'datacite_synced' => false,
+        'message' => 'The selected relation type is invalid.',
+    ])->and(SuggestedRelation::find($suggestion->id))->not->toBeNull();
 });
 
 it('rejects an inactive override without mutating the suggestion', function (): void {

--- a/tests/pest/Feature/Services/RelationSuggestionAcceptanceOverrideTest.php
+++ b/tests/pest/Feature/Services/RelationSuggestionAcceptanceOverrideTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\IdentifierType;
+use App\Models\RelatedIdentifier;
+use App\Models\RelationType;
+use App\Models\Resource;
+use App\Models\SuggestedRelation;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\DataCiteEventDataService;
+use App\Services\DataCiteSyncResult;
+use App\Services\DataCiteSyncService;
+use App\Services\RelationDiscoveryService;
+use App\Services\ScholExplorerService;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\RelationTypeSeeder;
+
+beforeEach(function (): void {
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+});
+
+afterEach(function (): void {
+    Mockery::close();
+});
+
+function relationAcceptanceService(
+    DataCiteSyncService $syncService,
+    RelatedIdentifierCitationLabelService $citationLabelService,
+): RelationDiscoveryService {
+    return new RelationDiscoveryService(
+        Mockery::mock(ScholExplorerService::class),
+        Mockery::mock(DataCiteEventDataService::class),
+        $syncService,
+        $citationLabelService,
+    );
+}
+
+function relationAcceptanceSuggestion(Resource $resource, RelationType $relationType, string $identifier): SuggestedRelation
+{
+    return SuggestedRelation::create([
+        'resource_id' => $resource->id,
+        'identifier' => $identifier,
+        'identifier_type_id' => IdentifierType::query()->where('slug', 'DOI')->value('id'),
+        'relation_type_id' => $relationType->id,
+        'source' => 'scholexplorer',
+        'source_title' => 'Relation override test',
+        'discovered_at' => now(),
+    ]);
+}
+
+it('stores an active override instead of the suggested relation type', function (): void {
+    $resource = Resource::factory()->create();
+    $suggestedType = RelationType::query()->where('slug', 'Cites')->firstOrFail();
+    $overrideType = RelationType::query()->where('slug', 'References')->firstOrFail();
+    $suggestion = relationAcceptanceSuggestion($resource, $suggestedType, '10.5880/override.2026.001');
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldReceive('syncIfRegistered')
+        ->once()
+        ->with(Mockery::on(fn (Resource $candidate): bool => $candidate->is($resource)))
+        ->andReturn(DataCiteSyncResult::notRequired());
+    $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $citationLabelService->shouldReceive('resolveBestEffort')->once()->andReturnNull();
+
+    $result = relationAcceptanceService($syncService, $citationLabelService)
+        ->acceptRelation($suggestion, $overrideType->id);
+    $stored = RelatedIdentifier::query()->where('resource_id', $resource->id)->sole();
+
+    expect($result['success'])->toBeTrue()
+        ->and($stored->relation_type_id)->toBe($overrideType->id)
+        ->and($stored->relation_type_id)->not->toBe($suggestedType->id)
+        ->and(SuggestedRelation::find($suggestion->id))->toBeNull();
+});
+
+it('rejects an inactive override without mutating the suggestion', function (): void {
+    $resource = Resource::factory()->create();
+    $suggestedType = RelationType::query()->where('slug', 'Cites')->firstOrFail();
+    $inactiveOverride = RelationType::query()->where('slug', 'References')->firstOrFail();
+    $inactiveOverride->update(['is_active' => false]);
+    $suggestion = relationAcceptanceSuggestion($resource, $suggestedType, '10.5880/override.2026.002');
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldNotReceive('syncIfRegistered');
+    $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $citationLabelService->shouldNotReceive('resolveBestEffort');
+
+    $result = relationAcceptanceService($syncService, $citationLabelService)
+        ->acceptRelation($suggestion, $inactiveOverride->id);
+
+    expect($result)->toMatchArray([
+        'success' => false,
+        'datacite_synced' => false,
+        'message' => 'The selected relation type is not available.',
+    ])->and(SuggestedRelation::find($suggestion->id))->not->toBeNull()
+        ->and(RelatedIdentifier::where('resource_id', $resource->id)->exists())->toBeFalse();
+});
+
+it('still accepts an inactive original type when no override is supplied', function (): void {
+    $resource = Resource::factory()->create();
+    $originalType = RelationType::query()->where('slug', 'Cites')->firstOrFail();
+    $suggestion = relationAcceptanceSuggestion($resource, $originalType, '10.5880/override.2026.003');
+    $originalType->update(['is_active' => false]);
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldReceive('syncIfRegistered')->once()->andReturn(DataCiteSyncResult::notRequired());
+    $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $citationLabelService->shouldReceive('resolveBestEffort')->once()->andReturnNull();
+
+    $result = relationAcceptanceService($syncService, $citationLabelService)->acceptRelation($suggestion);
+
+    expect($result['success'])->toBeTrue()
+        ->and(RelatedIdentifier::where([
+            'resource_id' => $resource->id,
+            'relation_type_id' => $originalType->id,
+        ])->exists())->toBeTrue()
+        ->and(SuggestedRelation::find($suggestion->id))->toBeNull();
+});
+
+it('uses the override for duplicate detection and preserves the curated relation', function (): void {
+    $resource = Resource::factory()->create();
+    $suggestedType = RelationType::query()->where('slug', 'Cites')->firstOrFail();
+    $overrideType = RelationType::query()->where('slug', 'References')->firstOrFail();
+    $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+    RelatedIdentifier::create([
+        'resource_id' => $resource->id,
+        'identifier' => '10.5880/override.2026.004',
+        'identifier_type_id' => $identifierTypeId,
+        'relation_type_id' => $overrideType->id,
+        'citation_label' => 'Curated label',
+        'position' => 0,
+    ]);
+    $suggestion = relationAcceptanceSuggestion($resource, $suggestedType, '10.5880/override.2026.004');
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldReceive('syncIfRegistered')->once()->andReturn(DataCiteSyncResult::notRequired());
+    $citationLabelService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $citationLabelService->shouldNotReceive('resolveBestEffort');
+
+    $result = relationAcceptanceService($syncService, $citationLabelService)
+        ->acceptRelation($suggestion, $overrideType->id);
+    $stored = RelatedIdentifier::where('resource_id', $resource->id)->get();
+
+    expect($result['success'])->toBeTrue()
+        ->and($stored)->toHaveCount(1)
+        ->and($stored->sole()->citation_label)->toBe('Curated label')
+        ->and($stored->sole()->relation_type_id)->toBe($overrideType->id)
+        ->and(SuggestedRelation::find($suggestion->id))->toBeNull();
+});

--- a/tests/pest/Unit/Http/Requests/Batch/BatchAndAssistanceFormRequestsTest.php
+++ b/tests/pest/Unit/Http/Requests/Batch/BatchAndAssistanceFormRequestsTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 use App\Enums\UserRole;
 use App\Http\Requests\Assistance\AcceptRorAffiliationMatchesRequest;
+use App\Http\Requests\Assistance\AcceptSuggestionRequest;
 use App\Http\Requests\Assistance\BatchSuggestionsRequest;
 use App\Http\Requests\Assistance\DeclineSuggestionRequest;
 use App\Http\Requests\Batch\DestroyIgsnsRequest;
 use App\Http\Requests\Batch\ExportResourcesRequest;
 use App\Http\Requests\Batch\RegisterIgsnsRequest;
 use App\Http\Requests\Batch\RegisterResourcesRequest;
+use App\Models\RelationType;
 use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -20,6 +22,7 @@ uses(RefreshDatabase::class);
 
 covers(
     AcceptRorAffiliationMatchesRequest::class,
+    AcceptSuggestionRequest::class,
     BatchSuggestionsRequest::class,
     DeclineSuggestionRequest::class,
     DestroyIgsnsRequest::class,
@@ -81,6 +84,37 @@ it('BatchSuggestionsRequest authorizes users and bounds resource-scoped selectio
             ...$valid,
             'reason' => str_repeat('x', 256),
         ], $rules)->fails())->toBeTrue();
+});
+
+it('acceptance requests allow only active relation type overrides', function (): void {
+    $active = RelationType::create(['name' => 'Cites', 'slug' => 'Cites', 'is_active' => true]);
+    $inactive = RelationType::create(['name' => 'References', 'slug' => 'References', 'is_active' => false]);
+
+    $request = new AcceptSuggestionRequest;
+    expect($request->authorize())->toBeFalse();
+    $request->setUserResolver(fn () => User::factory()->create());
+    expect($request->authorize())->toBeTrue();
+
+    $rules = $request->rules();
+    expect(Validator::make([], $rules)->fails())->toBeFalse()
+        ->and(Validator::make(['relation_type_id' => $active->id], $rules)->fails())->toBeFalse()
+        ->and(Validator::make(['relation_type_id' => $inactive->id], $rules)->fails())->toBeTrue()
+        ->and(Validator::make(['relation_type_id' => 999999], $rules)->fails())->toBeTrue()
+        ->and(Validator::make(['relation_type_id' => 'Cites'], $rules)->fails())->toBeTrue();
+
+    $batchRules = (new BatchSuggestionsRequest)->rules();
+    $payload = [
+        'resource_id' => 10,
+        'suggestions' => [[
+            'assistant_id' => 'relation-suggestion',
+            'suggestion_id' => 20,
+            'relation_type_id' => $active->id,
+        ]],
+    ];
+    expect(Validator::make($payload, $batchRules)->fails())->toBeFalse();
+
+    $payload['suggestions'][0]['relation_type_id'] = $inactive->id;
+    expect(Validator::make($payload, $batchRules)->fails())->toBeTrue();
 });
 
 it('DestroyIgsnsRequest authorizes only admins', function (): void {

--- a/tests/pest/Unit/Http/Requests/Batch/BatchAndAssistanceFormRequestsTest.php
+++ b/tests/pest/Unit/Http/Requests/Batch/BatchAndAssistanceFormRequestsTest.php
@@ -98,6 +98,7 @@ it('acceptance requests allow only active relation type overrides', function ():
     $rules = $request->rules();
     expect(Validator::make([], $rules)->fails())->toBeFalse()
         ->and(Validator::make(['relation_type_id' => $active->id], $rules)->fails())->toBeFalse()
+        ->and(Validator::make(['relation_type_id' => (string) $active->id], $rules)->fails())->toBeFalse()
         ->and(Validator::make(['relation_type_id' => $inactive->id], $rules)->fails())->toBeTrue()
         ->and(Validator::make(['relation_type_id' => 999999], $rules)->fails())->toBeTrue()
         ->and(Validator::make(['relation_type_id' => 'Cites'], $rules)->fails())->toBeTrue();
@@ -111,6 +112,9 @@ it('acceptance requests allow only active relation type overrides', function ():
             'relation_type_id' => $active->id,
         ]],
     ];
+    expect(Validator::make($payload, $batchRules)->fails())->toBeFalse();
+
+    $payload['suggestions'][0]['relation_type_id'] = (string) $active->id;
     expect(Validator::make($payload, $batchRules)->fails())->toBeFalse();
 
     $payload['suggestions'][0]['relation_type_id'] = $inactive->id;

--- a/tests/pest/Unit/Services/BatchSuggestionActionServiceTest.php
+++ b/tests/pest/Unit/Services/BatchSuggestionActionServiceTest.php
@@ -79,6 +79,34 @@ it('executes a validated batch and returns complete per-item feedback', function
         ->and($result['results'][1]['message'])->toBe('Stale suggestion.');
 });
 
+it('forwards a relation type override only when accepting', function (): void {
+    [$registrar, $assistant] = registerBatchAssistant([
+        1 => reviewSuggestion(1, 10),
+        2 => reviewSuggestion(2, 10),
+        3 => reviewSuggestion(3, 10),
+    ]);
+    $user = new User;
+    $assistant->shouldReceive('acceptSuggestion')->once()->with(1, ['relation_type_id' => 42])->andReturn([
+        'success' => true, 'message' => 'Accepted with first override.',
+    ]);
+    $assistant->shouldReceive('acceptSuggestion')->once()->with(2, ['relation_type_id' => 43])->andReturn([
+        'success' => true, 'message' => 'Accepted with second override.',
+    ]);
+    $assistant->shouldReceive('declineSuggestion')->once()->with(3, $user, null)->andReturn([
+        'success' => true,
+        'message' => 'Declined.',
+    ]);
+
+    $service = new BatchSuggestionActionService($registrar);
+    $service->execute('accept', 10, [
+        ['assistant_id' => 'test-assistant', 'suggestion_id' => 1, 'relation_type_id' => 42],
+        ['assistant_id' => 'test-assistant', 'suggestion_id' => 2, 'relation_type_id' => 43],
+    ], $user);
+    $service->execute('decline', 10, [[
+        'assistant_id' => 'test-assistant', 'suggestion_id' => 3, 'relation_type_id' => 42,
+    ]], $user);
+});
+
 it('allows multiple exclusive alternatives to be declined', function (): void {
     [$registrar, $assistant] = registerBatchAssistant([
         1 => reviewSuggestion(1, 10, 'person:5'),

--- a/tests/vitest/components/assistance-relation-type-select.test.tsx
+++ b/tests/vitest/components/assistance-relation-type-select.test.tsx
@@ -1,0 +1,83 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@tests/vitest/utils/render';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RelationTypeSelect } from '@/components/assistance/relation-type-select';
+import type { AssistanceRelationTypeOption, SuggestedRelationItem } from '@/types/assistance';
+
+const options: AssistanceRelationTypeOption[] = [
+    { id: 1, name: 'Cites', slug: 'Cites', usage_count: 50, is_most_used: true },
+    { id: 2, name: 'References', slug: 'References', usage_count: 40, is_most_used: true },
+    { id: 3, name: 'Documents', slug: 'Documents', usage_count: 30, is_most_used: true },
+    { id: 4, name: 'Has Part', slug: 'HasPart', usage_count: 20, is_most_used: true },
+    { id: 5, name: 'Compiles', slug: 'Compiles', usage_count: 10, is_most_used: true },
+    { id: 6, name: 'Is Derived From', slug: 'IsDerivedFrom', usage_count: 2, is_most_used: false },
+    { id: 7, name: 'Reviews', slug: 'Reviews', usage_count: 1, is_most_used: false },
+];
+
+function suggestion(overrides: Partial<SuggestedRelationItem> = {}): SuggestedRelationItem {
+    return {
+        id: 11,
+        resource_id: 10,
+        resource_doi: '10.5880/test.2026.011',
+        resource_title: 'Test resource',
+        identifier: '10.1234/related',
+        identifier_type: 'DOI',
+        identifier_type_name: 'DOI',
+        relation_type_id: 1,
+        relation_type: 'Cites',
+        relation_type_name: 'Cites',
+        source: 'scholexplorer',
+        source_title: 'Related resource',
+        source_type: 'Dataset',
+        source_publisher: 'GFZ',
+        source_publication_date: '2026',
+        discovered_at: '2026-07-26T10:00:00+00:00',
+        ...overrides,
+    };
+}
+
+describe('RelationTypeSelect', () => {
+    it('groups the dynamic top five before the remaining active relation types', async () => {
+        const user = userEvent.setup();
+        const onValueChange = vi.fn();
+
+        render(<RelationTypeSelect suggestion={suggestion()} options={options} value={1} disabled={false} onValueChange={onValueChange} />);
+
+        const select = screen.getByRole('combobox', { name: 'Relation type for 10.1234/related' });
+        expect(select).toHaveTextContent('Cites');
+
+        await user.click(select);
+
+        expect(screen.getByText('Most Used')).toBeInTheDocument();
+        expect(screen.getByText('All Relation Types')).toBeInTheDocument();
+        expect(screen.queryByText('Suggested Type')).not.toBeInTheDocument();
+        expect(screen.getAllByRole('option')).toHaveLength(7);
+
+        await user.click(screen.getByRole('option', { name: /^References/ }));
+        expect(onValueChange).toHaveBeenCalledWith(2);
+    });
+
+    it('keeps only the inactive original type available as a marked suggestion option', async () => {
+        const user = userEvent.setup();
+        const inactiveSuggestion = suggestion({
+            relation_type_id: 99,
+            relation_type: 'LegacyRelation',
+            relation_type_name: 'Legacy Relation',
+        });
+
+        render(<RelationTypeSelect suggestion={inactiveSuggestion} options={options} value={99} disabled={false} onValueChange={vi.fn()} />);
+
+        await user.click(screen.getByRole('combobox', { name: 'Relation type for 10.1234/related' }));
+
+        expect(screen.getByText('Suggested Type')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Legacy Relation (inactive)' })).toBeInTheDocument();
+        expect(screen.getAllByRole('option')).toHaveLength(8);
+    });
+
+    it('disables changes while the suggestion is processing', () => {
+        render(<RelationTypeSelect suggestion={suggestion()} options={options} value={1} disabled onValueChange={vi.fn()} />);
+
+        expect(screen.getByRole('combobox', { name: 'Relation type for 10.1234/related' })).toBeDisabled();
+    });
+});

--- a/tests/vitest/components/assistance-resource-review.test.tsx
+++ b/tests/vitest/components/assistance-resource-review.test.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ResourceReview } from '@/components/assistance/resource-review';
-import type { AssistanceResourceGroup, AssistantManifest, BaseSuggestionItem, PaginatedData } from '@/types/assistance';
+import type { AssistanceResourceGroup, AssistantManifest, BaseSuggestionItem, PaginatedData, SuggestionAcceptanceInput } from '@/types/assistance';
 
 vi.mock('@inertiajs/react', () => ({
     Link: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
@@ -57,7 +57,7 @@ function page(group: AssistanceResourceGroup): PaginatedData<AssistanceResourceG
     return { data: [group], current_page: 1, last_page: 1, per_page: 25, total: 1, from: 1, to: 1, links: [] };
 }
 
-function renderReview(items: BaseSuggestionItem[]) {
+function renderReview(items: BaseSuggestionItem[], acceptanceInputs: Record<string, SuggestionAcceptanceInput> = {}) {
     const group: AssistanceResourceGroup = {
         resource_id: 10,
         resource_doi: '10.1234/test',
@@ -80,14 +80,42 @@ function renderReview(items: BaseSuggestionItem[]) {
             onReload={onReload}
             onRorFollowUps={onRorFollowUps}
             renderSuggestion={(_manifest, item) => <p>{String(item.suggested_label)}</p>}
+            acceptanceInputs={acceptanceInputs}
         />,
     );
 
     return { onReload, onRorFollowUps, unmount: rendered.unmount };
 }
 
+function memoryStorage(): Storage {
+    const values = new Map<string, string>();
+
+    return {
+        get length() {
+            return values.size;
+        },
+        clear: () => values.clear(),
+        getItem: (key) => values.get(key) ?? null,
+        key: (index) => [...values.keys()][index] ?? null,
+        removeItem: (key) => {
+            values.delete(key);
+        },
+        setItem: (key, value) => {
+            values.set(key, value);
+        },
+    };
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
+
+    if (window.localStorage === undefined) {
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            value: memoryStorage(),
+        });
+    }
+
     window.localStorage.clear();
 });
 
@@ -260,5 +288,47 @@ describe('resource-oriented assistance review', () => {
             expect(onRorFollowUps).toHaveBeenCalledWith([followUp]);
             expect(onReload).toHaveBeenCalledOnce();
         });
+    });
+
+    it('never sends an acceptance override when declining a selection', async () => {
+        const user = userEvent.setup();
+        vi.mocked(axios.post).mockResolvedValueOnce({
+            data: {
+                success: true,
+                action: 'decline',
+                resource_id: 10,
+                resource_label: '10.1234/test',
+                processed_count: 1,
+                success_count: 1,
+                failure_count: 0,
+                message: '1 suggestion(s) declined.',
+                synced_dois: [],
+                follow_ups: [],
+                results: [
+                    {
+                        assistant_id: manifest.id,
+                        assistant_name: manifest.name,
+                        suggestion_id: 1,
+                        label: 'Normal candidate',
+                        success: true,
+                        message: 'Declined.',
+                        synced_dois: [],
+                    },
+                ],
+            },
+        });
+        renderReview([suggestion(1, 'Normal candidate')], {
+            [`${manifest.id}:1`]: { relation_type_id: 42 },
+        });
+
+        await user.click(screen.getByRole('checkbox', { name: 'Select Test assistant: Normal candidate' }));
+        await user.click(screen.getByRole('button', { name: 'Decline' }));
+
+        await waitFor(() =>
+            expect(axios.post).toHaveBeenCalledWith('/assistance/suggestions/batch/decline', {
+                resource_id: 10,
+                suggestions: [{ assistant_id: manifest.id, suggestion_id: 1 }],
+            }),
+        );
     });
 });

--- a/tests/vitest/pages/__tests__/assistance-links.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-links.test.tsx
@@ -124,6 +124,7 @@ function makeRelationSuggestion(overrides: Partial<SuggestedRelationItem> = {}):
         identifier_type: 'DOI',
         identifier_type_name: 'DOI',
         relation_type: 'IsSupplementTo',
+        relation_type_id: 1,
         relation_type_name: 'Is supplement to',
         source: 'scholexplorer',
         source_title: 'Suggested related resource',
@@ -1149,7 +1150,7 @@ describe('SpdxRightsSuggestionCard - SPDX preview', () => {
         await waitFor(() => {
             expect(mockedToastWarning).toHaveBeenCalledWith('Suggestion not found.');
             expect(mockedToastInfo).not.toHaveBeenCalled();
-            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
         });
     });
 });
@@ -1773,7 +1774,7 @@ describe('RorSuggestionCard – ROR link', () => {
 
         await waitFor(() => {
             expect(mockedAxiosPost).toHaveBeenNthCalledWith(1, '/assistance/rors/954/accept');
-            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         });
     });
@@ -1832,7 +1833,7 @@ describe('RorSuggestionCard – ROR link', () => {
             expect(mockedAxiosPost).toHaveBeenNthCalledWith(2, '/assistance/rors/bulk-affiliation-accept', {
                 bulk_token: BULK_TOKEN_MATCH,
             });
-            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
         });
     });
 
@@ -1939,7 +1940,7 @@ describe('RorSuggestionCard – ROR link', () => {
             expect(mockedAxiosPost).toHaveBeenNthCalledWith(3, '/assistance/rors/bulk-affiliation-accept', {
                 bulk_token: BULK_TOKEN_RETRY,
             });
-            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         });
     });
@@ -1990,7 +1991,7 @@ describe('RorSuggestionCard – ROR link', () => {
                 bulk_token: BULK_TOKEN_EXPIRED,
             });
             expect(mockedToastWarning).toHaveBeenCalledWith('Bulk ROR acceptance token is invalid or has expired.');
-            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         });
     });
@@ -2028,7 +2029,7 @@ describe('RorSuggestionCard – ROR link', () => {
 
         await waitFor(() => {
             expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
-            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'pendingAssistanceTotalCount'] });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         });
     });
@@ -2124,7 +2125,7 @@ describe('RorSuggestionCard – ROR link', () => {
         await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Decline' }));
         await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
         expect(mockedRouterReload).toHaveBeenCalledWith({
-            only: ['sections', 'allAssistantResources', 'pendingCounts', 'pendingAssistanceTotalCount'],
+            only: ['sections', 'allAssistantResources', 'pendingCounts', 'relationTypes', 'pendingAssistanceTotalCount'],
         });
     });
 });

--- a/tests/vitest/pages/__tests__/assistance-relation-type-acceptance.test.tsx
+++ b/tests/vitest/pages/__tests__/assistance-relation-type-acceptance.test.tsx
@@ -1,0 +1,227 @@
+import { router } from '@inertiajs/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@tests/vitest/utils/render';
+import axios from 'axios';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+    AssistanceRelationTypeOption,
+    AssistanceResourceGroup,
+    AssistantManifest,
+    BaseSuggestionItem,
+    PaginatedData,
+    SuggestedRelationItem,
+} from '@/types/assistance';
+
+vi.mock('@inertiajs/react', () => ({
+    Head: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+    usePage: () => ({ props: {} }),
+    router: { reload: vi.fn(), get: vi.fn() },
+}));
+
+vi.mock('@/layouts/app-layout', () => ({
+    default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock('axios', () => {
+    const post = vi.fn();
+    const get = vi.fn();
+    const isAxiosError = vi.fn(() => false);
+    return { default: { post, get, isAxiosError }, post, get, isAxiosError };
+});
+
+import AssistancePage from '@/pages/assistance';
+
+const mockedAxiosPost = axios.post as Mock;
+const mockedRouterReload = router.reload as Mock;
+
+const manifest: AssistantManifest = {
+    id: 'relation-suggestion',
+    name: 'Relation Suggestions',
+    description: 'Relation suggestion test',
+    icon: 'Link',
+    version: '1.0.0',
+    routePrefix: 'relations',
+    sortOrder: 10,
+    statusLabels: {},
+    emptyState: { title: 'No suggestions', description: 'No pending relations.' },
+    cardComponent: null,
+};
+
+const relationTypes: AssistanceRelationTypeOption[] = [
+    { id: 1, name: 'Is supplement to', slug: 'IsSupplementTo', usage_count: 50, is_most_used: true },
+    { id: 2, name: 'References', slug: 'References', usage_count: 40, is_most_used: true },
+    { id: 3, name: 'Cites', slug: 'Cites', usage_count: 30, is_most_used: true },
+    { id: 4, name: 'Documents', slug: 'Documents', usage_count: 20, is_most_used: true },
+    { id: 5, name: 'Has part', slug: 'HasPart', usage_count: 10, is_most_used: true },
+    { id: 6, name: 'Reviews', slug: 'Reviews', usage_count: 1, is_most_used: false },
+];
+
+function relationSuggestion(): SuggestedRelationItem {
+    return {
+        id: 11,
+        resource_id: 10,
+        resource_doi: '10.5880/test.2026.011',
+        resource_title: 'Test resource',
+        identifier: '10.1234/suggested-resource',
+        identifier_type: 'DOI',
+        identifier_type_name: 'DOI',
+        relation_type_id: 1,
+        relation_type: 'IsSupplementTo',
+        relation_type_name: 'Is supplement to',
+        source: 'scholexplorer',
+        source_title: 'Suggested related resource',
+        source_type: 'Dataset',
+        source_publisher: 'GFZ',
+        source_publication_date: '2026',
+        discovered_at: '2026-07-26T10:00:00+00:00',
+    };
+}
+
+function legacyPage(suggestion: SuggestedRelationItem): PaginatedData<BaseSuggestionItem> {
+    return {
+        data: [suggestion as unknown as BaseSuggestionItem],
+        current_page: 1,
+        last_page: 1,
+        per_page: 25,
+        total: 1,
+        from: 1,
+        to: 1,
+        links: [],
+    };
+}
+
+function groupedPage(suggestion: SuggestedRelationItem): PaginatedData<AssistanceResourceGroup> {
+    const item = {
+        ...suggestion,
+        assistant_id: manifest.id,
+        review: {
+            assistant_id: manifest.id,
+            assistant_name: manifest.name,
+            route_prefix: manifest.routePrefix,
+            can_accept: true,
+            can_decline: true,
+            exclusive_target_key: null,
+            label: suggestion.identifier,
+        },
+    } as unknown as BaseSuggestionItem;
+
+    return {
+        data: [
+            {
+                resource_id: suggestion.resource_id,
+                resource_doi: suggestion.resource_doi,
+                resource_title: suggestion.resource_title,
+                suggestion_count: 1,
+                suggestions: [item],
+            },
+        ],
+        current_page: 1,
+        last_page: 1,
+        per_page: 25,
+        total: 1,
+        from: 1,
+        to: 1,
+        links: [],
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('relation type acceptance input', () => {
+    it('sends a changed relation type through the single acceptance endpoint', async () => {
+        const user = userEvent.setup();
+        const suggestion = relationSuggestion();
+        mockedAxiosPost.mockResolvedValueOnce({ data: { success: true, message: 'Accepted.' } });
+
+        render(<AssistancePage sections={{ [manifest.id]: legacyPage(suggestion) }} manifests={[manifest]} relationTypes={relationTypes} />);
+
+        const select = screen.getByRole('combobox', { name: `Relation type for ${suggestion.identifier}` });
+        await user.click(select);
+        await user.click(screen.getByRole('option', { name: /^References/ }));
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => {
+            expect(mockedAxiosPost).toHaveBeenCalledWith('/assistance/relations/11/accept', { relation_type_id: 2 });
+            expect(mockedRouterReload).toHaveBeenCalledWith({ only: ['sections', 'relationTypes', 'pendingAssistanceTotalCount'] });
+        });
+    });
+
+    it('removes the override after changing back to the suggested type', async () => {
+        const user = userEvent.setup();
+        const suggestion = relationSuggestion();
+        mockedAxiosPost.mockResolvedValueOnce({ data: { success: true, message: 'Accepted.' } });
+
+        render(<AssistancePage sections={{ [manifest.id]: legacyPage(suggestion) }} manifests={[manifest]} relationTypes={relationTypes} />);
+
+        const select = screen.getByRole('combobox', { name: `Relation type for ${suggestion.identifier}` });
+        await user.click(select);
+        await user.click(screen.getByRole('option', { name: /^References/ }));
+        await user.click(select);
+        await user.click(screen.getByRole('option', { name: /^Is supplement to/ }));
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() => expect(mockedAxiosPost).toHaveBeenCalledWith('/assistance/relations/11/accept'));
+    });
+
+    it('shares the override between review tabs and includes it in the resource batch', async () => {
+        const user = userEvent.setup();
+        const suggestion = relationSuggestion();
+        const page = groupedPage(suggestion);
+        mockedAxiosPost.mockResolvedValueOnce({
+            data: {
+                success: true,
+                action: 'accept',
+                resource_id: suggestion.resource_id,
+                resource_label: suggestion.resource_doi,
+                processed_count: 1,
+                success_count: 1,
+                failure_count: 0,
+                message: 'Accepted.',
+                synced_dois: [],
+                follow_ups: [],
+                results: [
+                    {
+                        assistant_id: manifest.id,
+                        assistant_name: manifest.name,
+                        suggestion_id: suggestion.id,
+                        label: suggestion.identifier,
+                        success: true,
+                        message: 'Accepted.',
+                        synced_dois: [],
+                    },
+                ],
+            },
+        });
+
+        render(
+            <AssistancePage allAssistantResources={page} sections={{ [manifest.id]: page }} manifests={[manifest]} relationTypes={relationTypes} />,
+        );
+
+        await user.click(screen.getByRole('combobox', { name: `Relation type for ${suggestion.identifier}` }));
+        await user.click(screen.getByRole('option', { name: /^References/ }));
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+        expect(screen.getByRole('combobox', { name: `Relation type for ${suggestion.identifier}` })).toHaveTextContent('References');
+        await user.click(screen.getByRole('checkbox', { name: `Select ${manifest.name}: ${suggestion.identifier}` }));
+        await user.click(screen.getByRole('button', { name: 'Accept' }));
+
+        await waitFor(() =>
+            expect(mockedAxiosPost).toHaveBeenCalledWith('/assistance/suggestions/batch/accept', {
+                resource_id: suggestion.resource_id,
+                suggestions: [{ assistant_id: manifest.id, suggestion_id: suggestion.id, relation_type_id: 2 }],
+            }),
+        );
+    });
+});


### PR DESCRIPTION
This pull request introduces the ability for Group Leaders to select and change the DataCite relation type when accepting Relation Suggestions in the Assistance tool. The most-used relation types are highlighted for convenience, and this selection is consistently applied in both individual and batch acceptance workflows. The changes span backend validation, controller logic, service layers, and developer documentation to support this new feature.

**Feature: Selectable Relation Types for Assistance Suggestions**
- Added a relation type selector to the Assistance review UI, surfacing the five most-used types and listing all active types alphabetically for selection when accepting suggestions.
- Updated the changelog to announce this feature.

**Backend Validation and Request Handling**
- Introduced `AcceptSuggestionRequest` to validate the optional `relation_type_id` when accepting a suggestion, ensuring it references an active relation type. [[1]](diffhunk://#diff-5fd4c4488fbedebf37ccefee434848c933544c61e219f5809ee0269fbeb45a66R1-R33) [[2]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062R9-R12) [[3]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062L132-R167) [[4]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062L141-R176)
- Extended `BatchSuggestionsRequest` to validate `relation_type_id` for batch actions. [[1]](diffhunk://#diff-3ea0a3c89b6ae6160e2a6d03391daf163f7d84773e3c6e2d63a1122b4131134cR7-R9) [[2]](diffhunk://#diff-3ea0a3c89b6ae6160e2a6d03391daf163f7d84773e3c6e2d63a1122b4131134cR28-R34)

**Service Layer Enhancements**
- Updated the `acceptSuggestion` contract and implementations to accept optional input, including `relation_type_id`, and to propagate this through batch and single acceptance flows. [[1]](diffhunk://#diff-79a1fbde0952fb9e23aff5e5129629234c91f07995ea5f3976f8f48404c90ca5R102-R105) [[2]](diffhunk://#diff-b7a09054323ae2c41ffd9a9f10a978f2c96e2f3e4202da567ed42abe0a0c03e0L393-R393) [[3]](diffhunk://#diff-b7a09054323ae2c41ffd9a9f10a978f2c96e2f3e4202da567ed42abe0a0c03e0R405-R408) [[4]](diffhunk://#diff-b7a09054323ae2c41ffd9a9f10a978f2c96e2f3e4202da567ed42abe0a0c03e0L531-R532) [[5]](diffhunk://#diff-bd2ddb1f296aa4cbcd1f62e9f937c9876e9cb5f716427588161b83c93a94e197R65-R75) [[6]](diffhunk://#diff-bd2ddb1f296aa4cbcd1f62e9f937c9876e9cb5f716427588161b83c93a94e197L181-R200) [[7]](diffhunk://#diff-47c219c9d0da3746061ff8152abb92f8a31b6ed9f9a61eda3cfb4f14308cccc8L24-R24) [[8]](diffhunk://#diff-47c219c9d0da3746061ff8152abb92f8a31b6ed9f9a61eda3cfb4f14308cccc8R47-R53) [[9]](diffhunk://#diff-47c219c9d0da3746061ff8152abb92f8a31b6ed9f9a61eda3cfb4f14308cccc8L119-R123) [[10]](diffhunk://#diff-47c219c9d0da3746061ff8152abb92f8a31b6ed9f9a61eda3cfb4f14308cccc8R182-R192)
- Enhanced `RelationDiscoveryService::acceptRelation` to allow overriding the relation type and validate its activeness, applying the selected type throughout the acceptance process. [[1]](diffhunk://#diff-b536669dca2198ac619ec0984cb4acdbcb56f9a05a7fe09333bcb8a6bbdc485dL244-R273) [[2]](diffhunk://#diff-b536669dca2198ac619ec0984cb4acdbcb56f9a05a7fe09333bcb8a6bbdc485dL282-R291)
- Implemented assistant-specific handling for acceptance input in `RelationSuggestion\Assistant`.

**Data Exposure**
- Exposed `relation_type_id` in suggestion data for frontend consumption.

These changes ensure that curators have flexible, validated control over relation types when accepting suggestions, improving metadata accuracy and workflow efficiency.