### PR TITLE
Feature: Persist Assistant Accordion collapse State

### DIFF
--- a/app/Http/Controllers/AssistanceController.php
+++ b/app/Http/Controllers/AssistanceController.php
@@ -43,17 +43,24 @@ class AssistanceController extends Controller
     public function index(Request $request): Response
     {
         $perPage = max(1, min((int) $request->input('per_page', 25), 100));
+        $assistants = $this->registrar->getAll();
         $manifests = [];
 
-        foreach ($this->registrar->getAll() as $assistant) {
+        foreach ($assistants as $assistant) {
             $manifests[] = $assistant->getManifest()->toArray();
         }
 
         $review = $this->reviewService->build($request, $perPage);
+        $user = $request->user();
+        $savedCollapsedAssistantIds = $user instanceof User ? $user->assistance_collapsed_assistant_ids : null;
+        $collapsedAssistantIds = is_array($savedCollapsedAssistantIds)
+            ? array_values(array_intersect(array_keys($assistants), $savedCollapsedAssistantIds))
+            : null;
 
         return Inertia::render('assistance', [
             ...$review,
             'manifests' => $manifests,
+            'assistanceCollapsedAssistantIds' => $collapsedAssistantIds,
             'relationTypes' => $this->relationTypeOptions(),
         ]);
     }

--- a/app/Http/Controllers/Settings/AssistanceAccordionController.php
+++ b/app/Http/Controllers/Settings/AssistanceAccordionController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateAssistanceAccordionRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+
+class AssistanceAccordionController extends Controller
+{
+    /**
+     * Update the user's Assistance accordion preference.
+     */
+    public function update(UpdateAssistanceAccordionRequest $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $validated = $request->validated();
+
+        $user->update([
+            'assistance_collapsed_assistant_ids' => array_values($validated['collapsed_assistant_ids']),
+        ]);
+
+        return back();
+    }
+}

--- a/app/Http/Requests/Settings/UpdateAssistanceAccordionRequest.php
+++ b/app/Http/Requests/Settings/UpdateAssistanceAccordionRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use App\Services\Assistance\AssistantRegistrar;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAssistanceAccordionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('collapsed_assistant_ids')) {
+            $this->merge(['collapsed_assistant_ids' => []]);
+        }
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        /** @var AssistantRegistrar $registrar */
+        $registrar = app(AssistantRegistrar::class);
+
+        return [
+            'collapsed_assistant_ids' => ['present', 'array'],
+            'collapsed_assistant_ids.*' => ['string', 'distinct', Rule::in(array_keys($registrar->getAll()))],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Carbon;
  * @property bool $is_active
  * @property string|null $font_size_preference
  * @property array<int, string>|null $curation_accordion_open_items
+ * @property array<int, string>|null $assistance_collapsed_assistant_ids
  * @property Carbon|null $email_verified_at
  * @property Carbon|null $deactivated_at
  * @property int|null $deactivated_by
@@ -35,7 +36,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */
-#[Fillable(['name', 'email', 'password', 'password_set_at', 'font_size_preference', 'curation_accordion_open_items', 'role', 'is_active'])]
+#[Fillable(['name', 'email', 'password', 'password_set_at', 'font_size_preference', 'curation_accordion_open_items', 'assistance_collapsed_assistant_ids', 'role', 'is_active'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
@@ -54,6 +55,7 @@ class User extends Authenticatable
             'password' => 'hashed',
             'password_set_at' => 'datetime',
             'curation_accordion_open_items' => 'array',
+            'assistance_collapsed_assistant_ids' => 'array',
             'role' => UserRole::class,
             'is_active' => 'boolean',
             'deactivated_at' => 'datetime',

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -193,6 +193,7 @@ entity "users" as users {
     remember_token : VARCHAR
     * font_size_preference : VARCHAR = 'regular'
     curation_accordion_open_items : JSON <<nullable>>
+    assistance_collapsed_assistant_ids : JSON <<nullable>>
     * role : VARCHAR = 'curator'
     * is_active : BOOLEAN = true
     deactivated_at : TIMESTAMP

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -167,6 +167,7 @@ erDiagram
         varchar remember_token
         varchar font_size_preference "default: regular"
         json curation_accordion_open_items "nullable"
+        json assistance_collapsed_assistant_ids "nullable"
         varchar role "default: curator"
         boolean is_active "default: true"
         timestamp deactivated_at

--- a/database/migrations/2026_07_27_000001_add_assistance_collapsed_assistant_ids_to_users_table.php
+++ b/database/migrations/2026_07_27_000001_add_assistance_collapsed_assistant_ids_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            if (! Schema::hasColumn('users', 'assistance_collapsed_assistant_ids')) {
+                $table->json('assistance_collapsed_assistant_ids')->nullable()->after('curation_accordion_open_items');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            if (Schema::hasColumn('users', 'assistance_collapsed_assistant_ids')) {
+                $table->dropColumn('assistance_collapsed_assistant_ids');
+            }
+        });
+    }
+};

--- a/resources/js/components/assistance/resource-review.tsx
+++ b/resources/js/components/assistance/resource-review.tsx
@@ -1,9 +1,10 @@
 import { Link, router } from '@inertiajs/react';
 import axios from 'axios';
-import { Check, RefreshCw, X } from 'lucide-react';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { Check, ChevronsDown, ChevronsUp, RefreshCw, X } from 'lucide-react';
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -23,6 +24,8 @@ import {
 } from '@/types/assistance';
 
 const VIEW_STORAGE_KEY = 'assistance.review-view';
+const ASSISTANCE_ACCORDION_PREFERENCE_URL = '/settings/assistance-accordion';
+const ASSISTANCE_ACCORDION_PREFERENCE_DELAY_MS = 400;
 
 function initialReviewView(): 'all' | 'assistant' {
     if (typeof window === 'undefined') return 'all';
@@ -34,13 +37,23 @@ function initialReviewView(): 'all' | 'assistant' {
     }
 }
 
+function normalizeCollapsedAssistantIds(ids: readonly string[] | null | undefined, manifests: AssistantManifest[]): string[] {
+    const collapsed = new Set(ids ?? []);
+
+    return manifests.map((manifest) => manifest.id).filter((id) => collapsed.has(id));
+}
+
+function equalStringArrays(left: readonly string[], right: readonly string[]): boolean {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 type SectionData = PaginatedData<AssistanceResourceGroup> | PaginatedData<BaseSuggestionItem>;
 
 interface ResourceReviewProps {
     allAssistantResources?: PaginatedData<AssistanceResourceGroup>;
     sections: Record<string, SectionData>;
     manifests: AssistantManifest[];
-    pendingCounts?: Record<string, number>;
+    assistanceCollapsedAssistantIds?: string[] | null;
     checking: Record<string, boolean>;
     onCheck: (manifest: AssistantManifest) => void;
     onReload: () => void;
@@ -123,7 +136,7 @@ export function ResourceReview({
     allAssistantResources,
     sections,
     manifests,
-    pendingCounts,
+    assistanceCollapsedAssistantIds,
     checking,
     onCheck,
     onReload,
@@ -133,6 +146,12 @@ export function ResourceReview({
 }: ResourceReviewProps) {
     const manifestsById = useMemo(() => new Map(manifests.map((manifest) => [manifest.id, manifest])), [manifests]);
     const [activeView, setActiveView] = useState<'all' | 'assistant'>(initialReviewView);
+    const savedCollapsedAssistantIds = useMemo(
+        () => normalizeCollapsedAssistantIds(assistanceCollapsedAssistantIds, manifests),
+        [assistanceCollapsedAssistantIds, manifests],
+    );
+    const [collapsedAssistantIds, setCollapsedAssistantIds] = useState<string[]>(savedCollapsedAssistantIds);
+    const preferenceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [selected, setSelected] = useState<Set<string>>(() => new Set());
     const [processingResources, setProcessingResources] = useState<Set<number>>(() => new Set());
 
@@ -158,6 +177,83 @@ export function ResourceReview({
             return next.size === current.size ? current : next;
         });
     }, [availableIdentities]);
+
+    useEffect(() => {
+        setCollapsedAssistantIds((current) => (equalStringArrays(current, savedCollapsedAssistantIds) ? current : savedCollapsedAssistantIds));
+    }, [savedCollapsedAssistantIds]);
+
+    const persistCollapsedAssistantIds = useCallback((ids: readonly string[], immediate = false) => {
+        const persist = () => {
+            preferenceTimeoutRef.current = null;
+            router.put(
+                ASSISTANCE_ACCORDION_PREFERENCE_URL,
+                { collapsed_assistant_ids: [...ids] },
+                {
+                    preserveScroll: true,
+                    preserveState: true,
+                    only: ['assistanceCollapsedAssistantIds'],
+                    onError: () => toast.error('Failed to save the assistant display preference.'),
+                },
+            );
+        };
+
+        if (preferenceTimeoutRef.current !== null) {
+            clearTimeout(preferenceTimeoutRef.current);
+            preferenceTimeoutRef.current = null;
+        }
+
+        if (immediate) {
+            persist();
+            return;
+        }
+
+        preferenceTimeoutRef.current = setTimeout(persist, ASSISTANCE_ACCORDION_PREFERENCE_DELAY_MS);
+    }, []);
+
+    const updateCollapsedAssistantIds = useCallback(
+        (ids: readonly string[], immediate = false) => {
+            const normalized = normalizeCollapsedAssistantIds(ids, manifests);
+            setCollapsedAssistantIds(normalized);
+            persistCollapsedAssistantIds(normalized, immediate);
+        },
+        [manifests, persistCollapsedAssistantIds],
+    );
+
+    const openAssistantIds = useMemo(() => {
+        const collapsed = new Set(collapsedAssistantIds);
+
+        return manifests.map((manifest) => manifest.id).filter((id) => !collapsed.has(id));
+    }, [collapsedAssistantIds, manifests]);
+    const allAssistantsCollapsed = manifests.length > 0 && collapsedAssistantIds.length === manifests.length;
+    const allAssistantsExpanded = collapsedAssistantIds.length === 0;
+
+    const changeOpenAssistantIds = useCallback(
+        (ids: string[]) => {
+            const open = new Set(ids);
+            updateCollapsedAssistantIds(manifests.map((manifest) => manifest.id).filter((id) => !open.has(id)));
+        },
+        [manifests, updateCollapsedAssistantIds],
+    );
+
+    const collapseAllAssistants = useCallback(() => {
+        updateCollapsedAssistantIds(
+            manifests.map((manifest) => manifest.id),
+            true,
+        );
+    }, [manifests, updateCollapsedAssistantIds]);
+
+    const expandAllAssistants = useCallback(() => {
+        updateCollapsedAssistantIds([], true);
+    }, [updateCollapsedAssistantIds]);
+
+    useEffect(() => {
+        return () => {
+            if (preferenceTimeoutRef.current !== null) {
+                clearTimeout(preferenceTimeoutRef.current);
+                preferenceTimeoutRef.current = null;
+            }
+        };
+    }, []);
 
     const changeView = (value: string) => {
         const nextView = value === 'assistant' ? 'assistant' : 'all';
@@ -383,42 +479,76 @@ export function ResourceReview({
         );
     };
 
-    const renderSection = (sectionKey: string, data: PaginatedData<AssistanceResourceGroup>, manifest?: AssistantManifest) => {
-        const pendingCount = manifest
-            ? (pendingCounts?.[manifest.id] ?? data.data.reduce((sum, group) => sum + group.suggestion_count, 0))
-            : undefined;
-        const title = manifest?.name ?? 'All assistants';
-        const description = manifest
-            ? `${pendingCount} pending suggestion(s). ${manifest.description}`
-            : 'Review every pending suggestion for each resource in one place.';
-
+    const renderAllAssistantsSection = (sectionKey: string, data: PaginatedData<AssistanceResourceGroup>) => {
         return (
             <Card key={sectionKey}>
                 <CardHeader className="gap-4 sm:flex-row sm:items-center sm:justify-between">
                     <div className="space-y-1.5">
-                        <CardTitle>{title}</CardTitle>
-                        <CardDescription>{description}</CardDescription>
+                        <CardTitle>All assistants</CardTitle>
+                        <CardDescription>Review every pending suggestion for each resource in one place.</CardDescription>
                     </div>
-                    {manifest && (
-                        <Button variant="outline" size="sm" disabled={checking[manifest.id]} onClick={() => onCheck(manifest)}>
-                            {checking[manifest.id] ? <Spinner size="sm" className="mr-2" /> : <RefreshCw className="mr-2 h-4 w-4" />}
-                            Check {manifest.name}
-                        </Button>
-                    )}
                 </CardHeader>
                 <CardContent id={`assistance-results-${sectionKey}`} data-testid={`assistance-results-${sectionKey}`}>
                     {data.data.length > 0 ? (
-                        <div className="space-y-4">{data.data.map((group) => renderResource(group, sectionKey, manifest))}</div>
+                        <div className="space-y-4">{data.data.map((group) => renderResource(group, sectionKey))}</div>
                     ) : (
                         <div className="flex flex-col items-center justify-center py-12 text-center">
                             <div className="text-4xl">&#10003;</div>
-                            <p className="mt-2 text-lg font-medium">{manifest?.emptyState.title ?? 'No pending suggestions'}</p>
-                            <p className="text-sm text-muted-foreground">{manifest?.emptyState.description ?? 'All resources have been reviewed.'}</p>
+                            <p className="mt-2 text-lg font-medium">No pending suggestions</p>
+                            <p className="text-sm text-muted-foreground">All resources have been reviewed.</p>
                         </div>
                     )}
                     {renderPagination(data, sectionKey)}
                 </CardContent>
             </Card>
+        );
+    };
+
+    const renderAssistantSection = (manifest: AssistantManifest) => {
+        const data = normalizedSections[manifest.id];
+        const isOpen = openAssistantIds.includes(manifest.id);
+        const datasetLabel = `${data.total} ${data.total === 1 ? 'dataset' : 'datasets'} with suggestions`;
+
+        return (
+            <AccordionItem
+                key={manifest.id}
+                value={manifest.id}
+                className="overflow-hidden rounded-xl border bg-card text-card-foreground shadow-sm"
+                data-testid={`assistant-section-${manifest.id}`}
+            >
+                <AccordionTrigger
+                    className="px-6 py-6 hover:no-underline"
+                    aria-label={`${manifest.name}, ${datasetLabel}`}
+                    actions={
+                        isOpen ? (
+                            <Button variant="outline" size="sm" className="mr-6" disabled={checking[manifest.id]} onClick={() => onCheck(manifest)}>
+                                {checking[manifest.id] ? <Spinner size="sm" className="mr-2" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+                                Check {manifest.name}
+                            </Button>
+                        ) : undefined
+                    }
+                >
+                    <span className="flex flex-col gap-1.5">
+                        <span className="text-base leading-none font-semibold tracking-tight">{manifest.name}</span>
+                        <span className="text-sm font-normal text-muted-foreground">{datasetLabel}</span>
+                        {isOpen && <span className="text-sm font-normal text-muted-foreground">{manifest.description}</span>}
+                    </span>
+                </AccordionTrigger>
+                <AccordionContent className="px-6 pb-6">
+                    <div id={`assistance-results-${manifest.id}`} data-testid={`assistance-results-${manifest.id}`}>
+                        {data.data.length > 0 ? (
+                            <div className="space-y-4">{data.data.map((group) => renderResource(group, manifest.id, manifest))}</div>
+                        ) : (
+                            <div className="flex flex-col items-center justify-center py-12 text-center">
+                                <div className="text-4xl">&#10003;</div>
+                                <p className="mt-2 text-lg font-medium">{manifest.emptyState.title}</p>
+                                <p className="text-sm text-muted-foreground">{manifest.emptyState.description}</p>
+                            </div>
+                        )}
+                        {renderPagination(data, manifest.id)}
+                    </div>
+                </AccordionContent>
+            </AccordionItem>
         );
     };
 
@@ -428,9 +558,33 @@ export function ResourceReview({
                 <TabsTrigger value="all">All assistants</TabsTrigger>
                 <TabsTrigger value="assistant">By assistant</TabsTrigger>
             </TabsList>
-            <TabsContent value="all">{renderSection('all', allResources)}</TabsContent>
+            <TabsContent value="all">{renderAllAssistantsSection('all', allResources)}</TabsContent>
             <TabsContent value="assistant" className="space-y-6">
-                {manifests.map((manifest) => renderSection(manifest.id, normalizedSections[manifest.id], manifest))}
+                <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={manifests.length === 0 || allAssistantsCollapsed}
+                        onClick={collapseAllAssistants}
+                    >
+                        <ChevronsUp className="mr-2 h-4 w-4" aria-hidden="true" />
+                        Collapse all
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={manifests.length === 0 || allAssistantsExpanded}
+                        onClick={expandAllAssistants}
+                    >
+                        <ChevronsDown className="mr-2 h-4 w-4" aria-hidden="true" />
+                        Expand all
+                    </Button>
+                </div>
+                <Accordion type="multiple" value={openAssistantIds} onValueChange={changeOpenAssistantIds} className="space-y-6">
+                    {manifests.map(renderAssistantSection)}
+                </Accordion>
             </TabsContent>
         </Tabs>
     );

--- a/resources/js/components/assistance/resource-review.tsx
+++ b/resources/js/components/assistance/resource-review.tsx
@@ -507,7 +507,7 @@ export function ResourceReview({
     const renderAssistantSection = (manifest: AssistantManifest) => {
         const data = normalizedSections[manifest.id];
         const isOpen = openAssistantIds.includes(manifest.id);
-        const datasetLabel = `${data.total} ${data.total === 1 ? 'dataset' : 'datasets'} with suggestions`;
+        const resourceLabel = `${data.total} ${data.total === 1 ? 'resource' : 'resources'} with suggestions`;
 
         return (
             <AccordionItem
@@ -518,7 +518,7 @@ export function ResourceReview({
             >
                 <AccordionTrigger
                     className="px-6 py-6 hover:no-underline"
-                    aria-label={`${manifest.name}, ${datasetLabel}`}
+                    aria-label={`${manifest.name}, ${resourceLabel}`}
                     actions={
                         isOpen ? (
                             <Button variant="outline" size="sm" className="mr-6" disabled={checking[manifest.id]} onClick={() => onCheck(manifest)}>
@@ -530,7 +530,7 @@ export function ResourceReview({
                 >
                     <span className="flex flex-col gap-1.5">
                         <span className="text-base leading-none font-semibold tracking-tight">{manifest.name}</span>
-                        <span className="text-sm font-normal text-muted-foreground">{datasetLabel}</span>
+                        <span className="text-sm font-normal text-muted-foreground">{resourceLabel}</span>
                         {isOpen && <span className="text-sm font-normal text-muted-foreground">{manifest.description}</span>}
                     </span>
                 </AccordionTrigger>

--- a/resources/js/pages/assistance.tsx
+++ b/resources/js/pages/assistance.tsx
@@ -1486,7 +1486,13 @@ function useSectionState(manifests: AssistantManifest[]) {
 
 // ── Main page component ──────────────────────────────────────────────
 
-export default function AssistancePage({ sections, manifests, allAssistantResources, pendingCounts, relationTypes = [] }: AssistancePageProps) {
+export default function AssistancePage({
+    sections,
+    manifests,
+    allAssistantResources,
+    assistanceCollapsedAssistantIds,
+    relationTypes = [],
+}: AssistancePageProps) {
     const { states, patch, addProcessingId, removeProcessingId, pollingRefs } = useSectionState(manifests);
     const [acceptanceInputs, setAcceptanceInputs] = useState<Record<string, SuggestionAcceptanceInput>>({});
 
@@ -1990,7 +1996,7 @@ export default function AssistancePage({ sections, manifests, allAssistantResour
                         allAssistantResources={allAssistantResources}
                         sections={sections}
                         manifests={manifests}
-                        pendingCounts={pendingCounts}
+                        assistanceCollapsedAssistantIds={assistanceCollapsedAssistantIds}
                         checking={Object.fromEntries(manifests.map((manifest) => [manifest.id, states[manifest.id]?.isChecking ?? false]))}
                         onCheck={handleCheck}
                         onReload={reloadAssistanceSections}

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -590,7 +590,7 @@ DATACITE_TEST_PASSWORD=your_test_password`}
 
                         <p>
                             In the <strong>By assistant</strong> view, each assistant section can be collapsed independently. A collapsed section
-                            shows the assistant name and the number of datasets with suggestions; it deliberately does not show the usually larger
+                            shows the assistant name and the number of resources with suggestions; it deliberately does not show the usually larger
                             number of individual suggestions. Use <strong>Collapse all</strong> or <strong>Expand all</strong> to change every
                             assistant section at once. ERNIE saves these section states in your user profile and restores them the next time you open
                             Assistance, including on another browser or device.

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -588,6 +588,14 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             resources. Each assistant module focuses on one type of enrichment.
                         </p>
 
+                        <p>
+                            In the <strong>By assistant</strong> view, each assistant section can be collapsed independently. A collapsed section
+                            shows the assistant name and the number of datasets with suggestions; it deliberately does not show the usually larger
+                            number of individual suggestions. Use <strong>Collapse all</strong> or <strong>Expand all</strong> to change every
+                            assistant section at once. ERNIE saves these section states in your user profile and restores them the next time you open
+                            Assistance, including on another browser or device.
+                        </p>
+
                         <h4>Available Assistants</h4>
                         <ul className="list-inside list-disc space-y-1">
                             <li>

--- a/resources/js/types/assistance.ts
+++ b/resources/js/types/assistance.ts
@@ -315,6 +315,7 @@ export interface AssistancePageProps {
     sections: Record<string, PaginatedData<AssistanceResourceGroup> | PaginatedData<BaseSuggestionItem>>;
     allAssistantResources?: PaginatedData<AssistanceResourceGroup>;
     pendingCounts?: Record<string, number>;
+    assistanceCollapsedAssistantIds?: string[] | null;
     manifests: AssistantManifest[];
     relationTypes?: AssistanceRelationTypeOption[];
 }

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DatacenterController;
 use App\Http\Controllers\LandingPageDomainController;
+use App\Http\Controllers\Settings\AssistanceAccordionController;
 use App\Http\Controllers\Settings\CurationAccordionController;
 use App\Http\Controllers\Settings\EditorSettingsController;
 use App\Http\Controllers\Settings\FontSizeController;
@@ -39,6 +40,7 @@ Route::middleware('auth')->group(function () {
 
     Route::put('settings/font-size', [FontSizeController::class, 'update'])->name('font-size.update');
     Route::put('settings/curation-accordion', [CurationAccordionController::class, 'update'])->name('curation-accordion.update');
+    Route::put('settings/assistance-accordion', [AssistanceAccordionController::class, 'update'])->name('assistance-accordion.update');
 
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/appearance');

--- a/tests/pest/Feature/Controllers/AssistanceControllerTest.php
+++ b/tests/pest/Feature/Controllers/AssistanceControllerTest.php
@@ -54,6 +54,24 @@ describe('index', function () {
                 ->has('allAssistantResources')
                 ->has('pendingCounts')
                 ->has('manifests')
+                ->where('assistanceCollapsedAssistantIds', null)
+            );
+    });
+
+    it('exposes only registered collapsed Assistant IDs from the user profile', function () {
+        /** @var AssistantRegistrar $registrar */
+        $registrar = app(AssistantRegistrar::class);
+        $assistantId = (string) array_key_first($registrar->getAll());
+        $user = User::factory()->create([
+            'role' => 'admin',
+            'assistance_collapsed_assistant_ids' => [$assistantId, 'removed-assistant'],
+        ]);
+
+        $this->actingAs($user)
+            ->get('/assistance')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('assistanceCollapsedAssistantIds', [$assistantId])
             );
     });
 

--- a/tests/pest/Feature/Settings/AssistanceAccordionPreferenceTest.php
+++ b/tests/pest/Feature/Settings/AssistanceAccordionPreferenceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Services\Assistance\AssistantRegistrar;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+function loadAssistanceCollapsedAssistantIdsMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_07_27_000001_add_assistance_collapsed_assistant_ids_to_users_table.php');
+
+    return $migration;
+}
+
+/** @return list<string> */
+function registeredAssistantIds(): array
+{
+    /** @var AssistantRegistrar $registrar */
+    $registrar = app(AssistantRegistrar::class);
+
+    return array_keys($registrar->getAll());
+}
+
+test('guests are redirected when updating the Assistance accordion preference', function () {
+    $this->put(route('assistance-accordion.update'), [
+        'collapsed_assistant_ids' => [registeredAssistantIds()[0]],
+    ])->assertRedirect(route('login'));
+});
+
+test('authenticated users can persist collapsed Assistant IDs', function () {
+    $user = User::factory()->create();
+    $assistantIds = array_slice(registeredAssistantIds(), 0, 2);
+
+    $this->actingAs($user)
+        ->put(route('assistance-accordion.update'), [
+            'collapsed_assistant_ids' => $assistantIds,
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->assistance_collapsed_assistant_ids)->toBe($assistantIds);
+});
+
+test('authenticated users can persist all Assistants as expanded', function () {
+    $user = User::factory()->create([
+        'assistance_collapsed_assistant_ids' => [registeredAssistantIds()[0]],
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('assistance-accordion.update'), [
+            'collapsed_assistant_ids' => [],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->assistance_collapsed_assistant_ids)->toBe([]);
+});
+
+test('omitting collapsed Assistant IDs persists the expanded default', function () {
+    $user = User::factory()->create([
+        'assistance_collapsed_assistant_ids' => [registeredAssistantIds()[0]],
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('assistance-accordion.update'))
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->assistance_collapsed_assistant_ids)->toBe([]);
+});
+
+test('non-array collapsed Assistant IDs are rejected without changing the preference', function () {
+    $assistantId = registeredAssistantIds()[0];
+    $user = User::factory()->create([
+        'assistance_collapsed_assistant_ids' => [$assistantId],
+    ]);
+
+    $this->actingAs($user)
+        ->from('/assistance')
+        ->put(route('assistance-accordion.update'), [
+            'collapsed_assistant_ids' => $assistantId,
+        ])
+        ->assertRedirect('/assistance')
+        ->assertSessionHasErrors('collapsed_assistant_ids');
+
+    expect($user->refresh()->assistance_collapsed_assistant_ids)->toBe([$assistantId]);
+});
+
+test('unknown Assistant IDs are rejected without changing the preference', function () {
+    $assistantId = registeredAssistantIds()[0];
+    $user = User::factory()->create([
+        'assistance_collapsed_assistant_ids' => [$assistantId],
+    ]);
+
+    $this->actingAs($user)
+        ->from('/assistance')
+        ->put(route('assistance-accordion.update'), [
+            'collapsed_assistant_ids' => [$assistantId, 'removed-assistant'],
+        ])
+        ->assertRedirect('/assistance')
+        ->assertSessionHasErrors('collapsed_assistant_ids.1');
+
+    expect($user->refresh()->assistance_collapsed_assistant_ids)->toBe([$assistantId]);
+});
+
+test('duplicate Assistant IDs are rejected without changing the preference', function () {
+    $assistantId = registeredAssistantIds()[0];
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from('/assistance')
+        ->put(route('assistance-accordion.update'), [
+            'collapsed_assistant_ids' => [$assistantId, $assistantId],
+        ])
+        ->assertRedirect('/assistance')
+        ->assertSessionHasErrors('collapsed_assistant_ids.1');
+
+    expect($user->refresh()->assistance_collapsed_assistant_ids)->toBeNull();
+});
+
+test('Assistance accordion preferences are isolated per user', function () {
+    [$firstAssistantId, $secondAssistantId] = array_slice(registeredAssistantIds(), 0, 2);
+    $firstUser = User::factory()->create();
+    $secondUser = User::factory()->create([
+        'assistance_collapsed_assistant_ids' => [$secondAssistantId],
+    ]);
+
+    $this->actingAs($firstUser)
+        ->put(route('assistance-accordion.update'), [
+            'collapsed_assistant_ids' => [$firstAssistantId],
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect($firstUser->refresh()->assistance_collapsed_assistant_ids)->toBe([$firstAssistantId])
+        ->and($secondUser->refresh()->assistance_collapsed_assistant_ids)->toBe([$secondAssistantId]);
+});
+
+test('Assistance accordion migration can be rerun safely', function () {
+    $migration = loadAssistanceCollapsedAssistantIdsMigration();
+
+    expect(Schema::hasColumn('users', 'assistance_collapsed_assistant_ids'))->toBeTrue();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Schema::hasColumn('users', 'assistance_collapsed_assistant_ids'))->toBeTrue();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    expect(Schema::hasColumn('users', 'assistance_collapsed_assistant_ids'))->toBeFalse();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Schema::hasColumn('users', 'assistance_collapsed_assistant_ids'))->toBeTrue();
+});

--- a/tests/vitest/components/assistance-resource-review.test.tsx
+++ b/tests/vitest/components/assistance-resource-review.test.tsx
@@ -61,7 +61,7 @@ function page(group: AssistanceResourceGroup): PaginatedData<AssistanceResourceG
 function renderReview(
     items: BaseSuggestionItem[],
     acceptanceInputs: Record<string, SuggestionAcceptanceInput> = {},
-    options: { collapsedAssistantIds?: string[] | null; total?: number } = {},
+    options: { collapsedAssistantIds?: string[] | null; total?: number; lastPage?: number } = {},
 ) {
     const group: AssistanceResourceGroup = {
         resource_id: 10,
@@ -72,6 +72,7 @@ function renderReview(
     };
     const data = page(group);
     data.total = options.total ?? data.total;
+    data.last_page = options.lastPage ?? data.last_page;
     const onReload = vi.fn();
     const onRorFollowUps = vi.fn();
 
@@ -177,7 +178,7 @@ describe('resource-oriented assistance review', () => {
         await user.click(screen.getByRole('tab', { name: 'By assistant' }));
 
         expect(window.localStorage.getItem('assistance.review-view')).toBe('assistant');
-        expect(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Test assistant, 1 resource with suggestions' })).toBeInTheDocument();
     });
 
     it('restores a valid preference and ignores invalid stored values', () => {
@@ -191,15 +192,16 @@ describe('resource-oriented assistance review', () => {
         expect(screen.getByRole('tab', { name: 'All assistants' })).toHaveAttribute('data-state', 'active');
     });
 
-    it('opens every Assistant by default and shows the resource total instead of the suggestion count', async () => {
+    it('opens every Assistant by default and uses resource terminology for the total and pagination', async () => {
         const user = userEvent.setup();
-        renderReview([suggestion(1, 'First candidate'), suggestion(2, 'Second candidate')], {}, { total: 7 });
+        renderReview([suggestion(1, 'First candidate'), suggestion(2, 'Second candidate')], {}, { total: 7, lastPage: 2 });
 
         await user.click(screen.getByRole('tab', { name: 'By assistant' }));
 
-        const trigger = screen.getByRole('button', { name: 'Test assistant, 7 datasets with suggestions' });
+        const trigger = screen.getByRole('button', { name: 'Test assistant, 7 resources with suggestions' });
         expect(trigger).toHaveAttribute('aria-expanded', 'true');
-        expect(screen.getByText('7 datasets with suggestions')).toBeInTheDocument();
+        expect(screen.getByText('7 resources with suggestions')).toBeInTheDocument();
+        expect(screen.getByText('Showing 1–1 of 7 resources')).toBeInTheDocument();
         expect(screen.queryByText(/2 pending suggestion/)).not.toBeInTheDocument();
         expect(screen.getByText(manifest.description)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: `Check ${manifest.name}` })).toBeInTheDocument();
@@ -211,10 +213,10 @@ describe('resource-oriented assistance review', () => {
 
         await user.click(screen.getByRole('tab', { name: 'By assistant' }));
 
-        const trigger = screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' });
+        const trigger = screen.getByRole('button', { name: 'Test assistant, 1 resource with suggestions' });
         expect(trigger).toHaveAttribute('aria-expanded', 'false');
         expect(screen.getByText(manifest.name)).toBeInTheDocument();
-        expect(screen.getByText('1 dataset with suggestions')).toBeInTheDocument();
+        expect(screen.getByText('1 resource with suggestions')).toBeInTheDocument();
         expect(screen.queryByText(manifest.description)).not.toBeInTheDocument();
         expect(screen.queryByRole('button', { name: `Check ${manifest.name}` })).not.toBeInTheDocument();
         expect(screen.queryByTestId(`assistance-results-${manifest.id}`)).not.toBeInTheDocument();
@@ -225,7 +227,7 @@ describe('resource-oriented assistance review', () => {
         renderReview([suggestion(1, 'Toggle candidate')]);
         await user.click(screen.getByRole('tab', { name: 'By assistant' }));
 
-        await user.click(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' }));
+        await user.click(screen.getByRole('button', { name: 'Test assistant, 1 resource with suggestions' }));
 
         await waitFor(() =>
             expect(vi.mocked(router.put)).toHaveBeenCalledWith(
@@ -277,7 +279,7 @@ describe('resource-oriented assistance review', () => {
         options?.onError?.({});
 
         expect(toast.error).toHaveBeenCalledWith('Failed to save the assistant display preference.');
-        expect(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' })).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.getByRole('button', { name: 'Test assistant, 1 resource with suggestions' })).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('keeps newly registered Assistants expanded when they are absent from the stored collapsed IDs', async () => {
@@ -325,8 +327,8 @@ describe('resource-oriented assistance review', () => {
 
         await user.click(screen.getByRole('tab', { name: 'By assistant' }));
 
-        expect(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' })).toHaveAttribute('aria-expanded', 'false');
-        expect(screen.getByRole('button', { name: 'New assistant, 0 datasets with suggestions' })).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByRole('button', { name: 'Test assistant, 1 resource with suggestions' })).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.getByRole('button', { name: 'New assistant, 0 resources with suggestions' })).toHaveAttribute('aria-expanded', 'true');
         expect(screen.getByText(newManifest.description)).toBeInTheDocument();
         expect(screen.getByText(newManifest.emptyState.title)).toBeInTheDocument();
     });

--- a/tests/vitest/components/assistance-resource-review.test.tsx
+++ b/tests/vitest/components/assistance-resource-review.test.tsx
@@ -1,3 +1,4 @@
+import { router } from '@inertiajs/react';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@tests/vitest/utils/render';
 import axios from 'axios';
@@ -14,7 +15,7 @@ vi.mock('@inertiajs/react', () => ({
             {children}
         </a>
     ),
-    router: { get: vi.fn() },
+    router: { get: vi.fn(), put: vi.fn() },
 }));
 vi.mock('axios', () => ({ default: { post: vi.fn(), isAxiosError: vi.fn(() => false) } }));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() } }));
@@ -57,7 +58,11 @@ function page(group: AssistanceResourceGroup): PaginatedData<AssistanceResourceG
     return { data: [group], current_page: 1, last_page: 1, per_page: 25, total: 1, from: 1, to: 1, links: [] };
 }
 
-function renderReview(items: BaseSuggestionItem[], acceptanceInputs: Record<string, SuggestionAcceptanceInput> = {}) {
+function renderReview(
+    items: BaseSuggestionItem[],
+    acceptanceInputs: Record<string, SuggestionAcceptanceInput> = {},
+    options: { collapsedAssistantIds?: string[] | null; total?: number } = {},
+) {
     const group: AssistanceResourceGroup = {
         resource_id: 10,
         resource_doi: '10.1234/test',
@@ -66,6 +71,7 @@ function renderReview(items: BaseSuggestionItem[], acceptanceInputs: Record<stri
         suggestions: items,
     };
     const data = page(group);
+    data.total = options.total ?? data.total;
     const onReload = vi.fn();
     const onRorFollowUps = vi.fn();
 
@@ -74,7 +80,7 @@ function renderReview(items: BaseSuggestionItem[], acceptanceInputs: Record<stri
             allAssistantResources={data}
             sections={{ [manifest.id]: data }}
             manifests={[manifest]}
-            pendingCounts={{ [manifest.id]: items.length }}
+            assistanceCollapsedAssistantIds={options.collapsedAssistantIds}
             checking={{ [manifest.id]: false }}
             onCheck={vi.fn()}
             onReload={onReload}
@@ -171,7 +177,7 @@ describe('resource-oriented assistance review', () => {
         await user.click(screen.getByRole('tab', { name: 'By assistant' }));
 
         expect(window.localStorage.getItem('assistance.review-view')).toBe('assistant');
-        expect(screen.getByRole('heading', { name: manifest.name })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' })).toBeInTheDocument();
     });
 
     it('restores a valid preference and ignores invalid stored values', () => {
@@ -183,6 +189,146 @@ describe('resource-oriented assistance review', () => {
         window.localStorage.setItem('assistance.review-view', 'invalid');
         renderReview([suggestion(1, 'Invalid stored view candidate')]);
         expect(screen.getByRole('tab', { name: 'All assistants' })).toHaveAttribute('data-state', 'active');
+    });
+
+    it('opens every Assistant by default and shows the resource total instead of the suggestion count', async () => {
+        const user = userEvent.setup();
+        renderReview([suggestion(1, 'First candidate'), suggestion(2, 'Second candidate')], {}, { total: 7 });
+
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+
+        const trigger = screen.getByRole('button', { name: 'Test assistant, 7 datasets with suggestions' });
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText('7 datasets with suggestions')).toBeInTheDocument();
+        expect(screen.queryByText(/2 pending suggestion/)).not.toBeInTheDocument();
+        expect(screen.getByText(manifest.description)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: `Check ${manifest.name}` })).toBeInTheDocument();
+    });
+
+    it('restores a collapsed Assistant with only its name, resource total, and trigger visible', async () => {
+        const user = userEvent.setup();
+        renderReview([suggestion(1, 'Stored collapsed candidate')], {}, { collapsedAssistantIds: [manifest.id] });
+
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+
+        const trigger = screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' });
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.getByText(manifest.name)).toBeInTheDocument();
+        expect(screen.getByText('1 dataset with suggestions')).toBeInTheDocument();
+        expect(screen.queryByText(manifest.description)).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: `Check ${manifest.name}` })).not.toBeInTheDocument();
+        expect(screen.queryByTestId(`assistance-results-${manifest.id}`)).not.toBeInTheDocument();
+    });
+
+    it('persists an individual Assistant toggle after the preference debounce', async () => {
+        const user = userEvent.setup();
+        renderReview([suggestion(1, 'Toggle candidate')]);
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+
+        await user.click(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' }));
+
+        await waitFor(() =>
+            expect(vi.mocked(router.put)).toHaveBeenCalledWith(
+                '/settings/assistance-accordion',
+                { collapsed_assistant_ids: [manifest.id] },
+                expect.objectContaining({
+                    preserveScroll: true,
+                    preserveState: true,
+                    only: ['assistanceCollapsedAssistantIds'],
+                }),
+            ),
+        );
+    });
+
+    it('collapses and expands all Assistants immediately with matching disabled states', async () => {
+        const user = userEvent.setup();
+        renderReview([suggestion(1, 'Bulk toggle candidate')]);
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+
+        const collapseAll = screen.getByRole('button', { name: 'Collapse all' });
+        const expandAll = screen.getByRole('button', { name: 'Expand all' });
+        expect(collapseAll).toBeEnabled();
+        expect(expandAll).toBeDisabled();
+
+        await user.click(collapseAll);
+
+        expect(vi.mocked(router.put)).toHaveBeenLastCalledWith(
+            '/settings/assistance-accordion',
+            { collapsed_assistant_ids: [manifest.id] },
+            expect.any(Object),
+        );
+        expect(collapseAll).toBeDisabled();
+        expect(expandAll).toBeEnabled();
+
+        await user.click(expandAll);
+
+        expect(vi.mocked(router.put)).toHaveBeenLastCalledWith('/settings/assistance-accordion', { collapsed_assistant_ids: [] }, expect.any(Object));
+        expect(collapseAll).toBeEnabled();
+        expect(expandAll).toBeDisabled();
+    });
+
+    it('reports profile persistence failures without blocking the local accordion state', async () => {
+        const user = userEvent.setup();
+        renderReview([suggestion(1, 'Failed persistence candidate')]);
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+
+        await user.click(screen.getByRole('button', { name: 'Collapse all' }));
+        const options = vi.mocked(router.put).mock.calls.at(-1)?.[2];
+        options?.onError?.({});
+
+        expect(toast.error).toHaveBeenCalledWith('Failed to save the assistant display preference.');
+        expect(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('keeps newly registered Assistants expanded when they are absent from the stored collapsed IDs', async () => {
+        const user = userEvent.setup();
+        const newManifest: AssistantManifest = {
+            ...manifest,
+            id: 'new-assistant',
+            name: 'New assistant',
+            description: 'Reviews newly supported metadata.',
+            routePrefix: 'new-assistant',
+            emptyState: { title: 'No new work', description: 'The new assistant has nothing pending.' },
+        };
+        const existingGroup: AssistanceResourceGroup = {
+            resource_id: 10,
+            resource_doi: '10.1234/test',
+            resource_title: 'Test resource',
+            suggestion_count: 1,
+            suggestions: [suggestion(1, 'Existing candidate')],
+        };
+        const existingPage = page(existingGroup);
+        const newPage: PaginatedData<AssistanceResourceGroup> = {
+            data: [],
+            current_page: 1,
+            last_page: 1,
+            per_page: 25,
+            total: 0,
+            from: null,
+            to: null,
+            links: [],
+        };
+
+        render(
+            <ResourceReview
+                allAssistantResources={existingPage}
+                sections={{ [manifest.id]: existingPage, [newManifest.id]: newPage }}
+                manifests={[manifest, newManifest]}
+                assistanceCollapsedAssistantIds={[manifest.id]}
+                checking={{ [manifest.id]: false, [newManifest.id]: false }}
+                onCheck={vi.fn()}
+                onReload={vi.fn()}
+                onRorFollowUps={vi.fn()}
+                renderSuggestion={(_manifest, item) => <p>{String(item.suggested_label)}</p>}
+            />,
+        );
+
+        await user.click(screen.getByRole('tab', { name: 'By assistant' }));
+
+        expect(screen.getByRole('button', { name: 'Test assistant, 1 dataset with suggestions' })).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.getByRole('button', { name: 'New assistant, 0 datasets with suggestions' })).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText(newManifest.description)).toBeInTheDocument();
+        expect(screen.getByText(newManifest.emptyState.title)).toBeInTheDocument();
     });
 
     it('selects only compatible single candidates and blocks accepting decline-only hints', async () => {


### PR DESCRIPTION
This pull request introduces support for persisting and restoring each user's "collapsed assistants" accordion state in the assistance review UI. It adds backend storage for this preference, a migration and ERD updates, a new controller and request for updating the preference, and a significant refactor of the frontend to use and update this state, including "Collapse all" and "Expand all" actions.

The most important changes are:

**Backend: Persisting User Accordion State**
* Added a new nullable JSON column `assistance_collapsed_assistant_ids` to the `users` table, with corresponding migration (`2026_07_27_000001_add_assistance_collapsed_assistant_ids_to_users_table.php`) and updates to the ER diagrams (`er-diagram.md`, `er-diagram-plantuml.md`). [[1]](diffhunk://#diff-4d1c609bd1a0866c9ceb376248e7eb279a160f1c8e5e7c6d2d907cd70bde6be5R1-R34) [[2]](diffhunk://#diff-e0196f1170dc7341f74a244f8ee5ad1128d2350be6c80928486fe029eb3867e3R170) [[3]](diffhunk://#diff-a8d0111421d72b79d6b1e81ad37d41a69ce2f2f1b765ba6e5def7d7311d72814R196)
* Updated the `User` model to include the new property in fillable and casts arrays, allowing safe mass-assignment and automatic JSON casting. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR31-R39) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR58)

**Backend: Preference Update Endpoint**
* Added `AssistanceAccordionController` and `UpdateAssistanceAccordionRequest` to handle and validate updates to the user's collapsed assistants preference. Only valid assistant IDs are accepted. [[1]](diffhunk://#diff-c4f2536e2cb1e667fc0dd4a985a7caaac08c36b537514e3d5fe98f313c0e53a4R1-R30) [[2]](diffhunk://#diff-7da1ee1cfa1eec389215657bee6f21c70334c052932adcc9d64370c6ac27fb22R1-R47)

**Assistance Review UI: State Persistence & Controls**
* The backend now provides the `assistanceCollapsedAssistantIds` prop to the frontend, and the UI persists changes to this state via the new endpoint, debounced for efficiency. The state is normalized and validated on both client and server. [[1]](diffhunk://#diff-cd370b8a746f047a2d5b3f5f121e22f17980ae490354a65543e5eb901c7e7062R46-R63) [[2]](diffhunk://#diff-7579678eeec846f15fafdcbc73f0f080e138a2b9aafd3521497616ef84ce31eaR40-R56) [[3]](diffhunk://#diff-7579678eeec846f15fafdcbc73f0f080e138a2b9aafd3521497616ef84ce31eaL126-R139) [[4]](diffhunk://#diff-7579678eeec846f15fafdcbc73f0f080e138a2b9aafd3521497616ef84ce31eaR149-R154) [[5]](diffhunk://#diff-7579678eeec846f15fafdcbc73f0f080e138a2b9aafd3521497616ef84ce31eaR181-R257)
* The "By assistant" view now uses a multi-accordion UI with "Collapse all" and "Expand all" buttons, and each accordion's open/closed state is synchronized with the user's preference.

**UI Refactoring**
* Refactored the resource review component to separate rendering of the "All assistants" section and individual assistant sections, improving clarity and maintainability.

These changes together provide a more personalized and persistent experience for users reviewing assistance suggestions.