### PR TITLE
Feature: Machine-readable Metadata on Landing Pages

### DIFF
--- a/app/Enums/CacheKey.php
+++ b/app/Enums/CacheKey.php
@@ -73,11 +73,8 @@ enum CacheKey: string
     // F-UJI health check result (short-lived)
     case FUJI_HEALTH_STATUS = 'assessment:fuji_health_status';
 
-    // Landing page Schema.org JSON-LD
-    case SCHEMA_ORG_JSONLD = 'landing_pages:schema_org_jsonld';
-
     // Published landing page render payloads
-    case LANDING_PAGE_RENDER_DATA = 'landing_pages:render_data:v2';
+    case LANDING_PAGE_RENDER_DATA = 'landing_pages:render_data:v3';
 
     // Landing page setup modal download URL suggestions
     case LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS = 'landing-page.download-url-suggestions';
@@ -167,9 +164,6 @@ enum CacheKey: string
             // F-UJI health check result - 30 seconds (short-lived to reflect quick recovery)
             self::FUJI_HEALTH_STATUS => 30,
 
-            // Schema.org JSON-LD - 1 hour (invalidated by ResourceObserver on update)
-            self::SCHEMA_ORG_JSONLD => 3600,
-
             // Published landing page render data - short-lived and configurable
             self::LANDING_PAGE_RENDER_DATA => max(0, (int) config('bot_protection.landing_cache_ttl', 600)),
 
@@ -237,8 +231,6 @@ enum CacheKey: string
             self::ASSESSMENT_AVERAGE_SUMMARY => ['assessments'],
 
             self::FUJI_HEALTH_STATUS => ['assessments'],
-
-            self::SCHEMA_ORG_JSONLD => ['resources', 'landing_pages'],
 
             self::LANDING_PAGE_RENDER_DATA => ['resources', 'landing_pages'],
 

--- a/app/Http/Controllers/LandingPagePublicController.php
+++ b/app/Http/Controllers/LandingPagePublicController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Enums\CacheKey;
 use App\Models\LandingPage;
 use App\Models\LandingPageTemplate;
 use App\Models\Resource;
@@ -12,11 +11,10 @@ use App\Services\BotProtection\LandingPageRenderDataCacheService;
 use App\Services\BotProtection\LandingPageViewCounterService;
 use App\Services\Citations\LandingPageCitationService;
 use App\Services\DataCiteLinkedDataExporter;
+use App\Services\LandingPageMachineMetadataService;
 use App\Services\LandingPageMetadataLinkService;
 use App\Services\LandingPageResourceTransformer;
 use App\Services\LandingPageTemplateResolverService;
-use App\Services\SchemaOrgJsonLdExporter;
-use App\Support\Traits\ChecksCacheTagging;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -32,8 +30,6 @@ use Symfony\Component\HttpFoundation\Response as HttpResponse;
  */
 class LandingPagePublicController extends Controller
 {
-    use ChecksCacheTagging;
-
     /**
      * Regex pattern for valid slug characters.
      * Must match the route constraint in web.php.
@@ -84,6 +80,7 @@ class LandingPagePublicController extends Controller
         LandingPageViewCounterService $viewCounter,
         LandingPageCitationService $citationService,
         LandingPageTemplateResolverService $templateResolver,
+        LandingPageMachineMetadataService $machineMetadataService,
         LandingPageMetadataLinkService $metadataLinkService,
         string $doiPrefix,
         string $slug
@@ -137,6 +134,7 @@ class LandingPagePublicController extends Controller
             $viewCounter,
             $citationService,
             $templateResolver,
+            $machineMetadataService,
             $metadataLinkService,
             $previewToken,
         );
@@ -156,6 +154,7 @@ class LandingPagePublicController extends Controller
         LandingPageViewCounterService $viewCounter,
         LandingPageCitationService $citationService,
         LandingPageTemplateResolverService $templateResolver,
+        LandingPageMachineMetadataService $machineMetadataService,
         LandingPageMetadataLinkService $metadataLinkService,
         int $resourceId,
         string $slug
@@ -187,6 +186,7 @@ class LandingPagePublicController extends Controller
             $viewCounter,
             $citationService,
             $templateResolver,
+            $machineMetadataService,
             $metadataLinkService,
             $previewToken,
         );
@@ -262,6 +262,7 @@ class LandingPagePublicController extends Controller
         LandingPageViewCounterService $viewCounter,
         LandingPageCitationService $citationService,
         LandingPageTemplateResolverService $templateResolver,
+        LandingPageMachineMetadataService $machineMetadataService,
         LandingPageMetadataLinkService $metadataLinkService,
         ?string $previewToken
     ): HttpResponse|RedirectResponse {
@@ -314,7 +315,7 @@ class LandingPagePublicController extends Controller
             $viewCounter->record($request, $landingPage);
         }
 
-        $buildRenderData = function () use ($landingPage, $transformer, $citationService, $templateResolver, $metadataLinkService, $previewToken): array {
+        $buildRenderData = function () use ($landingPage, $transformer, $citationService, $templateResolver, $machineMetadataService, $previewToken): array {
             // Load resource with all necessary relationships
             $resource = Resource::with($transformer->requiredRelations())
                 ->findOrFail($landingPage->resource_id);
@@ -337,14 +338,9 @@ class LandingPagePublicController extends Controller
             ];
             $customLogoUrl = $templateConfig->logo_url;
 
-            // Generate Schema.org JSON-LD for inline SEO embedding (cached per resource)
-            $cacheKey = CacheKey::SCHEMA_ORG_JSONLD->key($resource->id);
-            $schemaOrgJsonLd = $this->getCacheInstance(CacheKey::SCHEMA_ORG_JSONLD->tags())
-                ->remember($cacheKey, CacheKey::SCHEMA_ORG_JSONLD->ttl(), function () use ($resource): array {
-                    $exporter = new SchemaOrgJsonLdExporter;
-
-                    return $exporter->export($resource);
-                });
+            $machineMetadata = $previewToken === null
+                ? $machineMetadataService->for($resource, $landingPage)
+                : null;
 
             $landingPageData = $this->applyDownloadsUnavailableDisplayPolicy(
                 LandingPageController::serializeLandingPagePayload($resource, $landingPage)
@@ -360,9 +356,8 @@ class LandingPagePublicController extends Controller
                     'resource' => $resourceData,
                     'citationStyles' => $citationService->format($resource),
                     'landingPage' => $landingPageData,
-                    'metadataLinks' => $metadataLinkService->for($resource, $landingPage),
+                    'metadataLinks' => $machineMetadata['metadataLinks'] ?? [],
                     'isPreview' => (bool) $previewToken,
-                    'schemaOrgJsonLd' => $schemaOrgJsonLd,
                     'sectionOrder' => $sectionOrder,
                     'customLogoUrl' => $customLogoUrl,
                     'landingPageTemplateSource' => $resolvedTemplate['source'],
@@ -373,6 +368,9 @@ class LandingPagePublicController extends Controller
                         'citationAuthors' => $templateConfig->citation_author_display_limit,
                     ],
                 ],
+                'viewData' => $machineMetadata === null
+                    ? []
+                    : ['landingPageMachineMetadata' => $machineMetadata],
             ];
         };
 
@@ -380,12 +378,20 @@ class LandingPagePublicController extends Controller
             ? $renderDataCache->remember($landingPage, $buildRenderData)
             : $buildRenderData();
 
-        $response = Inertia::render("LandingPages/{$renderData['template']}", $renderData['props'])
-            ->toResponse($request);
-        $metadataLinks = $renderData['props']['metadataLinks'] ?? [];
+        $inertiaResponse = Inertia::render("LandingPages/{$renderData['template']}", $renderData['props']);
+        $viewData = $renderData['viewData'] ?? [];
+        if ($viewData !== []) {
+            $inertiaResponse->withViewData($viewData);
+        }
 
-        $linkHeader = is_array($metadataLinks)
-            ? $metadataLinkService->toHttpLinkHeader($metadataLinks)
+        $response = $inertiaResponse->toResponse($request);
+        $machineMetadata = is_array($viewData['landingPageMachineMetadata'] ?? null)
+            ? $viewData['landingPageMachineMetadata']
+            : [];
+        $signpostingLinks = $machineMetadata['signpostingLinks'] ?? [];
+
+        $linkHeader = is_array($signpostingLinks)
+            ? $metadataLinkService->toSignpostingHttpLinkHeader($signpostingLinks)
             : null;
         if ($linkHeader !== null) {
             $response->headers->set('Link', $linkHeader, false);

--- a/app/Http/Controllers/PublicMetadataExportController.php
+++ b/app/Http/Controllers/PublicMetadataExportController.php
@@ -26,7 +26,11 @@ class PublicMetadataExportController extends Controller
         [$resource] = $this->resolvePublishedResource($doiPrefix, $slug);
         $xml = app(DataCiteXmlExporter::class)->export($resource);
 
-        return $this->xmlDownload($xml, "{$slug}-datacite.xml");
+        return $this->xmlDownload(
+            $xml,
+            "{$slug}-datacite.xml",
+            'application/vnd.datacite.datacite+xml',
+        );
     }
 
     public function dataCiteJson(string $doiPrefix, string $slug): JsonResponse
@@ -35,7 +39,7 @@ class PublicMetadataExportController extends Controller
         $json = app(DataCiteJsonExporter::class)->export($resource);
 
         return response()->json($json, Response::HTTP_OK, [
-            'Content-Type' => 'application/json; charset=UTF-8',
+            'Content-Type' => 'application/vnd.datacite.datacite+json; charset=UTF-8',
             'Content-Disposition' => $this->attachment("{$slug}-datacite.json"),
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
@@ -101,10 +105,10 @@ class PublicMetadataExportController extends Controller
         return [$resource, $landingPage];
     }
 
-    private function xmlDownload(string $xml, string $filename): Response
+    private function xmlDownload(string $xml, string $filename, string $mediaType = 'application/xml'): Response
     {
         return response($xml, Response::HTTP_OK, [
-            'Content-Type' => 'application/xml; charset=UTF-8',
+            'Content-Type' => $mediaType.'; charset=UTF-8',
             'Content-Disposition' => $this->attachment($filename),
         ]);
     }

--- a/app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php
+++ b/app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\LandingPage;
 
 use App\Http\Controllers\LandingPageController;
+use App\Models\LandingPageLink;
 use App\Rules\SafeUrl;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -41,6 +42,7 @@ class StoreLandingPagePreviewRequest extends FormRequest
             $rules['links'] = ['nullable', 'array', 'max:10'];
             $rules['links.*.url'] = ['required', new SafeUrl, 'max:2048'];
             $rules['links.*.label'] = ['required', 'string', 'max:255'];
+            $rules['links.*.kind'] = ['sometimes', 'string', Rule::in(LandingPageLink::KINDS)];
             $rules['links.*.position'] = ['required', 'integer', 'min:0', 'max:9', 'distinct'];
         }
 

--- a/app/Http/Requests/LandingPage/StoreLandingPageRequest.php
+++ b/app/Http/Requests/LandingPage/StoreLandingPageRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\LandingPage;
 
 use App\Http\Controllers\LandingPageController;
+use App\Models\LandingPageLink;
 use App\Rules\SafeUrl;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -47,6 +48,7 @@ class StoreLandingPageRequest extends FormRequest
             $rules['links'] = ['nullable', 'array', 'max:10'];
             $rules['links.*.url'] = ['required', new SafeUrl, 'max:2048'];
             $rules['links.*.label'] = ['required', 'string', 'max:255'];
+            $rules['links.*.kind'] = ['sometimes', 'string', Rule::in(LandingPageLink::KINDS)];
             $rules['links.*.position'] = ['required', 'integer', 'min:0', 'max:9', 'distinct'];
         }
 

--- a/app/Http/Requests/LandingPage/UpdateLandingPageRequest.php
+++ b/app/Http/Requests/LandingPage/UpdateLandingPageRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\LandingPage;
 
 use App\Http\Controllers\LandingPageController;
+use App\Models\LandingPageLink;
 use App\Rules\SafeUrl;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -37,6 +38,7 @@ class UpdateLandingPageRequest extends FormRequest
             'links' => ['nullable', 'array', 'max:10'],
             'links.*.url' => ['required', new SafeUrl, 'max:2048'],
             'links.*.label' => ['required', 'string', 'max:255'],
+            'links.*.kind' => ['sometimes', 'string', Rule::in(LandingPageLink::KINDS)],
             'links.*.position' => ['required', 'integer', 'min:0', 'max:9', 'distinct'],
             'external_domain_id' => ['required_if:template,external', 'integer', 'exists:landing_page_domains,id'],
             'external_path' => ['required_if:template,external', 'string', 'max:2048'],

--- a/app/Models/LandingPageLink.php
+++ b/app/Models/LandingPageLink.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * An additional link associated with a landing page.
@@ -18,14 +19,28 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $landing_page_id
  * @property string $url
  * @property string $label
+ * @property string $kind
  * @property int $position
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read LandingPage $landingPage
  */
-#[Fillable(['landing_page_id', 'url', 'label', 'position'])]
+#[Fillable(['landing_page_id', 'url', 'label', 'kind', 'position'])]
 class LandingPageLink extends Model
 {
+    public const KIND_RELATED = 'related';
+
+    public const KIND_DOWNLOAD = 'download';
+
+    public const KIND_REPOSITORY = 'repository';
+
+    /** @var list<string> */
+    public const KINDS = [
+        self::KIND_RELATED,
+        self::KIND_DOWNLOAD,
+        self::KIND_REPOSITORY,
+    ];
+
     /**
      * The attributes that should be cast.
      *

--- a/app/Observers/FormatObserver.php
+++ b/app/Observers/FormatObserver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\Format;
+use App\Models\LandingPage;
+use App\Services\BotProtection\LandingPageRenderDataCacheService;
+
+final class FormatObserver
+{
+    public function __construct(private readonly LandingPageRenderDataCacheService $renderDataCache) {}
+
+    public function saved(Format $format): void
+    {
+        $this->forget($format);
+    }
+
+    public function deleted(Format $format): void
+    {
+        $this->forget($format);
+    }
+
+    private function forget(Format $format): void
+    {
+        $landingPageId = LandingPage::query()
+            ->where('resource_id', $format->resource_id)
+            ->value('id');
+
+        if (is_numeric($landingPageId)) {
+            $this->renderDataCache->forgetById((int) $landingPageId);
+        }
+    }
+}

--- a/app/Observers/LandingPageFileObserver.php
+++ b/app/Observers/LandingPageFileObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\LandingPageFile;
+use App\Services\BotProtection\LandingPageRenderDataCacheService;
+
+final class LandingPageFileObserver
+{
+    public function __construct(private readonly LandingPageRenderDataCacheService $renderDataCache) {}
+
+    public function saved(LandingPageFile $file): void
+    {
+        $this->renderDataCache->forgetById($file->landing_page_id);
+    }
+
+    public function deleted(LandingPageFile $file): void
+    {
+        $this->renderDataCache->forgetById($file->landing_page_id);
+    }
+}

--- a/app/Observers/LandingPageLinkObserver.php
+++ b/app/Observers/LandingPageLinkObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\LandingPageLink;
+use App\Services\BotProtection\LandingPageRenderDataCacheService;
+
+final class LandingPageLinkObserver
+{
+    public function __construct(private readonly LandingPageRenderDataCacheService $renderDataCache) {}
+
+    public function saved(LandingPageLink $link): void
+    {
+        $this->renderDataCache->forgetById($link->landing_page_id);
+    }
+
+    public function deleted(LandingPageLink $link): void
+    {
+        $this->renderDataCache->forgetById($link->landing_page_id);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,12 +11,18 @@ use App\Jobs\ImportFromDataCiteJob;
 use App\Jobs\UpdatePidJob;
 use App\Jobs\UpdateThesaurusJob;
 use App\Listeners\MarkContactMessageAsSent;
+use App\Models\Format;
 use App\Models\LandingPage;
+use App\Models\LandingPageFile;
+use App\Models\LandingPageLink;
 use App\Models\Resource;
 use App\Models\ResourceAssessment;
 use App\Models\ResourceType;
 use App\Models\Subject;
 use App\Models\User;
+use App\Observers\FormatObserver;
+use App\Observers\LandingPageFileObserver;
+use App\Observers\LandingPageLinkObserver;
 use App\Observers\LandingPageObserver;
 use App\Observers\ResourceAssessmentObserver;
 use App\Observers\ResourceObserver;
@@ -71,6 +77,9 @@ class AppServiceProvider extends ServiceProvider
         ResourceAssessment::observe(ResourceAssessmentObserver::class);
         ResourceType::observe(ResourceTypeObserver::class);
         LandingPage::observe(LandingPageObserver::class);
+        Format::observe(FormatObserver::class);
+        LandingPageFile::observe(LandingPageFileObserver::class);
+        LandingPageLink::observe(LandingPageLinkObserver::class);
         Subject::observe(SubjectObserver::class);
         Event::listen(MessageSent::class, MarkContactMessageAsSent::class);
 

--- a/app/Services/BotProtection/LandingPageRenderDataCacheService.php
+++ b/app/Services/BotProtection/LandingPageRenderDataCacheService.php
@@ -17,8 +17,8 @@ class LandingPageRenderDataCacheService
     use ChecksCacheTagging;
 
     /**
-     * @param  Closure(): array{template: string, props: array<string, mixed>}  $resolver
-     * @return array{template: string, props: array<string, mixed>}
+     * @param  Closure(): array{template: string, props: array<string, mixed>, viewData?: array<string, mixed>}  $resolver
+     * @return array{template: string, props: array<string, mixed>, viewData?: array<string, mixed>}
      */
     public function remember(LandingPage $landingPage, Closure $resolver): array
     {
@@ -28,7 +28,7 @@ class LandingPageRenderDataCacheService
 
         $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA;
 
-        /** @var array{template: string, props: array<string, mixed>} */
+        /** @var array{template: string, props: array<string, mixed>, viewData?: array<string, mixed>} */
         return $this->getCacheInstance($cacheKey->tags())
             ->remember($cacheKey->key($landingPage->id), $cacheKey->ttl(), $resolver);
     }

--- a/app/Services/LandingPageContentLinkService.php
+++ b/app/Services/LandingPageContentLinkService.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\LandingPage;
+use App\Models\LandingPageLink;
+use App\Models\Resource;
+use App\Services\SizeFormat\SizeFormatFormatNormalizerService;
+
+final class LandingPageContentLinkService
+{
+    /**
+     * @return array{
+     *     mimeType: string|null,
+     *     contentLinks: list<array{url: string, mimeType: string}>,
+     *     repositories: list<string>
+     * }
+     */
+    public function resolve(Resource $resource, LandingPage $landingPage): array
+    {
+        $resource->loadMissing('formats');
+        $landingPage->loadMissing(['files', 'links']);
+
+        $mimeType = $this->firstValidMimeType($resource);
+        $repositories = $this->repositoryUrls($landingPage);
+
+        if ($landingPage->downloads_unavailable || $mimeType === null) {
+            return [
+                'mimeType' => $mimeType,
+                'contentLinks' => [],
+                'repositories' => $repositories,
+            ];
+        }
+
+        $urls = [];
+        $files = $landingPage->files
+            ->sortBy([['position', 'asc'], ['id', 'asc']])
+            ->values();
+
+        if ($files->isNotEmpty()) {
+            foreach ($files as $file) {
+                $this->appendSafeUniqueUrl($urls, $file->url);
+            }
+        } else {
+            $this->appendSafeUniqueUrl($urls, $landingPage->ftp_url);
+        }
+
+        foreach ($landingPage->links
+            ->where('kind', LandingPageLink::KIND_DOWNLOAD)
+            ->sortBy([['position', 'asc'], ['id', 'asc']]) as $link) {
+            $this->appendSafeUniqueUrl($urls, $link->url);
+        }
+
+        return [
+            'mimeType' => $mimeType,
+            'contentLinks' => array_map(
+                static fn (string $url): array => ['url' => $url, 'mimeType' => $mimeType],
+                array_values($urls),
+            ),
+            'repositories' => $repositories,
+        ];
+    }
+
+    private function firstValidMimeType(Resource $resource): ?string
+    {
+        foreach ($resource->formats->sortBy('id') as $format) {
+            $normalized = SizeFormatFormatNormalizerService::normalize($format->value);
+
+            if ($this->isValidMimeType($normalized)) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return list<string> */
+    private function repositoryUrls(LandingPage $landingPage): array
+    {
+        $urls = [];
+
+        foreach ($landingPage->links
+            ->where('kind', LandingPageLink::KIND_REPOSITORY)
+            ->sortBy([['position', 'asc'], ['id', 'asc']]) as $link) {
+            $this->appendSafeUniqueUrl($urls, $link->url);
+        }
+
+        return array_values($urls);
+    }
+
+    private function isValidMimeType(string $value): bool
+    {
+        return preg_match(
+            '/\A[a-z0-9][a-z0-9!#$&^_.+\-]*\/[a-z0-9][a-z0-9!#$&^_.+\-]*\z/i',
+            $value,
+        ) === 1;
+    }
+
+    /** @param array<string, string> $urls */
+    private function appendSafeUniqueUrl(array &$urls, mixed $candidate): void
+    {
+        if (! is_string($candidate)) {
+            return;
+        }
+
+        $url = trim($candidate);
+        if (! $this->isSafeAbsoluteHttpUrl($url)) {
+            return;
+        }
+
+        $urls[$url] = $url;
+    }
+
+    private function isSafeAbsoluteHttpUrl(string $url): bool
+    {
+        if ($url === '' || preg_match('/[\x00-\x1F\x7F<>]/', $url) === 1) {
+            return false;
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return is_string($scheme)
+            && in_array(strtolower($scheme), ['http', 'https'], true)
+            && is_string($host)
+            && $host !== '';
+    }
+}

--- a/app/Services/LandingPageLicenseResolver.php
+++ b/app/Services/LandingPageLicenseResolver.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+final class LandingPageLicenseResolver
+{
+    /** @param array<int, mixed> $rightsList */
+    public function resolve(array $rightsList): ?string
+    {
+        foreach ($rightsList as $rights) {
+            if (! is_array($rights)) {
+                continue;
+            }
+
+            $scheme = $rights['rightsIdentifierScheme'] ?? null;
+            $schemeUri = $rights['schemeUri'] ?? null;
+            $identifier = $rights['rightsIdentifier'] ?? null;
+
+            if (
+                is_string($scheme)
+                && strcasecmp($scheme, 'SPDX') === 0
+                && is_string($schemeUri)
+                && is_string($identifier)
+                && trim($identifier) !== ''
+            ) {
+                $spdxUri = rtrim(trim($schemeUri), '/').'/'.rawurlencode(trim($identifier));
+                if ($this->isSafeAbsoluteHttpUrl($spdxUri)) {
+                    return $spdxUri;
+                }
+            }
+        }
+
+        foreach ($rightsList as $rights) {
+            if (! is_array($rights) || ! is_string($rights['rightsUri'] ?? null)) {
+                continue;
+            }
+
+            $rightsUri = trim($rights['rightsUri']);
+            if ($this->isSafeAbsoluteHttpUrl($rightsUri)) {
+                return $rightsUri;
+            }
+        }
+
+        return null;
+    }
+
+    private function isSafeAbsoluteHttpUrl(string $url): bool
+    {
+        if ($url === '' || preg_match('/[\x00-\x1F\x7F<>]/', $url) === 1) {
+            return false;
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        return in_array(strtolower((string) parse_url($url, PHP_URL_SCHEME)), ['http', 'https'], true)
+            && is_string(parse_url($url, PHP_URL_HOST));
+    }
+}

--- a/app/Services/LandingPageLicenseResolverService.php
+++ b/app/Services/LandingPageLicenseResolverService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-final class LandingPageLicenseResolver
+final class LandingPageLicenseResolverService
 {
     /** @param array<int, mixed> $rightsList */
     public function resolve(array $rightsList): ?string

--- a/app/Services/LandingPageMachineMetadataService.php
+++ b/app/Services/LandingPageMachineMetadataService.php
@@ -10,6 +10,7 @@ use App\Models\Resource;
 final class LandingPageMachineMetadataService
 {
     private const JSON_FLAGS = JSON_THROW_ON_ERROR
+        | JSON_INVALID_UTF8_SUBSTITUTE
         | JSON_HEX_TAG
         | JSON_HEX_AMP
         | JSON_HEX_APOS

--- a/app/Services/LandingPageMachineMetadataService.php
+++ b/app/Services/LandingPageMachineMetadataService.php
@@ -28,7 +28,6 @@ final class LandingPageMachineMetadataService
 
     /**
      * @return array{
-     *     jsonLd: array<string, mixed>,
      *     jsonLdJson: string,
      *     dublinCore: list<array{name: string, content: string}>,
      *     signpostingLinks: list<array{rel: string, href: string, type: string|null, profile: string|null}>,
@@ -56,7 +55,6 @@ final class LandingPageMachineMetadataService
         );
 
         return [
-            'jsonLd' => $jsonLd,
             'jsonLdJson' => json_encode($jsonLd, self::JSON_FLAGS),
             'dublinCore' => $this->dublinCore($attributes, $jsonLd, $license, $landingPage),
             'signpostingLinks' => $signpostingLinks,

--- a/app/Services/LandingPageMachineMetadataService.php
+++ b/app/Services/LandingPageMachineMetadataService.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\LandingPage;
+use App\Models\Resource;
+
+final class LandingPageMachineMetadataService
+{
+    private const JSON_FLAGS = JSON_THROW_ON_ERROR
+        | JSON_HEX_TAG
+        | JSON_HEX_AMP
+        | JSON_HEX_APOS
+        | JSON_HEX_QUOT
+        | JSON_UNESCAPED_SLASHES
+        | JSON_UNESCAPED_UNICODE;
+
+    public function __construct(
+        private readonly LandingPageContentLinkService $contentLinkService,
+        private readonly LandingPageLicenseResolver $licenseResolver,
+        private readonly LandingPageMetadataLinkService $metadataLinkService,
+        private readonly SchemaOrgJsonLdExporter $schemaOrgExporter,
+        private readonly DataCiteJsonExporter $dataCiteExporter,
+    ) {}
+
+    /**
+     * @return array{
+     *     jsonLd: array<string, mixed>,
+     *     jsonLdJson: string,
+     *     dublinCore: list<array{name: string, content: string}>,
+     *     signpostingLinks: list<array{rel: string, href: string, type: string|null, profile: string|null}>,
+     *     metadataLinks: list<array{format: string, standard: string, label: string, url: string, mediaType: string, profile: string|null}>
+     * }|null
+     */
+    public function for(Resource $resource, LandingPage $landingPage): ?array
+    {
+        if (! $landingPage->isPublished() || $landingPage->doi_prefix === null) {
+            return null;
+        }
+
+        $content = $this->contentLinkService->resolve($resource, $landingPage);
+        $jsonLd = $this->schemaOrgExporter->export($resource, $landingPage, $content);
+        $attributes = $this->dataCiteExporter->export($resource)['data']['attributes'];
+        $rightsList = is_array($attributes['rightsList'] ?? null) ? $attributes['rightsList'] : [];
+        $license = $this->licenseResolver->resolve($rightsList);
+        $metadataLinks = $this->metadataLinkService->for($resource, $landingPage);
+        $signpostingLinks = $this->metadataLinkService->signpostingFor(
+            $resource,
+            $landingPage,
+            $metadataLinks,
+            $content,
+            $license,
+        );
+
+        return [
+            'jsonLd' => $jsonLd,
+            'jsonLdJson' => json_encode($jsonLd, self::JSON_FLAGS),
+            'dublinCore' => $this->dublinCore($attributes, $jsonLd, $license, $landingPage),
+            'signpostingLinks' => $signpostingLinks,
+            'metadataLinks' => $metadataLinks,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  array<string, mixed>  $jsonLd
+     * @return list<array{name: string, content: string}>
+     */
+    private function dublinCore(array $attributes, array $jsonLd, ?string $license, LandingPage $landingPage): array
+    {
+        $tags = [];
+        $doiUrl = 'https://doi.org/'.$landingPage->doi_prefix;
+        $this->appendTag($tags, 'DC.identifier', $doiUrl);
+        $this->appendTag($tags, 'DC.title', $this->mainTitle($attributes['titles'] ?? []));
+
+        $creators = is_array($attributes['creators'] ?? null) ? $attributes['creators'] : [];
+        foreach ($creators as $creator) {
+            if (is_array($creator)) {
+                $this->appendTag($tags, 'DC.creator', $creator['name'] ?? null);
+            }
+        }
+
+        $publisher = is_array($attributes['publisher'] ?? null) ? $attributes['publisher'] : [];
+        $this->appendTag($tags, 'DC.publisher', $publisher['name'] ?? null);
+        $this->appendTag($tags, 'DC.date', $jsonLd['datePublished'] ?? $attributes['publicationYear'] ?? null);
+        $this->appendTag($tags, 'DC.rights', $license);
+
+        $types = is_array($attributes['types'] ?? null) ? $attributes['types'] : [];
+        $this->appendTag($tags, 'DC.type', $types['resourceTypeGeneral'] ?? null);
+
+        return $tags;
+    }
+
+    /** @param array<int, mixed> $titles */
+    private function mainTitle(array $titles): ?string
+    {
+        foreach ($titles as $title) {
+            if (is_array($title) && ! isset($title['titleType']) && is_string($title['title'] ?? null)) {
+                return $title['title'];
+            }
+        }
+
+        $first = $titles[0] ?? null;
+
+        return is_array($first) && is_string($first['title'] ?? null) ? $first['title'] : null;
+    }
+
+    /**
+     * @param  list<array{name: string, content: string}>  $tags
+     */
+    private function appendTag(array &$tags, string $name, mixed $content): void
+    {
+        if (! is_scalar($content)) {
+            return;
+        }
+
+        $value = trim((string) $content);
+        if ($value !== '') {
+            $tags[] = ['name' => $name, 'content' => $value];
+        }
+    }
+}

--- a/app/Services/LandingPageMachineMetadataService.php
+++ b/app/Services/LandingPageMachineMetadataService.php
@@ -19,7 +19,7 @@ final class LandingPageMachineMetadataService
 
     public function __construct(
         private readonly LandingPageContentLinkService $contentLinkService,
-        private readonly LandingPageLicenseResolver $licenseResolver,
+        private readonly LandingPageLicenseResolverService $licenseResolver,
         private readonly LandingPageMetadataLinkService $metadataLinkService,
         private readonly SchemaOrgJsonLdExporter $schemaOrgExporter,
         private readonly DataCiteJsonExporter $dataCiteExporter,

--- a/app/Services/LandingPageMetadataLinkService.php
+++ b/app/Services/LandingPageMetadataLinkService.php
@@ -35,8 +35,8 @@ class LandingPageMetadataLinkService
 
         $baseUrl = url($landingPage->getPublicPath().'/metadata');
         $links = [
-            $this->link('datacite-xml', 'DataCite', 'DataCite XML', "{$baseUrl}/datacite.xml", 'application/xml'),
-            $this->link('datacite-json', 'DataCite', 'DataCite JSON', "{$baseUrl}/datacite.json", 'application/json'),
+            $this->link('datacite-xml', 'DataCite', 'DataCite XML', "{$baseUrl}/datacite.xml", 'application/vnd.datacite.datacite+xml'),
+            $this->link('datacite-json', 'DataCite', 'DataCite JSON', "{$baseUrl}/datacite.json", 'application/vnd.datacite.datacite+json'),
             $this->link('datacite-jsonld', 'DataCite', 'DataCite JSON-LD', "{$baseUrl}/datacite.jsonld", 'application/ld+json'),
         ];
 
@@ -52,6 +52,99 @@ class LandingPageMetadataLinkService
         }
 
         return $links;
+    }
+
+    /**
+     * @param  list<array{format: string, standard: string, label: string, url: string, mediaType: string, profile: string|null}>  $metadataLinks
+     * @param  array{mimeType: string|null, contentLinks: list<array{url: string, mimeType: string}>, repositories: list<string>}  $content
+     * @return list<array{rel: string, href: string, type: string|null, profile: string|null}>
+     */
+    public function signpostingFor(
+        Resource $resource,
+        LandingPage $landingPage,
+        array $metadataLinks,
+        array $content,
+        ?string $license,
+    ): array {
+        if (! $landingPage->isPublished() || $landingPage->doi_prefix === null) {
+            return [];
+        }
+
+        $primaryType = $resource->resourceType?->slug === 'software'
+            ? 'https://schema.org/SoftwareSourceCode'
+            : 'https://schema.org/Dataset';
+
+        $links = [
+            $this->signpostingLink('cite-as', 'https://doi.org/'.$landingPage->doi_prefix),
+            $this->signpostingLink('type', $primaryType),
+            $this->signpostingLink('type', 'https://schema.org/AboutPage'),
+        ];
+
+        foreach ($metadataLinks as $metadataLink) {
+            $links[] = $this->signpostingLink(
+                'describedby',
+                $metadataLink['url'],
+                $metadataLink['mediaType'],
+                $metadataLink['profile'],
+            );
+        }
+
+        if ($license !== null) {
+            $links[] = $this->signpostingLink('license', $license);
+        }
+
+        foreach ($content['contentLinks'] as $contentLink) {
+            $links[] = $this->signpostingLink('item', $contentLink['url'], $contentLink['mimeType']);
+        }
+
+        return $this->safeUniqueSignpostingLinks($links);
+    }
+
+    /**
+     * Serialize the complete FAIR Signposting contract for an HTTP Link header.
+     *
+     * @param  array<mixed, mixed>  $links
+     */
+    public function toSignpostingHttpLinkHeader(array $links): ?string
+    {
+        $values = [];
+        $quote = chr(34);
+
+        foreach ($links as $link) {
+            if (! is_array($link)) {
+                continue;
+            }
+
+            $rel = $link['rel'] ?? null;
+            $href = $link['href'] ?? null;
+            if (
+                ! is_string($rel)
+                || preg_match('/\A[a-z][a-z0-9-]*\z/', $rel) !== 1
+                || ! is_string($href)
+                || ! $this->isSafeAbsoluteHttpUrl($href)
+            ) {
+                continue;
+            }
+
+            $parameters = [
+                '<'.$href.'>',
+                'rel='.$quote.$this->quotedParameter($rel).$quote,
+            ];
+
+            $type = $link['type'] ?? null;
+            if (is_string($type) && $type !== '') {
+                $parameters[] = 'type='.$quote.$this->quotedParameter($type).$quote;
+            }
+
+            $profile = $link['profile'] ?? null;
+            if (is_string($profile) && $profile !== '') {
+                $parameters[] = 'profile='.$quote.$this->quotedParameter($profile).$quote;
+            }
+
+            $values[] = implode('; ', $parameters);
+        }
+
+        return $values !== [] ? implode(', ', array_values(array_unique($values))) : null;
     }
 
     /**
@@ -91,6 +184,57 @@ class LandingPageMetadataLinkService
         }
 
         return $values !== [] ? implode(', ', $values) : null;
+    }
+
+    /**
+     * @return array{rel: string, href: string, type: string|null, profile: string|null}
+     */
+    private function signpostingLink(
+        string $rel,
+        string $href,
+        ?string $type = null,
+        ?string $profile = null,
+    ): array {
+        return compact('rel', 'href', 'type', 'profile');
+    }
+
+    /**
+     * @param  list<array{rel: string, href: string, type: string|null, profile: string|null}>  $links
+     * @return list<array{rel: string, href: string, type: string|null, profile: string|null}>
+     */
+    private function safeUniqueSignpostingLinks(array $links): array
+    {
+        $unique = [];
+
+        foreach ($links as $link) {
+            if (! $this->isSafeAbsoluteHttpUrl($link['href'])) {
+                continue;
+            }
+
+            $key = implode('|', [
+                $link['rel'],
+                $link['href'],
+                $link['type'] ?? '',
+                $link['profile'] ?? '',
+            ]);
+            $unique[$key] = $link;
+        }
+
+        return array_values($unique);
+    }
+
+    private function isSafeAbsoluteHttpUrl(string $url): bool
+    {
+        if ($url === '' || preg_match('/[\x00-\x1F\x7F<>]/', $url) === 1) {
+            return false;
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        return in_array(strtolower((string) parse_url($url, PHP_URL_SCHEME)), ['http', 'https'], true)
+            && is_string(parse_url($url, PHP_URL_HOST));
     }
 
     private function quotedParameter(string $value): string

--- a/app/Services/SchemaOrgJsonLdExporter.php
+++ b/app/Services/SchemaOrgJsonLdExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Support\OrcidNormalizer;
 
@@ -36,28 +37,34 @@ class SchemaOrgJsonLdExporter
     ];
 
     /**
-     * Export a Resource as Schema.org Dataset JSON-LD.
+     * Export a Resource as Schema.org JSON-LD.
      *
+     * @param  array{mimeType: string|null, contentLinks: list<array{url: string, mimeType: string}>, repositories: list<string>}|null  $content
      * @return array<string, mixed>
      */
-    public function export(Resource $resource): array
+    public function export(Resource $resource, ?LandingPage $landingPage = null, ?array $content = null): array
     {
         $jsonExporter = new DataCiteJsonExporter;
         $dataCiteJson = $jsonExporter->export($resource);
         $attributes = $dataCiteJson['data']['attributes'];
 
+        $isSoftware = $resource->resourceType?->slug === 'software';
         $jsonLd = [
             '@context' => 'https://schema.org/',
-            '@type' => 'Dataset',
+            '@type' => $isSoftware ? ['SoftwareSourceCode', 'SoftwareApplication'] : 'Dataset',
             'isAccessibleForFree' => true,
         ];
 
         // @id and url from DOI
         if (isset($attributes['doi'])) {
-            $doiUrl = 'https://doi.org/' . $attributes['doi'];
+            $doiUrl = 'https://doi.org/'.$attributes['doi'];
             $jsonLd['@id'] = $doiUrl;
             $jsonLd['url'] = $doiUrl;
             $jsonLd['identifier'] = $this->buildDoiIdentifier($attributes['doi']);
+        }
+
+        if ($landingPage !== null) {
+            $jsonLd['url'] = url($landingPage->getPublicPath());
         }
 
         // Name from main title
@@ -100,6 +107,10 @@ class SchemaOrgJsonLdExporter
             $jsonLd['license'] = $this->transformLicense($attributes['rightsList']);
         }
 
+        if ($content !== null) {
+            $this->applyLandingPageContent($jsonLd, $content, $isSoftware);
+        }
+
         // Spatial coverage
         if (! empty($attributes['geoLocations'])) {
             $spatial = $this->transformSpatialCoverage($attributes['geoLocations']);
@@ -135,6 +146,50 @@ class SchemaOrgJsonLdExporter
     }
 
     /**
+     * @param  array<string, mixed>  $jsonLd
+     * @param  array{mimeType: string|null, contentLinks: list<array{url: string, mimeType: string}>, repositories: list<string>}  $content
+     */
+    private function applyLandingPageContent(array &$jsonLd, array $content, bool $isSoftware): void
+    {
+        $contentUrls = array_map(
+            static fn (array $link): string => $link['url'],
+            $content['contentLinks'],
+        );
+
+        if ($isSoftware) {
+            if ($content['repositories'] !== []) {
+                $jsonLd['codeRepository'] = $this->singleOrList($content['repositories']);
+            }
+
+            if ($contentUrls !== []) {
+                $jsonLd['downloadUrl'] = $this->singleOrList($contentUrls);
+            }
+
+            return;
+        }
+
+        if ($content['contentLinks'] !== []) {
+            $jsonLd['distribution'] = array_map(
+                static fn (array $link): array => [
+                    '@type' => 'DataDownload',
+                    'contentUrl' => $link['url'],
+                    'encodingFormat' => $link['mimeType'],
+                ],
+                $content['contentLinks'],
+            );
+        }
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return string|list<string>
+     */
+    private function singleOrList(array $values): string|array
+    {
+        return count($values) === 1 ? $values[0] : $values;
+    }
+
+    /**
      * Build a PropertyValue identifier for the DOI (ESIP recommendation).
      *
      * @return array<string, string>
@@ -142,11 +197,11 @@ class SchemaOrgJsonLdExporter
     private function buildDoiIdentifier(string $doi): array
     {
         return [
-            '@id' => 'https://doi.org/' . $doi,
+            '@id' => 'https://doi.org/'.$doi,
             '@type' => 'PropertyValue',
             'propertyID' => 'https://registry.identifiers.org/registry/doi',
-            'value' => 'doi:' . $doi,
-            'url' => 'https://doi.org/' . $doi,
+            'value' => 'doi:'.$doi,
+            'url' => 'https://doi.org/'.$doi,
         ];
     }
 
@@ -262,7 +317,7 @@ class SchemaOrgJsonLdExporter
                         '@id' => $orcidUrl,
                         '@type' => 'PropertyValue',
                         'propertyID' => 'https://registry.identifiers.org/registry/orcid',
-                        'value' => 'orcid:' . OrcidNormalizer::extractBareId($ni['nameIdentifier']),
+                        'value' => 'orcid:'.OrcidNormalizer::extractBareId($ni['nameIdentifier']),
                         'url' => $orcidUrl,
                     ];
                     break;
@@ -353,7 +408,7 @@ class SchemaOrgJsonLdExporter
         }
 
         // Single date becomes open-ended range
-        return $dateValue . '/..';
+        return $dateValue.'/..';
     }
 
     /**
@@ -407,7 +462,7 @@ class SchemaOrgJsonLdExporter
             if (! empty($rights['schemeUri'])) {
                 $spdxUri = rtrim($rights['schemeUri'], '/');
                 if (! empty($rights['rightsIdentifier'])) {
-                    $spdxUri .= '/' . $rights['rightsIdentifier'];
+                    $spdxUri .= '/'.$rights['rightsIdentifier'];
                 }
                 $uris[] = $spdxUri;
             }
@@ -473,7 +528,7 @@ class SchemaOrgJsonLdExporter
                     ),
                 ));
                 $pairs = array_map(
-                    fn (array $p): string => $p['pointLatitude'] . ' ' . $p['pointLongitude'],
+                    fn (array $p): string => $p['pointLatitude'].' '.$p['pointLongitude'],
                     $points
                 );
                 $place['geo'] = [
@@ -574,11 +629,11 @@ class SchemaOrgJsonLdExporter
                         // canonical resolver URL so we never emit
                         // `https://doi.org/https://doi.org/...`.
                         $bareDoi = $this->stripDoiPrefix($idVal);
-                        $entry['@id'] = 'https://doi.org/' . $this->encodeDoiPath($bareDoi);
+                        $entry['@id'] = 'https://doi.org/'.$this->encodeDoiPath($bareDoi);
                         $entry['identifier'] = [
                             '@type' => 'PropertyValue',
                             'propertyID' => 'https://registry.identifiers.org/registry/doi',
-                            'value' => 'doi:' . $bareDoi,
+                            'value' => 'doi:'.$bareDoi,
                         ];
                     } elseif ($idType === 'URL') {
                         $entry['url'] = $idVal;
@@ -632,17 +687,17 @@ class SchemaOrgJsonLdExporter
             // Bibliographic details
             $bibParts = [];
             if (isset($ri['volume'])) {
-                $bibParts[] = 'Vol. ' . $ri['volume'];
+                $bibParts[] = 'Vol. '.$ri['volume'];
             }
             if (isset($ri['issue'])) {
-                $bibParts[] = 'Issue ' . $ri['issue'];
+                $bibParts[] = 'Issue '.$ri['issue'];
             }
             if (isset($ri['firstPage'])) {
                 $pages = (string) $ri['firstPage'];
                 if (isset($ri['lastPage'])) {
-                    $pages .= '-' . (string) $ri['lastPage'];
+                    $pages .= '-'.(string) $ri['lastPage'];
                 }
-                $bibParts[] = 'pp. ' . $pages;
+                $bibParts[] = 'pp. '.$pages;
             }
             if ($bibParts !== []) {
                 $entry['description'] = implode(', ', $bibParts);

--- a/database/migrations/2026_07_27_000001_add_kind_to_landing_page_links_table.php
+++ b/database/migrations/2026_07_27_000001_add_kind_to_landing_page_links_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2026_07_27_000001_add_kind_to_landing_page_links_table.php
+++ b/database/migrations/2026_07_27_000001_add_kind_to_landing_page_links_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('landing_page_links', function (Blueprint $table): void {
+            $table->string('kind', 20)->default('related')->after('label');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('landing_page_links', function (Blueprint $table): void {
+            $table->dropColumn('kind');
+        });
+    }
+};

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -97,6 +97,7 @@ function cloneLandingPageLinks(links: LandingPageLink[] = []): LandingPageLink[]
         _clientId: link._clientId,
         url: link.url,
         label: link.label,
+        kind: link.kind ?? 'related',
         position: typeof link.position === 'number' ? link.position : index,
     }));
 }
@@ -113,15 +114,13 @@ function normalizePersistedLandingPageDraftState(draftState: PersistedLandingPag
         links: cloneLandingPageLinks(draftState.links).map((link, index) => ({
             url: link.url,
             label: link.label,
+            kind: link.kind ?? 'related',
             position: typeof link.position === 'number' ? link.position : index,
         })),
     };
 }
 
-function arePersistedLandingPageDraftStatesEqual(
-    left: PersistedLandingPageDraftState,
-    right: PersistedLandingPageDraftState,
-): boolean {
+function arePersistedLandingPageDraftStatesEqual(left: PersistedLandingPageDraftState, right: PersistedLandingPageDraftState): boolean {
     return JSON.stringify(normalizePersistedLandingPageDraftState(left)) === JSON.stringify(normalizePersistedLandingPageDraftState(right));
 }
 
@@ -139,24 +138,24 @@ function parsePersistedLandingPageDraftState(rawValue: string | null): Persisted
 
         const links = Array.isArray(parsed.links)
             ? parsed.links.map((link, index) => {
-                if (!link || typeof link !== 'object') {
-                    return {
-                        url: '',
-                        label: '',
-                        position: index,
-                    } satisfies LandingPageLink;
-                }
+                  if (!link || typeof link !== 'object') {
+                      return {
+                          url: '',
+                          label: '',
+                          position: index,
+                      } satisfies LandingPageLink;
+                  }
 
-                const candidate = link as Partial<LandingPageLink>;
+                  const candidate = link as Partial<LandingPageLink>;
 
-                return {
-                    id: typeof candidate.id === 'number' ? candidate.id : undefined,
-                    _clientId: typeof candidate._clientId === 'string' ? candidate._clientId : undefined,
-                    url: typeof candidate.url === 'string' ? candidate.url : '',
-                    label: typeof candidate.label === 'string' ? candidate.label : '',
-                    position: typeof candidate.position === 'number' ? candidate.position : index,
-                } satisfies LandingPageLink;
-            })
+                  return {
+                      id: typeof candidate.id === 'number' ? candidate.id : undefined,
+                      _clientId: typeof candidate._clientId === 'string' ? candidate._clientId : undefined,
+                      url: typeof candidate.url === 'string' ? candidate.url : '',
+                      label: typeof candidate.label === 'string' ? candidate.label : '',
+                      position: typeof candidate.position === 'number' ? candidate.position : index,
+                  } satisfies LandingPageLink;
+              })
             : [];
 
         return {
@@ -219,7 +218,7 @@ function SortableLinkItem({
     link: LandingPageLink;
     index: number;
     onRemove: (index: number) => void;
-    onUpdate: (index: number, field: 'url' | 'label', value: string) => void;
+    onUpdate: (index: number, field: 'url' | 'label' | 'kind', value: string) => void;
 }) {
     const sortableId = link.id ?? link._clientId ?? `new-${link.position}`;
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: sortableId });
@@ -248,6 +247,16 @@ function SortableLinkItem({
                     onChange={(e) => onUpdate(index, 'label', e.target.value)}
                     className="h-8 text-sm"
                 />
+                <Select value={link.kind ?? 'related'} onValueChange={(value) => onUpdate(index, 'kind', value)}>
+                    <SelectTrigger aria-label={'Link role'} size={'sm'}>
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value={'related'}>Related page</SelectItem>
+                        <SelectItem value={'download'}>Direct download</SelectItem>
+                        <SelectItem value={'repository'}>Source repository</SelectItem>
+                    </SelectContent>
+                </Select>
                 <Input
                     type="url"
                     placeholder="https://..."
@@ -256,14 +265,28 @@ function SortableLinkItem({
                     className="h-8 text-sm"
                 />
             </div>
-            <Button type="button" variant="ghost" size="icon" aria-label="Remove link" className="mt-1 size-7 shrink-0" onClick={() => onRemove(index)}>
+            <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove link"
+                className="mt-1 size-7 shrink-0"
+                onClick={() => onRemove(index)}
+            >
                 <X className="size-3.5" />
             </Button>
         </div>
     );
 }
 
-export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuccess, existingConfig, openPreviewOnSuccess = false }: SetupLandingPageModalProps) {
+export default function SetupLandingPageModal({
+    resource,
+    isOpen,
+    onClose,
+    onSuccess,
+    existingConfig,
+    openPreviewOnSuccess = false,
+}: SetupLandingPageModalProps) {
     const { auth } = usePage<{ auth: { user: AuthUser | null } }>().props;
     const canDeleteLandingPages = auth.user?.can_delete_landing_pages ?? false;
 
@@ -296,16 +319,22 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         };
     }, [resource.resourcetypegeneral, storageKey]);
 
-    const persistDraftState = useCallback((draftState: PersistedLandingPageDraftState) => {
-        if (typeof window === 'undefined' || storageKey === null) {
-            return;
-        }
+    const persistDraftState = useCallback(
+        (draftState: PersistedLandingPageDraftState) => {
+            if (typeof window === 'undefined' || storageKey === null) {
+                return;
+            }
 
-        writeSessionStorageItem(storageKey, JSON.stringify({
-            ...draftState,
-            links: cloneLandingPageLinks(draftState.links),
-        }));
-    }, [storageKey]);
+            writeSessionStorageItem(
+                storageKey,
+                JSON.stringify({
+                    ...draftState,
+                    links: cloneLandingPageLinks(draftState.links),
+                }),
+            );
+        },
+        [storageKey],
+    );
 
     const clearPersistedDraftState = useCallback(() => {
         if (typeof window === 'undefined' || storageKey === null) {
@@ -315,20 +344,23 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         removeSessionStorageItem(storageKey);
     }, [storageKey]);
 
-    const buildDraftStateFromConfig = useCallback((config: LandingPageConfig | null): PersistedLandingPageDraftState => {
-        const preferredTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, config?.template);
+    const buildDraftStateFromConfig = useCallback(
+        (config: LandingPageConfig | null): PersistedLandingPageDraftState => {
+            const preferredTemplate = getPreferredTemplateForResource(resource.resourcetypegeneral, config?.template);
 
-        return {
-            template: preferredTemplate,
-            ftpUrl: config?.ftp_url ?? '',
-            downloadsUnavailable: config?.downloads_unavailable === true,
-            isPublished: (config?.status ?? 'draft') === 'published',
-            externalDomainId: String(config?.external_domain_id ?? ''),
-            externalPath: config?.external_path ?? '',
-            landingPageTemplateId: getHydratedLandingPageTemplateId(preferredTemplate, config),
-            links: cloneLandingPageLinks(config?.links ?? []),
-        };
-    }, [resource.resourcetypegeneral]);
+            return {
+                template: preferredTemplate,
+                ftpUrl: config?.ftp_url ?? '',
+                downloadsUnavailable: config?.downloads_unavailable === true,
+                isPublished: (config?.status ?? 'draft') === 'published',
+                externalDomainId: String(config?.external_domain_id ?? ''),
+                externalPath: config?.external_path ?? '',
+                landingPageTemplateId: getHydratedLandingPageTemplateId(preferredTemplate, config),
+                links: cloneLandingPageLinks(config?.links ?? []),
+            };
+        },
+        [resource.resourcetypegeneral],
+    );
 
     const applyDraftState = useCallback((draftState: PersistedLandingPageDraftState) => {
         setTemplate(draftState.template);
@@ -396,47 +428,47 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     const isPhysicalObject = isIgsnLandingPageResourceType(resource.resourcetypegeneral);
     const eligibleTemplateType: 'resource' | 'igsn' = isPhysicalObject ? 'igsn' : 'resource';
     const eligibleCustomTemplates = useMemo(
-        () => customTemplates.filter(
-            (ct) => (ct.template_type ?? 'resource') === eligibleTemplateType && (!isPhysicalObject || !ct.is_default),
-        ),
+        () => customTemplates.filter((ct) => (ct.template_type ?? 'resource') === eligibleTemplateType && (!isPhysicalObject || !ct.is_default)),
         [customTemplates, eligibleTemplateType, isPhysicalObject],
     );
     const builtInTemplateOptions = useMemo(
-        () => getTemplateOptions(resource.resourcetypegeneral).filter(
-            (option) => isPhysicalObject || option.value !== 'default_gfz',
-        ),
+        () => getTemplateOptions(resource.resourcetypegeneral).filter((option) => isPhysicalObject || option.value !== 'default_gfz'),
         [isPhysicalObject, resource.resourcetypegeneral],
     );
-    const automaticTemplateDescription = templateOptions?.automatic_source === 'datacenter' && templateOptions.automatic_template
-        ? `Datacenter template: ${templateOptions.automatic_template.name}`
-        : `System default: ${templateOptions?.system_default?.name ?? 'Default GFZ Data Services'}`;
+    const automaticTemplateDescription =
+        templateOptions?.automatic_source === 'datacenter' && templateOptions.automatic_template
+            ? `Datacenter template: ${templateOptions.automatic_template.name}`
+            : `System default: ${templateOptions?.system_default?.name ?? 'Default GFZ Data Services'}`;
     const importedDownloadFiles = currentConfig?.files ?? existingConfig?.files ?? [];
     const hasImportedFiles = importedDownloadFiles.length > 0;
-    const currentDraftState = useMemo<PersistedLandingPageDraftState>(() => ({
-        template,
-        ftpUrl,
-        downloadsUnavailable,
-        isPublished,
-        externalDomainId,
-        externalPath,
-        landingPageTemplateId,
-        links: cloneLandingPageLinks(links),
-    }), [downloadsUnavailable, externalDomainId, externalPath, ftpUrl, isPublished, landingPageTemplateId, links, template]);
-    const baselineDraftState = useMemo(
-        () => buildDraftStateFromConfig(currentConfig),
-        [buildDraftStateFromConfig, currentConfig],
+    const currentDraftState = useMemo<PersistedLandingPageDraftState>(
+        () => ({
+            template,
+            ftpUrl,
+            downloadsUnavailable,
+            isPublished,
+            externalDomainId,
+            externalPath,
+            landingPageTemplateId,
+            links: cloneLandingPageLinks(links),
+        }),
+        [downloadsUnavailable, externalDomainId, externalPath, ftpUrl, isPublished, landingPageTemplateId, links, template],
     );
+    const baselineDraftState = useMemo(() => buildDraftStateFromConfig(currentConfig), [buildDraftStateFromConfig, currentConfig]);
 
-    const applyConfigState = useCallback((config: LandingPageConfig | null) => {
-        const baseDraftState = buildDraftStateFromConfig(config);
-        const persistedDraftState = readPersistedDraftState();
+    const applyConfigState = useCallback(
+        (config: LandingPageConfig | null) => {
+            const baseDraftState = buildDraftStateFromConfig(config);
+            const persistedDraftState = readPersistedDraftState();
 
-        hydratedDraftStateKeyRef.current = storageKey;
-        setCurrentConfig(config);
-        setPreviewUrl(config?.preview_url ?? '');
-        applyDraftState(persistedDraftState ?? baseDraftState);
-        setHasHydratedDraftState(true);
-    }, [applyDraftState, buildDraftStateFromConfig, readPersistedDraftState, storageKey]);
+            hydratedDraftStateKeyRef.current = storageKey;
+            setCurrentConfig(config);
+            setPreviewUrl(config?.preview_url ?? '');
+            applyDraftState(persistedDraftState ?? baseDraftState);
+            setHasHydratedDraftState(true);
+        },
+        [applyDraftState, buildDraftStateFromConfig, readPersistedDraftState, storageKey],
+    );
 
     useEffect(() => {
         if (!isOpen || !hasHydratedDraftState || hydratedDraftStateKeyRef.current !== storageKey) {
@@ -449,15 +481,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
         }
 
         persistDraftState(currentDraftState);
-    }, [
-        baselineDraftState,
-        clearPersistedDraftState,
-        currentDraftState,
-        hasHydratedDraftState,
-        isOpen,
-        persistDraftState,
-        storageKey,
-    ]);
+    }, [baselineDraftState, clearPersistedDraftState, currentDraftState, hasHydratedDraftState, isOpen, persistDraftState, storageKey]);
 
     const loadAvailableDomains = async () => {
         try {
@@ -540,7 +564,16 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             setDownloadUrlSuggestionQuery('');
             setActiveDownloadUrlSuggestionIndex(null);
         }
-    }, [applyConfigState, applyDraftState, buildDraftStateFromConfig, existingConfig, isOpen, loadCustomTemplates, loadLandingPageConfig, resource.id]);
+    }, [
+        applyConfigState,
+        applyDraftState,
+        buildDraftStateFromConfig,
+        existingConfig,
+        isOpen,
+        loadCustomTemplates,
+        loadLandingPageConfig,
+        resource.id,
+    ]);
 
     useEffect(() => {
         if (!supportsFtpUrl || hasImportedFiles) {
@@ -700,7 +733,20 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             );
         }
         return baseChanges || linksChanged;
-    }, [currentConfig, template, ftpUrl, downloadsUnavailable, isPublished, externalDomainId, externalPath, links, landingPageTemplateId, resource.resourcetypegeneral, supportsFtpUrl, supportsDownloadsUnavailable]);
+    }, [
+        currentConfig,
+        template,
+        ftpUrl,
+        downloadsUnavailable,
+        isPublished,
+        externalDomainId,
+        externalPath,
+        links,
+        landingPageTemplateId,
+        resource.resourcetypegeneral,
+        supportsFtpUrl,
+        supportsDownloadsUnavailable,
+    ]);
 
     const copyToClipboard = async (text: string, label: string) => {
         try {
@@ -770,9 +816,8 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
     const shouldShowDownloadUrlSuggestions = supportsFtpUrl && !hasImportedFiles && downloadUrlSuggestionsOpen;
     const hasVisibleDownloadUrlSuggestions = filteredDownloadUrlSuggestions.domains.length > 0 || filteredDownloadUrlSuggestions.urls.length > 0;
-    const activeDownloadUrlSuggestion = activeDownloadUrlSuggestionIndex === null
-        ? null
-        : (visibleDownloadUrlSuggestionEntries[activeDownloadUrlSuggestionIndex] ?? null);
+    const activeDownloadUrlSuggestion =
+        activeDownloadUrlSuggestionIndex === null ? null : (visibleDownloadUrlSuggestionEntries[activeDownloadUrlSuggestionIndex] ?? null);
 
     useEffect(() => {
         if (!shouldShowDownloadUrlSuggestions) {
@@ -781,10 +826,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
             return;
         }
 
-        if (
-            activeDownloadUrlSuggestionIndex !== null
-            && activeDownloadUrlSuggestionIndex >= visibleDownloadUrlSuggestionEntries.length
-        ) {
+        if (activeDownloadUrlSuggestionIndex !== null && activeDownloadUrlSuggestionIndex >= visibleDownloadUrlSuggestionEntries.length) {
             setActiveDownloadUrlSuggestionIndex(null);
         }
     }, [activeDownloadUrlSuggestionIndex, shouldShowDownloadUrlSuggestions, visibleDownloadUrlSuggestionEntries.length]);
@@ -901,38 +943,32 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
     };
 
     // --- Additional Links management ---
-    const sensors = useSensors(
-        useSensor(PointerSensor),
-        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-    );
+    const sensors = useSensors(useSensor(PointerSensor), useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }));
 
-    const handleDragEnd = useCallback(
-        (event: DragEndEvent) => {
-            const { active, over } = event;
-            if (!over || active.id === over.id) return;
+    const handleDragEnd = useCallback((event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
 
-            setLinks((prev) => {
-                const getSortableId = (l: LandingPageLink) => l.id ?? l._clientId ?? `new-${l.position}`;
-                const oldIndex = prev.findIndex((l) => getSortableId(l) === active.id);
-                const newIndex = prev.findIndex((l) => getSortableId(l) === over.id);
-                if (oldIndex === -1 || newIndex === -1) return prev;
-                const reordered = arrayMove(prev, oldIndex, newIndex);
-                return reordered.map((link, i) => ({ ...link, position: i }));
-            });
-        },
-        [],
-    );
+        setLinks((prev) => {
+            const getSortableId = (l: LandingPageLink) => l.id ?? l._clientId ?? `new-${l.position}`;
+            const oldIndex = prev.findIndex((l) => getSortableId(l) === active.id);
+            const newIndex = prev.findIndex((l) => getSortableId(l) === over.id);
+            if (oldIndex === -1 || newIndex === -1) return prev;
+            const reordered = arrayMove(prev, oldIndex, newIndex);
+            return reordered.map((link, i) => ({ ...link, position: i }));
+        });
+    }, []);
 
     const addLink = useCallback(() => {
         if (links.length >= MAX_LINKS) return;
-        setLinks((prev) => [...prev, { url: '', label: '', position: prev.length, _clientId: crypto.randomUUID() }]);
+        setLinks((prev) => [...prev, { url: '', label: '', kind: 'related', position: prev.length, _clientId: crypto.randomUUID() }]);
     }, [links.length]);
 
     const removeLink = useCallback((index: number) => {
         setLinks((prev) => prev.filter((_, i) => i !== index).map((link, i) => ({ ...link, position: i })));
     }, []);
 
-    const updateLink = useCallback((index: number, field: 'url' | 'label', value: string) => {
+    const updateLink = useCallback((index: number, field: 'url' | 'label' | 'kind', value: string) => {
         setLinks((prev) => prev.map((link, i) => (i === index ? { ...link, [field]: value } : link)));
     }, []);
 
@@ -940,10 +976,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent
-                data-testid="setup-lp-modal-content"
-                className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0"
-            >
+            <DialogContent data-testid="setup-lp-modal-content" className="flex max-h-[90vh] max-w-2xl flex-col gap-0 overflow-hidden p-0">
                 <DialogHeader className="shrink-0 border-b px-6 pt-6 pb-4">
                     <DialogTitle className="flex items-center gap-2">
                         <Globe className="size-5" />
@@ -961,7 +994,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                     <span
                                         data-testid="setup-lp-modal-resource-title"
                                         tabIndex={0}
-                                        className="mt-1 block line-clamp-2 wrap-break-word rounded-sm font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                                        className="mt-1 line-clamp-2 block rounded-sm font-medium wrap-break-word text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                                     >
                                         {displayTitle}
                                     </span>
@@ -969,7 +1002,7 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                                 <TooltipContent
                                     data-testid="setup-lp-modal-resource-title-tooltip"
                                     side="bottom"
-                                    className="max-w-[min(32rem,calc(100vw-2rem))] wrap-break-word whitespace-normal text-left"
+                                    className="max-w-[min(32rem,calc(100vw-2rem))] text-left wrap-break-word whitespace-normal"
                                 >
                                     {displayTitle}
                                 </TooltipContent>
@@ -981,450 +1014,458 @@ export default function SetupLandingPageModal({ resource, isOpen, onClose, onSuc
                 {isLoading ? (
                     <div
                         data-testid="setup-lp-modal-scroll-area"
-                        className="flex-1 min-h-0 overflow-y-auto px-6 py-8 text-center text-muted-foreground"
+                        className="min-h-0 flex-1 overflow-y-auto px-6 py-8 text-center text-muted-foreground"
                     >
                         Loading configuration...
                     </div>
                 ) : (
-                    <div data-testid="setup-lp-modal-scroll-area" className="flex-1 min-h-0 overflow-y-auto px-6 py-4">
+                    <div data-testid="setup-lp-modal-scroll-area" className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
                         <div className="space-y-6">
-                        {/* Template Selection */}
-                        <div className="space-y-2">
-                            <Label htmlFor="template">Landing Page Template</Label>
-                            <Select
-                                value={
-                                    landingPageTemplateId
-                                        ? `custom:${landingPageTemplateId}`
-                                        : (!isPhysicalObject && template === 'default_gfz' ? 'automatic' : template)
-                                }
-                                onValueChange={(val) => {
-                                    if (val === 'automatic') {
-                                        setLandingPageTemplateId(null);
-                                        setTemplate('default_gfz');
-                                    } else
-                                    if (val.startsWith('custom:')) {
-                                        const id = Number(val.replace('custom:', ''));
-                                        setLandingPageTemplateId(id);
-                                        // Resolve the renderer key from the selected custom
-                                        // template's template_type (resource → default_gfz,
-                                        // igsn → default_gfz_igsn) so the correct landing
-                                        // page renderer is used regardless of which custom
-                                        // template the curator picks.
-                                        const selected = customTemplates.find((ct) => ct.id === id);
-                                        const rendererKey = (selected?.template_type ?? 'resource') === 'igsn'
-                                            ? 'default_gfz_igsn'
-                                            : 'default_gfz';
-                                        setTemplate(rendererKey);
-                                    } else {
-                                        setLandingPageTemplateId(null);
-                                        setTemplate(val);
-                                    }
-                                }}
-                            >
-                                <SelectTrigger id="template">
-                                    <SelectValue placeholder="Select a template" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {!isPhysicalObject && (
-                                        <>
-                                            <SelectItem value="automatic">
-                                                <div className="flex flex-col">
-                                                    <span>Use automatic template</span>
-                                                    <span className="text-xs text-muted-foreground">{automaticTemplateDescription}</span>
-                                                </div>
-                                            </SelectItem>
-                                            <SelectSeparator />
-                                        </>
-                                    )}
-                                    {builtInTemplateOptions.map((tmpl) => (
-                                        <SelectItem key={tmpl.value} value={tmpl.value}>
-                                            <div className="flex flex-col">
-                                                <span>{tmpl.label}</span>
-                                                <span className="text-xs text-muted-foreground">{tmpl.description}</span>
-                                            </div>
-                                        </SelectItem>
-                                    ))}
-                                    {eligibleCustomTemplates.length > 0 && (
-                                        <>
-                                            <SelectSeparator />
-                                            <SelectGroup>
-                                                <SelectLabel>{isPhysicalObject ? 'Custom Templates' : 'Explicit Templates'}</SelectLabel>
-                                                {eligibleCustomTemplates.map((ct) => (
-                                                    <SelectItem key={`custom:${ct.id}`} value={`custom:${ct.id}`}>
-                                                        <div className="flex flex-col">
-                                                            <span>{ct.name}</span>
-                                                            <span className="text-xs text-muted-foreground">
-                                                                {ct.is_default
-                                                                    ? 'Explicit system default (overrides datacenter inheritance)'
-                                                                    : `Custom section order${ct.logo_url ? ' & logo' : ''}`}
-                                                            </span>
-                                                        </div>
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectGroup>
-                                        </>
-                                    )}
-                                </SelectContent>
-                            </Select>
-                            <p className="text-sm text-muted-foreground">Choose the design template for your landing page</p>
-                        </div>
-
-                        {/* External Landing Page Fields */}
-                        {isExternal && (
-                            <ExternalLandingPageFields
-                                availableDomains={availableDomains}
-                                externalDomainId={externalDomainId}
-                                onExternalDomainIdChange={setExternalDomainId}
-                                externalPath={externalPath}
-                                onExternalPathChange={setExternalPath}
-                                computedExternalUrl={computedExternalUrl}
-                                pathExample="/dataset/12345"
-                            />
-                        )}
-
-                        {/* FTP URL (hidden for external landing pages, disabled when imported files exist) */}
-                        {supportsFtpUrl && (
+                            {/* Template Selection */}
                             <div className="space-y-2">
-                                <Label htmlFor="ftp-url">Download URL</Label>
-                                <div
-                                    className="relative"
-                                    onFocusCapture={openDownloadUrlSuggestions}
-                                    onBlurCapture={(event) => {
-                                        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
-                                            return;
+                                <Label htmlFor="template">Landing Page Template</Label>
+                                <Select
+                                    value={
+                                        landingPageTemplateId
+                                            ? `custom:${landingPageTemplateId}`
+                                            : !isPhysicalObject && template === 'default_gfz'
+                                              ? 'automatic'
+                                              : template
+                                    }
+                                    onValueChange={(val) => {
+                                        if (val === 'automatic') {
+                                            setLandingPageTemplateId(null);
+                                            setTemplate('default_gfz');
+                                        } else if (val.startsWith('custom:')) {
+                                            const id = Number(val.replace('custom:', ''));
+                                            setLandingPageTemplateId(id);
+                                            // Resolve the renderer key from the selected custom
+                                            // template's template_type (resource → default_gfz,
+                                            // igsn → default_gfz_igsn) so the correct landing
+                                            // page renderer is used regardless of which custom
+                                            // template the curator picks.
+                                            const selected = customTemplates.find((ct) => ct.id === id);
+                                            const rendererKey =
+                                                (selected?.template_type ?? 'resource') === 'igsn' ? 'default_gfz_igsn' : 'default_gfz';
+                                            setTemplate(rendererKey);
+                                        } else {
+                                            setLandingPageTemplateId(null);
+                                            setTemplate(val);
                                         }
-
-                                        setDownloadUrlSuggestionsOpen(false);
-                                        setDownloadUrlSuggestionQuery('');
-                                        setActiveDownloadUrlSuggestionIndex(null);
                                     }}
                                 >
-                                    <Input
-                                        id="ftp-url"
-                                        type="url"
-                                        role="combobox"
-                                        placeholder="https://datapub.gfz-potsdam.de/download/..."
-                                        value={ftpUrl}
-                                        onChange={(e) => {
-                                            setFtpUrl(e.target.value);
-                                            setDownloadUrlSuggestionQuery(e.target.value);
-                                            setActiveDownloadUrlSuggestionIndex(null);
-
-                                            if (!downloadUrlSuggestionsOpen) {
-                                                setDownloadUrlSuggestionsOpen(true);
-                                            }
-
-                                            void loadDownloadUrlSuggestions();
-                                        }}
-                                        onKeyDown={(event) => {
-                                            if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && !downloadUrlSuggestionsOpen) {
-                                                setDownloadUrlSuggestionsOpen(true);
-                                                setActiveDownloadUrlSuggestionIndex(null);
-                                                void loadDownloadUrlSuggestions();
-                                            }
-
-                                            if (event.key === 'ArrowDown') {
-                                                event.preventDefault();
-                                                moveActiveDownloadUrlSuggestion('next');
-
-                                                return;
-                                            }
-
-                                            if (event.key === 'ArrowUp') {
-                                                event.preventDefault();
-                                                moveActiveDownloadUrlSuggestion('previous');
-
-                                                return;
-                                            }
-
-                                            if (event.key === 'Enter' && activeDownloadUrlSuggestion !== null) {
-                                                event.preventDefault();
-                                                applyDownloadUrlSuggestion(activeDownloadUrlSuggestion.value);
-
-                                                return;
-                                            }
-
-                                            if (event.key === 'Escape') {
-                                                setDownloadUrlSuggestionsOpen(false);
-                                                setDownloadUrlSuggestionQuery('');
-                                                setActiveDownloadUrlSuggestionIndex(null);
-                                            }
-                                        }}
-                                        disabled={hasImportedFiles}
-                                        autoComplete="off"
-                                        aria-activedescendant={activeDownloadUrlSuggestion?.id}
-                                        aria-autocomplete="list"
-                                        aria-expanded={shouldShowDownloadUrlSuggestions}
-                                        aria-controls={shouldShowDownloadUrlSuggestions ? 'ftp-url-suggestions' : undefined}
-                                        aria-haspopup="listbox"
-                                    />
-
-                                    {shouldShowDownloadUrlSuggestions && (
-                                        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md">
-                                            <div id="ftp-url-suggestions" role="listbox" className="max-h-64 overflow-y-auto py-1">
-                                                {downloadUrlSuggestionsLoading ? (
-                                                    <div className="px-3 py-2 text-sm text-muted-foreground" role="status">
-                                                        Loading suggestions...
+                                    <SelectTrigger id="template">
+                                        <SelectValue placeholder="Select a template" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {!isPhysicalObject && (
+                                            <>
+                                                <SelectItem value="automatic">
+                                                    <div className="flex flex-col">
+                                                        <span>Use automatic template</span>
+                                                        <span className="text-xs text-muted-foreground">{automaticTemplateDescription}</span>
                                                     </div>
-                                                ) : !hasVisibleDownloadUrlSuggestions ? (
-                                                    <div className="px-3 py-2 text-sm text-muted-foreground">No matching suggestions.</div>
-                                                ) : (
-                                                    <>
-                                                        {filteredDownloadUrlSuggestions.domains.length > 0 && (
-                                                            <div className="p-1 text-foreground">
-                                                                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Suggested domains</div>
-                                                                {filteredDownloadUrlSuggestions.domains.map((suggestion, index) => {
-                                                                    const suggestionId = `ftp-url-domain-suggestion-${index}`;
-                                                                    const suggestionIndex = index;
-                                                                    const isActive = activeDownloadUrlSuggestion?.id === suggestionId;
-
-                                                                    return (
-                                                                        <div
-                                                                            key={`domain-${suggestion.value}`}
-                                                                            id={suggestionId}
-                                                                            role="option"
-                                                                            aria-selected={isActive}
-                                                                            className={cn(
-                                                                                'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
-                                                                                isActive ? 'bg-accent text-accent-foreground' : 'text-foreground',
-                                                                            )}
-                                                                            onMouseDown={(event) => event.preventDefault()}
-                                                                            onMouseEnter={() => setActiveDownloadUrlSuggestionIndex(suggestionIndex)}
-                                                                            onClick={() => applyDownloadUrlSuggestion(suggestion.value)}
-                                                                        >
-                                                                            <span className="truncate">{suggestion.value}</span>
-                                                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                                                                                {suggestion.usage_count}x
-                                                                            </span>
-                                                                        </div>
-                                                                    );
-                                                                })}
+                                                </SelectItem>
+                                                <SelectSeparator />
+                                            </>
+                                        )}
+                                        {builtInTemplateOptions.map((tmpl) => (
+                                            <SelectItem key={tmpl.value} value={tmpl.value}>
+                                                <div className="flex flex-col">
+                                                    <span>{tmpl.label}</span>
+                                                    <span className="text-xs text-muted-foreground">{tmpl.description}</span>
+                                                </div>
+                                            </SelectItem>
+                                        ))}
+                                        {eligibleCustomTemplates.length > 0 && (
+                                            <>
+                                                <SelectSeparator />
+                                                <SelectGroup>
+                                                    <SelectLabel>{isPhysicalObject ? 'Custom Templates' : 'Explicit Templates'}</SelectLabel>
+                                                    {eligibleCustomTemplates.map((ct) => (
+                                                        <SelectItem key={`custom:${ct.id}`} value={`custom:${ct.id}`}>
+                                                            <div className="flex flex-col">
+                                                                <span>{ct.name}</span>
+                                                                <span className="text-xs text-muted-foreground">
+                                                                    {ct.is_default
+                                                                        ? 'Explicit system default (overrides datacenter inheritance)'
+                                                                        : `Custom section order${ct.logo_url ? ' & logo' : ''}`}
+                                                                </span>
                                                             </div>
-                                                        )}
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectGroup>
+                                            </>
+                                        )}
+                                    </SelectContent>
+                                </Select>
+                                <p className="text-sm text-muted-foreground">Choose the design template for your landing page</p>
+                            </div>
 
-                                                        {filteredDownloadUrlSuggestions.urls.length > 0 && (
-                                                            <div className="p-1 text-foreground">
-                                                                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Previously used full URLs</div>
-                                                                {filteredDownloadUrlSuggestions.urls.map((suggestion, index) => {
-                                                                    const suggestionId = `ftp-url-full-suggestion-${index}`;
-                                                                    const suggestionIndex = filteredDownloadUrlSuggestions.domains.length + index;
-                                                                    const isActive = activeDownloadUrlSuggestion?.id === suggestionId;
+                            {/* External Landing Page Fields */}
+                            {isExternal && (
+                                <ExternalLandingPageFields
+                                    availableDomains={availableDomains}
+                                    externalDomainId={externalDomainId}
+                                    onExternalDomainIdChange={setExternalDomainId}
+                                    externalPath={externalPath}
+                                    onExternalPathChange={setExternalPath}
+                                    computedExternalUrl={computedExternalUrl}
+                                    pathExample="/dataset/12345"
+                                />
+                            )}
 
-                                                                    return (
-                                                                        <div
-                                                                            key={`url-${suggestion.value}`}
-                                                                            id={suggestionId}
-                                                                            role="option"
-                                                                            aria-selected={isActive}
-                                                                            className={cn(
-                                                                                'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
-                                                                                isActive ? 'bg-accent text-accent-foreground' : 'text-foreground',
-                                                                            )}
-                                                                            onMouseDown={(event) => event.preventDefault()}
-                                                                            onMouseEnter={() => setActiveDownloadUrlSuggestionIndex(suggestionIndex)}
-                                                                            onClick={() => applyDownloadUrlSuggestion(suggestion.value)}
-                                                                        >
-                                                                            <span className="truncate">{suggestion.value}</span>
-                                                                            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                                                                                {suggestion.usage_count}x
-                                                                            </span>
-                                                                        </div>
-                                                                    );
-                                                                })}
-                                                            </div>
-                                                        )}
-                                                    </>
-                                                )}
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-                                {hasImportedFiles ? (
-                                    <p className="text-sm text-muted-foreground">
-                                        This field is not used because imported download files are available below.
-                                    </p>
-                                ) : (
-                                    <p className="text-sm text-muted-foreground">
-                                        Direct link to download the primary data files. Start typing or pick a suggested domain or full URL from
-                                        existing landing pages.
-                                    </p>
-                                )}
+                            {/* FTP URL (hidden for external landing pages, disabled when imported files exist) */}
+                            {supportsFtpUrl && (
+                                <div className="space-y-2">
+                                    <Label htmlFor="ftp-url">Download URL</Label>
+                                    <div
+                                        className="relative"
+                                        onFocusCapture={openDownloadUrlSuggestions}
+                                        onBlurCapture={(event) => {
+                                            if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
+                                                return;
+                                            }
 
-                                {supportsDownloadsUnavailable && (
-                                    <div className="space-y-2 rounded-md border p-3">
-                                        <div className="flex items-start gap-3">
-                                            <Checkbox
-                                                id="downloads-unavailable"
-                                                checked={downloadsUnavailable}
-                                                onCheckedChange={(checked) => setDownloadsUnavailable(checked === true)}
-                                                className="mt-0.5"
-                                            />
-                                            <div className="space-y-1">
-                                                <Label htmlFor="downloads-unavailable" className="text-sm font-medium">
-                                                    No data available for download
-                                                </Label>
-                                                <p className="text-sm text-muted-foreground">
-                                                    Hide the Files section on the landing page while keeping saved download values for later use.
-                                                </p>
-                                            </div>
-                                        </div>
+                                            setDownloadUrlSuggestionsOpen(false);
+                                            setDownloadUrlSuggestionQuery('');
+                                            setActiveDownloadUrlSuggestionIndex(null);
+                                        }}
+                                    >
+                                        <Input
+                                            id="ftp-url"
+                                            type="url"
+                                            role="combobox"
+                                            placeholder="https://datapub.gfz-potsdam.de/download/..."
+                                            value={ftpUrl}
+                                            onChange={(e) => {
+                                                setFtpUrl(e.target.value);
+                                                setDownloadUrlSuggestionQuery(e.target.value);
+                                                setActiveDownloadUrlSuggestionIndex(null);
 
-                                        {downloadsUnavailable && hasImportedFiles && (
-                                            <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
-                                                <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
-                                                <p>Imported download files will be hidden on the public landing page while this option is enabled.</p>
+                                                if (!downloadUrlSuggestionsOpen) {
+                                                    setDownloadUrlSuggestionsOpen(true);
+                                                }
+
+                                                void loadDownloadUrlSuggestions();
+                                            }}
+                                            onKeyDown={(event) => {
+                                                if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && !downloadUrlSuggestionsOpen) {
+                                                    setDownloadUrlSuggestionsOpen(true);
+                                                    setActiveDownloadUrlSuggestionIndex(null);
+                                                    void loadDownloadUrlSuggestions();
+                                                }
+
+                                                if (event.key === 'ArrowDown') {
+                                                    event.preventDefault();
+                                                    moveActiveDownloadUrlSuggestion('next');
+
+                                                    return;
+                                                }
+
+                                                if (event.key === 'ArrowUp') {
+                                                    event.preventDefault();
+                                                    moveActiveDownloadUrlSuggestion('previous');
+
+                                                    return;
+                                                }
+
+                                                if (event.key === 'Enter' && activeDownloadUrlSuggestion !== null) {
+                                                    event.preventDefault();
+                                                    applyDownloadUrlSuggestion(activeDownloadUrlSuggestion.value);
+
+                                                    return;
+                                                }
+
+                                                if (event.key === 'Escape') {
+                                                    setDownloadUrlSuggestionsOpen(false);
+                                                    setDownloadUrlSuggestionQuery('');
+                                                    setActiveDownloadUrlSuggestionIndex(null);
+                                                }
+                                            }}
+                                            disabled={hasImportedFiles}
+                                            autoComplete="off"
+                                            aria-activedescendant={activeDownloadUrlSuggestion?.id}
+                                            aria-autocomplete="list"
+                                            aria-expanded={shouldShowDownloadUrlSuggestions}
+                                            aria-controls={shouldShowDownloadUrlSuggestions ? 'ftp-url-suggestions' : undefined}
+                                            aria-haspopup="listbox"
+                                        />
+
+                                        {shouldShowDownloadUrlSuggestions && (
+                                            <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md">
+                                                <div id="ftp-url-suggestions" role="listbox" className="max-h-64 overflow-y-auto py-1">
+                                                    {downloadUrlSuggestionsLoading ? (
+                                                        <div className="px-3 py-2 text-sm text-muted-foreground" role="status">
+                                                            Loading suggestions...
+                                                        </div>
+                                                    ) : !hasVisibleDownloadUrlSuggestions ? (
+                                                        <div className="px-3 py-2 text-sm text-muted-foreground">No matching suggestions.</div>
+                                                    ) : (
+                                                        <>
+                                                            {filteredDownloadUrlSuggestions.domains.length > 0 && (
+                                                                <div className="p-1 text-foreground">
+                                                                    <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                                                                        Suggested domains
+                                                                    </div>
+                                                                    {filteredDownloadUrlSuggestions.domains.map((suggestion, index) => {
+                                                                        const suggestionId = `ftp-url-domain-suggestion-${index}`;
+                                                                        const suggestionIndex = index;
+                                                                        const isActive = activeDownloadUrlSuggestion?.id === suggestionId;
+
+                                                                        return (
+                                                                            <div
+                                                                                key={`domain-${suggestion.value}`}
+                                                                                id={suggestionId}
+                                                                                role="option"
+                                                                                aria-selected={isActive}
+                                                                                className={cn(
+                                                                                    'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
+                                                                                    isActive ? 'bg-accent text-accent-foreground' : 'text-foreground',
+                                                                                )}
+                                                                                onMouseDown={(event) => event.preventDefault()}
+                                                                                onMouseEnter={() =>
+                                                                                    setActiveDownloadUrlSuggestionIndex(suggestionIndex)
+                                                                                }
+                                                                                onClick={() => applyDownloadUrlSuggestion(suggestion.value)}
+                                                                            >
+                                                                                <span className="truncate">{suggestion.value}</span>
+                                                                                <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                                                                                    {suggestion.usage_count}x
+                                                                                </span>
+                                                                            </div>
+                                                                        );
+                                                                    })}
+                                                                </div>
+                                                            )}
+
+                                                            {filteredDownloadUrlSuggestions.urls.length > 0 && (
+                                                                <div className="p-1 text-foreground">
+                                                                    <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                                                                        Previously used full URLs
+                                                                    </div>
+                                                                    {filteredDownloadUrlSuggestions.urls.map((suggestion, index) => {
+                                                                        const suggestionId = `ftp-url-full-suggestion-${index}`;
+                                                                        const suggestionIndex = filteredDownloadUrlSuggestions.domains.length + index;
+                                                                        const isActive = activeDownloadUrlSuggestion?.id === suggestionId;
+
+                                                                        return (
+                                                                            <div
+                                                                                key={`url-${suggestion.value}`}
+                                                                                id={suggestionId}
+                                                                                role="option"
+                                                                                aria-selected={isActive}
+                                                                                className={cn(
+                                                                                    'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
+                                                                                    isActive ? 'bg-accent text-accent-foreground' : 'text-foreground',
+                                                                                )}
+                                                                                onMouseDown={(event) => event.preventDefault()}
+                                                                                onMouseEnter={() =>
+                                                                                    setActiveDownloadUrlSuggestionIndex(suggestionIndex)
+                                                                                }
+                                                                                onClick={() => applyDownloadUrlSuggestion(suggestion.value)}
+                                                                            >
+                                                                                <span className="truncate">{suggestion.value}</span>
+                                                                                <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                                                                                    {suggestion.usage_count}x
+                                                                                </span>
+                                                                            </div>
+                                                                        );
+                                                                    })}
+                                                                </div>
+                                                            )}
+                                                        </>
+                                                    )}
+                                                </div>
                                             </div>
                                         )}
                                     </div>
-                                )}
-                            </div>
-                        )}
+                                    {hasImportedFiles ? (
+                                        <p className="text-sm text-muted-foreground">
+                                            This field is not used because imported download files are available below.
+                                        </p>
+                                    ) : (
+                                        <p className="text-sm text-muted-foreground">
+                                            Direct link to download the primary data files. Start typing or pick a suggested domain or full URL from
+                                            existing landing pages.
+                                        </p>
+                                    )}
 
-                        {/* Imported download files (read-only, from legacy database) */}
-                        {!isExternal && hasImportedFiles && (
-                            <div className="space-y-2">
-                                <Label>Imported Download Files</Label>
-                                <div className="space-y-1 rounded-md border bg-muted/50 p-3">
-                                    {importedDownloadFiles.map((file) => (
-                                        <a
-                                            key={file.id ?? file.url}
-                                            href={file.url}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="block truncate text-sm text-blue-600 hover:underline dark:text-blue-400"
-                                        >
-                                            {file.url}
-                                        </a>
-                                    ))}
+                                    {supportsDownloadsUnavailable && (
+                                        <div className="space-y-2 rounded-md border p-3">
+                                            <div className="flex items-start gap-3">
+                                                <Checkbox
+                                                    id="downloads-unavailable"
+                                                    checked={downloadsUnavailable}
+                                                    onCheckedChange={(checked) => setDownloadsUnavailable(checked === true)}
+                                                    className="mt-0.5"
+                                                />
+                                                <div className="space-y-1">
+                                                    <Label htmlFor="downloads-unavailable" className="text-sm font-medium">
+                                                        No data available for download
+                                                    </Label>
+                                                    <p className="text-sm text-muted-foreground">
+                                                        Hide the Files section on the landing page while keeping saved download values for later use.
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            {downloadsUnavailable && hasImportedFiles && (
+                                                <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
+                                                    <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                                                    <p>
+                                                        Imported download files will be hidden on the public landing page while this option is
+                                                        enabled.
+                                                    </p>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
-                                <p className="text-sm text-muted-foreground">
-                                    These files were imported from the legacy database and cannot be edited here.
-                                </p>
-                            </div>
-                        )}
+                            )}
 
-                        {/* Additional Links (only for GFZ templates, not external or IGSN) */}
-                        {supportsLinks && (
-                            <div className="space-y-3">
-                                <div className="space-y-1">
-                                    <Label>Additional Links</Label>
+                            {/* Imported download files (read-only, from legacy database) */}
+                            {!isExternal && hasImportedFiles && (
+                                <div className="space-y-2">
+                                    <Label>Imported Download Files</Label>
+                                    <div className="space-y-1 rounded-md border bg-muted/50 p-3">
+                                        {importedDownloadFiles.map((file) => (
+                                            <a
+                                                key={file.id ?? file.url}
+                                                href={file.url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="block truncate text-sm text-blue-600 hover:underline dark:text-blue-400"
+                                            >
+                                                {file.url}
+                                            </a>
+                                        ))}
+                                    </div>
                                     <p className="text-sm text-muted-foreground">
-                                        Additional download links displayed below the main download link on the landing page (e.g., GitLab
-                                        repository, project website)
+                                        These files were imported from the legacy database and cannot be edited here.
                                     </p>
                                 </div>
+                            )}
 
-                                {links.length > 0 && (
-                                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-                                        <SortableContext
-                                            items={links.map((l) => l.id ?? l._clientId ?? `new-${l.position}`)}
-                                            strategy={verticalListSortingStrategy}
+                            {/* Additional Links (only for GFZ templates, not external or IGSN) */}
+                            {supportsLinks && (
+                                <div className="space-y-3">
+                                    <div className="space-y-1">
+                                        <Label>Additional Links</Label>
+                                        <p className="text-sm text-muted-foreground">
+                                            Additional download links displayed below the main download link on the landing page (e.g., GitLab
+                                            repository, project website)
+                                        </p>
+                                    </div>
+
+                                    {links.length > 0 && (
+                                        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                                            <SortableContext
+                                                items={links.map((l) => l.id ?? l._clientId ?? `new-${l.position}`)}
+                                                strategy={verticalListSortingStrategy}
+                                            >
+                                                <div className="space-y-2">
+                                                    {links.map((link, index) => (
+                                                        <SortableLinkItem
+                                                            key={link.id ?? link._clientId ?? `new-${link.position}`}
+                                                            link={link}
+                                                            index={index}
+                                                            onRemove={removeLink}
+                                                            onUpdate={updateLink}
+                                                        />
+                                                    ))}
+                                                </div>
+                                            </SortableContext>
+                                        </DndContext>
+                                    )}
+
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={addLink}
+                                        disabled={links.length >= MAX_LINKS}
+                                        className="w-full"
+                                    >
+                                        <Plus className="mr-2 size-4" />
+                                        Add Link ({links.length}/{MAX_LINKS})
+                                    </Button>
+                                </div>
+                            )}
+
+                            {/* Unsaved Changes Warning */}
+                            {hasUnsavedChanges && (
+                                <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-200">
+                                    You have unsaved changes. Preview will show the new configuration.
+                                </div>
+                            )}
+
+                            {/* Status Toggle */}
+                            <div className="flex items-center justify-between rounded-lg border p-4">
+                                <div className="space-y-0.5">
+                                    <Label htmlFor="published" className="text-base">
+                                        Publish Landing Page
+                                    </Label>
+                                    <p className="text-sm text-muted-foreground">
+                                        {currentConfig?.status === 'published'
+                                            ? 'This landing page is published. DOIs are persistent and must always resolve to a valid landing page.'
+                                            : 'Make this landing page publicly accessible'}
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="published"
+                                    checked={isPublished}
+                                    onCheckedChange={setIsPublished}
+                                    disabled={currentConfig?.status === 'published'}
+                                />
+                            </div>
+
+                            {/* Preview URL (if draft exists) */}
+                            {currentConfig && currentConfig.status === 'draft' && previewUrl && (
+                                <div className="space-y-2 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
+                                    <Label className="text-blue-900 dark:text-blue-100">Preview URL (Draft Mode)</Label>
+                                    <div className="flex gap-2">
+                                        <Input readOnly value={previewUrl} className="bg-white font-mono text-xs dark:bg-gray-950" />
+                                        <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="outline"
+                                            onClick={() => copyToClipboard(previewUrl, 'Preview URL')}
+                                            title="Copy preview URL"
                                         >
-                                            <div className="space-y-2">
-                                                {links.map((link, index) => (
-                                                    <SortableLinkItem
-                                                        key={link.id ?? link._clientId ?? `new-${link.position}`}
-                                                        link={link}
-                                                        index={index}
-                                                        onRemove={removeLink}
-                                                        onUpdate={updateLink}
-                                                    />
-                                                ))}
-                                            </div>
-                                        </SortableContext>
-                                    </DndContext>
-                                )}
-
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={addLink}
-                                    disabled={links.length >= MAX_LINKS}
-                                    className="w-full"
-                                >
-                                    <Plus className="mr-2 size-4" />
-                                    Add Link ({links.length}/{MAX_LINKS})
-                                </Button>
-                            </div>
-                        )}
-
-                        {/* Unsaved Changes Warning */}
-                        {hasUnsavedChanges && (
-                            <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950/30 dark:text-yellow-200">
-                                You have unsaved changes. Preview will show the new configuration.
-                            </div>
-                        )}
-
-                        {/* Status Toggle */}
-                        <div className="flex items-center justify-between rounded-lg border p-4">
-                            <div className="space-y-0.5">
-                                <Label htmlFor="published" className="text-base">
-                                    Publish Landing Page
-                                </Label>
-                                <p className="text-sm text-muted-foreground">
-                                    {currentConfig?.status === 'published'
-                                        ? 'This landing page is published. DOIs are persistent and must always resolve to a valid landing page.'
-                                        : 'Make this landing page publicly accessible'}
-                                </p>
-                            </div>
-                            <Switch
-                                id="published"
-                                checked={isPublished}
-                                onCheckedChange={setIsPublished}
-                                disabled={currentConfig?.status === 'published'}
-                            />
-                        </div>
-
-                        {/* Preview URL (if draft exists) */}
-                        {currentConfig && currentConfig.status === 'draft' && previewUrl && (
-                            <div className="space-y-2 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
-                                <Label className="text-blue-900 dark:text-blue-100">Preview URL (Draft Mode)</Label>
-                                <div className="flex gap-2">
-                                    <Input readOnly value={previewUrl} className="bg-white font-mono text-xs dark:bg-gray-950" />
-                                    <Button
-                                        type="button"
-                                        size="icon"
-                                        variant="outline"
-                                        onClick={() => copyToClipboard(previewUrl, 'Preview URL')}
-                                        title="Copy preview URL"
-                                    >
-                                        <Copy className="size-4" />
-                                    </Button>
+                                            <Copy className="size-4" />
+                                        </Button>
+                                    </div>
+                                    <p className="text-xs text-blue-700 dark:text-blue-300">
+                                        Share this URL with authors for review (requires preview token)
+                                    </p>
                                 </div>
-                                <p className="text-xs text-blue-700 dark:text-blue-300">
-                                    Share this URL with authors for review (requires preview token)
-                                </p>
-                            </div>
-                        )}
+                            )}
 
-                        {/* Public URL (only if actually published in database) */}
-                        {currentConfig && currentConfig.status === 'published' && currentConfig.public_url && (
-                            <div className="space-y-2 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/30">
-                                <Label className="text-green-900 dark:text-green-100">Public URL</Label>
-                                <div className="flex gap-2">
-                                    <Input readOnly value={currentConfig.public_url} className="bg-white font-mono text-xs dark:bg-gray-950" />
-                                    <Button
-                                        type="button"
-                                        size="icon"
-                                        variant="outline"
-                                        onClick={() => copyToClipboard(currentConfig.public_url, 'Public URL')}
-                                        title="Copy public URL"
-                                    >
-                                        <Copy className="size-4" />
-                                    </Button>
+                            {/* Public URL (only if actually published in database) */}
+                            {currentConfig && currentConfig.status === 'published' && currentConfig.public_url && (
+                                <div className="space-y-2 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/30">
+                                    <Label className="text-green-900 dark:text-green-100">Public URL</Label>
+                                    <div className="flex gap-2">
+                                        <Input readOnly value={currentConfig.public_url} className="bg-white font-mono text-xs dark:bg-gray-950" />
+                                        <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="outline"
+                                            onClick={() => copyToClipboard(currentConfig.public_url, 'Public URL')}
+                                            title="Copy public URL"
+                                        >
+                                            <Copy className="size-4" />
+                                        </Button>
+                                    </div>
+                                    <p className="text-xs text-green-700 dark:text-green-300">This landing page is publicly accessible</p>
                                 </div>
-                                <p className="text-xs text-green-700 dark:text-green-300">This landing page is publicly accessible</p>
-                            </div>
-                        )}
+                            )}
                         </div>
                     </div>
                 )}
 
-                <DialogFooter
-                    data-testid="setup-lp-modal-footer"
-                    className="shrink-0 flex-wrap gap-2 border-t px-6 py-4"
-                >
+                <DialogFooter data-testid="setup-lp-modal-footer" className="shrink-0 flex-wrap gap-2 border-t px-6 py-4">
                     {/* Only show Remove Preview for draft landing pages.
                         Published landing pages cannot be removed because DOIs are persistent. */}
                     {canDeleteLandingPages && currentConfig && currentConfig.status === 'draft' && (

--- a/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
+++ b/resources/js/components/landing-pages/modals/SetupLandingPageModal.tsx
@@ -91,13 +91,17 @@ type ResourceTemplateOptions = {
     supports_datacenter_inheritance: boolean;
 };
 
+function isLandingPageLinkKind(value: unknown): value is NonNullable<LandingPageLink['kind']> {
+    return value === 'related' || value === 'download' || value === 'repository';
+}
+
 function cloneLandingPageLinks(links: LandingPageLink[] = []): LandingPageLink[] {
     return links.map((link, index) => ({
         id: link.id,
         _clientId: link._clientId,
         url: link.url,
         label: link.label,
-        kind: link.kind ?? 'related',
+        kind: isLandingPageLinkKind(link.kind) ? link.kind : 'related',
         position: typeof link.position === 'number' ? link.position : index,
     }));
 }
@@ -153,6 +157,7 @@ function parsePersistedLandingPageDraftState(rawValue: string | null): Persisted
                       _clientId: typeof candidate._clientId === 'string' ? candidate._clientId : undefined,
                       url: typeof candidate.url === 'string' ? candidate.url : '',
                       label: typeof candidate.label === 'string' ? candidate.label : '',
+                      kind: isLandingPageLinkKind(candidate.kind) ? candidate.kind : 'related',
                       position: typeof candidate.position === 'number' ? candidate.position : index,
                   } satisfies LandingPageLink;
               })

--- a/resources/js/components/landing-pages/modals/landing-page-modal-helpers.ts
+++ b/resources/js/components/landing-pages/modals/landing-page-modal-helpers.ts
@@ -132,6 +132,7 @@ function getCompleteLandingPageLinks(links: LandingPageLink[] = []) {
         .map((link, index) => ({
             url: link.url,
             label: link.label,
+            kind: link.kind ?? 'related',
             position: index,
         }));
 }
@@ -170,7 +171,9 @@ function buildLandingPagePayload(options: BuildLandingPagePayloadOptions): Recor
     return payload;
 }
 
-export function buildLandingPageSetupPayload(options: Omit<BuildLandingPagePayloadOptions, 'includeStatus' | 'includeEmptyLinks'>): Record<string, unknown> {
+export function buildLandingPageSetupPayload(
+    options: Omit<BuildLandingPagePayloadOptions, 'includeStatus' | 'includeEmptyLinks'>,
+): Record<string, unknown> {
     return buildLandingPagePayload({
         ...options,
         includeStatus: true,
@@ -178,7 +181,9 @@ export function buildLandingPageSetupPayload(options: Omit<BuildLandingPagePaylo
     });
 }
 
-export function buildLandingPagePreviewPayload(options: Omit<BuildLandingPagePayloadOptions, 'includeStatus' | 'includeEmptyLinks' | 'isPublished'>): Record<string, unknown> {
+export function buildLandingPagePreviewPayload(
+    options: Omit<BuildLandingPagePayloadOptions, 'includeStatus' | 'includeEmptyLinks' | 'isPublished'>,
+): Record<string, unknown> {
     return buildLandingPagePayload({
         ...options,
         includeStatus: false,
@@ -202,7 +207,9 @@ export function getLandingPageRequestErrorMessage(error: unknown, fallback: stri
     }
 
     if (typeof data === 'object' && data !== null && 'errors' in data && typeof data.errors === 'object' && data.errors !== null) {
-        return Object.values(data.errors as Record<string, string | string[]>).flat().join(', ');
+        return Object.values(data.errors as Record<string, string | string[]>)
+            .flat()
+            .join(', ');
     }
 
     return fallback;

--- a/resources/js/pages/LandingPages/components/LandingPageShell.tsx
+++ b/resources/js/pages/LandingPages/components/LandingPageShell.tsx
@@ -1,7 +1,4 @@
-import { Head } from '@inertiajs/react';
 import type { ReactNode } from 'react';
-
-import type { LandingPageMetadataLink } from '@/types/landing-page';
 
 import { BackToTopButton } from './BackToTopButton';
 import { DarkModeImage } from './DarkModeImage';
@@ -11,8 +8,6 @@ interface LandingPageShellProps {
     isPreview: boolean;
     isDark: boolean;
     mainAriaLabel: string;
-    schemaOrgJsonLd?: Record<string, unknown>;
-    metadataLinks?: LandingPageMetadataLink[];
     customLogoUrl?: string | null;
     hero: ReactNode;
     metadataSection: ReactNode;
@@ -25,8 +20,6 @@ export function LandingPageShell({
     isPreview,
     isDark,
     mainAriaLabel,
-    schemaOrgJsonLd,
-    metadataLinks = [],
     customLogoUrl,
     hero,
     metadataSection,
@@ -38,19 +31,6 @@ export function LandingPageShell({
 
     return (
         <>
-            {(schemaOrgJsonLd || metadataLinks.length > 0) && (
-                <Head>
-                    {schemaOrgJsonLd && <script type="application/ld+json">{JSON.stringify(schemaOrgJsonLd)}</script>}
-                    {metadataLinks.map((metadataLink) => (
-                        <link
-                            key={metadataLink.format}
-                            rel={metadataLink.format === 'iso19115-3' ? 'describedby' : 'alternate'}
-                            href={metadataLink.url}
-                            type={metadataLink.mediaType}
-                        />
-                    ))}
-                </Head>
-            )}
             <div data-landing-page className="min-h-screen bg-gfz-primary pt-6 dark:bg-gray-950">
                 <a
                     href="#main-content"

--- a/resources/js/pages/LandingPages/default_gfz.tsx
+++ b/resources/js/pages/LandingPages/default_gfz.tsx
@@ -39,7 +39,6 @@ interface DefaultGfzTemplatePageProps {
     resource: LandingPageResource;
     landingPage: LandingPageConfig | null;
     isPreview: boolean;
-    schemaOrgJsonLd?: Record<string, unknown>;
     sectionOrder?: SectionOrder | null;
     customLogoUrl?: string | null;
     displayLimits?: LandingPageDisplayLimits;
@@ -56,7 +55,7 @@ const DEFAULT_DISPLAY_LIMITS: LandingPageDisplayLimits = {
 };
 
 export default function DefaultGfzTemplate() {
-    const { resource, landingPage, isPreview, schemaOrgJsonLd, metadataLinks, sectionOrder, customLogoUrl, displayLimits, citationStyles } =
+    const { resource, landingPage, isPreview, metadataLinks, sectionOrder, customLogoUrl, displayLimits, citationStyles } =
         usePage<DefaultGfzTemplatePageProps>().props;
     const isDark = useSystemDarkMode();
     const peopleDisplayLimits = displayLimits ?? DEFAULT_DISPLAY_LIMITS;
@@ -142,8 +141,6 @@ export default function DefaultGfzTemplate() {
             isPreview={isPreview}
             isDark={isDark}
             mainAriaLabel="Dataset details"
-            schemaOrgJsonLd={schemaOrgJsonLd}
-            metadataLinks={metadataLinks}
             customLogoUrl={customLogoUrl}
             hero={<ResourceHero resourceType={resourceType} status={status} mainTitle={mainTitle} subtitle={subtitle} citation={citation} />}
             metadataSection={rightSectionRegistry.metadata}

--- a/resources/js/pages/LandingPages/default_gfz_igsn.tsx
+++ b/resources/js/pages/LandingPages/default_gfz_igsn.tsx
@@ -36,7 +36,6 @@ interface DefaultGfzIgsnTemplatePageProps {
     resource: LandingPageResource;
     landingPage: LandingPageConfig | null;
     isPreview: boolean;
-    schemaOrgJsonLd?: Record<string, unknown>;
     sectionOrder?: SectionOrder | null;
     customLogoUrl?: string | null;
     displayLimits?: LandingPageDisplayLimits;
@@ -60,7 +59,7 @@ const DEFAULT_DISPLAY_LIMITS: LandingPageDisplayLimits = {
  * with IGSN-specific General and Acquisition modules in the left column.
  */
 export default function DefaultGfzIgsnTemplate() {
-    const { resource, landingPage, isPreview, schemaOrgJsonLd, metadataLinks, sectionOrder, customLogoUrl, displayLimits, citationStyles } =
+    const { resource, landingPage, isPreview, metadataLinks, sectionOrder, customLogoUrl, displayLimits, citationStyles } =
         usePage<DefaultGfzIgsnTemplatePageProps>().props;
     const isDark = useSystemDarkMode();
     const peopleDisplayLimits = displayLimits ?? DEFAULT_DISPLAY_LIMITS;
@@ -153,8 +152,6 @@ export default function DefaultGfzIgsnTemplate() {
             isPreview={isPreview}
             isDark={isDark}
             mainAriaLabel="Sample details"
-            schemaOrgJsonLd={schemaOrgJsonLd}
-            metadataLinks={metadataLinks}
             customLogoUrl={customLogoUrl}
             hero={
                 <ResourceHero resourceType="IGSN" status={status} mainTitle={mainTitle} subtitle={subtitle} citation={citation} useIgsnIcon={true} />

--- a/resources/js/types/landing-page.ts
+++ b/resources/js/types/landing-page.ts
@@ -238,6 +238,9 @@ export interface LandingPageLink {
     /** Curator-defined display text */
     label: string;
 
+    /** Machine-readable role; omitted only by legacy cached client data */
+    kind?: 'related' | 'download' | 'repository';
+
     /** Display order (drag-and-drop) */
     position: number;
 }

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -69,7 +69,7 @@
                             type="{{ $link['type'] }}"
                         @endif
                         @if(is_string($link['profile'] ?? null) && $link['profile'] !== '')
-                            profile="{{ $link['profile'] }}"
+                            data-profile="{{ $link['profile'] }}"
                         @endif
                     >
                 @endif

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -49,6 +49,33 @@
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 
+        @if(isset($landingPageMachineMetadata) && is_array($landingPageMachineMetadata))
+            @if(is_string($landingPageMachineMetadata['jsonLdJson'] ?? null))
+                <script type="application/ld+json">{!! $landingPageMachineMetadata['jsonLdJson'] !!}</script>
+            @endif
+
+            @foreach(($landingPageMachineMetadata['dublinCore'] ?? []) as $meta)
+                @if(is_array($meta) && is_string($meta['name'] ?? null) && is_string($meta['content'] ?? null))
+                    <meta name="{{ $meta['name'] }}" content="{{ $meta['content'] }}">
+                @endif
+            @endforeach
+
+            @foreach(($landingPageMachineMetadata['signpostingLinks'] ?? []) as $link)
+                @if(is_array($link) && is_string($link['rel'] ?? null) && is_string($link['href'] ?? null))
+                    <link
+                        rel="{{ $link['rel'] }}"
+                        href="{{ $link['href'] }}"
+                        @if(is_string($link['type'] ?? null) && $link['type'] !== '')
+                            type="{{ $link['type'] }}"
+                        @endif
+                        @if(is_string($link['profile'] ?? null) && $link['profile'] !== '')
+                            profile="{{ $link['profile'] }}"
+                        @endif
+                    >
+                @endif
+            @endforeach
+        @endif
+
         <link rel="icon" href="{{ asset('favicon.ico') }}" sizes="any">
         <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">
         <link rel="apple-touch-icon" href="{{ asset('apple-touch-icon.png') }}">

--- a/tests/pest/Feature/LandingPages/LandingPageLinksTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageLinksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\LandingPageController;
 use App\Models\LandingPage;
+use App\Models\LandingPageDomain;
 use App\Models\LandingPageLink;
 use App\Models\Resource;
 use App\Models\ResourceType;
@@ -28,8 +29,8 @@ describe('Landing Page Links - Store', function () {
             'template' => 'default_gfz',
             'status' => 'draft',
             'links' => [
-                ['url' => 'https://gitlab.com/example/repo', 'label' => 'GitLab Repository', 'position' => 0],
-                ['url' => 'https://example.com/project', 'label' => 'Project Website', 'position' => 1],
+                ['url' => 'https://gitlab.com/example/repo', 'label' => 'GitLab Repository', 'kind' => 'repository', 'position' => 0],
+                ['url' => 'https://example.com/project', 'label' => 'Project Website', 'kind' => 'download', 'position' => 1],
             ],
         ]);
 
@@ -39,8 +40,10 @@ describe('Landing Page Links - Store', function () {
         expect($landingPage->links)->toHaveCount(2);
         expect($landingPage->links[0]->label)->toBe('GitLab Repository');
         expect($landingPage->links[0]->url)->toBe('https://gitlab.com/example/repo');
+        expect($landingPage->links[0]->kind)->toBe(LandingPageLink::KIND_REPOSITORY);
         expect($landingPage->links[0]->position)->toBe(0);
         expect($landingPage->links[1]->label)->toBe('Project Website');
+        expect($landingPage->links[1]->kind)->toBe(LandingPageLink::KIND_DOWNLOAD);
         expect($landingPage->links[1]->position)->toBe(1);
     });
 
@@ -54,6 +57,30 @@ describe('Landing Page Links - Store', function () {
 
         $landingPage = $this->resource->fresh()->landingPage;
         expect($landingPage->links)->toHaveCount(0);
+    });
+
+    test('defaults legacy link payloads without a kind to related', function () {
+        $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'status' => 'draft',
+            'links' => [
+                ['url' => 'https://example.com/project', 'label' => 'Project', 'position' => 0],
+            ],
+        ])->assertCreated();
+
+        expect($this->resource->fresh()->landingPage->links->sole()->kind)
+            ->toBe(LandingPageLink::KIND_RELATED);
+    });
+
+    test('rejects unknown machine-readable link kinds', function () {
+        $this->postJson("/resources/{$this->resource->id}/landing-page", [
+            'template' => 'default_gfz',
+            'status' => 'draft',
+            'links' => [
+                ['url' => 'https://example.com/project', 'label' => 'Project', 'kind' => 'guessed', 'position' => 0],
+            ],
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors('links.0.kind');
     });
 
     test('limits links to 10 per landing page', function () {
@@ -123,7 +150,7 @@ describe('Landing Page Links - Store', function () {
     });
 
     test('does not accept links for external templates', function () {
-        $domain = \App\Models\LandingPageDomain::factory()->create();
+        $domain = LandingPageDomain::factory()->create();
 
         $response = $this->postJson("/resources/{$this->resource->id}/landing-page", [
             'template' => 'external',
@@ -183,7 +210,7 @@ describe('Landing Page Links - Update', function () {
     });
 
     test('clears links when switching to external template', function () {
-        $domain = \App\Models\LandingPageDomain::factory()->create();
+        $domain = LandingPageDomain::factory()->create();
 
         $landingPage = LandingPage::factory()->draft()->create([
             'resource_id' => $this->resource->id,

--- a/tests/pest/Feature/LandingPages/LandingPageMachineMetadataCacheTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageMachineMetadataCacheTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CacheKey;
+use App\Models\Format;
+use App\Models\LandingPage;
+use App\Models\LandingPageFile;
+use App\Models\LandingPageLink;
+use App\Models\Resource;
+use App\Observers\FormatObserver;
+use App\Observers\LandingPageFileObserver;
+use App\Observers\LandingPageLinkObserver;
+use Illuminate\Support\Facades\Cache;
+
+covers(FormatObserver::class, LandingPageFileObserver::class, LandingPageLinkObserver::class);
+
+function putLandingPageRenderCache(LandingPage $landingPage): void
+{
+    Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put(
+        CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id),
+        ['template' => 'default_gfz', 'props' => [], 'viewData' => []],
+        600,
+    );
+}
+
+function expectLandingPageRenderCacheMissing(LandingPage $landingPage): void
+{
+    expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has(
+        CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id),
+    ))->toBeFalse();
+}
+
+test('format create update and delete invalidate the landing page render cache', function () {
+    $resource = Resource::factory()->create();
+    $landingPage = LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+
+    putLandingPageRenderCache($landingPage);
+    $format = Format::create(['resource_id' => $resource->id, 'value' => 'application/zip']);
+    expectLandingPageRenderCacheMissing($landingPage);
+
+    putLandingPageRenderCache($landingPage);
+    $format->update(['value' => 'application/pdf']);
+    expectLandingPageRenderCacheMissing($landingPage);
+
+    putLandingPageRenderCache($landingPage);
+    $format->delete();
+    expectLandingPageRenderCacheMissing($landingPage);
+});
+
+test('landing page file create update and delete invalidate the render cache', function () {
+    $landingPage = LandingPage::factory()->published()->create();
+
+    putLandingPageRenderCache($landingPage);
+    $file = LandingPageFile::create([
+        'landing_page_id' => $landingPage->id,
+        'url' => 'https://downloads.example.org/data.zip',
+        'position' => 0,
+    ]);
+    expectLandingPageRenderCacheMissing($landingPage);
+
+    putLandingPageRenderCache($landingPage);
+    $file->update(['url' => 'https://downloads.example.org/data-v2.zip']);
+    expectLandingPageRenderCacheMissing($landingPage);
+
+    putLandingPageRenderCache($landingPage);
+    $file->delete();
+    expectLandingPageRenderCacheMissing($landingPage);
+});
+
+test('landing page link create update and delete invalidate the render cache', function () {
+    $landingPage = LandingPage::factory()->published()->create();
+
+    putLandingPageRenderCache($landingPage);
+    $link = LandingPageLink::create([
+        'landing_page_id' => $landingPage->id,
+        'url' => 'https://example.org/project',
+        'label' => 'Project',
+        'kind' => LandingPageLink::KIND_RELATED,
+        'position' => 0,
+    ]);
+    expectLandingPageRenderCacheMissing($landingPage);
+
+    putLandingPageRenderCache($landingPage);
+    $link->update(['kind' => LandingPageLink::KIND_REPOSITORY]);
+    expectLandingPageRenderCacheMissing($landingPage);
+
+    putLandingPageRenderCache($landingPage);
+    $link->delete();
+    expectLandingPageRenderCacheMissing($landingPage);
+});

--- a/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\LandingPagePublicController;
+use App\Models\LandingPage;
+use App\Models\LandingPageLink;
+use App\Models\Person;
+use App\Models\Resource;
+use App\Models\ResourceCreator;
+use App\Models\ResourceType;
+use App\Models\Right;
+use App\Models\Title;
+use App\Services\LandingPageMachineMetadataService;
+
+covers(LandingPagePublicController::class, LandingPageMachineMetadataService::class);
+
+/** @return array{0: Resource, 1: LandingPage} */
+function machineMetadataLandingPage(string $resourceTypeSlug = 'dataset', array $landingPageAttributes = []): array
+{
+    $resourceType = ResourceType::firstOrCreate(
+        ['slug' => $resourceTypeSlug],
+        ['name' => $resourceTypeSlug === 'software' ? 'Software' : 'Dataset', 'is_active' => true],
+    );
+    $resource = Resource::factory()->create([
+        'doi' => '10.5880/test.machine.001',
+        'resource_type_id' => $resourceType->id,
+        'publication_year' => 2026,
+    ]);
+    Title::factory()->create([
+        'resource_id' => $resource->id,
+        'value' => 'Machine metadata test',
+    ]);
+    $person = Person::factory()->create([
+        'given_name' => 'Ada',
+        'family_name' => 'Lovelace',
+    ]);
+    ResourceCreator::create([
+        'resource_id' => $resource->id,
+        'creatorable_type' => Person::class,
+        'creatorable_id' => $person->id,
+        'position' => 0,
+    ]);
+
+    $landingPage = LandingPage::factory()->published()->create([
+        'resource_id' => $resource->id,
+        'doi_prefix' => $resource->doi,
+        'slug' => 'machine-metadata-test',
+        'template' => 'default_gfz',
+        ...$landingPageAttributes,
+    ]);
+
+    return [$resource->refresh(), $landingPage];
+}
+
+/** @return array<string, mixed> */
+function decodedEmbeddedSchemaOrg(string $html): array
+{
+    $matched = preg_match(
+        '/<script type="application\/ld\+json">(.*?)<\/script>/s',
+        $html,
+        $matches,
+    );
+
+    expect($matched)->toBe(1);
+    $decoded = json_decode($matches[1], true, 512, JSON_THROW_ON_ERROR);
+    expect($decoded)->toBeArray();
+
+    return $decoded;
+}
+
+test('raw dataset HTML and GET HEAD responses expose complete machine metadata', function () {
+    [$resource, $landingPage] = machineMetadataLandingPage(landingPageAttributes: [
+        'ftp_url' => 'https://downloads.example.org/fallback.zip',
+    ]);
+    $resource->formats()->create(['value' => 'application/pdf']);
+    $landingPage->files()->create([
+        'url' => 'https://downloads.example.org/article.pdf',
+        'position' => 0,
+    ]);
+
+    $right = Right::firstOrCreate(
+        ['identifier' => 'CC-BY-4.0'],
+        [
+            'name' => 'Creative Commons Attribution 4.0 International',
+            'uri' => 'https://creativecommons.org/licenses/by/4.0/',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+        ],
+    );
+    $resource->rights()->attach($right->id);
+
+    $response = $this->get($landingPage->getPublicPath())->assertOk();
+    $html = $response->getContent();
+    $jsonLd = decodedEmbeddedSchemaOrg($html);
+    $linkHeader = $response->headers->get('Link');
+
+    expect($jsonLd['@type'])->toBe('Dataset')
+        ->and($jsonLd['@id'])->toBe('https://doi.org/10.5880/test.machine.001')
+        ->and($jsonLd['url'])->toBe(url($landingPage->getPublicPath()))
+        ->and($jsonLd['distribution'])->toBe([
+            [
+                '@type' => 'DataDownload',
+                'contentUrl' => 'https://downloads.example.org/article.pdf',
+                'encodingFormat' => 'application/pdf',
+            ],
+        ])
+        ->and($linkHeader)->toContain('<https://doi.org/10.5880/test.machine.001>; rel="cite-as"')
+        ->toContain('<https://schema.org/Dataset>; rel="type"')
+        ->toContain('<https://schema.org/AboutPage>; rel="type"')
+        ->toContain('rel="describedby"; type="application/vnd.datacite.datacite+xml"')
+        ->toContain('<https://spdx.org/licenses/CC-BY-4.0>; rel="license"')
+        ->toContain('<https://downloads.example.org/article.pdf>; rel="item"; type="application/pdf"')
+        ->and($html)->toContain('name="DC.identifier"')
+        ->toContain('name="DC.title"')
+        ->toContain('name="DC.creator"')
+        ->toContain('name="DC.publisher"')
+        ->toContain('name="DC.date"')
+        ->toContain('name="DC.rights"')
+        ->toContain('name="DC.type"')
+        ->toContain('rel="cite-as"')
+        ->toContain('rel="describedby"')
+        ->toContain('rel="item"');
+
+    $response->assertInertia(fn ($page) => $page
+        ->missing('schemaOrgJsonLd')
+        ->has('metadataLinks', 4)
+        ->where('metadataLinks.0.mediaType', 'application/vnd.datacite.datacite+xml')
+        ->where('metadataLinks.1.mediaType', 'application/vnd.datacite.datacite+json')
+    );
+
+    $this->head($landingPage->getPublicPath())
+        ->assertOk()
+        ->assertHeader('Link', $linkHeader);
+});
+
+test('software JSON-LD exposes software types repository and direct downloads', function () {
+    [$resource, $landingPage] = machineMetadataLandingPage('software', [
+        'ftp_url' => 'https://downloads.example.org/software.zip',
+    ]);
+    $resource->formats()->create(['value' => 'zip']);
+    $landingPage->links()->create([
+        'url' => 'https://git.example.org/team/software',
+        'label' => 'Source code',
+        'kind' => LandingPageLink::KIND_REPOSITORY,
+        'position' => 0,
+    ]);
+
+    $response = $this->get($landingPage->getPublicPath())->assertOk();
+    $jsonLd = decodedEmbeddedSchemaOrg($response->getContent());
+    $linkHeader = $response->headers->get('Link');
+
+    expect($jsonLd['@type'])->toBe(['SoftwareSourceCode', 'SoftwareApplication'])
+        ->and($jsonLd['codeRepository'])->toBe('https://git.example.org/team/software')
+        ->and($jsonLd['downloadUrl'])->toBe('https://downloads.example.org/software.zip')
+        ->and($jsonLd)->not->toHaveKey('distribution')
+        ->and($linkHeader)->toContain('<https://schema.org/SoftwareSourceCode>; rel="type"')
+        ->toContain('<https://downloads.example.org/software.zip>; rel="item"; type="application/zip"');
+});
+
+test('missing MIME data omits content identifiers instead of inferring them', function () {
+    [, $landingPage] = machineMetadataLandingPage(landingPageAttributes: [
+        'ftp_url' => 'https://downloads.example.org/data-with-obvious-extension.zip',
+    ]);
+
+    $response = $this->get($landingPage->getPublicPath())->assertOk();
+    $jsonLd = decodedEmbeddedSchemaOrg($response->getContent());
+    $linkHeader = $response->headers->get('Link');
+
+    expect($jsonLd)->not->toHaveKey('distribution')
+        ->and($linkHeader)->not->toContain('rel="item"')
+        ->not->toContain('data-with-obvious-extension.zip');
+});
+
+test('downloads unavailable suppresses JSON-LD and Signposting content links', function () {
+    [$resource, $landingPage] = machineMetadataLandingPage(landingPageAttributes: [
+        'ftp_url' => 'https://downloads.example.org/data.zip',
+        'downloads_unavailable' => true,
+    ]);
+    $resource->formats()->create(['value' => 'application/zip']);
+
+    $response = $this->get($landingPage->getPublicPath())->assertOk();
+    $jsonLd = decodedEmbeddedSchemaOrg($response->getContent());
+
+    expect($jsonLd)->not->toHaveKey('distribution')
+        ->and($response->headers->get('Link'))->not->toContain('rel="item"');
+});
+
+test('JSON-LD encoding cannot be terminated by metadata containing script markup', function () {
+    [$resource, $landingPage] = machineMetadataLandingPage();
+    $dangerousTitle = 'Danger </script><script>alert(1)</script> — safe data';
+    $resource->titles()->delete();
+    Title::factory()->create(['resource_id' => $resource->id, 'value' => $dangerousTitle]);
+
+    $response = $this->get($landingPage->getPublicPath())->assertOk();
+    $html = $response->getContent();
+    $jsonLd = decodedEmbeddedSchemaOrg($html);
+
+    expect(substr_count($html, '<script type="application/ld+json">'))->toBe(1)
+        ->and($html)->not->toContain('</script><script>alert(1)</script>')
+        ->and($html)->toContain('\u003C/script\u003E')
+        ->and($jsonLd['name'])->toBe($dangerousTitle);
+});

--- a/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
@@ -12,6 +12,7 @@ use App\Models\ResourceType;
 use App\Models\Right;
 use App\Models\Title;
 use App\Services\LandingPageMachineMetadataService;
+use App\Services\SchemaOrgJsonLdExporter;
 
 covers(LandingPagePublicController::class, LandingPageMachineMetadataService::class);
 
@@ -199,4 +200,20 @@ test('JSON-LD encoding cannot be terminated by metadata containing script markup
         ->and($html)->not->toContain('</script><script>alert(1)</script>')
         ->and($html)->toContain('\u003C/script\u003E')
         ->and($jsonLd['name'])->toBe($dangerousTitle);
+});
+
+test('invalid UTF-8 metadata is substituted instead of failing public rendering', function () {
+    [, $landingPage] = machineMetadataLandingPage();
+    $schemaOrgExporter = Mockery::mock(SchemaOrgJsonLdExporter::class);
+    $schemaOrgExporter->shouldReceive('export')->once()->andReturn([
+        '@context' => 'https://schema.org',
+        '@type' => 'Dataset',
+        'name' => "Invalid \xB1 title",
+    ]);
+    $this->app->instance(SchemaOrgJsonLdExporter::class, $schemaOrgExporter);
+
+    $response = $this->get($landingPage->getPublicPath())->assertOk();
+    $jsonLd = decodedEmbeddedSchemaOrg($response->getContent());
+
+    expect($jsonLd['name'])->toBe("Invalid \u{FFFD} title");
 });

--- a/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
@@ -70,6 +70,19 @@ function decodedEmbeddedSchemaOrg(string $html): array
     return $decoded;
 }
 
+test('machine metadata contract exposes encoded JSON-LD without caching the source array', function () {
+    [$resource, $landingPage] = machineMetadataLandingPage();
+
+    $metadata = app(LandingPageMachineMetadataService::class)->for($resource, $landingPage);
+
+    expect($metadata)
+        ->toBeArray()
+        ->toHaveKeys(['jsonLdJson', 'dublinCore', 'signpostingLinks', 'metadataLinks'])
+        ->not->toHaveKey('jsonLd')
+        ->and(json_decode($metadata['jsonLdJson'], true, 512, JSON_THROW_ON_ERROR))
+        ->toBeArray();
+});
+
 test('raw dataset HTML and GET HEAD responses expose complete machine metadata', function () {
     [$resource, $landingPage] = machineMetadataLandingPage(landingPageAttributes: [
         'ftp_url' => 'https://downloads.example.org/fallback.zip',

--- a/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageMachineMetadataTest.php
@@ -122,6 +122,7 @@ test('raw dataset HTML and GET HEAD responses expose complete machine metadata',
         ->toContain('<https://schema.org/Dataset>; rel="type"')
         ->toContain('<https://schema.org/AboutPage>; rel="type"')
         ->toContain('rel="describedby"; type="application/vnd.datacite.datacite+xml"')
+        ->toContain('profile="'.config('iso19115.profile').'"')
         ->toContain('<https://spdx.org/licenses/CC-BY-4.0>; rel="license"')
         ->toContain('<https://downloads.example.org/article.pdf>; rel="item"; type="application/pdf"')
         ->and($html)->toContain('name="DC.identifier"')
@@ -133,7 +134,9 @@ test('raw dataset HTML and GET HEAD responses expose complete machine metadata',
         ->toContain('name="DC.type"')
         ->toContain('rel="cite-as"')
         ->toContain('rel="describedby"')
-        ->toContain('rel="item"');
+        ->toContain('rel="item"')
+        ->toContain('data-profile="'.e(config('iso19115.profile')).'"')
+        ->not->toContain(' profile="'.e(config('iso19115.profile')).'"');
 
     $response->assertInertia(fn ($page) => $page
         ->missing('schemaOrgJsonLd')

--- a/tests/pest/Feature/LandingPages/LandingPageMetadataDiscoveryTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageMetadataDiscoveryTest.php
@@ -6,9 +6,10 @@ use App\Http\Controllers\LandingPagePublicController;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\ResourceType;
+use App\Services\LandingPageMachineMetadataService;
 use App\Services\LandingPageMetadataLinkService;
 
-covers(LandingPagePublicController::class, LandingPageMetadataLinkService::class);
+covers(LandingPagePublicController::class, LandingPageMachineMetadataService::class, LandingPageMetadataLinkService::class);
 
 /**
  * @return array{0: Resource, 1: LandingPage}
@@ -34,12 +35,20 @@ function landingPageForMetadataDiscovery(string $resourceTypeSlug = 'dataset', b
     return [$resource->refresh(), $landingPage];
 }
 
+function completeLandingPageLinkHeader(Resource $resource, LandingPage $landingPage): ?string
+{
+    $machineMetadata = app(LandingPageMachineMetadataService::class)->for($resource, $landingPage);
+
+    return app(LandingPageMetadataLinkService::class)->toSignpostingHttpLinkHeader(
+        $machineMetadata['signpostingLinks'] ?? [],
+    );
+}
+
 test('eligible landing pages expose canonical metadata links and ISO describedby header', function () {
     [$resource, $landingPage] = landingPageForMetadataDiscovery();
     $metadataBaseUrl = url($landingPage->getPublicPath().'/metadata');
     $isoUrl = "{$metadataBaseUrl}/iso-19115-3.xml";
-    $linkService = app(LandingPageMetadataLinkService::class);
-    $linkHeader = $linkService->toHttpLinkHeader($linkService->for($resource, $landingPage));
+    $linkHeader = completeLandingPageLinkHeader($resource, $landingPage);
 
     $this->get($landingPage->getPublicPath())
         ->assertOk()
@@ -48,8 +57,10 @@ test('eligible landing pages expose canonical metadata links and ISO describedby
             ->has('metadataLinks', 4)
             ->where('metadataLinks.0.format', 'datacite-xml')
             ->where('metadataLinks.0.url', "{$metadataBaseUrl}/datacite.xml")
+            ->where('metadataLinks.0.mediaType', 'application/vnd.datacite.datacite+xml')
             ->where('metadataLinks.1.format', 'datacite-json')
             ->where('metadataLinks.1.url', "{$metadataBaseUrl}/datacite.json")
+            ->where('metadataLinks.1.mediaType', 'application/vnd.datacite.datacite+json')
             ->where('metadataLinks.2.format', 'datacite-jsonld')
             ->where('metadataLinks.2.url', "{$metadataBaseUrl}/datacite.jsonld")
             ->where('metadataLinks.3.format', 'iso19115-3')
@@ -61,8 +72,7 @@ test('eligible landing pages expose canonical metadata links and ISO describedby
 
 test('excluded resource types retain DataCite links without advertising ISO metadata', function () {
     [$resource, $landingPage] = landingPageForMetadataDiscovery('project');
-    $linkService = app(LandingPageMetadataLinkService::class);
-    $linkHeader = $linkService->toHttpLinkHeader($linkService->for($resource, $landingPage));
+    $linkHeader = completeLandingPageLinkHeader($resource, $landingPage);
 
     $this->get($landingPage->getPublicPath())
         ->assertOk()
@@ -80,8 +90,7 @@ test('excluded resource types retain DataCite links without advertising ISO meta
 test('ISO feature flag removes discovery without affecting DataCite representations', function () {
     [$resource, $landingPage] = landingPageForMetadataDiscovery();
     config(['iso19115.enabled' => false]);
-    $linkService = app(LandingPageMetadataLinkService::class);
-    $linkHeader = $linkService->toHttpLinkHeader($linkService->for($resource, $landingPage));
+    $linkHeader = completeLandingPageLinkHeader($resource, $landingPage);
 
     $this->get($landingPage->getPublicPath())
         ->assertOk()
@@ -123,4 +132,18 @@ test('HTTP metadata link serialization rejects unsafe URLs and escapes quoted pa
             .'profile="https://example.org/profileignored"',
         )
         ->and($service->toHttpLinkHeader([$unsafeLink]))->toBeNull();
+});
+
+test('complete Signposting serialization preserves order and rejects header injection', function () {
+    $service = app(LandingPageMetadataLinkService::class);
+    $links = [
+        ['rel' => 'cite-as', 'href' => 'https://doi.org/10.5880/test', 'type' => null, 'profile' => null],
+        ['rel' => 'item', 'href' => 'https://example.org/data.zip', 'type' => 'application/zip', 'profile' => null],
+        ['rel' => 'item', 'href' => "https://example.org/bad.zip>\r\nX-Test: injected", 'type' => 'application/zip', 'profile' => null],
+    ];
+
+    expect($service->toSignpostingHttpLinkHeader($links))->toBe(
+        '<https://doi.org/10.5880/test>; rel="cite-as", '
+        .'<https://example.org/data.zip>; rel="item"; type="application/zip"',
+    );
 });

--- a/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPagePublicControllerTest.php
@@ -322,7 +322,7 @@ describe('Landing Page Caching', function () {
             ->assertInertia(fn ($page) => $page->where('landingPage.ftp_url', 'https://data.gfz.de/new.zip'));
     });
 
-    test('ignores a legacy unversioned render payload and caches citation styles under the v2 key', function () {
+    test('ignores a legacy unversioned render payload and caches citation styles under the v3 key', function () {
         config([
             'bot_protection.enabled' => true,
             'bot_protection.landing_cache_ttl' => 600,

--- a/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
+++ b/tests/pest/Feature/LandingPages/LandingPageTemplateControllerTest.php
@@ -469,12 +469,9 @@ describe('Update', function (): void {
         ]);
 
         $cacheKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($landingPage->id);
-        $schemaOrgCacheKey = CacheKey::SCHEMA_ORG_JSONLD->key($resource->id);
         Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($cacheKey, ['template' => 'default_gfz', 'props' => []], 600);
-        Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->put($schemaOrgCacheKey, ['@context' => 'https://schema.org'], 600);
 
-        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue()
-            ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgCacheKey))->toBeTrue();
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeTrue();
 
         $this->actingAs($this->admin)
             ->putJson("/landing-pages/{$template->id}", [
@@ -484,8 +481,7 @@ describe('Update', function (): void {
             ])
             ->assertOk();
 
-        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse()
-            ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgCacheKey))->toBeTrue();
+        expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($cacheKey))->toBeFalse();
     });
 
     it('does not forget cached public landing page render data for empty template updates', function (): void {

--- a/tests/pest/Feature/LandingPages/PublicMetadataExportControllerTest.php
+++ b/tests/pest/Feature/LandingPages/PublicMetadataExportControllerTest.php
@@ -46,13 +46,13 @@ test('serves all canonical public metadata representations for a published landi
 
     $this->get("{$base}/datacite.xml")
         ->assertOk()
-        ->assertHeader('Content-Type', 'application/xml; charset=UTF-8')
+        ->assertHeader('Content-Type', 'application/vnd.datacite.datacite+xml; charset=UTF-8')
         ->assertHeader('Content-Disposition', 'attachment; filename="metadata-test-datacite.xml"')
         ->assertSee('http://datacite.org/schema/kernel-4', escape: false);
 
     $this->get("{$base}/datacite.json")
         ->assertOk()
-        ->assertHeader('Content-Type', 'application/json; charset=UTF-8')
+        ->assertHeader('Content-Type', 'application/vnd.datacite.datacite+json; charset=UTF-8')
         ->assertHeader('Content-Disposition', 'attachment; filename="metadata-test-datacite.json"')
         ->assertJsonPath('data.type', 'dois');
 

--- a/tests/pest/Feature/Migrations/LandingPageLinkKindMigrationTest.php
+++ b/tests/pest/Feature/Migrations/LandingPageLinkKindMigrationTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+test('landing page links contain the machine-readable kind column', function () {
+    expect(Schema::hasColumn('landing_page_links', 'kind'))->toBeTrue();
+});
+
+test('landing page link kind migration can roll back and re-apply', function () {
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_07_27_000001_add_kind_to_landing_page_links_table.php');
+
+    $migration->down();
+    expect(Schema::hasColumn('landing_page_links', 'kind'))->toBeFalse();
+
+    $migration->up();
+    expect(Schema::hasColumn('landing_page_links', 'kind'))->toBeTrue();
+});

--- a/tests/pest/Unit/BotProtection/LandingPageRenderDataCacheServiceTest.php
+++ b/tests/pest/Unit/BotProtection/LandingPageRenderDataCacheServiceTest.php
@@ -156,7 +156,7 @@ it('forgets versioned render data by id without deleting a legacy entry', functi
         ->and($cache->has($legacyCacheKey))->toBeTrue();
 });
 
-it('forgets cached render data for landing pages using a custom template without clearing same-tag schema cache', function (): void {
+it('forgets cached render data only for landing pages using a custom template', function (): void {
     $service = new LandingPageRenderDataCacheService;
     $template = LandingPageTemplate::factory()->create();
     $otherTemplate = LandingPageTemplate::factory()->create();
@@ -171,21 +171,17 @@ it('forgets cached render data for landing pages using a custom template without
 
     $affectedRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($affectedLandingPage->id);
     $unaffectedRenderKey = CacheKey::LANDING_PAGE_RENDER_DATA->key($unaffectedLandingPage->id);
-    $schemaOrgKey = CacheKey::SCHEMA_ORG_JSONLD->key($affectedLandingPage->resource_id);
 
     Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($affectedRenderKey, ['template' => 'default_gfz', 'props' => []], 600);
     Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->put($unaffectedRenderKey, ['template' => 'default_gfz', 'props' => []], 600);
-    Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->put($schemaOrgKey, ['@context' => 'https://schema.org'], 600);
 
     expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($affectedRenderKey))->toBeTrue()
-        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($unaffectedRenderKey))->toBeTrue()
-        ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgKey))->toBeTrue();
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($unaffectedRenderKey))->toBeTrue();
 
     $service->forgetForTemplate($template);
 
     expect(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($affectedRenderKey))->toBeFalse()
-        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($unaffectedRenderKey))->toBeTrue()
-        ->and(Cache::tags(CacheKey::SCHEMA_ORG_JSONLD->tags())->has($schemaOrgKey))->toBeTrue();
+        ->and(Cache::tags(CacheKey::LANDING_PAGE_RENDER_DATA->tags())->has($unaffectedRenderKey))->toBeTrue();
 });
 
 it('forgets cached render data for default-template pages without clearing matching custom-template pages', function (): void {

--- a/tests/pest/Unit/Enums/CacheKeyTest.php
+++ b/tests/pest/Unit/Enums/CacheKeyTest.php
@@ -25,8 +25,8 @@ it('generates correct cache keys with integer suffix', function () {
 });
 
 it('versions landing page render data cache keys', function () {
-    expect(CacheKey::LANDING_PAGE_RENDER_DATA->key())->toBe('landing_pages:render_data:v2')
-        ->and(CacheKey::LANDING_PAGE_RENDER_DATA->key(123))->toBe('landing_pages:render_data:v2:123');
+    expect(CacheKey::LANDING_PAGE_RENDER_DATA->key())->toBe('landing_pages:render_data:v3')
+        ->and(CacheKey::LANDING_PAGE_RENDER_DATA->key(123))->toBe('landing_pages:render_data:v3:123');
 });
 
 it('returns correct TTL for resources', function () {

--- a/tests/pest/Unit/Services/LandingPageContentLinkServiceTest.php
+++ b/tests/pest/Unit/Services/LandingPageContentLinkServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\LandingPageLink;
+use App\Models\Resource;
+use App\Services\LandingPageContentLinkService;
+
+covers(LandingPageContentLinkService::class);
+
+/** @return array{0: Resource, 1: LandingPage} */
+function landingPageContentFixture(array $landingPageAttributes = []): array
+{
+    $resource = Resource::factory()->create();
+    $landingPage = LandingPage::factory()->published()->create([
+        'resource_id' => $resource->id,
+        'doi_prefix' => $resource->doi,
+        'ftp_url' => 'https://downloads.example.org/fallback.zip',
+        ...$landingPageAttributes,
+    ]);
+
+    return [$resource, $landingPage];
+}
+
+test('uses the first valid stored format and imported files before the primary URL', function () {
+    [$resource, $landingPage] = landingPageContentFixture();
+    $resource->formats()->create(['value' => 'not a mime type']);
+    $resource->formats()->create(['value' => '.PDF']);
+    $resource->formats()->create(['value' => 'application/zip']);
+
+    $landingPage->files()->createMany([
+        ['url' => 'https://downloads.example.org/second.pdf', 'position' => 1],
+        ['url' => 'https://downloads.example.org/first.pdf', 'position' => 0],
+    ]);
+    $landingPage->links()->createMany([
+        [
+            'url' => 'https://downloads.example.org/extra.pdf',
+            'label' => 'Extra file',
+            'kind' => LandingPageLink::KIND_DOWNLOAD,
+            'position' => 0,
+        ],
+        [
+            'url' => 'https://git.example.org/project/repository',
+            'label' => 'Repository',
+            'kind' => LandingPageLink::KIND_REPOSITORY,
+            'position' => 1,
+        ],
+    ]);
+
+    $result = app(LandingPageContentLinkService::class)->resolve($resource, $landingPage);
+
+    expect($result['mimeType'])->toBe('application/pdf')
+        ->and($result['contentLinks'])->toBe([
+            ['url' => 'https://downloads.example.org/first.pdf', 'mimeType' => 'application/pdf'],
+            ['url' => 'https://downloads.example.org/second.pdf', 'mimeType' => 'application/pdf'],
+            ['url' => 'https://downloads.example.org/extra.pdf', 'mimeType' => 'application/pdf'],
+        ])
+        ->and($result['repositories'])->toBe(['https://git.example.org/project/repository'])
+        ->and(array_column($result['contentLinks'], 'url'))->not->toContain('https://downloads.example.org/fallback.zip');
+});
+
+test('uses the original primary URL when no imported file exists', function () {
+    [$resource, $landingPage] = landingPageContentFixture();
+    $resource->formats()->create(['value' => 'zip']);
+
+    $result = app(LandingPageContentLinkService::class)->resolve($resource, $landingPage);
+
+    expect($result['contentLinks'])->toBe([
+        ['url' => 'https://downloads.example.org/fallback.zip', 'mimeType' => 'application/zip'],
+    ]);
+});
+
+test('omits content without a valid database MIME type but retains repositories', function () {
+    [$resource, $landingPage] = landingPageContentFixture();
+    $resource->formats()->create(['value' => 'unknown-format']);
+    $landingPage->links()->create([
+        'url' => 'https://git.example.org/project/repository',
+        'label' => 'Repository',
+        'kind' => LandingPageLink::KIND_REPOSITORY,
+        'position' => 0,
+    ]);
+
+    $result = app(LandingPageContentLinkService::class)->resolve($resource, $landingPage);
+
+    expect($result['mimeType'])->toBeNull()
+        ->and($result['contentLinks'])->toBe([])
+        ->and($result['repositories'])->toBe(['https://git.example.org/project/repository']);
+});
+
+test('downloads unavailable suppresses every content URL', function () {
+    [$resource, $landingPage] = landingPageContentFixture(['downloads_unavailable' => true]);
+    $resource->formats()->create(['value' => 'application/zip']);
+    $landingPage->files()->create(['url' => 'https://downloads.example.org/file.zip', 'position' => 0]);
+    $landingPage->links()->create([
+        'url' => 'https://downloads.example.org/extra.zip',
+        'label' => 'Extra',
+        'kind' => LandingPageLink::KIND_DOWNLOAD,
+        'position' => 0,
+    ]);
+
+    expect(app(LandingPageContentLinkService::class)->resolve($resource, $landingPage)['contentLinks'])
+        ->toBe([]);
+});
+
+test('rejects unsafe URLs and deduplicates safe URLs without inference', function () {
+    [$resource, $landingPage] = landingPageContentFixture(['ftp_url' => 'javascript:alert(1)']);
+    $resource->formats()->create(['value' => 'text/csv; charset=UTF-8']);
+    $landingPage->files()->createMany([
+        ['url' => 'https://downloads.example.org/data.csv', 'position' => 0],
+        ['url' => 'https://downloads.example.org/data.csv', 'position' => 1],
+        ['url' => "https://downloads.example.org/bad.csv\r\nX-Test: injected", 'position' => 2],
+    ]);
+
+    $result = app(LandingPageContentLinkService::class)->resolve($resource, $landingPage);
+
+    expect($result['mimeType'])->toBe('text/csv')
+        ->and($result['contentLinks'])->toBe([
+            ['url' => 'https://downloads.example.org/data.csv', 'mimeType' => 'text/csv'],
+        ]);
+});

--- a/tests/pest/Unit/Services/LandingPageLicenseResolverServiceTest.php
+++ b/tests/pest/Unit/Services/LandingPageLicenseResolverServiceTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use App\Services\LandingPageLicenseResolver;
+use App\Services\LandingPageLicenseResolverService;
 
-covers(LandingPageLicenseResolver::class);
+covers(LandingPageLicenseResolverService::class);
 
 test('prefers the first valid SPDX license over earlier rights URIs', function () {
     $rightsList = [
@@ -18,7 +18,7 @@ test('prefers the first valid SPDX license over earlier rights URIs', function (
         ],
     ];
 
-    expect(app(LandingPageLicenseResolver::class)->resolve($rightsList))
+    expect(app(LandingPageLicenseResolverService::class)->resolve($rightsList))
         ->toBe('https://spdx.org/licenses/CC-BY-4.0');
 });
 
@@ -29,12 +29,12 @@ test('falls back to the first valid rights URI in stable order', function () {
         ['rights' => 'Second valid', 'rightsUri' => 'https://example.org/license-b'],
     ];
 
-    expect(app(LandingPageLicenseResolver::class)->resolve($rightsList))
+    expect(app(LandingPageLicenseResolverService::class)->resolve($rightsList))
         ->toBe('https://example.org/license-a');
 });
 
 test('returns null when no safe HTTP license URI exists', function () {
-    expect(app(LandingPageLicenseResolver::class)->resolve([
+    expect(app(LandingPageLicenseResolverService::class)->resolve([
         ['rights' => 'Text only'],
         ['rights' => 'Local file', 'rightsUri' => 'file:///tmp/license'],
         ['rights' => 'Script', 'rightsUri' => 'javascript:alert(1)'],

--- a/tests/pest/Unit/Services/LandingPageLicenseResolverTest.php
+++ b/tests/pest/Unit/Services/LandingPageLicenseResolverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\LandingPageLicenseResolver;
+
+covers(LandingPageLicenseResolver::class);
+
+test('prefers the first valid SPDX license over earlier rights URIs', function () {
+    $rightsList = [
+        ['rights' => 'Custom', 'rightsUri' => 'https://example.org/custom-license'],
+        [
+            'rights' => 'CC BY 4.0',
+            'rightsIdentifier' => 'CC-BY-4.0',
+            'rightsIdentifierScheme' => 'SPDX',
+            'schemeUri' => 'https://spdx.org/licenses/',
+            'rightsUri' => 'https://creativecommons.org/licenses/by/4.0/',
+        ],
+    ];
+
+    expect(app(LandingPageLicenseResolver::class)->resolve($rightsList))
+        ->toBe('https://spdx.org/licenses/CC-BY-4.0');
+});
+
+test('falls back to the first valid rights URI in stable order', function () {
+    $rightsList = [
+        ['rights' => 'Unsafe', 'rightsUri' => "https://example.org/license\r\nX-Test: injected"],
+        ['rights' => 'First valid', 'rightsUri' => 'https://example.org/license-a'],
+        ['rights' => 'Second valid', 'rightsUri' => 'https://example.org/license-b'],
+    ];
+
+    expect(app(LandingPageLicenseResolver::class)->resolve($rightsList))
+        ->toBe('https://example.org/license-a');
+});
+
+test('returns null when no safe HTTP license URI exists', function () {
+    expect(app(LandingPageLicenseResolver::class)->resolve([
+        ['rights' => 'Text only'],
+        ['rights' => 'Local file', 'rightsUri' => 'file:///tmp/license'],
+        ['rights' => 'Script', 'rightsUri' => 'javascript:alert(1)'],
+    ]))->toBeNull();
+});

--- a/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
+++ b/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Models\DateType;
 use App\Models\DescriptionType;
+use App\Models\LandingPage;
 use App\Models\Person;
 use App\Models\Resource;
 use App\Models\ResourceCreator;
+use App\Models\ResourceType;
+use App\Models\Right;
 use App\Models\TitleType;
 use App\Services\SchemaOrgJsonLdExporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -232,7 +236,7 @@ describe('dates', function () {
     it('maps Issued date to datePublished', function () {
         $resource = createSchemaOrgResource();
 
-        $issuedType = \App\Models\DateType::where('slug', 'Issued')->first();
+        $issuedType = DateType::where('slug', 'Issued')->first();
         $resource->dates()->create([
             'date_value' => '2025-06-01',
             'date_type_id' => $issuedType?->id,
@@ -246,7 +250,7 @@ describe('dates', function () {
     it('maps Created date to dateCreated', function () {
         $resource = createSchemaOrgResource();
 
-        $createdType = \App\Models\DateType::where('slug', 'Created')->first();
+        $createdType = DateType::where('slug', 'Created')->first();
         $resource->dates()->create([
             'date_value' => '2025-01-15',
             'date_type_id' => $createdType?->id,
@@ -260,7 +264,7 @@ describe('dates', function () {
     it('maps Updated date to dateModified', function () {
         $resource = createSchemaOrgResource();
 
-        $updatedType = \App\Models\DateType::where('slug', 'Updated')->first();
+        $updatedType = DateType::where('slug', 'Updated')->first();
         $resource->dates()->create([
             'date_value' => '2025-07-01',
             'date_type_id' => $updatedType?->id,
@@ -274,7 +278,7 @@ describe('dates', function () {
     it('maps single Collected date to temporalCoverage with open end', function () {
         $resource = createSchemaOrgResource();
 
-        $collectedType = \App\Models\DateType::where('slug', 'Collected')->first();
+        $collectedType = DateType::where('slug', 'Collected')->first();
         $resource->dates()->create([
             'date_value' => '2024-01-01',
             'date_type_id' => $collectedType?->id,
@@ -288,7 +292,7 @@ describe('dates', function () {
     it('maps date range Collected to temporalCoverage as-is', function () {
         $resource = createSchemaOrgResource();
 
-        $collectedType = \App\Models\DateType::where('slug', 'Collected')->first();
+        $collectedType = DateType::where('slug', 'Collected')->first();
         $resource->dates()->create([
             'date_value' => '2024-01-01/2024-12-31',
             'date_type_id' => $collectedType?->id,
@@ -349,7 +353,7 @@ describe('license', function () {
     it('transforms rights with SPDX scheme to license URI', function () {
         $resource = createSchemaOrgResource();
 
-        $right = \App\Models\Right::firstOrCreate(
+        $right = Right::firstOrCreate(
             ['identifier' => 'CC-BY-4.0'],
             [
                 'name' => 'Creative Commons Attribution 4.0 International',
@@ -462,6 +466,61 @@ describe('output is valid JSON-LD', function () {
         $json = json_encode($result, JSON_PRETTY_PRINT);
         expect($json)->not->toBeFalse();
         expect(json_decode($json, true))->toBe($result);
+    });
+});
+
+describe('landing page content', function () {
+    it('adds canonical landing page URL and Dataset distributions', function () {
+        $resource = createSchemaOrgResource();
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+            'doi_prefix' => $resource->doi,
+            'slug' => 'schema-org-content',
+        ]);
+
+        $result = $this->exporter->export($resource, $landingPage, [
+            'mimeType' => 'application/zip',
+            'contentLinks' => [
+                ['url' => 'https://downloads.example.org/data.zip', 'mimeType' => 'application/zip'],
+            ],
+            'repositories' => [],
+        ]);
+
+        expect($result['url'])->toBe(url($landingPage->getPublicPath()))
+            ->and($result['distribution'])->toBe([
+                [
+                    '@type' => 'DataDownload',
+                    'contentUrl' => 'https://downloads.example.org/data.zip',
+                    'encodingFormat' => 'application/zip',
+                ],
+            ]);
+    });
+
+    it('uses software types repository and downloadUrl for Software resources', function () {
+        $softwareType = ResourceType::firstOrCreate(
+            ['slug' => 'software'],
+            ['name' => 'Software', 'is_active' => true],
+        );
+        $resource = createSchemaOrgResource();
+        $resource->update(['resource_type_id' => $softwareType->id]);
+        $landingPage = LandingPage::factory()->published()->create([
+            'resource_id' => $resource->id,
+            'doi_prefix' => $resource->doi,
+            'slug' => 'schema-org-software',
+        ]);
+
+        $result = $this->exporter->export($resource->fresh(), $landingPage, [
+            'mimeType' => 'application/zip',
+            'contentLinks' => [
+                ['url' => 'https://downloads.example.org/source.zip', 'mimeType' => 'application/zip'],
+            ],
+            'repositories' => ['https://git.example.org/source'],
+        ]);
+
+        expect($result['@type'])->toBe(['SoftwareSourceCode', 'SoftwareApplication'])
+            ->and($result['codeRepository'])->toBe('https://git.example.org/source')
+            ->and($result['downloadUrl'])->toBe('https://downloads.example.org/source.zip')
+            ->and($result)->not->toHaveKey('distribution');
     });
 });
 

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -23,11 +23,7 @@ vi.mock('axios', () => {
     const put = vi.fn();
     const deleteMethod = vi.fn();
     const isAxiosError = vi.fn((value: unknown): value is { isAxiosError: true } => {
-        return (
-            typeof value === 'object' &&
-            value !== null &&
-            (value as { isAxiosError?: boolean }).isAxiosError === true
-        );
+        return typeof value === 'object' && value !== null && (value as { isAxiosError?: boolean }).isAxiosError === true;
     });
     return {
         default: { get, post, put, delete: deleteMethod, isAxiosError },
@@ -95,7 +91,8 @@ describe('SetupLandingPageModal', () => {
         created_at: '2025-01-01T00:00:00Z',
         updated_at: '2025-01-02T00:00:00Z',
         public_url: 'http://localhost/10.5880/GFZ.TEST.2025.001/test-resource-title',
-        preview_url: 'http://localhost/10.5880/GFZ.TEST.2025.001/test-resource-title?preview=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        preview_url:
+            'http://localhost/10.5880/GFZ.TEST.2025.001/test-resource-title?preview=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
         contact_url: 'http://localhost/10.5880/GFZ.TEST.2025.001/test-resource-title/contact',
     };
 
@@ -177,13 +174,7 @@ describe('SetupLandingPageModal', () => {
                 response: { status: 404 },
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -192,13 +183,7 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('does not render when closed', () => {
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={false}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={false} onClose={mockOnClose} />);
 
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
         });
@@ -210,22 +195,14 @@ describe('SetupLandingPageModal', () => {
                 response: { status: 404 },
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 // Component shows title if available, otherwise "Resource #${id}".
                 // Scope to the title testid: Radix Tooltip adds a VisuallyHidden
                 // accessibility node that also contains the title text, so a
                 // plain `getByText` would match more than one element.
-                expect(screen.getByTestId('setup-lp-modal-resource-title')).toHaveTextContent(
-                    'Test Resource Title',
-                );
+                expect(screen.getByTestId('setup-lp-modal-resource-title')).toHaveTextContent('Test Resource Title');
             });
         });
     });
@@ -238,13 +215,7 @@ describe('SetupLandingPageModal', () => {
                 response: { status: 404 },
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/Landing Page Template/i)).toBeInTheDocument();
@@ -260,13 +231,7 @@ describe('SetupLandingPageModal', () => {
                 response: { status: 404 },
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByText(/Default GFZ Data Services/i)).toBeInTheDocument();
@@ -282,11 +247,7 @@ describe('SetupLandingPageModal', () => {
             const user = userEvent.setup();
 
             render(
-                <SetupLandingPageModal
-                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
+                <SetupLandingPageModal resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }} isOpen={true} onClose={mockOnClose} />,
             );
 
             await waitFor(() => {
@@ -305,13 +266,7 @@ describe('SetupLandingPageModal', () => {
         it('loads existing configuration', async () => {
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: mockExistingConfig } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 const ftpInput = screen.getByLabelText(/^Download URL$/i) as HTMLInputElement;
@@ -329,13 +284,7 @@ describe('SetupLandingPageModal', () => {
                 },
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             expect(await screen.findByRole('checkbox', { name: /no data available for download/i })).toBeChecked();
         });
@@ -345,13 +294,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.click(screen.getByRole('checkbox', { name: /no data available for download/i }));
@@ -364,13 +307,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.click(ftpInput);
@@ -388,13 +325,7 @@ describe('SetupLandingPageModal', () => {
         it('exposes the download url input as a combobox for assistive technology', async () => {
             mockModalGetRequests();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
@@ -407,13 +338,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
@@ -438,13 +363,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
@@ -459,13 +378,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
 
@@ -573,13 +486,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.click(ftpInput);
@@ -648,18 +555,10 @@ describe('SetupLandingPageModal', () => {
         it('fetches existing config on mount', async () => {
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: mockExistingConfig } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
-                expect(axios.get).toHaveBeenCalledWith(
-                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
-                );
+                expect(axios.get).toHaveBeenCalledWith(expect.stringContaining(`/resources/${mockResource.id}/landing-page`));
             });
         });
 
@@ -695,11 +594,7 @@ describe('SetupLandingPageModal', () => {
             const user = userEvent.setup();
 
             render(
-                <SetupLandingPageModal
-                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
+                <SetupLandingPageModal resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }} isOpen={true} onClose={mockOnClose} />,
             );
 
             await waitFor(() => {
@@ -771,11 +666,7 @@ describe('SetupLandingPageModal', () => {
             const user = userEvent.setup();
 
             render(
-                <SetupLandingPageModal
-                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
+                <SetupLandingPageModal resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }} isOpen={true} onClose={mockOnClose} />,
             );
 
             await waitFor(() => {
@@ -812,13 +703,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -840,6 +725,47 @@ describe('SetupLandingPageModal', () => {
                         template: 'default_gfz',
                         ftp_url: 'https://datapub.gfz-potsdam.de/download/new-data',
                         status: 'draft',
+                    }),
+                );
+            });
+        });
+
+        it('selects and submits a machine-readable role for an additional link', async () => {
+            mockedAxiosGet.mockRejectedValue({
+                isAxiosError: true,
+                response: { status: 404 },
+            });
+            mockedAxiosPost.mockResolvedValue({
+                data: {
+                    landing_page: {
+                        ...mockExistingConfig,
+                        status: 'draft',
+                    },
+                },
+            });
+            const user = userEvent.setup();
+
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            await user.click(await screen.findByRole('button', { name: /Add Link/i }));
+            await user.type(screen.getByPlaceholderText('Display text'), 'Download package');
+            await user.type(screen.getByPlaceholderText('https://...'), 'https://example.org/package.zip');
+            await user.click(screen.getByRole('combobox', { name: 'Link role' }));
+            await user.click(await screen.findByRole('option', { name: 'Direct download' }));
+            await user.click(screen.getByRole('button', { name: /Create Preview/i }));
+
+            await waitFor(() => {
+                expect(mockedAxiosPost).toHaveBeenCalledWith(
+                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
+                    expect.objectContaining({
+                        links: [
+                            {
+                                url: 'https://example.org/package.zip',
+                                label: 'Download package',
+                                kind: 'download',
+                                position: 0,
+                            },
+                        ],
                     }),
                 );
             });
@@ -905,22 +831,13 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    openPreviewOnSuccess={true}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} openPreviewOnSuccess={true} />);
 
             await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
             expect(mockedAxiosPost).not.toHaveBeenCalled();
-            expect(mockedToastError).toHaveBeenCalledWith(
-                'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.',
-            );
+            expect(mockedToastError).toHaveBeenCalledWith('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
 
             vi.unstubAllGlobals();
         });
@@ -941,14 +858,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    openPreviewOnSuccess={true}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} openPreviewOnSuccess={true} />);
 
             await user.click(await screen.findByRole('button', { name: /Create Preview/i }));
 
@@ -981,13 +891,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.type(ftpInput, 'https://datapub.gfz-potsdam.de/download/no-data-record.zip');
@@ -1025,11 +929,7 @@ describe('SetupLandingPageModal', () => {
             const user = userEvent.setup();
 
             render(
-                <SetupLandingPageModal
-                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
+                <SetupLandingPageModal resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }} isOpen={true} onClose={mockOnClose} />,
             );
 
             await waitFor(() => {
@@ -1056,13 +956,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1105,13 +999,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
             await user.click(screen.getByRole('button', { name: /Update/i }));
@@ -1137,18 +1025,14 @@ describe('SetupLandingPageModal', () => {
             mockedAxiosDelete.mockResolvedValue({ data: { message: 'Landing page deleted successfully' } });
 
             // Mock window.confirm to return true
-            vi.stubGlobal('confirm', vi.fn(() => true));
+            vi.stubGlobal(
+                'confirm',
+                vi.fn(() => true),
+            );
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    onSuccess={onSuccess}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} onSuccess={onSuccess} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1160,9 +1044,7 @@ describe('SetupLandingPageModal', () => {
             await user.click(removePreviewButton);
 
             await waitFor(() => {
-                expect(axios.delete).toHaveBeenCalledWith(
-                    expect.stringContaining(`/resources/${mockResource.id}/landing-page`),
-                );
+                expect(axios.delete).toHaveBeenCalledWith(expect.stringContaining(`/resources/${mockResource.id}/landing-page`));
             });
             expect(onSuccess).toHaveBeenCalledWith(null);
 
@@ -1174,13 +1056,7 @@ describe('SetupLandingPageModal', () => {
             // Published landing pages cannot be depublished because DOIs are persistent
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: mockExistingConfig } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1196,13 +1072,7 @@ describe('SetupLandingPageModal', () => {
             });
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: { ...mockExistingConfig, status: 'draft' } } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1215,13 +1085,7 @@ describe('SetupLandingPageModal', () => {
             // Published landing pages cannot be unpublished because DOIs are persistent
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: mockExistingConfig } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1241,22 +1105,14 @@ describe('SetupLandingPageModal', () => {
             const draftConfig = { ...mockExistingConfig, status: 'draft' as const };
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: draftConfig } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 // Check for the label
                 expect(screen.getByText(/Preview URL/i)).toBeInTheDocument();
                 // Check that the URL input field exists and contains the preview URL
                 // Preview tokens are 64-character hex strings, validate format not specific value
-                const urlInputs = screen.getAllByDisplayValue(
-                    new RegExp(`\\?preview=[a-f0-9]{64}`),
-                );
+                const urlInputs = screen.getAllByDisplayValue(new RegExp(`\\?preview=[a-f0-9]{64}`));
                 expect(urlInputs.length).toBeGreaterThan(0);
             });
         });
@@ -1264,21 +1120,13 @@ describe('SetupLandingPageModal', () => {
         it('displays public URL for published configs', async () => {
             mockedAxiosGet.mockResolvedValue({ data: { landing_page: mockExistingConfig } });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 // Check for the label
                 expect(screen.getByText(/Public URL/i)).toBeInTheDocument();
                 // Check that the URL input field exists with semantic URL (DOI-based)
-                const urlInput = screen.getByDisplayValue(
-                    new RegExp(`10\\.5880/GFZ\\.TEST\\.2025\\.001/test-resource-title`),
-                );
+                const urlInput = screen.getByDisplayValue(new RegExp(`10\\.5880/GFZ\\.TEST\\.2025\\.001/test-resource-title`));
                 expect(urlInput).toBeInTheDocument();
             });
         });
@@ -1292,13 +1140,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             // Wait for modal and config to load
             await waitFor(() => {
@@ -1316,13 +1158,11 @@ describe('SetupLandingPageModal', () => {
             await user.click(copyButton);
 
             // Small delay to allow async operations
-            await new Promise(resolve => setTimeout(resolve, 100));
+            await new Promise((resolve) => setTimeout(resolve, 100));
 
             // Verify clipboard was called with the preview URL containing a valid token format
             expect(writeTextSpy).toHaveBeenCalledTimes(1);
-            expect(writeTextSpy).toHaveBeenCalledWith(
-                expect.stringMatching(/preview=[a-f0-9]{64}/)
-            );
+            expect(writeTextSpy).toHaveBeenCalledWith(expect.stringMatching(/preview=[a-f0-9]{64}/));
 
             writeTextSpy.mockRestore();
         });
@@ -1335,13 +1175,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1367,13 +1201,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1381,9 +1209,7 @@ describe('SetupLandingPageModal', () => {
 
             // Get the Preview button with Eye icon (not the "Remove Preview" destructive button)
             const previewButtons = screen.getAllByRole('button', { name: /Preview/i });
-            const previewButton = previewButtons.find(
-                (btn) => btn.className.includes('outline') || btn.textContent?.trim() === 'Preview'
-            );
+            const previewButton = previewButtons.find((btn) => btn.className.includes('outline') || btn.textContent?.trim() === 'Preview');
             expect(previewButton).toBeDefined();
             await user.click(previewButton!);
 
@@ -1414,13 +1240,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
             await user.click(screen.getByRole('button', { name: /^Preview$/i }));
@@ -1459,22 +1279,14 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
             await user.click(screen.getByRole('button', { name: /^Preview$/i }));
 
             expect(mockOpen).toHaveBeenCalledWith('about:blank', '_blank');
             expect(mockedAxiosPost).not.toHaveBeenCalled();
-            expect(mockedToastError).toHaveBeenCalledWith(
-                'Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.',
-            );
+            expect(mockedToastError).toHaveBeenCalledWith('Your browser blocked the landing page tab. Please allow pop-ups for ERNIE and try again.');
 
             vi.unstubAllGlobals();
         });
@@ -1498,13 +1310,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await user.click(await screen.findByRole('checkbox', { name: /no data available for download/i }));
             await user.click(screen.getByRole('button', { name: /^Preview$/i }));
@@ -1562,9 +1368,7 @@ describe('SetupLandingPageModal', () => {
             expect(screen.queryByText(/You have unsaved changes/i)).not.toBeInTheDocument();
 
             const previewButtons = screen.getAllByRole('button', { name: /Preview/i });
-            const previewButton = previewButtons.find(
-                (button) => button.className.includes('outline') || button.textContent?.trim() === 'Preview'
-            );
+            const previewButton = previewButtons.find((button) => button.className.includes('outline') || button.textContent?.trim() === 'Preview');
 
             expect(previewButton).toBeDefined();
             await user.click(previewButton!);
@@ -1590,13 +1394,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1644,14 +1442,7 @@ describe('SetupLandingPageModal', () => {
                 external_url: 'https://example.org/saved-resource',
             };
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    existingConfig={existingExternalConfig}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} existingConfig={existingExternalConfig} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/Path/i)).toHaveValue('/saved-resource');
@@ -1677,13 +1468,7 @@ describe('SetupLandingPageModal', () => {
                 },
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             // Should still render but in create mode
             await waitFor(() => {
@@ -1707,13 +1492,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1739,13 +1518,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1766,13 +1539,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -1788,13 +1555,7 @@ describe('SetupLandingPageModal', () => {
             mockModalGetRequests({ landingPage: null });
 
             const user = userEvent.setup();
-            const { rerender } = render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            const { rerender } = render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.clear(ftpInput);
@@ -1811,23 +1572,11 @@ describe('SetupLandingPageModal', () => {
                 expect(persistedDraft.downloadsUnavailable).toBe(true);
             });
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={false}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={false} onClose={mockOnClose} />);
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const reopenedFtpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const reopenedFtpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(reopenedFtpInput.value).toBe('https://downloads.example.org/draft-file.zip');
             expect(screen.getByRole('checkbox', { name: /no data available for download/i })).toBeChecked();
@@ -1856,13 +1605,7 @@ describe('SetupLandingPageModal', () => {
             mockedAxiosDelete.mockResolvedValue({});
 
             const user = userEvent.setup();
-            const { rerender } = render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            const { rerender } = render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             const ftpInput = await screen.findByLabelText(/^Download URL$/i);
             await user.clear(ftpInput);
@@ -1884,23 +1627,11 @@ describe('SetupLandingPageModal', () => {
 
             mockModalGetRequests({ landingPage: savedConfig });
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={false}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={false} onClose={mockOnClose} />);
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const reopenedFtpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const reopenedFtpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(reopenedFtpInput.value).toBe('https://saved.example.org/final-file.zip');
             expect(screen.queryByDisplayValue('Temporary Link')).not.toBeInTheDocument();
@@ -1910,15 +1641,9 @@ describe('SetupLandingPageModal', () => {
         it('does not persist a draft when the hydrated state matches the server config', async () => {
             mockModalGetRequests({ landingPage: mockExistingConfig });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const ftpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
 
@@ -1935,15 +1660,9 @@ describe('SetupLandingPageModal', () => {
             try {
                 mockModalGetRequests({ landingPage: mockExistingConfig });
 
-                render(
-                    <SetupLandingPageModal
-                        resource={mockResource}
-                        isOpen={true}
-                        onClose={mockOnClose}
-                    />,
-                );
+                render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-                const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+                const ftpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
                 expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
             } finally {
@@ -1960,13 +1679,7 @@ describe('SetupLandingPageModal', () => {
                 mockModalGetRequests({ landingPage: null });
 
                 const user = userEvent.setup();
-                render(
-                    <SetupLandingPageModal
-                        resource={mockResource}
-                        isOpen={true}
-                        onClose={mockOnClose}
-                    />,
-                );
+                render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
                 const ftpInput = await screen.findByLabelText(/^Download URL$/i);
                 await user.clear(ftpInput);
@@ -2002,13 +1715,7 @@ describe('SetupLandingPageModal', () => {
                 });
 
                 const user = userEvent.setup();
-                render(
-                    <SetupLandingPageModal
-                        resource={mockResource}
-                        isOpen={true}
-                        onClose={mockOnClose}
-                    />,
-                );
+                render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
                 const ftpInput = await screen.findByLabelText(/^Download URL$/i);
                 await user.clear(ftpInput);
@@ -2029,15 +1736,9 @@ describe('SetupLandingPageModal', () => {
             window.sessionStorage.setItem('setup-landing-page-modal:draft:123', '{not-valid-json');
             mockModalGetRequests({ landingPage: mockExistingConfig });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const ftpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
         });
@@ -2052,15 +1753,9 @@ describe('SetupLandingPageModal', () => {
             );
             mockModalGetRequests({ landingPage: mockExistingConfig });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const ftpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
             expect(screen.queryByDisplayValue('Invalid persisted link')).not.toBeInTheDocument();
@@ -2095,16 +1790,13 @@ describe('SetupLandingPageModal', () => {
 
             mockModalGetRequests({ landingPage: draftConfig });
             mockedAxiosDelete.mockResolvedValue({ data: { message: 'Landing page deleted successfully' } });
-            vi.stubGlobal('confirm', vi.fn(() => true));
+            vi.stubGlobal(
+                'confirm',
+                vi.fn(() => true),
+            );
 
             const user = userEvent.setup();
-            const { rerender } = render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            const { rerender } = render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await screen.findByRole('dialog');
             await user.click(screen.getByRole('button', { name: /remove preview/i }));
@@ -2119,23 +1811,11 @@ describe('SetupLandingPageModal', () => {
 
             mockModalGetRequests({ landingPage: null });
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={false}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={false} onClose={mockOnClose} />);
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const reopenedFtpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const reopenedFtpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(reopenedFtpInput.value).toBe('');
             expect(screen.queryByDisplayValue('Stale link')).not.toBeInTheDocument();
@@ -2180,18 +1860,10 @@ describe('SetupLandingPageModal', () => {
                 return Promise.reject({ isAxiosError: true, response: { status: 404 } });
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
-                expect(mockedAxiosGet).toHaveBeenCalledWith(
-                    expect.stringContaining('/landing-page/template-options'),
-                );
+                expect(mockedAxiosGet).toHaveBeenCalledWith(expect.stringContaining('/landing-page/template-options'));
             });
         });
 
@@ -2208,13 +1880,7 @@ describe('SetupLandingPageModal', () => {
                 return Promise.reject({ isAxiosError: true, response: { status: 404 } });
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             // Should still render without crashing
             await waitFor(() => {
@@ -2244,14 +1910,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    existingConfig={configWithTemplate}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} existingConfig={configWithTemplate} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2306,13 +1965,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2373,13 +2026,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2463,11 +2110,7 @@ describe('SetupLandingPageModal', () => {
             const user = userEvent.setup();
 
             render(
-                <SetupLandingPageModal
-                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
+                <SetupLandingPageModal resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }} isOpen={true} onClose={mockOnClose} />,
             );
 
             await waitFor(() => {
@@ -2542,11 +2185,7 @@ describe('SetupLandingPageModal', () => {
             const user = userEvent.setup();
 
             render(
-                <SetupLandingPageModal
-                    resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
+                <SetupLandingPageModal resource={{ ...mockResource, resourcetypegeneral: 'Physical Object' }} isOpen={true} onClose={mockOnClose} />,
             );
 
             await waitFor(() => {
@@ -2562,9 +2201,7 @@ describe('SetupLandingPageModal', () => {
             await user.click(screen.getByText('Preview Sample Layout'));
 
             const previewButtons = screen.getAllByRole('button', { name: /Preview/i });
-            const previewButton = previewButtons.find(
-                (btn) => btn.className.includes('outline') || btn.textContent?.trim() === 'Preview'
-            );
+            const previewButton = previewButtons.find((btn) => btn.className.includes('outline') || btn.textContent?.trim() === 'Preview');
 
             expect(previewButton).toBeDefined();
             await user.click(previewButton!);
@@ -2630,14 +2267,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    existingConfig={configWithCustomTemplate}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} existingConfig={configWithCustomTemplate} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2692,14 +2322,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    onSuccess={onSuccess}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} onSuccess={onSuccess} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2735,14 +2358,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    onSuccess={onSuccess}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} onSuccess={onSuccess} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2781,13 +2397,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -2818,13 +2428,7 @@ describe('SetupLandingPageModal', () => {
                 });
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(toast.error).toHaveBeenCalledWith('Failed to load landing page configuration');
@@ -2868,15 +2472,9 @@ describe('SetupLandingPageModal', () => {
                 });
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
-            const ftpInput = await screen.findByLabelText(/^Download URL$/i) as HTMLInputElement;
+            const ftpInput = (await screen.findByLabelText(/^Download URL$/i)) as HTMLInputElement;
 
             expect(ftpInput.value).toBe('https://downloads.example.org/persisted.zip');
             expect(screen.getByRole('checkbox', { name: /no data available for download/i })).toBeChecked();
@@ -2922,26 +2520,14 @@ describe('SetupLandingPageModal', () => {
                 });
             });
 
-            const { rerender } = render(
-                <SetupLandingPageModal
-                    resource={firstResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            const { rerender } = render(<SetupLandingPageModal resource={firstResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/^Download URL$/i)).toHaveValue('https://downloads.example.org/first-resource.zip');
             });
             expect(screen.getByDisplayValue('First resource link')).toBeInTheDocument();
 
-            rerender(
-                <SetupLandingPageModal
-                    resource={secondResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={secondResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/^Download URL$/i)).toHaveValue('');
@@ -2962,13 +2548,7 @@ describe('SetupLandingPageModal', () => {
                 return Promise.resolve({ data: { landing_page: mockExistingConfig } });
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -3029,13 +2609,7 @@ describe('SetupLandingPageModal', () => {
                 return Promise.resolve({ data: { landing_page: serverConfig } });
             });
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             // The select trigger should display the custom template name, not
             // the fallback "Default GFZ Data Services".
@@ -3068,13 +2642,7 @@ describe('SetupLandingPageModal', () => {
                 return Promise.resolve({ data: { landing_page: serverConfig } });
             });
 
-            const { rerender } = render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            const { rerender } = render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             // First open: custom template is shown.
             await waitFor(() => {
@@ -3083,26 +2651,14 @@ describe('SetupLandingPageModal', () => {
 
             // Close the dialog (state is reset in the component's useEffect
             // cleanup branch when isOpen transitions to false).
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={false}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={false} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
             });
 
             // Reopen the dialog — this re-triggers loadLandingPageConfig().
-            rerender(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            rerender(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             // After reopen, the custom template must still be selected.
             await waitFor(() => {
@@ -3136,13 +2692,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -3192,13 +2742,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 const trigger = screen.getByLabelText(/Landing Page Template/i);
@@ -3259,13 +2803,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByLabelText(/Landing Page Template/i)).toHaveTextContent('Default GFZ Data Services');
@@ -3312,13 +2850,7 @@ describe('SetupLandingPageModal', () => {
 
             const user = userEvent.setup();
 
-            render(
-                <SetupLandingPageModal
-                    resource={mockResource}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
 
             await waitFor(() => {
                 expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -3415,13 +2947,7 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('falls back to "Resource #<id>" when title is missing and still exposes it via the accessible tooltip', async () => {
-            render(
-                <SetupLandingPageModal
-                    resource={{ id: 777 }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={{ id: 777 }} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
             expect(titleEl).toHaveTextContent('Resource #777');
@@ -3494,13 +3020,7 @@ describe('SetupLandingPageModal', () => {
         });
 
         it('applies the same accessible tooltip and layout classes for short titles', async () => {
-            render(
-                <SetupLandingPageModal
-                    resource={{ id: 1, title: 'Short title' }}
-                    isOpen={true}
-                    onClose={mockOnClose}
-                />,
-            );
+            render(<SetupLandingPageModal resource={{ id: 1, title: 'Short title' }} isOpen={true} onClose={mockOnClose} />);
 
             const titleEl = await screen.findByTestId('setup-lp-modal-resource-title');
             // Short titles use the same accessible tooltip pattern for consistency.

--- a/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
+++ b/tests/vitest/components/landing-pages/modals/__tests__/SetupLandingPageModal.test.tsx
@@ -1565,11 +1565,14 @@ describe('SetupLandingPageModal', () => {
             await user.click(screen.getByRole('button', { name: /add link/i }));
             await user.type(screen.getByPlaceholderText(/display text/i), 'Project Website');
             await user.type(screen.getByPlaceholderText('https://...'), 'https://example.org/project');
+            await user.click(screen.getByRole('combobox', { name: 'Link role' }));
+            await user.click(await screen.findByRole('option', { name: 'Source repository' }));
 
             await waitFor(() => {
                 const persistedDraft = JSON.parse(window.sessionStorage.getItem('setup-landing-page-modal:draft:123') ?? '{}');
 
                 expect(persistedDraft.downloadsUnavailable).toBe(true);
+                expect(persistedDraft.links).toEqual([expect.objectContaining({ kind: 'repository' })]);
             });
 
             rerender(<SetupLandingPageModal resource={mockResource} isOpen={false} onClose={mockOnClose} />);
@@ -1582,6 +1585,7 @@ describe('SetupLandingPageModal', () => {
             expect(screen.getByRole('checkbox', { name: /no data available for download/i })).toBeChecked();
             expect(screen.getByDisplayValue('Project Website')).toBeInTheDocument();
             expect(screen.getByDisplayValue('https://example.org/project')).toBeInTheDocument();
+            expect(screen.getByRole('combobox', { name: 'Link role' })).toHaveTextContent('Source repository');
         });
 
         it('clears persisted unsaved values after a successful save', async () => {
@@ -1759,6 +1763,35 @@ describe('SetupLandingPageModal', () => {
 
             expect(ftpInput.value).toBe(mockExistingConfig.ftp_url);
             expect(screen.queryByDisplayValue('Invalid persisted link')).not.toBeInTheDocument();
+        });
+
+        it('defaults invalid persisted link roles to related', async () => {
+            window.sessionStorage.setItem(
+                'setup-landing-page-modal:draft:123',
+                JSON.stringify({
+                    template: 'default_gfz',
+                    ftpUrl: '',
+                    downloadsUnavailable: false,
+                    isPublished: false,
+                    externalDomainId: '',
+                    externalPath: '',
+                    landingPageTemplateId: null,
+                    links: [
+                        {
+                            label: 'Manipulated role',
+                            url: 'https://example.org/manipulated',
+                            kind: 'unsupported',
+                            position: 0,
+                        },
+                    ],
+                }),
+            );
+            mockModalGetRequests({ landingPage: null });
+
+            render(<SetupLandingPageModal resource={mockResource} isOpen={true} onClose={mockOnClose} />);
+
+            expect(await screen.findByDisplayValue('Manipulated role')).toBeInTheDocument();
+            expect(screen.getByRole('combobox', { name: 'Link role' })).toHaveTextContent('Related page');
         });
 
         it('clears a persisted draft after removing a preview and reopens with empty defaults', async () => {

--- a/tests/vitest/components/landing-pages/modals/__tests__/landing-page-modal-helpers.test.ts
+++ b/tests/vitest/components/landing-pages/modals/__tests__/landing-page-modal-helpers.test.ts
@@ -8,64 +8,90 @@ import {
 
 describe('landing-page-modal-helpers', () => {
     it('builds resource setup payloads with download URL and complete links', () => {
-        expect(buildLandingPageSetupPayload({
-            template: 'default_gfz',
-            landingPageTemplateId: 42,
-            isPublished: true,
-            supportsFtpUrl: true,
-            ftpUrl: '',
-            supportsLinks: true,
-            links: [
-                { url: 'https://example.org/a', label: 'A', position: 3 },
-                { url: '', label: 'Incomplete', position: 4 },
-                { url: 'https://example.org/b', label: 'B', position: 5 },
-            ],
-            isExternal: false,
-        })).toEqual({
+        expect(
+            buildLandingPageSetupPayload({
+                template: 'default_gfz',
+                landingPageTemplateId: 42,
+                isPublished: true,
+                supportsFtpUrl: true,
+                ftpUrl: '',
+                supportsLinks: true,
+                links: [
+                    { url: 'https://example.org/a', label: 'A', position: 3 },
+                    { url: '', label: 'Incomplete', position: 4 },
+                    { url: 'https://example.org/b', label: 'B', position: 5 },
+                ],
+                isExternal: false,
+            }),
+        ).toEqual({
             template: 'default_gfz',
             landing_page_template_id: 42,
             status: 'published',
             ftp_url: null,
             links: [
-                { url: 'https://example.org/a', label: 'A', position: 0 },
-                { url: 'https://example.org/b', label: 'B', position: 1 },
+                { url: 'https://example.org/a', label: 'A', kind: 'related', position: 0 },
+                { url: 'https://example.org/b', label: 'B', kind: 'related', position: 1 },
             ],
         });
     });
 
     it('includes downloads unavailable for generated resource setup payloads', () => {
-        expect(buildLandingPageSetupPayload({
-            template: 'default_gfz',
-            landingPageTemplateId: null,
-            isPublished: false,
-            supportsFtpUrl: true,
-            ftpUrl: 'https://datapub.example.org/download',
-            supportsDownloadsUnavailable: true,
-            downloadsUnavailable: true,
-            supportsLinks: true,
-            links: [{ url: 'https://example.org/repository', label: 'Repository', position: 0 }],
-            isExternal: false,
-        })).toEqual({
+        expect(
+            buildLandingPageSetupPayload({
+                template: 'default_gfz',
+                landingPageTemplateId: null,
+                isPublished: false,
+                supportsFtpUrl: true,
+                ftpUrl: 'https://datapub.example.org/download',
+                supportsDownloadsUnavailable: true,
+                downloadsUnavailable: true,
+                supportsLinks: true,
+                links: [{ url: 'https://example.org/repository', label: 'Repository', position: 0 }],
+                isExternal: false,
+            }),
+        ).toEqual({
             template: 'default_gfz',
             landing_page_template_id: null,
             status: 'draft',
             ftp_url: 'https://datapub.example.org/download',
             downloads_unavailable: true,
-            links: [{ url: 'https://example.org/repository', label: 'Repository', position: 0 }],
+            links: [{ url: 'https://example.org/repository', label: 'Repository', kind: 'related', position: 0 }],
         });
     });
 
+    it('preserves explicit download and repository roles in setup payloads', () => {
+        expect(
+            buildLandingPageSetupPayload({
+                template: 'default_gfz',
+                landingPageTemplateId: null,
+                isPublished: false,
+                supportsFtpUrl: true,
+                supportsLinks: true,
+                links: [
+                    { url: 'https://example.org/data.zip', label: 'Data', kind: 'download', position: 0 },
+                    { url: 'https://git.example.org/source', label: 'Source', kind: 'repository', position: 1 },
+                ],
+                isExternal: false,
+            }).links,
+        ).toEqual([
+            { url: 'https://example.org/data.zip', label: 'Data', kind: 'download', position: 0 },
+            { url: 'https://git.example.org/source', label: 'Source', kind: 'repository', position: 1 },
+        ]);
+    });
+
     it('builds IGSN setup payloads without resource-only fields', () => {
-        expect(buildLandingPageSetupPayload({
-            template: 'default_gfz_igsn',
-            landingPageTemplateId: 7,
-            isPublished: false,
-            supportsFtpUrl: false,
-            ftpUrl: 'https://ignored.example.org',
-            supportsLinks: false,
-            links: [{ url: 'https://ignored.example.org', label: 'Ignored', position: 0 }],
-            isExternal: false,
-        })).toEqual({
+        expect(
+            buildLandingPageSetupPayload({
+                template: 'default_gfz_igsn',
+                landingPageTemplateId: 7,
+                isPublished: false,
+                supportsFtpUrl: false,
+                ftpUrl: 'https://ignored.example.org',
+                supportsLinks: false,
+                links: [{ url: 'https://ignored.example.org', label: 'Ignored', position: 0 }],
+                isExternal: false,
+            }),
+        ).toEqual({
             template: 'default_gfz_igsn',
             landing_page_template_id: 7,
             status: 'draft',
@@ -73,16 +99,18 @@ describe('landing-page-modal-helpers', () => {
     });
 
     it('normalizes external setup payloads', () => {
-        expect(buildLandingPageSetupPayload({
-            template: 'external',
-            landingPageTemplateId: 99,
-            isPublished: true,
-            supportsFtpUrl: false,
-            supportsLinks: false,
-            isExternal: true,
-            externalDomainId: '12',
-            externalPath: ' /dataset/123 ',
-        })).toEqual({
+        expect(
+            buildLandingPageSetupPayload({
+                template: 'external',
+                landingPageTemplateId: 99,
+                isPublished: true,
+                supportsFtpUrl: false,
+                supportsLinks: false,
+                isExternal: true,
+                externalDomainId: '12',
+                externalPath: ' /dataset/123 ',
+            }),
+        ).toEqual({
             template: 'external',
             landing_page_template_id: null,
             status: 'published',
@@ -92,15 +120,17 @@ describe('landing-page-modal-helpers', () => {
     });
 
     it('builds preview payloads without status or empty links', () => {
-        expect(buildLandingPagePreviewPayload({
-            template: 'default_gfz',
-            landingPageTemplateId: null,
-            supportsFtpUrl: true,
-            ftpUrl: 'https://datapub.example.org/download',
-            supportsLinks: true,
-            links: [{ url: '', label: '', position: 0 }],
-            isExternal: false,
-        })).toEqual({
+        expect(
+            buildLandingPagePreviewPayload({
+                template: 'default_gfz',
+                landingPageTemplateId: null,
+                supportsFtpUrl: true,
+                ftpUrl: 'https://datapub.example.org/download',
+                supportsLinks: true,
+                links: [{ url: '', label: '', position: 0 }],
+                isExternal: false,
+            }),
+        ).toEqual({
             template: 'default_gfz',
             landing_page_template_id: null,
             ftp_url: 'https://datapub.example.org/download',
@@ -108,17 +138,19 @@ describe('landing-page-modal-helpers', () => {
     });
 
     it('includes downloads unavailable in generated resource preview payloads', () => {
-        expect(buildLandingPagePreviewPayload({
-            template: 'default_gfz',
-            landingPageTemplateId: null,
-            supportsFtpUrl: true,
-            ftpUrl: 'https://datapub.example.org/download',
-            supportsDownloadsUnavailable: true,
-            downloadsUnavailable: true,
-            supportsLinks: true,
-            links: [],
-            isExternal: false,
-        })).toEqual({
+        expect(
+            buildLandingPagePreviewPayload({
+                template: 'default_gfz',
+                landingPageTemplateId: null,
+                supportsFtpUrl: true,
+                ftpUrl: 'https://datapub.example.org/download',
+                supportsDownloadsUnavailable: true,
+                downloadsUnavailable: true,
+                supportsLinks: true,
+                links: [],
+                isExternal: false,
+            }),
+        ).toEqual({
             template: 'default_gfz',
             landing_page_template_id: null,
             ftp_url: 'https://datapub.example.org/download',
@@ -127,11 +159,13 @@ describe('landing-page-modal-helpers', () => {
     });
 
     it('resolves previewable external URLs from selected domain and path', () => {
-        expect(getPreviewableExternalUrl({
-            availableDomains: [{ id: 1, domain: 'https://example.org/' }],
-            externalDomainId: '1',
-            externalPath: '/landing/page',
-            isExternal: true,
-        })).toBe('https://example.org/landing/page');
+        expect(
+            getPreviewableExternalUrl({
+                availableDomains: [{ id: 1, domain: 'https://example.org/' }],
+                externalDomainId: '1',
+                externalPath: '/landing/page',
+                isExternal: true,
+            }),
+        ).toBe('https://example.org/landing/page');
     });
 });

--- a/tests/vitest/pages/LandingPages/__tests__/default_gfz.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/default_gfz.test.tsx
@@ -437,8 +437,8 @@ describe('DefaultGfzTemplate', () => {
         });
     });
 
-    describe('Schema.org JSON-LD', () => {
-        it('renders JSON-LD script tag when schemaOrgJsonLd is provided', () => {
+    describe('server-owned machine metadata', () => {
+        it('does not duplicate JSON-LD client-side when a legacy prop is provided', () => {
             const schemaOrgJsonLd = { '@context': 'https://schema.org', '@type': 'Dataset', name: 'Test' };
 
             mockUsePage.mockReturnValue({
@@ -452,12 +452,10 @@ describe('DefaultGfzTemplate', () => {
 
             render(<DefaultGfzTemplate />);
 
-            // The Head component renders children directly in our mock
-            const scriptContent = JSON.stringify(schemaOrgJsonLd);
-            expect(document.body.textContent).toContain(scriptContent);
+            expect(document.querySelector('script[type="application/ld+json"]')).not.toBeInTheDocument();
         });
 
-        it('renders canonical metadata discovery links including ISO describedby', () => {
+        it('does not duplicate canonical metadata discovery links in the React head', () => {
             mockUsePage.mockReturnValue({
                 props: {
                     resource: mockResource,
@@ -486,8 +484,9 @@ describe('DefaultGfzTemplate', () => {
 
             render(<DefaultGfzTemplate />);
 
-            expect(document.querySelector('link[rel="alternate"]')).toHaveAttribute('href', 'https://example.com/metadata/datacite.xml');
-            expect(document.querySelector('link[rel="describedby"]')).toHaveAttribute('href', 'https://example.com/metadata/iso-19115-3.xml');
+            expect(document.querySelector('link[rel="alternate"]')).not.toBeInTheDocument();
+            expect(document.querySelector('link[rel="describedby"]')).not.toBeInTheDocument();
+            expect(screen.getByText('Download Metadata')).toBeInTheDocument();
         });
 
         it('does not render JSON-LD script tag when schemaOrgJsonLd is not provided', () => {

--- a/tests/vitest/pages/LandingPages/__tests__/default_gfz_igsn.test.tsx
+++ b/tests/vitest/pages/LandingPages/__tests__/default_gfz_igsn.test.tsx
@@ -548,7 +548,7 @@ describe('DefaultGfzIgsnTemplate', () => {
             expect(acquisition.compareDocumentPosition(general) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
         });
 
-        it('embeds schema.org JSON-LD when provided', () => {
+        it('does not duplicate server-rendered schema.org JSON-LD when a legacy prop is provided', () => {
             mockUsePage.mockReturnValue({
                 props: {
                     resource: mockResource,
@@ -561,7 +561,7 @@ describe('DefaultGfzIgsnTemplate', () => {
             render(<DefaultGfzIgsnTemplate />);
 
             const script = document.querySelector('script[type="application/ld+json"]');
-            expect(script?.textContent).toContain('"@type":"Dataset"');
+            expect(script).not.toBeInTheDocument();
         });
 
         it('falls back to "published" status when landingPage has no status and not in preview', () => {


### PR DESCRIPTION
This pull request introduces several significant improvements and refactorings related to landing page rendering, metadata export, and cache management. The main changes include a refactor of how machine-readable metadata is generated and delivered for landing pages, stricter validation for landing page links, and the introduction of cache invalidation observers for related models. It also updates DataCite metadata exports to use more specific media types.

**Landing Page Rendering and Metadata Handling:**

* Refactored landing page rendering to use a new `LandingPageMachineMetadataService` for generating machine-readable metadata, replacing the previous inline Schema.org JSON-LD export and cache logic. The metadata is now injected into the view and signposting links are provided via HTTP headers. (`app/Http/Controllers/LandingPagePublicController.php`) [[1]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cL340-R343) [[2]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cL317-R318) [[3]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cL363-L365) [[4]](diffhunk://#diff-118a0daf8b5aea008c991c8c9c8fbee7ac090b1ebca4f4aefb3240f810724f3cR371-R394)
* Removed the `SCHEMA_ORG_JSONLD` cache key and all related cache tagging and TTL logic, as this is now handled by the new service. (`app/Enums/CacheKey.php`) [[1]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfL76-R77) [[2]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfL170-L172) [[3]](diffhunk://#diff-a2af560e2bbe9218845c3874fafc441c2a2f05619040c79e5459af8ef5d4fcdfL241-L242)

**Landing Page Links Validation and Model:**

* Added a new `kind` field to `LandingPageLink`, with allowed values (`related`, `download`, `repository`), and updated validation rules in all relevant request classes to enforce this. (`app/Models/LandingPageLink.php`, `app/Http/Requests/LandingPage/StoreLandingPageRequest.php`, `app/Http/Requests/LandingPage/UpdateLandingPageRequest.php`, `app/Http/Requests/LandingPage/StoreLandingPagePreviewRequest.php`) [[1]](diffhunk://#diff-755128fad4a003c975a8cf4a3ac1a076739ecb1e300c17176b43afcbab4949bfR22-R43) [[2]](diffhunk://#diff-755128fad4a003c975a8cf4a3ac1a076739ecb1e300c17176b43afcbab4949bfR10) [[3]](diffhunk://#diff-47427e3a32e02ff427464f6cd49d8655b47681f669dd559a506838146f71105bR51) [[4]](diffhunk://#diff-67c35778b8a5cf0bf203763fb5caee4705f968b03f7831d0152cbb4ffd791307R41) [[5]](diffhunk://#diff-40a414bdbd6186fcef3412e08caf184b38f1895938d7f8fd9130ccdab85a2292R45)

**Cache Invalidation Observers:**

* Introduced new observers for `Format`, `LandingPageFile`, and `LandingPageLink` models to automatically invalidate landing page render data cache when these related models are updated or deleted. (`app/Observers/FormatObserver.php`, `app/Observers/LandingPageFileObserver.php`, `app/Observers/LandingPageLinkObserver.php`) [[1]](diffhunk://#diff-99b99c1bae5aab4df5408e03efe76283d7dbc892cc0a4b6dc4a62d8edc9efd96R1-R35) [[2]](diffhunk://#diff-5af769f1de7242a8503061e18962d566b1e0a39c87bbd611b31b9028b6e80486R1-R23) [[3]](diffhunk://#diff-2c83ca3f2aa701bf0cc51635bd46e38dab2f89c1c840919fc46398d92c9c9991R1-R23)

**DataCite Metadata Export Improvements:**

* Updated DataCite XML and JSON exports to use the official media types (`application/vnd.datacite.datacite+xml` and `application/vnd.datacite.datacite+json`) for better standards compliance. (`app/Http/Controllers/PublicMetadataExportController.php`) [[1]](diffhunk://#diff-50699026a518c2d6ee2944a37327fed5855142ca0773ba7c7a62f32fc5001561L29-R33) [[2]](diffhunk://#diff-50699026a518c2d6ee2944a37327fed5855142ca0773ba7c7a62f32fc5001561L38-R42) [[3]](diffhunk://#diff-50699026a518c2d6ee2944a37327fed5855142ca0773ba7c7a62f32fc5001561L104-R111)

These changes improve the maintainability and standards compliance of landing page rendering, metadata export, and cache management.