### PR TITLE
Feature Move Clear Filters above Portal Scroll Area

### DIFF
--- a/resources/js/components/portal/PortalFilters.tsx
+++ b/resources/js/components/portal/PortalFilters.tsx
@@ -110,7 +110,9 @@ export function PortalFilters({
                     <Filter className="h-5 w-5 text-muted-foreground" />
                     <Search className="h-5 w-5 text-muted-foreground" />
                 </div>
-                {hasActiveFilters && <div className="mt-4 h-2 w-2 rounded-full bg-primary" title="Filters active" />}
+                {hasActiveFilters && (
+                    <div role="status" aria-label="Filters active" className="mt-4 h-2 w-2 rounded-full bg-primary" title="Filters active" />
+                )}
             </div>
         );
     }

--- a/resources/js/components/portal/PortalFilters.tsx
+++ b/resources/js/components/portal/PortalFilters.tsx
@@ -103,22 +103,14 @@ export function PortalFilters({
     if (isCollapsed) {
         return (
             <div className="flex h-full flex-col items-center border-r bg-muted/30 py-4">
-                <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={onToggleCollapse}
-                    className="mb-4"
-                    aria-label="Expand filters"
-                >
+                <Button variant="ghost" size="icon" onClick={onToggleCollapse} className="mb-4" aria-label="Expand filters">
                     <ChevronRight className="h-4 w-4" />
                 </Button>
                 <div className="flex flex-col items-center gap-4">
                     <Filter className="h-5 w-5 text-muted-foreground" />
                     <Search className="h-5 w-5 text-muted-foreground" />
                 </div>
-                {hasActiveFilters && (
-                    <div className="mt-4 h-2 w-2 rounded-full bg-primary" title="Filters active" />
-                )}
+                {hasActiveFilters && <div className="mt-4 h-2 w-2 rounded-full bg-primary" title="Filters active" />}
             </div>
         );
     }
@@ -131,15 +123,20 @@ export function PortalFilters({
                     <Filter className="h-4 w-4" />
                     <span className="font-semibold">Filters</span>
                 </div>
-                <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={onToggleCollapse}
-                    aria-label="Collapse filters"
-                >
+                <Button variant="ghost" size="icon" onClick={onToggleCollapse} aria-label="Collapse filters">
                     <ChevronLeft className="h-4 w-4" />
                 </Button>
             </div>
+
+            {/* Clear Filters */}
+            {hasActiveFilters && (
+                <div className="shrink-0 border-b px-4 py-3">
+                    <Button variant="outline" size="sm" onClick={onClearFilters} className="w-full">
+                        <X className="mr-2 h-4 w-4" />
+                        Clear All Filters
+                    </Button>
+                </div>
+            )}
 
             <ScrollArea className="flex-1">
                 <div className="space-y-6 p-4">
@@ -150,14 +147,14 @@ export function PortalFilters({
                         </Label>
                         <form onSubmit={handleSearchSubmit} className="flex gap-2">
                             <div className="relative flex-1">
-                                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                                 <Input
                                     id="portal-search"
                                     type="text"
                                     placeholder="Search datasets..."
                                     value={searchInput}
                                     onChange={(e) => setSearchInput(e.target.value)}
-                                    className="pl-9 pr-8"
+                                    className="pr-8 pl-9"
                                 />
                                 {searchInput && (
                                     <Button
@@ -165,7 +162,7 @@ export function PortalFilters({
                                         variant="ghost"
                                         size="icon"
                                         onClick={handleClearSearch}
-                                        className="absolute right-2 top-1/2 h-6 w-6 -translate-y-1/2"
+                                        className="absolute top-1/2 right-2 h-6 w-6 -translate-y-1/2"
                                         aria-label="Clear search"
                                     >
                                         <X className="h-3 w-3" />
@@ -176,9 +173,7 @@ export function PortalFilters({
                                 Search
                             </Button>
                         </form>
-                        <p className="text-xs text-muted-foreground">
-                            Search in titles, authors, DOIs, descriptions, and keywords
-                        </p>
+                        <p className="text-xs text-muted-foreground">Search in titles, authors, DOIs, descriptions, and keywords</p>
                     </div>
 
                     {/* Keyword Filter */}
@@ -231,19 +226,6 @@ export function PortalFilters({
                             onSelectionChange={onDatacenterChange}
                         />
                     </div>
-
-                    {/* Clear Filters */}
-                    {hasActiveFilters && (
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={onClearFilters}
-                            className="w-full"
-                        >
-                            <X className="mr-2 h-4 w-4" />
-                            Clear All Filters
-                        </Button>
-                    )}
                 </div>
             </ScrollArea>
 

--- a/tests/vitest/components/portal/portal-filters.test.tsx
+++ b/tests/vitest/components/portal/portal-filters.test.tsx
@@ -301,12 +301,15 @@ describe('PortalFilters', () => {
 
             // Toggle button should be visible
             expect(screen.getByRole('button', { name: /expand filters/i })).toBeInTheDocument();
+            expect(screen.queryByRole('status')).not.toBeInTheDocument();
         });
 
-        it('shows only the active indicator when filters are active', () => {
+        it('exposes active filters as a named status without showing the clear action', () => {
             render(<PortalFilters {...defaultProps} isCollapsed={true} hasActiveFilters={true} />);
 
-            expect(screen.getByTitle('Filters active')).toBeInTheDocument();
+            const activeFiltersStatus = screen.getByRole('status', { name: 'Filters active' });
+
+            expect(activeFiltersStatus).toHaveAttribute('title', 'Filters active');
             expect(screen.queryByRole('button', { name: /clear all/i })).not.toBeInTheDocument();
         });
 

--- a/tests/vitest/components/portal/portal-filters.test.tsx
+++ b/tests/vitest/components/portal/portal-filters.test.tsx
@@ -146,11 +146,7 @@ describe('PortalFilters', () => {
             const onThesaurusKeywordsChange = vi.fn();
 
             render(
-                <PortalFilters
-                    {...defaultProps}
-                    thesaurusFacets={defaultThesaurusFacets}
-                    onThesaurusKeywordsChange={onThesaurusKeywordsChange}
-                />,
+                <PortalFilters {...defaultProps} thesaurusFacets={defaultThesaurusFacets} onThesaurusKeywordsChange={onThesaurusKeywordsChange} />,
             );
 
             await user.click(screen.getByLabelText('Select thesaurus keyword EARTH SCIENCE'));
@@ -204,14 +200,7 @@ describe('PortalFilters', () => {
             const user = userEvent.setup();
             const onSearchChange = vi.fn();
             const filters: PortalFiltersType = { ...defaultFilters, query: 'existing query' };
-            render(
-                <PortalFilters
-                    {...defaultProps}
-                    filters={filters}
-                    onSearchChange={onSearchChange}
-                    hasActiveFilters={true}
-                />,
-            );
+            render(<PortalFilters {...defaultProps} filters={filters} onSearchChange={onSearchChange} hasActiveFilters={true} />);
 
             // Find the clear X button next to search input (the one in the input container)
             const clearButton = screen.getByRole('button', { name: /clear search/i });
@@ -250,6 +239,41 @@ describe('PortalFilters', () => {
             expect(screen.getByRole('button', { name: /clear all/i })).toBeInTheDocument();
         });
 
+        it('keeps the clear filters action above and outside the scrollable controls', () => {
+            render(<PortalFilters {...defaultProps} hasActiveFilters={true} />);
+
+            const clearButton = screen.getByRole('button', { name: /clear all/i });
+            const searchInput = screen.getByPlaceholderText(/search datasets/i);
+            const actionRow = clearButton.parentElement;
+
+            expect(actionRow).toHaveClass('shrink-0', 'border-b');
+            expect(clearButton.closest('[data-slot="scroll-area"]')).toBeNull();
+            expect(searchInput.closest('[data-slot="scroll-area"]')).toBeInTheDocument();
+            expect(clearButton.compareDocumentPosition(searchInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        });
+
+        it('preserves the existing filter order below the clear action', () => {
+            render(<PortalFilters {...defaultProps} hasActiveFilters={true} />);
+
+            const orderedControls = [
+                screen.getByPlaceholderText(/search datasets/i),
+                screen.getByText('Free Keywords'),
+                screen.getByText('Thesaurus Keywords'),
+                screen.getByText('Temporal Filter'),
+                screen.getByText('Geographic Filter'),
+                screen.getByText('Resource Type'),
+                screen.getByText('Datacenter'),
+            ];
+
+            for (const [index, control] of orderedControls.entries()) {
+                const nextControl = orderedControls[index + 1];
+
+                if (nextControl) {
+                    expect(control.compareDocumentPosition(nextControl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+                }
+            }
+        });
+
         it('does not show clear filters button when hasActiveFilters is false', () => {
             render(<PortalFilters {...defaultProps} hasActiveFilters={false} />);
 
@@ -277,6 +301,13 @@ describe('PortalFilters', () => {
 
             // Toggle button should be visible
             expect(screen.getByRole('button', { name: /expand filters/i })).toBeInTheDocument();
+        });
+
+        it('shows only the active indicator when filters are active', () => {
+            render(<PortalFilters {...defaultProps} isCollapsed={true} hasActiveFilters={true} />);
+
+            expect(screen.getByTitle('Filters active')).toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: /clear all/i })).not.toBeInTheDocument();
         });
 
         it('calls onToggleCollapse when collapsed sidebar button is clicked', async () => {


### PR DESCRIPTION
This pull request refactors the `PortalFilters` component UI to improve clarity and accessibility, especially for the "Clear All Filters" action. It also updates related tests to verify the new layout and behavior. The most important changes are grouped below.

**UI/UX Improvements:**

* Moved the "Clear All Filters" button above the scrollable filter controls and outside the scroll area, making it always visible and easier to access when filters are active. The button is now rendered in a dedicated, non-scrolling action row with improved styling. [[1]](diffhunk://#diff-2ce66bb24514cd3473fb17c7dd875536ef43ceae23b568b1b5fa937c99bf18b1L134-R140) [[2]](diffhunk://#diff-2ce66bb24514cd3473fb17c7dd875536ef43ceae23b568b1b5fa937c99bf18b1L234-L246)
* Ensured the filter controls order is preserved below the new clear action location.
* Minor code and style cleanups for consistency, including single-line JSX for buttons, improved class ordering, and concise text rendering. [[1]](diffhunk://#diff-2ce66bb24514cd3473fb17c7dd875536ef43ceae23b568b1b5fa937c99bf18b1L106-R113) [[2]](diffhunk://#diff-2ce66bb24514cd3473fb17c7dd875536ef43ceae23b568b1b5fa937c99bf18b1L153-R165) [[3]](diffhunk://#diff-2ce66bb24514cd3473fb17c7dd875536ef43ceae23b568b1b5fa937c99bf18b1L179-R176)

**Accessibility and Behavior:**

* The active filters indicator (blue dot) is shown only in collapsed mode, and the clear filters button is hidden when collapsed, clarifying the UI state. [[1]](diffhunk://#diff-2ce66bb24514cd3473fb17c7dd875536ef43ceae23b568b1b5fa937c99bf18b1L106-R113) [[2]](diffhunk://#diff-89a579e53e685a7d47ef47374a1bd42421190365da73475bacf5ff820241c9e6R306-R312)

**Testing Updates:**

* Added and updated tests to verify the new layout, including checks that the clear filters action is outside the scroll area, always visible when filters are active, and that the filter controls remain in the correct order. [[1]](diffhunk://#diff-89a579e53e685a7d47ef47374a1bd42421190365da73475bacf5ff820241c9e6R242-R276) [[2]](diffhunk://#diff-89a579e53e685a7d47ef47374a1bd42421190365da73475bacf5ff820241c9e6R306-R312)
* Refactored test code for conciseness and clarity. [[1]](diffhunk://#diff-89a579e53e685a7d47ef47374a1bd42421190365da73475bacf5ff820241c9e6L149-R149) [[2]](diffhunk://#diff-89a579e53e685a7d47ef47374a1bd42421190365da73475bacf5ff820241c9e6L207-R203)