### PR TITLE
Fix: Preserve Line Breaks in DataCite Description Exports

### DIFF
--- a/app/Services/DataCite/Mapping/DataCiteDescriptionMappingService.php
+++ b/app/Services/DataCite/Mapping/DataCiteDescriptionMappingService.php
@@ -26,6 +26,24 @@ final class DataCiteDescriptionMappingService
      */
     public function toJsonValue(string $description): string
     {
-        return implode('<br>', $this->segments($description));
+        $segments = array_map(
+            fn (string $segment): string => $this->escapeTagLikeLessThan($segment),
+            $this->segments($description),
+        );
+
+        return implode('<br>', $segments);
+    }
+
+    /**
+     * Restore canonical line breaks for non-DataCite derivative formats.
+     */
+    public function fromJsonValue(string $description): string
+    {
+        return str_replace('<br>', chr(10), $description);
+    }
+
+    private function escapeTagLikeLessThan(string $description): string
+    {
+        return preg_replace('/<(?=\/?[A-Za-z]|[!?])/', '&lt;', $description) ?? $description;
     }
 }

--- a/app/Services/DataCite/Mapping/DataCiteDescriptionMappingService.php
+++ b/app/Services/DataCite/Mapping/DataCiteDescriptionMappingService.php
@@ -34,14 +34,6 @@ final class DataCiteDescriptionMappingService
         return implode('<br>', $segments);
     }
 
-    /**
-     * Restore canonical line breaks for non-DataCite derivative formats.
-     */
-    public function fromJsonValue(string $description): string
-    {
-        return str_replace('<br>', chr(10), $description);
-    }
-
     private function escapeTagLikeLessThan(string $description): string
     {
         return preg_replace('/<(?=\/?[A-Za-z]|[!?])/', '&lt;', $description) ?? $description;

--- a/app/Services/DataCite/Mapping/DataCiteDescriptionMappingService.php
+++ b/app/Services/DataCite/Mapping/DataCiteDescriptionMappingService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\DataCite\Mapping;
+
+final class DataCiteDescriptionMappingService
+{
+    /**
+     * Split a canonical plain-text description into DataCite text segments.
+     *
+     * Empty segments are intentionally retained so consecutive, leading, and
+     * trailing line breaks can be serialized without data loss.
+     *
+     * @return list<string>
+     */
+    public function segments(string $description): array
+    {
+        $normalized = str_replace(["\r\n", "\r"], "\n", $description);
+
+        return explode("\n", $normalized);
+    }
+
+    /**
+     * Serialize canonical line breaks for the DataCite JSON/API representation.
+     */
+    public function toJsonValue(string $description): string
+    {
+        return implode('<br>', $this->segments($description));
+    }
+}

--- a/app/Services/DataCiteJsonExporter.php
+++ b/app/Services/DataCiteJsonExporter.php
@@ -42,9 +42,10 @@ class DataCiteJsonExporter
      * Export a Resource to DataCite JSON format
      *
      * @param  Resource  $resource  The resource to export
+     * @param  bool  $serializeDescriptionsForDataCite  Whether descriptions should use DataCite-safe markup
      * @return array<string, mixed> The DataCite JSON structure
      */
-    public function export(Resource $resource): array
+    public function export(Resource $resource, bool $serializeDescriptionsForDataCite = true): array
     {
         // Load only missing relationships to honor caller's eager-loading
         $resource->loadMissing($this->getRequiredRelations());
@@ -52,7 +53,7 @@ class DataCiteJsonExporter
         return [
             'data' => [
                 'type' => 'dois',
-                'attributes' => $this->buildAttributes($resource),
+                'attributes' => $this->buildAttributes($resource, $serializeDescriptionsForDataCite),
             ],
         ];
     }
@@ -62,7 +63,7 @@ class DataCiteJsonExporter
      *
      * @return array<string, mixed>
      */
-    private function buildAttributes(Resource $resource): array
+    private function buildAttributes(Resource $resource, bool $serializeDescriptionsForDataCite): array
     {
         $attributes = [
             'titles' => $this->buildTitles($resource),
@@ -86,7 +87,7 @@ class DataCiteJsonExporter
             $attributes['subjects'] = $subjects;
         }
 
-        if ($descriptions = $this->buildDescriptions($resource)) {
+        if ($descriptions = $this->buildDescriptions($resource, $serializeDescriptionsForDataCite)) {
             $attributes['descriptions'] = $descriptions;
         }
 
@@ -664,13 +665,15 @@ class DataCiteJsonExporter
      *
      * @return array<int, array<string, mixed>>|null
      */
-    private function buildDescriptions(Resource $resource): ?array
+    private function buildDescriptions(Resource $resource, bool $serializeForDataCite): ?array
     {
         $descriptions = [];
 
         foreach ($resource->descriptions as $description) {
             $descriptionData = [
-                'description' => $this->dataCiteDescriptionMapper()->toJsonValue($description->value),
+                'description' => $serializeForDataCite
+                    ? $this->dataCiteDescriptionMapper()->toJsonValue($description->value)
+                    : $description->value,
                 'descriptionType' => $description->descriptionType->slug ?? 'Other',
             ];
 

--- a/app/Services/DataCiteJsonExporter.php
+++ b/app/Services/DataCiteJsonExporter.php
@@ -670,7 +670,7 @@ class DataCiteJsonExporter
 
         foreach ($resource->descriptions as $description) {
             $descriptionData = [
-                'description' => $description->value,
+                'description' => $this->dataCiteDescriptionMapper()->toJsonValue($description->value),
                 'descriptionType' => $description->descriptionType->slug ?? 'Other',
             ];
 

--- a/app/Services/DataCiteLinkedDataExporter.php
+++ b/app/Services/DataCiteLinkedDataExporter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Resource;
+use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
 
 /**
  * Transforms DataCite JSON export into DataCite Linked Data JSON-LD format.
@@ -16,6 +17,10 @@ use App\Models\Resource;
  */
 class DataCiteLinkedDataExporter
 {
+    public function __construct(
+        private readonly DataCiteDescriptionMappingService $descriptionMapper = new DataCiteDescriptionMappingService,
+    ) {}
+
     /**
      * Export a Resource as DataCite Linked Data JSON-LD.
      *
@@ -568,7 +573,9 @@ class DataCiteLinkedDataExporter
                 'lang' => $desc['lang'] ?? null,
             ]);
 
-            $result = ['value' => $desc['description']];
+            $result = [
+                'value' => $this->descriptionMapper->fromJsonValue((string) $desc['description']),
+            ];
             if (! empty($attrs)) {
                 $result['attrs'] = $attrs;
             }

--- a/app/Services/DataCiteLinkedDataExporter.php
+++ b/app/Services/DataCiteLinkedDataExporter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Resource;
-use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
 
 /**
  * Transforms DataCite JSON export into DataCite Linked Data JSON-LD format.
@@ -17,10 +16,6 @@ use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
  */
 class DataCiteLinkedDataExporter
 {
-    public function __construct(
-        private readonly DataCiteDescriptionMappingService $descriptionMapper = new DataCiteDescriptionMappingService,
-    ) {}
-
     /**
      * Export a Resource as DataCite Linked Data JSON-LD.
      *
@@ -29,7 +24,7 @@ class DataCiteLinkedDataExporter
     public function export(Resource $resource): array
     {
         $jsonExporter = new DataCiteJsonExporter;
-        $dataCiteJson = $jsonExporter->export($resource);
+        $dataCiteJson = $jsonExporter->export($resource, serializeDescriptionsForDataCite: false);
         $attributes = $dataCiteJson['data']['attributes'];
 
         $jsonLd = [
@@ -573,9 +568,7 @@ class DataCiteLinkedDataExporter
                 'lang' => $desc['lang'] ?? null,
             ]);
 
-            $result = [
-                'value' => $this->descriptionMapper->fromJsonValue((string) $desc['description']),
-            ];
+            $result = ['value' => $desc['description']];
             if (! empty($attrs)) {
                 $result['attrs'] = $attrs;
             }

--- a/app/Services/DataCiteXmlExporter.php
+++ b/app/Services/DataCiteXmlExporter.php
@@ -1222,7 +1222,7 @@ class DataCiteXmlExporter
         $descriptions = $this->dom->createElement('descriptions');
 
         foreach ($resource->descriptions as $description) {
-            $descriptionElement = $this->dom->createElement('description', htmlspecialchars($description->value));
+            $descriptionElement = $this->dom->createElement('description');
             $descriptionElement->setAttribute('descriptionType', $description->descriptionType->slug ?? 'Abstract');
 
             if ($resource->language) {
@@ -1238,6 +1238,16 @@ class DataCiteXmlExporter
                     'xml:lang',
                     'en'
                 );
+            }
+
+            foreach ($this->dataCiteDescriptionMapper()->segments($description->value) as $index => $segment) {
+                if ($index > 0) {
+                    $descriptionElement->appendChild($this->dom->createElement('br'));
+                }
+
+                if ($segment !== '') {
+                    $descriptionElement->appendChild($this->dom->createTextNode($segment));
+                }
             }
 
             $descriptions->appendChild($descriptionElement);

--- a/app/Services/SchemaOrgJsonLdExporter.php
+++ b/app/Services/SchemaOrgJsonLdExporter.php
@@ -6,7 +6,6 @@ namespace App\Services;
 
 use App\Models\LandingPage;
 use App\Models\Resource;
-use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
 use App\Support\OrcidNormalizer;
 
 /**
@@ -20,10 +19,6 @@ use App\Support\OrcidNormalizer;
  */
 class SchemaOrgJsonLdExporter
 {
-    public function __construct(
-        private readonly DataCiteDescriptionMappingService $descriptionMapper = new DataCiteDescriptionMappingService,
-    ) {}
-
     /**
      * Controlled vocabulary subject schemes that should be emitted as Schema.org DefinedTerm.
      *
@@ -50,7 +45,7 @@ class SchemaOrgJsonLdExporter
     public function export(Resource $resource, ?LandingPage $landingPage = null, ?array $content = null): array
     {
         $jsonExporter = new DataCiteJsonExporter;
-        $dataCiteJson = $jsonExporter->export($resource);
+        $dataCiteJson = $jsonExporter->export($resource, serializeDescriptionsForDataCite: false);
         $attributes = $dataCiteJson['data']['attributes'];
 
         $isSoftware = $resource->resourceType?->slug === 'software';
@@ -266,7 +261,7 @@ class SchemaOrgJsonLdExporter
     {
         foreach ($descriptions as $desc) {
             if (($desc['descriptionType'] ?? '') === 'Abstract') {
-                return $this->descriptionMapper->fromJsonValue((string) $desc['description']);
+                return (string) $desc['description'];
             }
         }
 

--- a/app/Services/SchemaOrgJsonLdExporter.php
+++ b/app/Services/SchemaOrgJsonLdExporter.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\Models\LandingPage;
 use App\Models\Resource;
+use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
 use App\Support\OrcidNormalizer;
 
 /**
@@ -19,6 +20,10 @@ use App\Support\OrcidNormalizer;
  */
 class SchemaOrgJsonLdExporter
 {
+    public function __construct(
+        private readonly DataCiteDescriptionMappingService $descriptionMapper = new DataCiteDescriptionMappingService,
+    ) {}
+
     /**
      * Controlled vocabulary subject schemes that should be emitted as Schema.org DefinedTerm.
      *
@@ -261,7 +266,7 @@ class SchemaOrgJsonLdExporter
     {
         foreach ($descriptions as $desc) {
             if (($desc['descriptionType'] ?? '') === 'Abstract') {
-                return $desc['description'];
+                return $this->descriptionMapper->fromJsonValue((string) $desc['description']);
             }
         }
 

--- a/app/Services/Traits/DataCiteExporterHelpers.php
+++ b/app/Services/Traits/DataCiteExporterHelpers.php
@@ -12,6 +12,7 @@ use App\Models\Person;
 use App\Models\ResourceContributor;
 use App\Models\ResourceCreator;
 use App\Models\ResourceDate;
+use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
 use App\Services\DataCite\Mapping\DataCiteFundingReferenceMappingService;
 use App\Services\DataCite\Mapping\DataCitePartyMappingService;
 
@@ -23,6 +24,11 @@ use App\Services\DataCite\Mapping\DataCitePartyMappingService;
  */
 trait DataCiteExporterHelpers
 {
+    protected function dataCiteDescriptionMapper(): DataCiteDescriptionMappingService
+    {
+        return app(DataCiteDescriptionMappingService::class);
+    }
+
     protected function dataCitePartyMapper(): DataCitePartyMappingService
     {
         return app(DataCitePartyMappingService::class);

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -380,6 +380,10 @@
         ],
         "fixes": [
             {
+                "title": "Preserved DataCite Description Line Breaks",
+                "description": "DataCite registration, metadata updates, and JSON/XML exports now preserve logical description line breaks using DataCite's allowed <br> representation. JSON API payloads emit literal <br> markers and XML exports emit real <br/> child elements, while all other landing-page HTML remains excluded. Existing resources require no migration."
+            },
+            {
                 "title": "Legacy Resource Download Links Import",
                 "description": "Legacy resource imports from /resources now persist SUMARIO download URLs and additional legacy download links from the queue worker. Re-running the single or bulk import for an already imported DOI can backfill missing landing page download links without overwriting curator-provided values, and the import summary now reports when existing resources had legacy links added."
             },

--- a/resources/js/components/curation/fields/description-field.tsx
+++ b/resources/js/components/curation/fields/description-field.tsx
@@ -153,9 +153,9 @@ export default function DescriptionField({
         <div className="space-y-4">
             <Alert className="bg-muted/40">
                 <AlertDescription>
-                    Landing pages support a limited HTML subset in descriptions: &lt;p&gt;, &lt;br&gt;, &lt;strong&gt;, &lt;em&gt;,
-                    &lt;ul&gt;, &lt;ol&gt;, &lt;li&gt;, &lt;a&gt;, &lt;sub&gt;, &lt;sup&gt;, and &lt;code&gt;. ERNIE stores a plain-text version
-                    for DataCite, XML, JSON, and JSON-LD exports.
+                    Landing pages support a limited HTML subset in descriptions: &lt;p&gt;, &lt;br&gt;, &lt;strong&gt;, &lt;em&gt;, &lt;ul&gt;,
+                    &lt;ol&gt;, &lt;li&gt;, &lt;a&gt;, &lt;sub&gt;, &lt;sup&gt;, and &lt;code&gt;. DataCite JSON and XML retain line breaks as
+                    &lt;br&gt;; all other formatting remains landing-page only. JSON-LD and Schema.org outputs remain plain text.
                 </AlertDescription>
             </Alert>
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as DescriptionType)}>

--- a/tests/pest/Feature/Services/DataCiteDescriptionExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteDescriptionExporterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Description;
+use App\Models\DescriptionType;
+use App\Models\Resource;
+use App\Services\DataCiteJsonExporter;
+use App\Services\DataCiteXmlExporter;
+
+test('exports line breaks for every datacite description type', function () {
+    $resource = Resource::factory()->create();
+    $typeNames = [
+        'Abstract',
+        'Methods',
+        'SeriesInformation',
+        'TableOfContents',
+        'TechnicalInfo',
+        'Other',
+    ];
+
+    foreach ($typeNames as $position => $typeName) {
+        $type = DescriptionType::firstOrCreate(
+            ['slug' => $typeName],
+            ['name' => $typeName, 'is_active' => true]
+        );
+
+        Description::create([
+            'resource_id' => $resource->id,
+            'value' => $typeName.' first'.PHP_EOL.$typeName.' second',
+            'description_type_id' => $type->id,
+            'position' => $position,
+        ]);
+    }
+
+    $json = (new DataCiteJsonExporter)->export($resource->fresh());
+    $jsonDescriptions = collect($json['data']['attributes']['descriptions'])
+        ->keyBy('descriptionType');
+
+    expect($jsonDescriptions)->toHaveCount(6);
+
+    foreach ($typeNames as $typeName) {
+        expect($jsonDescriptions[$typeName]['description'])
+            ->toBe($typeName.' first<br>'.$typeName.' second');
+    }
+
+    $xml = (new DataCiteXmlExporter)->export($resource->fresh());
+    $dom = new DOMDocument;
+    $dom->loadXML($xml);
+    $xmlDescriptions = $dom->getElementsByTagName('description');
+
+    expect($xmlDescriptions->length)->toBe(6);
+
+    foreach ($xmlDescriptions as $xmlDescription) {
+        $typeName = $xmlDescription->getAttribute('descriptionType');
+
+        expect($xmlDescription->getElementsByTagName('br')->length)->toBe(1)
+            ->and($xmlDescription->textContent)->toBe($typeName.' first'.$typeName.' second');
+    }
+});

--- a/tests/pest/Feature/Services/DataCiteDescriptionRoundTripTest.php
+++ b/tests/pest/Feature/Services/DataCiteDescriptionRoundTripTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Description;
+use App\Models\DescriptionType;
+use App\Models\Resource;
+use App\Services\DataCiteJsonExporter;
+use App\Services\DataCiteXmlExporter;
+use App\Services\Xml\Sections\DescriptionSectionParser;
+use Saloon\XmlWrangler\XmlReader;
+
+test('preserves datacite breaks through import storage and both exports', function () {
+    $sourceXml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <descriptions>
+    <description descriptionType="Abstract">First line.<br/><br/>Second line.</description>
+  </descriptions>
+</resource>
+XML;
+
+    $parsed = (new DescriptionSectionParser)->parse(
+        XmlReader::fromString($sourceXml),
+        $sourceXml
+    );
+
+    expect($parsed)->toHaveCount(1)
+        ->and($parsed[0]['description'])->toBe("First line.\n\nSecond line.");
+
+    $resource = Resource::factory()->create();
+    $type = DescriptionType::firstOrCreate(
+        ['slug' => $parsed[0]['type']],
+        ['name' => $parsed[0]['type'], 'is_active' => true]
+    );
+
+    $description = Description::create([
+        'resource_id' => $resource->id,
+        'value' => $parsed[0]['description'],
+        'description_type_id' => $type->id,
+    ]);
+
+    expect($description->fresh()->value)->toBe("First line.\n\nSecond line.");
+
+    $json = (new DataCiteJsonExporter)->export($resource->fresh());
+    expect($json['data']['attributes']['descriptions'][0]['description'])
+        ->toBe('First line.<br><br>Second line.');
+
+    $xml = (new DataCiteXmlExporter)->export($resource->fresh());
+    $dom = new DOMDocument;
+    $dom->loadXML($xml);
+
+    expect($dom->getElementsByTagName('br')->length)->toBe(2)
+        ->and($xml)->toContain('First line.<br/><br/>Second line.</description>')
+        ->and($xml)->not->toContain('&lt;br&gt;');
+});

--- a/tests/pest/Feature/Services/DataCiteIgsnRegistrationDescriptionTest.php
+++ b/tests/pest/Feature/Services/DataCiteIgsnRegistrationDescriptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\Description;
+use App\Models\DescriptionType;
+use App\Models\LandingPage;
+use App\Models\Resource;
+use App\Services\DataCiteRegistrationService;
+use Illuminate\Support\Facades\Http;
+
+test('registerIgsn sends descriptions with datacite breaks', function () {
+    config([
+        'datacite.test_mode' => true,
+        'datacite.test.username' => 'TEST.USER',
+        'datacite.test.password' => 'test-password',
+        'datacite.test.endpoint' => 'https://api.test.datacite.org',
+        'datacite.test.prefixes' => ['10.83279'],
+    ]);
+
+    $resource = Resource::factory()->create([
+        'doi' => '10.83279/IGSN-1004',
+    ]);
+    LandingPage::factory()->create([
+        'resource_id' => $resource->id,
+    ]);
+    $type = DescriptionType::firstOrCreate(
+        ['slug' => 'Abstract'],
+        ['name' => 'Abstract', 'is_active' => true]
+    );
+    Description::create([
+        'resource_id' => $resource->id,
+        'value' => "First line.\n\nSecond line.",
+        'landing_page_html' => '<p>First <strong>line</strong>.</p><p>Second line.</p>',
+        'description_type_id' => $type->id,
+    ]);
+
+    Http::fake([
+        '*datacite.org/*' => Http::response([
+            'data' => [
+                'id' => $resource->doi,
+                'type' => 'dois',
+                'attributes' => ['doi' => $resource->doi],
+            ],
+        ], 201),
+    ]);
+
+    $response = app(DataCiteRegistrationService::class)->registerIgsn($resource);
+
+    expect($response['data']['id'])->toBe($resource->doi);
+
+    Http::assertSent(function ($request) use ($resource) {
+        $body = json_decode($request->body(), true);
+        $description = $body['data']['attributes']['descriptions'][0]['description'];
+
+        return $request->method() === 'POST'
+            && $body['data']['attributes']['doi'] === $resource->doi
+            && $description === 'First line.<br><br>Second line.'
+            && ! str_contains($description, '<strong>');
+    });
+});

--- a/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
@@ -400,7 +400,7 @@ describe('DataCiteJsonExporter - Descriptions', function () {
         expect($descriptions[0]['descriptionType'])->toBeIn(['Methods', 'methods']);
     });
 
-    test('exports plain text descriptions even when landing page html exists', function () {
+    test('exports datacite breaks while excluding landing page html', function () {
         $resource = Resource::factory()->create();
         $abstractType = DescriptionType::firstOrCreate(
             ['slug' => 'Abstract'],
@@ -409,15 +409,16 @@ describe('DataCiteJsonExporter - Descriptions', function () {
 
         Description::create([
             'resource_id' => $resource->id,
-            'value' => 'Plain export description.',
-            'landing_page_html' => '<p>Plain <strong>export</strong> description.</p>',
+            'value' => 'First paragraph.'.PHP_EOL.PHP_EOL.'Second paragraph.',
+            'landing_page_html' => '<p>First <strong>paragraph</strong>.</p><p>Second paragraph.</p>',
             'description_type_id' => $abstractType->id,
         ]);
 
         $result = $this->exporter->export($resource);
         $descriptions = $result['data']['attributes']['descriptions'];
 
-        expect($descriptions[0]['description'])->toBe('Plain export description.')
+        expect($descriptions[0]['description'])->toBe('First paragraph.<br><br>Second paragraph.')
+            ->and($descriptions[0]['description'])->not->toContain('<p>')
             ->and($descriptions[0]['description'])->not->toContain('<strong>');
     });
 });

--- a/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteJsonExporterTest.php
@@ -421,6 +421,28 @@ describe('DataCiteJsonExporter - Descriptions', function () {
             ->and($descriptions[0]['description'])->not->toContain('<p>')
             ->and($descriptions[0]['description'])->not->toContain('<strong>');
     });
+
+    test('escapes tag-like plain text while preserving comparison operators', function () {
+        $resource = Resource::factory()->create();
+        $abstractType = DescriptionType::firstOrCreate(
+            ['slug' => 'Abstract'],
+            ['name' => 'Abstract']
+        );
+
+        Description::create([
+            'resource_id' => $resource->id,
+            'value' => 'Math x < 5.'.chr(10).'<strong>bold</strong> and <script>alert(1)</script>.',
+            'description_type_id' => $abstractType->id,
+        ]);
+
+        $result = $this->exporter->export($resource);
+        $description = $result['data']['attributes']['descriptions'][0]['description'];
+
+        expect($description)
+            ->toBe('Math x < 5.<br>&lt;strong>bold&lt;/strong> and &lt;script>alert(1)&lt;/script>.')
+            ->and($description)->not->toContain('<strong>')
+            ->and($description)->not->toContain('<script>');
+    });
 });
 
 describe('DataCiteJsonExporter - Resource Types', function () {

--- a/tests/pest/Feature/Services/DataCiteRegistrationServiceTest.php
+++ b/tests/pest/Feature/Services/DataCiteRegistrationServiceTest.php
@@ -1,12 +1,29 @@
 <?php
 
 use App\Enums\UserRole;
+use App\Models\Description;
+use App\Models\DescriptionType;
 use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\DataCiteRegistrationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+
+function attachDataCiteMultilineDescription(Resource $resource): void
+{
+    $type = DescriptionType::firstOrCreate(
+        ['slug' => 'Abstract'],
+        ['name' => 'Abstract', 'is_active' => true]
+    );
+
+    Description::create([
+        'resource_id' => $resource->id,
+        'value' => 'First line.'.PHP_EOL.PHP_EOL.'Second line.',
+        'landing_page_html' => '<p>First <strong>line</strong>.</p><p>Second line.</p>',
+        'description_type_id' => $type->id,
+    ]);
+}
 
 uses(RefreshDatabase::class);
 
@@ -58,6 +75,8 @@ test('registerDoi generates new doi with correct format', function () {
 });
 
 test('registerDoi sends correct payload to datacite api', function () {
+    attachDataCiteMultilineDescription($this->resource);
+
     Http::fake([
         '*datacite.org/*' => Http::response([
             'data' => [
@@ -76,10 +95,14 @@ test('registerDoi sends correct payload to datacite api', function () {
     expect($result)->toBeArray();
 
     Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+
         return str_contains($request->url(), 'api.test.datacite.org/dois')
             && $request->method() === 'POST'
             && $request->hasHeader('Content-Type', 'application/vnd.api+json')
-            && $request->hasHeader('Authorization');
+            && $request->hasHeader('Authorization')
+            && $body['data']['attributes']['descriptions'][0]['description'] === 'First line.<br><br>Second line.'
+            && ! str_contains($body['data']['attributes']['descriptions'][0]['description'], '<strong>');
     });
 });
 
@@ -137,6 +160,7 @@ test('registerDoi includes event publish parameter', function () {
 
 test('updateMetadata sends put request to correct endpoint', function () {
     $this->resource->update(['doi' => '10.83279/existing']);
+    attachDataCiteMultilineDescription($this->resource);
 
     Http::fake([
         '*datacite.org/*' => Http::response([
@@ -157,9 +181,11 @@ test('updateMetadata sends put request to correct endpoint', function () {
     Http::assertSent(function ($request) {
         // DOI is now URL-encoded in the path
         $expectedEncodedDoi = urlencode('10.83279/existing');
+        $body = json_decode($request->body(), true);
 
         return str_contains($request->url(), $expectedEncodedDoi)
-            && $request->method() === 'PUT';
+            && $request->method() === 'PUT'
+            && $body['data']['attributes']['descriptions'][0]['description'] === 'First line.<br><br>Second line.';
     });
 });
 

--- a/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
@@ -586,7 +586,7 @@ describe('DataCiteXmlExporter - Descriptions', function () {
             ->and($xml)->toContain('Methodology used in data collection.</description>');
     });
 
-    test('exports plain text descriptions when landing page html exists', function () {
+    test('exports real datacite break elements while excluding landing page html', function () {
         $resource = Resource::factory()->create();
 
         $abstractType = DescriptionType::firstOrCreate(
@@ -596,15 +596,24 @@ describe('DataCiteXmlExporter - Descriptions', function () {
 
         Description::create([
             'resource_id' => $resource->id,
-            'value' => 'Plain XML description.',
-            'landing_page_html' => '<p>Plain <strong>XML</strong> description.</p>',
+            'value' => 'First line.'.PHP_EOL.PHP_EOL.'Second line.',
+            'landing_page_html' => '<p>First <strong>line</strong>.</p><p>Second line.</p>',
             'description_type_id' => $abstractType->id,
         ]);
 
         $xml = $this->exporter->export($resource);
+        $dom = new DOMDocument;
+        $dom->loadXML($xml);
+        $descriptionElement = $dom->getElementsByTagName('description')->item(0);
+        $breakElement = $dom->getElementsByTagName('br')->item(0);
 
-        expect($xml)->toContain('Plain XML description.</description>')
-            ->and($xml)->not->toContain('<strong>XML</strong>');
+        expect($dom->getElementsByTagName('br')->length)->toBe(2)
+            ->and($breakElement?->namespaceURI)->toBe('http://datacite.org/schema/kernel-4')
+            ->and($descriptionElement?->getAttribute('xml:lang'))->toBe('en')
+            ->and($xml)->toContain('First line.<br/><br/>Second line.</description>')
+            ->and($xml)->not->toContain('&lt;br&gt;')
+            ->and($xml)->not->toContain('<p>')
+            ->and($xml)->not->toContain('<strong>');
     });
 });
 

--- a/tests/pest/Unit/Services/DataCiteDescriptionMappingServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteDescriptionMappingServiceTest.php
@@ -30,11 +30,6 @@ it('retains consecutive leading and trailing line breaks', function (): void {
         ->and($this->mapper->toJsonValue($description))->toBe('<br>First<br><br>Second<br>');
 });
 
-it('restores datacite json break markers as canonical line breaks', function (): void {
-    expect($this->mapper->fromJsonValue('First<br><br>Second'))
-        ->toBe('First'.chr(10).chr(10).'Second');
-});
-
 it('escapes tag-like less-than signs without changing comparisons', function (): void {
     $description = 'Use <strong>bold</strong> and <script>alert(1)</script>, but x < 5.';
 

--- a/tests/pest/Unit/Services/DataCiteDescriptionMappingServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteDescriptionMappingServiceTest.php
@@ -30,6 +30,18 @@ it('retains consecutive leading and trailing line breaks', function (): void {
         ->and($this->mapper->toJsonValue($description))->toBe('<br>First<br><br>Second<br>');
 });
 
+it('restores datacite json break markers as canonical line breaks', function (): void {
+    expect($this->mapper->fromJsonValue('First<br><br>Second'))
+        ->toBe('First'.chr(10).chr(10).'Second');
+});
+
+it('escapes tag-like less-than signs without changing comparisons', function (): void {
+    $description = 'Use <strong>bold</strong> and <script>alert(1)</script>, but x < 5.';
+
+    expect($this->mapper->toJsonValue($description))
+        ->toBe('Use &lt;strong>bold&lt;/strong> and &lt;script>alert(1)&lt;/script>, but x < 5.');
+});
+
 it('preserves unicode and plain-text symbols', function (): void {
     $description = "Temperatur < 5 °C & Schnee\n第二行";
 

--- a/tests/pest/Unit/Services/DataCiteDescriptionMappingServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteDescriptionMappingServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DataCite\Mapping\DataCiteDescriptionMappingService;
+
+covers(DataCiteDescriptionMappingService::class);
+
+beforeEach(function (): void {
+    $this->mapper = new DataCiteDescriptionMappingService;
+});
+
+it('leaves a single-line description unchanged', function (): void {
+    expect($this->mapper->toJsonValue('A single line.'))->toBe('A single line.');
+});
+
+it('normalizes every supported line ending to a datacite break', function (string $lineEnding): void {
+    expect($this->mapper->toJsonValue('First'.$lineEnding.'Second'))
+        ->toBe('First<br>Second');
+})->with([
+    'LF' => "\n",
+    'CRLF' => "\r\n",
+    'CR' => "\r",
+]);
+
+it('retains consecutive leading and trailing line breaks', function (): void {
+    $description = "\nFirst\n\nSecond\n";
+
+    expect($this->mapper->segments($description))->toBe(['', 'First', '', 'Second', ''])
+        ->and($this->mapper->toJsonValue($description))->toBe('<br>First<br><br>Second<br>');
+});
+
+it('preserves unicode and plain-text symbols', function (): void {
+    $description = "Temperatur < 5 °C & Schnee\n第二行";
+
+    expect($this->mapper->toJsonValue($description))
+        ->toBe('Temperatur < 5 °C & Schnee<br>第二行');
+});

--- a/tests/pest/Unit/Services/DataCiteLinkedDataExporterTest.php
+++ b/tests/pest/Unit/Services/DataCiteLinkedDataExporterTest.php
@@ -256,20 +256,21 @@ describe('descriptions', function () {
         expect($desc['attrs']['descriptionType'])->toBe('Abstract');
     });
 
-    it('keeps linked data descriptions plain text when landing page html exists', function () {
+    it('keeps linked data description line breaks as plain text', function () {
         $resource = createResourceWithTitle();
 
         $abstractType = DescriptionType::where('slug', 'Abstract')->first();
         $resource->descriptions()->create([
-            'value' => 'Plain JSON-LD description',
-            'landing_page_html' => '<p>Plain <strong>JSON-LD</strong> description</p>',
+            'value' => 'JSON-LD first line'.chr(10).chr(10).'second line',
+            'landing_page_html' => '<p>JSON-LD <strong>first</strong> line</p><p>second line</p>',
             'description_type_id' => $abstractType?->id,
         ]);
 
         $result = $this->exporter->export($resource->fresh());
         $desc = $result['descriptions']['description'];
 
-        expect($desc['value'])->toBe('Plain JSON-LD description')
+        expect($desc['value'])->toBe('JSON-LD first line'.chr(10).chr(10).'second line')
+            ->and($desc['value'])->not->toContain('<br>')
             ->and($desc['value'])->not->toContain('<strong>');
     });
 });

--- a/tests/pest/Unit/Services/DataCiteLinkedDataExporterTest.php
+++ b/tests/pest/Unit/Services/DataCiteLinkedDataExporterTest.php
@@ -256,12 +256,12 @@ describe('descriptions', function () {
         expect($desc['attrs']['descriptionType'])->toBe('Abstract');
     });
 
-    it('keeps linked data description line breaks as plain text', function () {
+    it('preserves the exact canonical linked data description text', function () {
         $resource = createResourceWithTitle();
 
         $abstractType = DescriptionType::where('slug', 'Abstract')->first();
         $resource->descriptions()->create([
-            'value' => 'JSON-LD first line'.chr(10).chr(10).'second line',
+            'value' => 'JSON-LD first line'.chr(10).chr(10).'<strong>literal</strong> &lt;encoded>',
             'landing_page_html' => '<p>JSON-LD <strong>first</strong> line</p><p>second line</p>',
             'description_type_id' => $abstractType?->id,
         ]);
@@ -269,9 +269,9 @@ describe('descriptions', function () {
         $result = $this->exporter->export($resource->fresh());
         $desc = $result['descriptions']['description'];
 
-        expect($desc['value'])->toBe('JSON-LD first line'.chr(10).chr(10).'second line')
-            ->and($desc['value'])->not->toContain('<br>')
-            ->and($desc['value'])->not->toContain('<strong>');
+        expect($desc['value'])
+            ->toBe('JSON-LD first line'.chr(10).chr(10).'<strong>literal</strong> &lt;encoded>')
+            ->and($desc['value'])->not->toContain('<br>');
     });
 });
 

--- a/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
+++ b/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
@@ -215,19 +215,20 @@ describe('descriptions', function () {
         expect($result)->not->toHaveKey('description');
     });
 
-    it('keeps schema org description plain text when landing page html exists', function () {
+    it('keeps schema org description line breaks as plain text', function () {
         $resource = createSchemaOrgResource();
 
         $abstractType = DescriptionType::where('slug', 'Abstract')->first();
         $resource->descriptions()->create([
-            'value' => 'Schema.org plain text abstract',
-            'landing_page_html' => '<p>Schema.org <strong>formatted</strong> abstract</p>',
+            'value' => 'Schema.org first line'.chr(10).chr(10).'second line',
+            'landing_page_html' => '<p>Schema.org <strong>first</strong> line</p><p>second line</p>',
             'description_type_id' => $abstractType?->id,
         ]);
 
         $result = $this->exporter->export($resource->fresh());
 
-        expect($result['description'])->toBe('Schema.org plain text abstract')
+        expect($result['description'])->toBe('Schema.org first line'.chr(10).chr(10).'second line')
+            ->and($result['description'])->not->toContain('<br>')
             ->and($result['description'])->not->toContain('<strong>');
     });
 });

--- a/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
+++ b/tests/pest/Unit/Services/SchemaOrgJsonLdExporterTest.php
@@ -215,21 +215,21 @@ describe('descriptions', function () {
         expect($result)->not->toHaveKey('description');
     });
 
-    it('keeps schema org description line breaks as plain text', function () {
+    it('preserves the exact canonical schema org description text', function () {
         $resource = createSchemaOrgResource();
 
         $abstractType = DescriptionType::where('slug', 'Abstract')->first();
         $resource->descriptions()->create([
-            'value' => 'Schema.org first line'.chr(10).chr(10).'second line',
+            'value' => 'Schema.org first line'.chr(10).chr(10).'<strong>literal</strong> &lt;encoded>',
             'landing_page_html' => '<p>Schema.org <strong>first</strong> line</p><p>second line</p>',
             'description_type_id' => $abstractType?->id,
         ]);
 
         $result = $this->exporter->export($resource->fresh());
 
-        expect($result['description'])->toBe('Schema.org first line'.chr(10).chr(10).'second line')
-            ->and($result['description'])->not->toContain('<br>')
-            ->and($result['description'])->not->toContain('<strong>');
+        expect($result['description'])
+            ->toBe('Schema.org first line'.chr(10).chr(10).'<strong>literal</strong> &lt;encoded>')
+            ->and($result['description'])->not->toContain('<br>');
     });
 });
 

--- a/tests/vitest/components/curation/fields/__tests__/description-field.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/description-field.test.tsx
@@ -54,7 +54,8 @@ describe('DescriptionField', () => {
         const notice = screen.getByRole('alert');
 
         expect(notice).toHaveTextContent(/Landing pages support a limited HTML subset in descriptions/i);
-        expect(notice).toHaveTextContent(/DataCite, XML, JSON, and JSON-LD exports/i);
+        expect(notice).toHaveTextContent(/DataCite JSON and XML retain line breaks as <br>/i);
+        expect(notice).toHaveTextContent(/all other formatting remains landing-page only/i);
     });
 
     it('renders Abstract textarea with placeholder', () => {

--- a/tests/vitest/components/curation/fields/__tests__/description-field.test.tsx
+++ b/tests/vitest/components/curation/fields/__tests__/description-field.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@tests/vitest/utils/render';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import DescriptionField, { DescriptionEntry } from '@/components/curation/fields/description-field';


### PR DESCRIPTION
This pull request introduces a new service to preserve and serialize line breaks in DataCite descriptions, ensuring that logical line breaks are consistently represented as `<br>` in DataCite JSON and as `<br/>` elements in XML exports. The update also ensures that all other formats (e.g., landing pages, JSON-LD, Schema.org) remain unaffected and receive only plain text. Comprehensive tests are added to validate this behavior, and documentation and UI messaging are updated accordingly.

**DataCite Description Line Break Preservation**

* Added `DataCiteDescriptionMappingService` to handle normalization, serialization, and deserialization of description line breaks for DataCite exports. This service converts line breaks to `<br>` for JSON and real `<br/>` elements for XML, and escapes tag-like substrings to prevent injection of HTML tags.
* Updated `DataCiteJsonExporter` and `DataCiteXmlExporter` to use the new mapping service, ensuring that line breaks are preserved and correctly serialized in both formats. [[1]](diffhunk://#diff-b455a049403e769a03cc100e9aee67b9b148e3c18f62208c963e249dd85a2128L673-R673) [[2]](diffhunk://#diff-b1bd763f891ec19887d2cd42c228ce9c434a70474ffd12f1a06b1035096f4710L1225-R1225) [[3]](diffhunk://#diff-b1bd763f891ec19887d2cd42c228ce9c434a70474ffd12f1a06b1035096f4710R1243-R1252) [[4]](diffhunk://#diff-45f609689defef84960cb9d40a6bd153fef0522fd70a129e7145fcf96c6c03b8R15) [[5]](diffhunk://#diff-45f609689defef84960cb9d40a6bd153fef0522fd70a129e7145fcf96c6c03b8R27-R31)
* Updated `DataCiteLinkedDataExporter` and `SchemaOrgJsonLdExporter` to deserialize descriptions for formats that require plain text, ensuring correct round-trip handling. [[1]](diffhunk://#diff-5956f033a0485e2378c3765851209a695a83b47e2af48425c30204a7d30cca5eR8) [[2]](diffhunk://#diff-5956f033a0485e2378c3765851209a695a83b47e2af48425c30204a7d30cca5eR20-R23) [[3]](diffhunk://#diff-5956f033a0485e2378c3765851209a695a83b47e2af48425c30204a7d30cca5eL571-R578) [[4]](diffhunk://#diff-a0456cc11ebd05b2169d428f2e394908bdebddce3e4319d389c722db49eab914R9) [[5]](diffhunk://#diff-a0456cc11ebd05b2169d428f2e394908bdebddce3e4319d389c722db49eab914R23-R26) [[6]](diffhunk://#diff-a0456cc11ebd05b2169d428f2e394908bdebddce3e4319d389c722db49eab914L264-R269)

**Testing and Validation**

* Added comprehensive feature tests to verify that line breaks are preserved through storage, export, and DataCite registration, and that tag-like content is safely escaped. [[1]](diffhunk://#diff-92ed6893b543bfec89885672d69ad30ddb1992c56212d31e435c32447259f846R1-R58) [[2]](diffhunk://#diff-4a8f175eaecbf40da63b97d2dad9fcdab903af96b6ec383c105510c4b2c1ac45R1-R54) [[3]](diffhunk://#diff-4d8cff35a911dd60d0bd9e9dd06188a2a055f8cd584287f9ee85c3a98290fa71R1-R59) [[4]](diffhunk://#diff-21bca6f2999ebb27e00286f25b0588ec584ce64168da0cdf69ffcb476d2a7ebcL403-R403) [[5]](diffhunk://#diff-21bca6f2999ebb27e00286f25b0588ec584ce64168da0cdf69ffcb476d2a7ebcL412-R445) [[6]](diffhunk://#diff-47937a30c6c13a02cee33e2196ce571d2d0363ffa2bd82c9111445a50428e479R4-R27) [[7]](diffhunk://#diff-47937a30c6c13a02cee33e2196ce571d2d0363ffa2bd82c9111445a50428e479R78-R79) [[8]](diffhunk://#diff-47937a30c6c13a02cee33e2196ce571d2d0363ffa2bd82c9111445a50428e479R98-R105)

**Documentation and UI Updates**

* Updated the changelog to announce the new DataCite description line break preservation.
* Clarified the description field UI to explain the new export behavior for DataCite JSON and XML.

These changes ensure DataCite exports are now standards-compliant with respect to line breaks, improve data fidelity, and maintain security by escaping tag-like content. Existing resources require no migration.