### PR TITLE
Fix: Responsive Layout in Resource Information Section

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -384,6 +384,10 @@
         ],
         "fixes": [
             {
+                "title": "Responsive Resource Information Layout",
+                "description": "The Data Editor now keeps its basic Resource Information fields proportional across screen sizes: one compact row on large desktops, two balanced rows at medium widths, and full-width stacked controls on mobile. Language of Data no longer sits alone in a mostly empty row on wide screens."
+            },
+            {
                 "title": "Preserved DataCite Description Line Breaks",
                 "description": "DataCite registration, metadata updates, and JSON/XML exports now preserve logical description line breaks using DataCite's allowed <br> representation. JSON API payloads emit literal <br> markers and XML exports emit real <br/> child elements, while all other landing-page HTML remains excluded. Existing resources require no migration."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -3031,7 +3031,7 @@ export default function DataCiteForm({
                                       ? 'As an administrator, you can edit this DOI. Be careful when changing registered DOIs.'
                                       : 'Enter DOI in format 10.xxxx/xxxxx or https://doi.org/10.xxxx/xxxxx'
                             }
-                            className="md:col-span-3"
+                            className="md:col-span-4 xl:col-span-3"
                             readOnly={isDoiReadonly}
                             disabled={isDoiValidating}
                         />
@@ -3045,7 +3045,7 @@ export default function DataCiteForm({
                             validationMessages={getFieldState('year').messages}
                             touched={getFieldState('year').touched}
                             placeholder="2024"
-                            className="md:col-span-1"
+                            className="md:col-span-2 xl:col-span-1"
                             required
                         />
                         <SelectField
@@ -3060,7 +3060,7 @@ export default function DataCiteForm({
                                 value: String(type.id),
                                 label: type.name,
                             }))}
-                            className="md:col-span-3"
+                            className="min-w-0 md:col-span-6 xl:col-span-2"
                             required
                             data-testid="resource-type-select"
                         />
@@ -3074,7 +3074,7 @@ export default function DataCiteForm({
                                 setDatacenterTouched(true);
                                 clearDatacenterValidationErrors();
                             }}
-                            className="min-w-0 md:col-span-3"
+                            className="min-w-0 md:col-span-6 xl:col-span-3"
                             required
                             hasError={datacenterErrorMessage !== null}
                             errorMessage={datacenterErrorMessage ?? undefined}
@@ -3090,7 +3090,7 @@ export default function DataCiteForm({
                             placeholder="1.0"
                             labelTooltip="Version number (e.g., 1.0, 2.1, 1.0.0)"
                             maxLength={50}
-                            className="min-w-0 md:col-span-1"
+                            className="min-w-0 md:col-span-2 xl:col-span-1"
                         />
                         <SelectField
                             id="language"
@@ -3104,7 +3104,7 @@ export default function DataCiteForm({
                                 value: l.code,
                                 label: l.name,
                             }))}
-                            className="md:col-span-2"
+                            className="min-w-0 md:col-span-4 xl:col-span-2"
                             required
                             data-testid="language-select"
                         />

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -945,7 +945,7 @@ describe('DataCiteForm', () => {
         expect(screen.getAllByRole('textbox', { name: /Title/ })).toHaveLength(1);
     });
 
-    it('gives the datacenter field more grid width and keeps long selected datacenter badges wrapped', () => {
+    it('uses responsive resource information spans and keeps long selected datacenter badges wrapped', () => {
         const longDatacenterName = 'DEKORP - German Continental Seismic Reflection Program';
 
         render(
@@ -965,13 +965,25 @@ describe('DataCiteForm', () => {
             />,
         );
 
+        const doiField = screen.getByLabelText('DOI').parentElement;
+        expect(doiField).toHaveClass('md:col-span-4', 'xl:col-span-3');
+
+        const yearField = screen.getByLabelText('Year', { exact: false }).parentElement;
+        expect(yearField).toHaveClass('md:col-span-2', 'xl:col-span-1');
+
+        const resourceTypeField = screen.getByTestId('resource-type-select').parentElement;
+        expect(resourceTypeField).toHaveClass('min-w-0', 'md:col-span-6', 'xl:col-span-2');
+
         const datacenterField = screen.getByTestId('datacenter-select').parentElement;
         expect(datacenterField).toHaveClass('min-w-0');
-        expect(datacenterField).toHaveClass('md:col-span-3');
+        expect(datacenterField).toHaveClass('md:col-span-6', 'xl:col-span-3');
 
         const versionField = screen.getByLabelText('Version').parentElement;
         expect(versionField).toHaveClass('min-w-0');
-        expect(versionField).toHaveClass('md:col-span-1');
+        expect(versionField).toHaveClass('md:col-span-2', 'xl:col-span-1');
+
+        const languageField = screen.getByTestId('language-select').parentElement;
+        expect(languageField).toHaveClass('min-w-0', 'md:col-span-4', 'xl:col-span-2');
 
         const selectedDatacenter = screen.getByText(longDatacenterName);
         expect(selectedDatacenter).toHaveClass('whitespace-normal');


### PR DESCRIPTION
This pull request improves the responsiveness and layout of the Resource Information section in the Data Editor, ensuring that form fields adapt proportionally across different screen sizes for a better user experience. The main changes include updating the grid column spans for key fields in `DataCiteForm`, enhancing test coverage to verify these layout adjustments, and updating the changelog to document the improvement.

**UI Responsiveness and Layout Improvements:**

* Updated grid column spans for resource information fields in `DataCiteForm` to achieve a proportional, responsive layout: fields now stack in one compact row on large screens, two rows at medium widths, and full-width on mobile. This ensures fields like "Language of Data" no longer appear isolated on wide screens. (`resources/js/components/curation/datacite-form.tsx`) [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3034-R3034) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3048-R3048) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3063-R3063) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3077-R3077) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3093-R3093) [[6]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3107-R3107)

**Testing Enhancements:**

* Expanded the DataCiteForm test to verify that each field receives the correct responsive grid classes, ensuring the new layout works as intended across breakpoints. (`tests/vitest/components/curation/__tests__/datacite-form.test.tsx`) [[1]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9L948-R948) [[2]](diffhunk://#diff-1c3cb6a1a044ec6413144c01dd2b165a80dc29ca4ddf2c60546b7664153faae9R968-R986)

**Documentation:**

* Added a changelog entry describing the responsive resource information layout improvements and the enhanced arrangement of the "Language of Data" field. (`resources/data/changelog.json`)