### PR TITLE
Fix: Make Resource Language optional in Data Editor

### DIFF
--- a/app/Services/OldDatasetEditorLoader.php
+++ b/app/Services/OldDatasetEditorLoader.php
@@ -189,13 +189,12 @@ class OldDatasetEditorLoader
      */
     private function mapLanguage(?string $oldLanguage): string
     {
-        if (empty($oldLanguage)) {
-            return 'en'; // Default to English
+        if ($oldLanguage === null) {
+            return '';
         }
 
-        // Old DB uses ISO 639-1 codes (en, de, etc.), new DB too
-        // Just normalize to lowercase
-        return strtolower($oldLanguage);
+        // Old DB uses ISO 639-1 codes (en, de, etc.), new DB too.
+        return strtolower(trim($oldLanguage));
     }
 
     /**

--- a/app/Services/SumarioPendingResourceImportService.php
+++ b/app/Services/SumarioPendingResourceImportService.php
@@ -257,7 +257,7 @@ class SumarioPendingResourceImportService
             'doi' => $doi,
             'year' => $this->normaliseYear($editorData['year'] ?? $oldDataset->publicationyear),
             'version' => $this->filledString($editorData['version'] ?? null),
-            'language' => $this->filledString($editorData['language'] ?? null) ?? 'en',
+            'language' => $this->filledString($editorData['language'] ?? null),
             'resourceType' => $this->resolveResourceTypeId($editorData['resourceType'] ?? null),
             'titles' => $this->normaliseTitles($editorData['titles'] ?? [], $oldDataset, $doi),
             'licenses' => $this->normaliseStringList($editorData['initialRights'] ?? []),

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -384,6 +384,10 @@
         ],
         "fixes": [
             {
+                "title": "Optional Data Language in the Data Editor",
+                "description": "The Data Editor no longer defaults missing resource-language metadata to English or requires curators to select a language. New, uploaded, existing, and legacy resources preserve an explicitly supplied language, while missing values remain unset and existing selections can be cleared without blocking validation."
+            },
+            {
                 "title": "Precision-Aware Date Plausibility Hints",
                 "description": "The Date Type Assistant now treats year-only and year-month values as calendar intervals and compares ISO date-times by their actual instants across timezone offsets. Overlaps with more precise dates no longer produce false 'occurs after' hints, while definitively reversed dates continue to be flagged for review."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -665,19 +665,6 @@ export default function DataCiteForm({
         },
     ];
 
-    // Language validation rules
-    const languageValidationRules: ValidationRule[] = [
-        {
-            validate: (value) => {
-                const result = validateRequired(String(value || ''), 'Language');
-                if (!result.isValid) {
-                    return { severity: 'error', message: result.error! };
-                }
-                return null;
-            },
-        },
-    ];
-
     // Version validation rules (optional, aligned with DataCite/backend limits)
     const versionValidationRules: ValidationRule[] = [
         {
@@ -1390,10 +1377,6 @@ export default function DataCiteForm({
             appendValidationMessage(errors, 'resourceType', 'Resource Type is required.');
         }
 
-        if (!form.language) {
-            appendValidationMessage(errors, 'language', 'Language is required.');
-        }
-
         if (!licenseEntries.some(hasLicenseEntryEvidence)) {
             appendValidationMessage(errors, 'licenses', 'At least one License is required.');
         }
@@ -1463,7 +1446,7 @@ export default function DataCiteForm({
         dateValidationIssues.forEach((issue) => appendValidationMessage(errors, 'dates', issue));
 
         return errors;
-    }, [authors, descriptions, form.language, form.resourceType, form.year, licenseEntries, selectedDatacenterId, titles, dateValidationIssues]);
+    }, [authors, descriptions, form.resourceType, form.year, licenseEntries, selectedDatacenterId, titles, dateValidationIssues]);
 
     // ===================================================================
     // Accordion Section Status Badges
@@ -1478,7 +1461,6 @@ export default function DataCiteForm({
         const hasMainTitle = Boolean(mainTitleEntry?.title.trim());
         const hasYear = Boolean(form.year?.trim());
         const hasResourceType = Boolean(form.resourceType);
-        const hasLanguage = Boolean(form.language);
         const hasDatacenter = selectedDatacenterId !== null;
 
         // Check if DOI has validation errors (if present)
@@ -1493,14 +1475,14 @@ export default function DataCiteForm({
         const versionMessages = getFieldState('version').messages;
         const hasVersionError = versionMessages.some((msg) => msg.severity === 'error');
 
-        const allRequiredPresent = hasMainTitle && hasYear && hasResourceType && hasLanguage && hasDatacenter;
+        const allRequiredPresent = hasMainTitle && hasYear && hasResourceType && hasDatacenter;
         const hasErrors = hasDoiError || hasYearError || hasVersionError;
 
         if (!allRequiredPresent || hasErrors) {
             return 'invalid';
         }
         return 'valid';
-    }, [titles, form.year, form.resourceType, form.language, selectedDatacenterId, getFieldState]);
+    }, [titles, form.year, form.resourceType, selectedDatacenterId, getFieldState]);
 
     const licensesStatus = useMemo(() => {
         const hasCompleteLicense = licenseEntries.some(hasLicenseEntryEvidence);
@@ -1672,14 +1654,6 @@ export default function DataCiteForm({
                     fieldId: 'resourceType',
                     value,
                     rules: resourceTypeValidationRules,
-                    formData: form,
-                });
-                break;
-            case 'language':
-                validateField({
-                    fieldId: 'language',
-                    value,
-                    rules: languageValidationRules,
                     formData: form,
                 });
                 break;
@@ -3003,7 +2977,7 @@ export default function DataCiteForm({
                         />
                     </div>
                     <div data-slot="accordion-actions" className="flex shrink-0 items-center gap-1 py-4">
-                        {renderSectionActions('Resource Information', 'Required fields: Year, Resource Type, Main Title, Language, Datacenter')}
+                        {renderSectionActions('Resource Information', 'Required fields: Year, Resource Type, Main Title, Datacenter')}
                     </div>
                 </div>
                 <div className="space-y-6 pb-4">
@@ -3104,8 +3078,10 @@ export default function DataCiteForm({
                                 value: l.code,
                                 label: l.name,
                             }))}
+                            placeholder="Select language"
                             className="min-w-0 md:col-span-4 xl:col-span-2"
-                            required
+                            clearable
+                            clearLabel="Clear language selection"
                             data-testid="language-select"
                         />
                     </div>

--- a/resources/js/components/curation/fields/select-field.tsx
+++ b/resources/js/components/curation/fields/select-field.tsx
@@ -2,7 +2,7 @@ import { type HTMLAttributes } from 'react';
 
 import { FieldValidationFeedback } from '@/components/ui/field-validation-feedback';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { ValidationMessage } from '@/hooks/use-form-validation';
 import { cn } from '@/lib/utils';
@@ -22,6 +22,8 @@ interface SelectFieldProps {
     className?: string;
     hideLabel?: boolean;
     required?: boolean;
+    clearable?: boolean;
+    clearLabel?: string;
     containerProps?: HTMLAttributes<HTMLDivElement> & { 'data-testid'?: string };
     triggerClassName?: string;
     'data-testid'?: string;
@@ -45,6 +47,8 @@ export function SelectField({
     className,
     hideLabel = false,
     required = false,
+    clearable = false,
+    clearLabel = 'Clear selection',
     containerProps,
     triggerClassName,
     'data-testid': dataTestId,
@@ -71,9 +75,11 @@ export function SelectField({
     // Only use aria-label when label is hidden; otherwise use aria-labelledby
     const ariaProps = hideLabel ? { 'aria-label': label } : { 'aria-labelledby': labelId };
 
+    const clearValue = `__clear-${id}__`;
+
     // Handle value change with optional blur callback
     const handleValueChange = (newValue: string) => {
-        onValueChange(newValue);
+        onValueChange(newValue === clearValue ? '' : newValue);
         // Call validation blur after value changes (select acts like blur)
         if (onValidationBlur) {
             // Small delay to ensure state updates
@@ -132,6 +138,12 @@ export function SelectField({
                     <SelectValue placeholder={placeholder} />
                 </SelectTrigger>
                 <SelectContent>
+                    {clearable && value && (
+                        <>
+                            <SelectItem value={clearValue}>{clearLabel}</SelectItem>
+                            <SelectSeparator />
+                        </>
+                    )}
                     {options.map((option) => (
                         <SelectItem key={option.value} value={option.value}>
                             {option.label}

--- a/resources/js/components/curation/utils/language-resolver.ts
+++ b/resources/js/components/curation/utils/language-resolver.ts
@@ -5,55 +5,29 @@ export interface LanguageOption {
 
 const normalize = (value?: string | null) => value?.trim().toLowerCase() ?? '';
 
-const expandCandidate = (value?: string | null): string[] => {
-    const normalized = normalize(value);
-
-    if (!normalized) {
-        return [];
-    }
-
-    const base = normalized.split('-')[0];
-    const candidates = new Set<string>([normalized]);
-
-    if (base && base !== normalized) {
-        candidates.add(base);
-    }
-
-    return [...candidates];
-};
-
 const findLanguageCode = (languages: LanguageOption[], ...rawCandidates: (string | null | undefined)[]): string => {
-    const candidates = new Set(rawCandidates.flatMap((candidate) => expandCandidate(candidate)));
+    const candidates = rawCandidates.map((candidate) => normalize(candidate)).filter(Boolean);
 
-    if (!candidates.size) {
-        return '';
+    for (const candidate of candidates) {
+        const exactMatch = languages.find((lang) => normalize(lang.code) === candidate || normalize(lang.name) === candidate);
+
+        if (exactMatch?.code) {
+            return exactMatch.code;
+        }
     }
 
-    return (
-        languages.find((lang) => {
-            const code = normalize(lang.code);
-            const name = normalize(lang.name);
+    for (const candidate of candidates) {
+        const base = candidate.split('-')[0];
+        const baseMatch = languages.find((lang) => normalize(lang.code).split('-')[0] === base);
 
-            return (!!code && candidates.has(code)) || (!!name && candidates.has(name));
-        })?.code ?? ''
-    );
+        if (baseMatch?.code) {
+            return baseMatch.code;
+        }
+    }
+
+    return '';
 };
 
 export function resolveInitialLanguageCode(languages: LanguageOption[], initialLanguage?: string | null): string {
-    const initialMatch = findLanguageCode(languages, initialLanguage);
-    if (initialMatch) {
-        return initialMatch;
-    }
-
-    const englishMatch = findLanguageCode(languages, 'english', 'en');
-    if (englishMatch) {
-        return englishMatch;
-    }
-
-    const firstWithCode = languages.find((lang) => lang.code?.trim())?.code ?? '';
-    if (firstWithCode) {
-        return firstWithCode;
-    }
-
-    return languages.find((lang) => lang.name?.trim())?.code ?? '';
+    return findLanguageCode(languages, initialLanguage);
 }

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -973,7 +973,8 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                                     </li>
                                     <li>
                                         <strong>"Save &amp; Validate"</strong> – Save and validate the complete dataset. All mandatory fields (title,
-                                        year, resource type, datacenter, language, license, authors, abstract) must be filled.
+                                        year, resource type, datacenter, license, authors, abstract) must be filled. Language of Data is optional and
+                                        can be left unset or cleared when the metadata does not specify a language.
                                     </li>
                                 </ul>
                                 <p className="mt-3">

--- a/resources/js/schemas/resource.schema.ts
+++ b/resources/js/schemas/resource.schema.ts
@@ -165,7 +165,7 @@ const resourceBaseSchema = z.object({
     year: yearSchema,
     resourceType: z.string().min(1, 'Resource type is required'),
     version: versionSchema,
-    language: z.string().min(1, 'Language is required'),
+    language: z.string().optional(),
 
     // Titles (at least one required)
     titles: titlesArraySchema,

--- a/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
+++ b/tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php
@@ -74,6 +74,58 @@ beforeEach(function () {
     $this->datacenter = Datacenter::create(['name' => 'Test Datacenter']);
 });
 
+describe('Resource language persistence', function () {
+    it('stores an explicitly selected resource language', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), validPayloadWithLanguage());
+
+        $response->assertStatus(201);
+
+        expect(Resource::latest()->first()?->language_id)->toBe($this->language->id);
+    });
+
+    it('stores a null resource language when the field is omitted', function () {
+        $payload = validPayloadWithLanguage();
+        unset($payload['language']);
+
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), $payload);
+
+        $response->assertStatus(201);
+
+        expect(Resource::latest()->first()?->language_id)->toBeNull();
+    });
+
+    it('normalizes an empty resource language to null', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), validPayloadWithLanguage([
+                'language' => '',
+            ]));
+
+        $response->assertStatus(201);
+
+        expect(Resource::latest()->first()?->language_id)->toBeNull();
+    });
+
+    it('clears an existing resource language during update', function () {
+        $createResponse = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), validPayloadWithLanguage());
+
+        $createResponse->assertStatus(201);
+        $resource = Resource::latest()->firstOrFail();
+
+        $updateResponse = $this->actingAs($this->user)
+            ->postJson(route('editor.resources.store'), validPayloadWithLanguage([
+                'resourceId' => $resource->id,
+                'language' => '',
+            ]));
+
+        $updateResponse->assertStatus(200);
+
+        expect($resource->refresh()->language_id)->toBeNull();
+    });
+});
+
 describe('Title and description language preservation', function () {
     it('stores title language through prepareForValidation', function () {
         $payload = validPayloadWithLanguage([

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -1036,8 +1036,8 @@ describe('DataCiteToResourceTransformer', function (): void {
 
             $resource = $transformer->transform($doiData, $user->id);
 
-            // Test passes - language can be null or have a default
-            expect($resource)->toBeInstanceOf(Resource::class);
+            expect($resource)->toBeInstanceOf(Resource::class)
+                ->and($resource->language_id)->toBeNull();
         });
 
     });

--- a/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
+++ b/tests/pest/Feature/Services/DataCiteXmlExporterTest.php
@@ -1255,6 +1255,14 @@ describe('DataCiteXmlExporter - Version & Language', function () {
         expect($xml)->toContain('<language>');
     });
 
+    test('omits language when not set', function () {
+        $resource = Resource::factory()->create(['language_id' => null]);
+
+        $xml = $this->exporter->export($resource);
+
+        expect($xml)->not->toContain('<language>');
+    });
+
     test('skips version when not set', function () {
         $resource = Resource::factory()->create(['version' => null]);
 

--- a/tests/pest/Feature/Services/OldDatasetEditorLoaderTest.php
+++ b/tests/pest/Feature/Services/OldDatasetEditorLoaderTest.php
@@ -2,6 +2,25 @@
 
 use App\Services\OldDatasetEditorLoader;
 
+describe('language mapping', function () {
+    it('normalizes explicit legacy language codes', function () {
+        $loader = new OldDatasetEditorLoader;
+        $method = (new ReflectionClass($loader))->getMethod('mapLanguage');
+
+        expect($method->invoke($loader, 'DE'))->toBe('de')
+            ->and($method->invoke($loader, ' en '))->toBe('en');
+    });
+
+    it('keeps missing legacy languages empty', function () {
+        $loader = new OldDatasetEditorLoader;
+        $method = (new ReflectionClass($loader))->getMethod('mapLanguage');
+
+        expect($method->invoke($loader, null))->toBe('')
+            ->and($method->invoke($loader, ''))->toBe('')
+            ->and($method->invoke($loader, '   '))->toBe('');
+    });
+});
+
 // Tests that don't require database connection - test license mapping logic
 describe('license mapping', function () {
     it('maps CC BY 4.0 license correctly', function () {

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -62,7 +62,7 @@ describe('SumarioPendingResourceImportService', function () {
                 'doi' => '10.5880/pending.one',
                 'year' => '2024',
                 'version' => '1.0',
-                'language' => 'en',
+                'language' => '',
                 'resourceType' => '1',
                 'titles' => [
                     ['title' => 'Legacy Pending Dataset', 'titleType' => 'main-title'],
@@ -96,6 +96,7 @@ describe('SumarioPendingResourceImportService', function () {
             ->andReturnUsing(function (array $payload, int $userId) use ($user, $datacenter): array {
                 expect($userId)->toBe($user->id)
                     ->and($payload['doi'])->toBe('10.5880/pending.one')
+                    ->and($payload['language'])->toBeNull()
                     ->and($payload['authors'][0]['isContact'])->toBeTrue()
                     ->and($payload['authors'][0]['email'])->toBe('jane@example.org')
                     ->and($payload['datacenter_id'])->toBe($datacenter->id);
@@ -221,6 +222,7 @@ describe('SumarioPendingResourceImportService', function () {
             ->andReturnUsing(function (array $payload, int $userId) use ($user, $arbodat): array {
                 expect($userId)->toBe($user->id)
                     ->and($payload['doi'])->toBe('10.5880/ha-arbodat_ak1')
+                    ->and($payload['language'])->toBe('en')
                     ->and($payload['datacenter_id'])->toBe($arbodat->id);
 
                 return [

--- a/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test.tsx
@@ -579,6 +579,22 @@ describe('DataCiteForm', () => {
             expect(helpButton.closest('[data-slot="accordion-trigger"]')).toBeNull();
         });
 
+        it('marks Resource Information complete without a language selection', () => {
+            renderDataCiteForm({
+                initialYear: '2024',
+                initialResourceType: '1',
+                initialTitles: [{ title: 'Dataset without language metadata', titleType: 'main-title' }],
+                availableDatacenters,
+                initialDatacenterId: 1,
+            });
+
+            const resourceSection = getResourceInfoSection();
+
+            expect(within(resourceSection).getByLabelText('Section complete')).toBeInTheDocument();
+            expect(within(resourceSection).queryByLabelText('Section incomplete or has errors')).not.toBeInTheDocument();
+            expect(within(resourceSection).getByLabelText('Language of Data', { exact: false })).toHaveTextContent('Select language');
+        });
+
         it('keeps counters and status indicators in accordion triggers without duplicate content headings', () => {
             renderDataCiteForm();
 
@@ -860,9 +876,10 @@ describe('DataCiteForm', () => {
         const languageTrigger = screen.getByLabelText('Language of Data', {
             exact: false,
         });
-        expect(languageTrigger).toHaveAttribute('aria-required', 'true');
+        expect(languageTrigger).not.toHaveAttribute('aria-required');
+        expect(languageTrigger).toHaveTextContent('Select language');
         const languageLabel = screen.getByText(/Language of Data/, { selector: 'label' });
-        expect(languageLabel).toHaveTextContent('*');
+        expect(languageLabel).not.toHaveTextContent('*');
         await user.click(languageTrigger);
         for (const option of languages) {
             expect(await screen.findByRole('option', { name: option.name })).toBeInTheDocument();
@@ -2446,7 +2463,38 @@ describe('DataCiteForm', () => {
         expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('German');
     });
 
-    it('defaults Language to English when initialLanguage is missing', () => {
+    it('allows an imported language selection to be cleared', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+        render(
+            <DataCiteForm
+                resourceTypes={resourceTypes}
+                titleTypes={titleTypes}
+                dateTypes={dateTypes}
+                licenses={licenses}
+                languages={languages}
+                contributorPersonRoles={contributorPersonRoles}
+                contributorInstitutionRoles={contributorInstitutionRoles}
+                authorRoles={authorRoles}
+                initialLanguage="de"
+                descriptionTypes={descriptionTypes}
+                googleMapsApiKey="test-api-key"
+            />,
+        );
+
+        const languageTrigger = screen.getByLabelText('Language of Data', { exact: false });
+        expect(languageTrigger).toHaveTextContent('German');
+
+        await user.click(languageTrigger);
+        await user.click(await screen.findByRole('option', { name: 'Clear language selection' }));
+
+        expect(languageTrigger).toHaveTextContent('Select language');
+
+        await user.click(languageTrigger);
+        expect(screen.queryByRole('option', { name: 'Clear language selection' })).not.toBeInTheDocument();
+    });
+
+    it('leaves Language empty when initialLanguage is missing', () => {
         render(
             <DataCiteForm
                 resourceTypes={resourceTypes}
@@ -2461,10 +2509,10 @@ describe('DataCiteForm', () => {
                 googleMapsApiKey="test-api-key"
             />,
         );
-        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('English');
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('Select language');
     });
 
-    it('defaults Language to English even when English is not the first option', () => {
+    it('does not default Language when English is not the first option', () => {
         const shuffledLanguages: Language[] = [
             { id: 2, code: 'de', name: 'German' },
             { id: 3, code: 'fr', name: 'French' },
@@ -2483,7 +2531,7 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('English');
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('Select language');
     });
 
     it('prefills Language when initialLanguage name is provided', () => {
@@ -2524,7 +2572,7 @@ describe('DataCiteForm', () => {
         expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('French');
     });
 
-    it('falls back to the first language with a code when English is unavailable', () => {
+    it('does not fall back to the first language when English is unavailable', () => {
         const limitedLanguages = [
             { id: 4, code: 'de', name: 'German' },
             { id: 5, code: 'fr', name: 'French' },
@@ -2542,10 +2590,10 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('German');
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('Select language');
     });
 
-    it('defaults to English when languages include incomplete entries', () => {
+    it('leaves Language empty when languages include incomplete entries', () => {
         const incompleteLanguages = [
             { id: 1, code: ' ', name: ' ' },
             { id: 2, code: 'en', name: 'English' },
@@ -2564,7 +2612,7 @@ describe('DataCiteForm', () => {
             />,
         );
 
-        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('English');
+        expect(screen.getByLabelText('Language of Data', { exact: false })).toHaveTextContent('Select language');
     });
 
     it('prefills Resource Type when initialResourceType is provided', () => {
@@ -2919,6 +2967,7 @@ describe('DataCiteForm', () => {
         expect(body).toMatchObject({
             year: 2024,
             resourceType: 1,
+            language: '',
             titles: [
                 {
                     title: 'First Title',

--- a/tests/vitest/components/curation/fields/select-field-validation.test.tsx
+++ b/tests/vitest/components/curation/fields/select-field-validation.test.tsx
@@ -322,6 +322,33 @@ describe('SelectField with Validation', () => {
             expect(onValueChange).toHaveBeenCalledWith('option1');
         });
 
+        it('should emit an empty value when an optional selection is cleared', async () => {
+            const user = userEvent.setup();
+            const onValueChange = vi.fn();
+            const onValidationBlur = vi.fn();
+
+            render(
+                <SelectField
+                    id="test-select"
+                    label="Test Label"
+                    value="option1"
+                    onValueChange={onValueChange}
+                    onValidationBlur={onValidationBlur}
+                    options={mockOptions}
+                    clearable
+                    clearLabel="Clear test selection"
+                />,
+            );
+
+            await user.click(screen.getByRole('combobox'));
+            await user.click(await screen.findByRole('option', { name: 'Clear test selection' }));
+
+            expect(onValueChange).toHaveBeenCalledWith('');
+            await vi.waitFor(() => {
+                expect(onValidationBlur).toHaveBeenCalledTimes(1);
+            });
+        });
+
         it('should call onValidationBlur after value changes', async () => {
             const user = userEvent.setup();
             const onValidationBlur = vi.fn();
@@ -421,6 +448,37 @@ describe('SelectField with Validation', () => {
             expect(await screen.findByRole('option', { name: 'Option 1' })).toBeInTheDocument();
             expect(await screen.findByRole('option', { name: 'Option 2' })).toBeInTheDocument();
             expect(await screen.findByRole('option', { name: 'Option 3' })).toBeInTheDocument();
+        });
+
+        it('should hide the clear action when clearing is disabled or the field is empty', async () => {
+            const user = userEvent.setup();
+            const { rerender } = render(
+                <SelectField
+                    id="test-select"
+                    label="Test Label"
+                    value="option1"
+                    onValueChange={vi.fn()}
+                    options={mockOptions}
+                />,
+            );
+
+            await user.click(screen.getByRole('combobox'));
+            expect(screen.queryByRole('option', { name: 'Clear selection' })).not.toBeInTheDocument();
+            await user.keyboard('{Escape}');
+
+            rerender(
+                <SelectField
+                    id="test-select"
+                    label="Test Label"
+                    value=""
+                    onValueChange={vi.fn()}
+                    options={mockOptions}
+                    clearable
+                />,
+            );
+
+            await user.click(screen.getByRole('combobox'));
+            expect(screen.queryByRole('option', { name: 'Clear selection' })).not.toBeInTheDocument();
         });
 
         it('should handle empty options array', () => {

--- a/tests/vitest/components/curation/utils/__tests__/language-resolver.test.ts
+++ b/tests/vitest/components/curation/utils/__tests__/language-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { type LanguageOption,resolveInitialLanguageCode } from '@/components/curation/utils/language-resolver';
+import { type LanguageOption, resolveInitialLanguageCode } from '@/components/curation/utils/language-resolver';
 
 const baseLanguages: LanguageOption[] = [
     { code: 'en', name: 'English' },
@@ -9,17 +9,19 @@ const baseLanguages: LanguageOption[] = [
 ];
 
 describe('resolveInitialLanguageCode', () => {
-    it('returns the initial language when provided', () => {
+    it('returns a recognized initial language by code or name', () => {
         expect(resolveInitialLanguageCode(baseLanguages, 'de')).toBe('de');
         expect(resolveInitialLanguageCode(baseLanguages, 'German')).toBe('de');
     });
 
-    it('falls back to English when no initial language is provided', () => {
-        expect(resolveInitialLanguageCode(baseLanguages, undefined)).toBe('en');
-        expect(resolveInitialLanguageCode(baseLanguages, '')).toBe('en');
+    it('leaves the language empty when no initial value is provided', () => {
+        expect(resolveInitialLanguageCode(baseLanguages, undefined)).toBe('');
+        expect(resolveInitialLanguageCode(baseLanguages, null)).toBe('');
+        expect(resolveInitialLanguageCode(baseLanguages, '')).toBe('');
+        expect(resolveInitialLanguageCode(baseLanguages, '   ')).toBe('');
     });
 
-    it('matches initial codes with hyphenated variants', () => {
+    it('matches exact and base codes with hyphenated variants', () => {
         const languages: LanguageOption[] = [
             { code: 'en-US', name: 'English (US)' },
             { code: 'en-GB', name: 'English (UK)' },
@@ -29,31 +31,27 @@ describe('resolveInitialLanguageCode', () => {
         expect(resolveInitialLanguageCode(languages, 'en')).toBe('en-US');
     });
 
-    it('prefers English even if it is not the first language', () => {
+    it('does not default to English or the first configured language', () => {
         const shuffled: LanguageOption[] = [
             { code: 'de', name: 'German' },
             { code: 'fr', name: 'French' },
             { code: 'en', name: 'English' },
         ];
 
-        expect(resolveInitialLanguageCode(shuffled)).toBe('en');
+        expect(resolveInitialLanguageCode(shuffled)).toBe('');
     });
 
-    it('returns the first language with a code when English is unavailable', () => {
-        const languages: LanguageOption[] = [
-            { code: '', name: '' },
-            { code: 'de', name: 'German' },
-        ];
-
-        expect(resolveInitialLanguageCode(languages)).toBe('de');
+    it('leaves unsupported initial values empty instead of substituting another language', () => {
+        expect(resolveInitialLanguageCode(baseLanguages, 'es')).toBe('');
+        expect(resolveInitialLanguageCode(baseLanguages, 'Spanish')).toBe('');
     });
 
-    it('falls back to an empty string when no codes are present', () => {
+    it('ignores incomplete language options', () => {
         const languages: LanguageOption[] = [
             { code: '', name: '' },
             { code: null, name: 'Français' },
         ];
 
-        expect(resolveInitialLanguageCode(languages)).toBe('');
+        expect(resolveInitialLanguageCode(languages, 'Français')).toBe('');
     });
 });

--- a/tests/vitest/schemas/__tests__/resource.schema.test.ts
+++ b/tests/vitest/schemas/__tests__/resource.schema.test.ts
@@ -133,6 +133,19 @@ describe('Resource Schemas', () => {
             expect(result.success).toBe(true);
         });
 
+        it('accepts omitted and empty optional resource languages', () => {
+            const resourceWithoutLanguage = {
+                resourceType: 'Dataset',
+                titles: [{ id: '1', title: 'Test', titleType: 'main-title' }],
+                authors: [{ id: '1', type: 'person' as const, firstName: 'Jane', lastName: 'Doe' }],
+                contributors: [],
+                licenses: [{ id: '1', license: 'CC-BY-4.0' }],
+            };
+
+            expect(resourceSchema.safeParse(resourceWithoutLanguage).success).toBe(true);
+            expect(resourceSchema.safeParse({ ...resourceWithoutLanguage, language: '' }).success).toBe(true);
+        });
+
         it('requires resource type', () => {
             const result = resourceSchema.safeParse({
                 resourceType: '',


### PR DESCRIPTION
This pull request makes the resource "Language" field optional throughout the data editor and backend, removing the previous requirement to always specify a language (which defaulted to English when missing). Now, resources can be saved without a language, and curators can clear or omit the field as needed. The changes ensure that explicit language selections are preserved, missing values remain unset, and legacy data is handled consistently. The pull request also updates validation logic, UI components, backend mapping, and test coverage to reflect this new behavior.

**Resource Language Optionality and Data Handling:**
- The "Language" field is no longer required in the resource editor UI, backend validation, or storage; missing or empty values are stored as null and are not defaulted to English. Existing selections can be cleared without blocking validation. (`resources/js/components/curation/datacite-form.tsx` [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L668-L680) [[2]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1393-L1396) [[3]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1466-R1449) [[4]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1481) [[5]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1496-R1485) [[6]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L1678-L1685) [[7]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0L3006-R2980) [[8]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R3081-R3084); `app/Services/OldDatasetEditorLoader.php` [[9]](diffhunk://#diff-07571e5ba002b97a8dc56cb8a1fd435f4845205de77b632262c750f6c35ea2f7L192-R197); `app/Services/SumarioPendingResourceImportService.php` [[10]](diffhunk://#diff-b799a2f884a1af868f6fdba21a80fe75421b4c69a6e4e66bd8000adf50523241L260-R260); `resources/js/schemas/resource.schema.ts` [[11]](diffhunk://#diff-6f1269b84427c61834269f9c61c90c543d8c699ba2bda974584822c29f06914aL168-R168)
- The backend now preserves explicit language codes, normalizes them, and keeps missing or empty values unset instead of defaulting. (`app/Services/OldDatasetEditorLoader.php` [[1]](diffhunk://#diff-07571e5ba002b97a8dc56cb8a1fd435f4845205de77b632262c750f6c35ea2f7L192-R197); `app/Services/SumarioPendingResourceImportService.php` [[2]](diffhunk://#diff-b799a2f884a1af868f6fdba21a80fe75421b4c69a6e4e66bd8000adf50523241L260-R260); `resources/js/components/curation/utils/language-resolver.ts` [[3]](diffhunk://#diff-8d3b599baee11b2849403d8816d86b1b59b265c15809ad1171d7fcc2658adebeL8-R32)

**User Interface and Usability Improvements:**
- The language select field is now clearable and no longer marked as required. The UI allows curators to clear the language selection, and the field's placeholder and helper text reflect its optional status. (`resources/js/components/curation/datacite-form.tsx` [[1]](diffhunk://#diff-aace58b23a05402d977f4d87c97bca3ef93293c8c78a6c0e5a659c5fa4d3f6f0R3081-R3084); `resources/js/components/curation/fields/select-field.tsx` [[2]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfL5-R5) [[3]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfR25-R26) [[4]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfR50-R51) [[5]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfR78-R82) [[6]](diffhunk://#diff-2d891560867c68fdc1adfc59c143368d675ef5a5885990e63316c2d9298bcdcfR141-R146)
- Documentation and UI copy are updated to clarify that the language field is optional. (`resources/js/pages/docs.tsx` [resources/js/pages/docs.tsxL976-R977](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aL976-R977))

**Test Coverage and Validation:**
- Adds and updates tests to verify that language can be set, omitted, or cleared, and that these states are correctly persisted and exported. (`tests/pest/Feature/Http/Controllers/ResourceControllerLanguageFieldTest.php` [[1]](diffhunk://#diff-a0e32fef0a44a48ace5c2af90edd81d2d82b30c6533a62c571ff872088ff0483R77-R128); `tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php` [[2]](diffhunk://#diff-ce0e99186c9a85ae88649b002e0203ad69a90a6b4937c9dfeb6e151378daf6cbL1039-R1040); `tests/pest/Feature/Services/DataCiteXmlExporterTest.php` [[3]](diffhunk://#diff-f8f1956c3f2d0cc3e5ad6d100ee88111e6d98886ae30b5fd2d28757e3ea81e7dR1258-R1265); `tests/pest/Feature/Services/OldDatasetEditorLoaderTest.php` [[4]](diffhunk://#diff-d434a2565efc03d39c41fbeef0687fab01e30ca94fb8b8d7aa44f466120136baR5-R23)

**Changelog:**
- Documents the new optionality of the language field for curators and users. (`resources/data/changelog.json` [resources/data/changelog.jsonR386-R389](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR386-R389))

These changes make the resource language field fully optional, improving flexibility for datasets where language metadata is missing or not applicable.