### PR TITLE
Fix: Enrichment of metadata with embedded XMLs

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -16,6 +16,7 @@ use App\Services\GfzDataServicesPortalService;
 use App\Services\LegacyLandingPageDecisionService;
 use App\Services\LegacyLandingPageImportService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
+use App\Services\LegacyResourceLookupService;
 use App\Services\MetaworksDownloadUrlService;
 use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
@@ -887,6 +888,8 @@ class ImportFromDataCiteJob implements ShouldQueue
         bool $shouldLookupMetaworks = true,
         ?array $portalDatacenterNames = null,
     ): array {
+        $metaworksUnavailable = false;
+
         if ($this->shouldSkipLegacyDoi($doi)) {
             Log::info('Skipping legacy DOI marked as test/delete', ['doi' => $doi]);
 
@@ -917,7 +920,23 @@ class ImportFromDataCiteJob implements ShouldQueue
                 ];
             }
 
-            $preparedDoiRecord = $transformer->prepareDoiData($doiRecord);
+            $legacyRelatedIdentifiers = [];
+
+            if ($shouldLookupMetaworks) {
+                try {
+                    $legacyRelatedIdentifiers = app(LegacyResourceLookupService::class)
+                        ->relatedIdentifiersByDoi($doi);
+                } catch (\Throwable $exception) {
+                    $metaworksUnavailable = true;
+
+                    Log::warning('Metaworks DB unavailable while loading related identifiers; continuing without legacy enrichment.', [
+                        'doi' => $doi,
+                        'error' => $exception->getMessage(),
+                    ]);
+                }
+            }
+
+            $preparedDoiRecord = $transformer->prepareDoiData($doiRecord, $legacyRelatedIdentifiers);
 
             // Use database transaction to ensure atomicity of the check-then-insert operation.
             //
@@ -945,13 +964,13 @@ class ImportFromDataCiteJob implements ShouldQueue
                     : $this->emptyDataCiteLandingPageSyncResult();
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
-                if ($existingResource !== null && $shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
+                if ($existingResource !== null && $shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
                     $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
                 }
 
                 return [
                     'status' => 'skipped',
-                    'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
+                    'metaworks_unavailable' => $metaworksUnavailable || $legacyDownloadSync['metaworks_unavailable'],
                     'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
                 ];
             }
@@ -969,7 +988,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
             $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
-            if ($shouldLookupMetaworks && ! LandingPage::where('resource_id', $importedResource->id)->exists()) {
+            if ($shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $importedResource->id)->exists()) {
                 $legacyDownloadSync = $this->syncLegacyDownloadLinks($importedResource, $doi, $metaworksService);
             }
 
@@ -979,7 +998,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
             return [
                 'status' => 'imported',
-                'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
+                'metaworks_unavailable' => $metaworksUnavailable || $legacyDownloadSync['metaworks_unavailable'],
                 'enriched' => false,
             ];
         } catch (QueryException $exception) {
@@ -1000,13 +1019,13 @@ class ImportFromDataCiteJob implements ShouldQueue
                     : $this->emptyDataCiteLandingPageSyncResult();
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
-                if ($existingResource !== null && $shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
+                if ($existingResource !== null && $shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
                     $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
                 }
 
                 return [
                     'status' => 'skipped',
-                    'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
+                    'metaworks_unavailable' => $metaworksUnavailable || $legacyDownloadSync['metaworks_unavailable'],
                     'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
                 ];
             }

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -930,6 +930,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                     $metaworksUnavailable = true;
 
                     Log::warning('Metaworks DB unavailable while loading related identifiers; continuing without legacy enrichment.', [
+                        'import_id' => $this->importId,
                         'doi' => $doi,
                         'error' => $exception->getMessage(),
                     ]);

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -38,6 +38,7 @@ use App\Models\Title;
 use App\Models\TitleType;
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
 use App\Services\Rights\ResourceRightsStorageService;
+use App\Services\Xml\OriginalDataCiteRelatedIdentifierExtractionService;
 use App\Services\Xml\Sections\RightsSectionParser;
 use App\Support\DataCiteDateNormalizer;
 use App\Support\OrcidNormalizer;
@@ -64,6 +65,8 @@ class DataCiteToResourceTransformer
         private ?SubjectBreadcrumbPathResolverService $subjectBreadcrumbPathResolver = null,
         private ?RightsSectionParser $xmlRightsParser = null,
         private ?DataCiteJsonImportNormalizerService $jsonImportNormalizer = null,
+        private ?OriginalDataCiteRelatedIdentifierExtractionService $xmlRelatedIdentifierExtractor = null,
+        private ?RelatedIdentifierImportMergeService $relatedIdentifierImportMergeService = null,
     ) {}
 
     /**
@@ -118,22 +121,23 @@ class DataCiteToResourceTransformer
 
     /**
      * @param  array<string, mixed>  $doiData
+     * @param  array<int, mixed>  $legacyRelatedIdentifiers
      * @return array<string, mixed>
      */
-    public function prepareDoiData(array $doiData): array
+    public function prepareDoiData(array $doiData, array $legacyRelatedIdentifiers = []): array
     {
         if (($doiData[self::PREPARED_MARKER] ?? false) === true) {
             return $doiData;
         }
 
         if (is_array($doiData['attributes'] ?? null)) {
-            $doiData['attributes'] = $this->prepareAttributes($doiData['attributes']);
+            $doiData['attributes'] = $this->prepareAttributes($doiData['attributes'], $legacyRelatedIdentifiers);
             $doiData[self::PREPARED_MARKER] = true;
 
             return $doiData;
         }
 
-        $preparedAttributes = $this->prepareAttributes($doiData);
+        $preparedAttributes = $this->prepareAttributes($doiData, $legacyRelatedIdentifiers);
         $preparedAttributes[self::PREPARED_MARKER] = true;
 
         return $preparedAttributes;
@@ -141,26 +145,30 @@ class DataCiteToResourceTransformer
 
     /**
      * @param  array<string, mixed>  $attributes
+     * @param  array<int, mixed>  $legacyRelatedIdentifiers
      * @return array<string, mixed>
      */
-    private function prepareAttributes(array $attributes): array
+    private function prepareAttributes(array $attributes, array $legacyRelatedIdentifiers = []): array
     {
-        $attributes = $this->preferOriginalXmlRights($attributes);
+        $xml = $this->xmlRelatedIdentifierExtractor()->decode($attributes['xml'] ?? null);
+        $xmlRelatedIdentifiers = $xml === null
+            ? []
+            : $this->xmlRelatedIdentifierExtractor()->extract($xml, (string) ($attributes['doi'] ?? ''));
+
+        $attributes = $this->preferOriginalXmlRights($attributes, $xml);
         $attributes = ($this->jsonImportNormalizer ??= new DataCiteJsonImportNormalizerService)->normalize($attributes);
-
-        $relatedIdentifiers = $attributes['relatedIdentifiers'] ?? null;
-
-        if (! is_array($relatedIdentifiers)) {
-            return $attributes;
-        }
+        $jsonRelatedIdentifiers = is_array($attributes['relatedIdentifiers'] ?? null)
+            ? $attributes['relatedIdentifiers']
+            : [];
+        $relatedIdentifiers = $this->relatedIdentifierImportMergeService()->merge(
+            $jsonRelatedIdentifiers,
+            $xmlRelatedIdentifiers,
+            $legacyRelatedIdentifiers,
+        );
 
         $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
 
         foreach ($relatedIdentifiers as $index => $relatedIdentifier) {
-            if (! is_array($relatedIdentifier)) {
-                continue;
-            }
-
             $identifier = isset($relatedIdentifier['relatedIdentifier'])
                 ? trim((string) $relatedIdentifier['relatedIdentifier'])
                 : '';
@@ -211,10 +219,8 @@ class DataCiteToResourceTransformer
      * @param  array<string, mixed>  $attributes
      * @return array<string, mixed>
      */
-    private function preferOriginalXmlRights(array $attributes): array
+    private function preferOriginalXmlRights(array $attributes, ?string $xml): array
     {
-        $xml = $this->decodedOriginalXml($attributes['xml'] ?? null);
-
         if ($xml === null) {
             return $attributes;
         }
@@ -247,17 +253,14 @@ class DataCiteToResourceTransformer
         return $attributes;
     }
 
-    private function decodedOriginalXml(mixed $value): ?string
+    private function xmlRelatedIdentifierExtractor(): OriginalDataCiteRelatedIdentifierExtractionService
     {
-        if (! is_string($value) || trim($value) === '') {
-            return null;
-        }
+        return $this->xmlRelatedIdentifierExtractor ??= app(OriginalDataCiteRelatedIdentifierExtractionService::class);
+    }
 
-        $value = trim($value);
-        $decoded = base64_decode($value, true);
-        $xml = $decoded === false ? $value : $decoded;
-
-        return str_contains($xml, '<') ? $xml : null;
+    private function relatedIdentifierImportMergeService(): RelatedIdentifierImportMergeService
+    {
+        return $this->relatedIdentifierImportMergeService ??= app(RelatedIdentifierImportMergeService::class);
     }
 
     private function citationLabelService(): RelatedIdentifierCitationLabelService
@@ -1437,9 +1440,11 @@ class DataCiteToResourceTransformer
     private function transformRelatedIdentifiers(array $relatedIdentifiers, Resource $resource): void
     {
         foreach ($relatedIdentifiers as $position => $relIdData) {
-            $identifier = $relIdData['relatedIdentifier'] ?? null;
+            $identifier = isset($relIdData['relatedIdentifier'])
+                ? trim((string) $relIdData['relatedIdentifier'])
+                : '';
 
-            if ($identifier === null) {
+            if ($identifier === '') {
                 continue;
             }
 
@@ -1478,6 +1483,7 @@ class DataCiteToResourceTransformer
                 'related_metadata_scheme' => $relIdData['relatedMetadataScheme'] ?? null,
                 'scheme_uri' => $relIdData['schemeUri'] ?? null,
                 'scheme_type' => $relIdData['schemeType'] ?? null,
+                'resource_type_general' => $relIdData['resourceTypeGeneral'] ?? null,
                 'position' => $position + 1,
             ]);
         }

--- a/app/Services/LegacyResourceLookupService.php
+++ b/app/Services/LegacyResourceLookupService.php
@@ -14,4 +14,16 @@ class LegacyResourceLookupService
             ->whereRaw('LOWER(identifier) = ?', [strtolower(trim($doi))])
             ->exists();
     }
+
+    /**
+     * @return array<int, array{identifier: string, identifierType: string, relationType: string, position: int}>
+     */
+    public function relatedIdentifiersByDoi(string $doi): array
+    {
+        $resource = OldDataset::query()
+            ->whereRaw('LOWER(identifier) = ?', [strtolower(trim($doi))])
+            ->first();
+
+        return $resource?->getRelatedIdentifiers() ?? [];
+    }
 }

--- a/app/Services/RelatedIdentifierImportMergeService.php
+++ b/app/Services/RelatedIdentifierImportMergeService.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+/**
+ * Merges related identifiers in source priority order without creating duplicates.
+ */
+final readonly class RelatedIdentifierImportMergeService
+{
+    /** @var list<string> */
+    private const OPTIONAL_FIELDS = [
+        'resourceTypeGeneral',
+        'relationTypeInformation',
+        'relatedMetadataScheme',
+        'schemeUri',
+        'schemeType',
+        'citationLabel',
+    ];
+
+    public function __construct(
+        private RelatedIdentifierTypeResolverService $typeResolver,
+    ) {}
+
+    /**
+     * @param  array<int, mixed>  $jsonRelatedIdentifiers
+     * @param  array<int, mixed>  $xmlRelatedIdentifiers
+     * @param  array<int, mixed>  $legacyRelatedIdentifiers
+     * @return list<array<string, string>>
+     */
+    public function merge(
+        array $jsonRelatedIdentifiers,
+        array $xmlRelatedIdentifiers,
+        array $legacyRelatedIdentifiers = [],
+    ): array {
+        $json = $this->canonicalizeList($jsonRelatedIdentifiers, true);
+        $xml = $this->canonicalizeList($xmlRelatedIdentifiers, false);
+        $legacy = $this->canonicalizeList($legacyRelatedIdentifiers, false);
+        $usedXmlIndexes = [];
+
+        /** @var list<array<string, string|int>> $repairedJson */
+        $repairedJson = [];
+
+        foreach ($json as $relatedIdentifier) {
+            if ($this->identifier($relatedIdentifier) !== '') {
+                $repairedJson[] = $relatedIdentifier;
+
+                continue;
+            }
+
+            $xmlIndex = $this->matchingXmlIndex($relatedIdentifier, $xml, $usedXmlIndexes);
+
+            if ($xmlIndex === null) {
+                continue;
+            }
+
+            $repairedJson[] = $this->supplement($relatedIdentifier, $xml[$xmlIndex]);
+            $usedXmlIndexes[$xmlIndex] = true;
+        }
+
+        /** @var list<array<string, string>> $merged */
+        $merged = [];
+        /** @var array<string, int> $keyIndexes */
+        $keyIndexes = [];
+
+        foreach ($repairedJson as $relatedIdentifier) {
+            $this->appendOrSupplement($merged, $keyIndexes, $relatedIdentifier);
+        }
+
+        foreach ($xml as $xmlIndex => $relatedIdentifier) {
+            if (isset($usedXmlIndexes[$xmlIndex])) {
+                continue;
+            }
+
+            $this->appendOrSupplement($merged, $keyIndexes, $relatedIdentifier);
+        }
+
+        foreach ($legacy as $relatedIdentifier) {
+            $this->appendOrSupplement($merged, $keyIndexes, $relatedIdentifier);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * @param  array<int, mixed>  $records
+     * @return list<array<string, string|int>>
+     */
+    private function canonicalizeList(array $records, bool $keepIncomplete): array
+    {
+        $canonical = [];
+
+        foreach (array_values($records) as $position => $record) {
+            if (! is_array($record)) {
+                continue;
+            }
+
+            $identifierType = $this->typeResolver->resolveIdentifierType(
+                $record['relatedIdentifierType'] ?? $record['identifierType'] ?? $record['identifier_type'] ?? null,
+            );
+            $relationType = $this->typeResolver->resolveRelationType(
+                $record['relationType'] ?? $record['relation_type'] ?? null,
+            );
+
+            if ($identifierType === null || $relationType === null) {
+                continue;
+            }
+
+            $identifier = $record['relatedIdentifier'] ?? $record['identifier'] ?? '';
+            $identifier = is_string($identifier) ? trim($identifier) : '';
+
+            if ($identifier === '' && ! $keepIncomplete) {
+                continue;
+            }
+
+            $item = [
+                'relatedIdentifier' => $identifier,
+                'relatedIdentifierType' => $identifierType,
+                'relationType' => $relationType,
+                '__position' => $position,
+            ];
+
+            foreach (self::OPTIONAL_FIELDS as $field) {
+                $value = $this->optionalValue($record, $field);
+
+                if ($value !== null) {
+                    $item[$field] = $value;
+                }
+            }
+
+            $canonical[] = $item;
+        }
+
+        return $canonical;
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     */
+    private function optionalValue(array $record, string $field): ?string
+    {
+        $aliases = match ($field) {
+            'resourceTypeGeneral' => ['resourceTypeGeneral', 'resource_type_general'],
+            'relationTypeInformation' => ['relationTypeInformation', 'relation_type_information'],
+            'relatedMetadataScheme' => ['relatedMetadataScheme', 'related_metadata_scheme'],
+            'schemeUri' => ['schemeUri', 'schemeURI', 'scheme_uri'],
+            'schemeType' => ['schemeType', 'scheme_type'],
+            'citationLabel' => ['citationLabel', 'citation_label'],
+            default => [],
+        };
+
+        foreach ($aliases as $alias) {
+            if (! isset($record[$alias]) || ! is_scalar($record[$alias])) {
+                continue;
+            }
+
+            $value = trim((string) $record[$alias]);
+
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, string|int>  $incomplete
+     * @param  list<array<string, string|int>>  $xml
+     * @param  array<int, true>  $usedXmlIndexes
+     */
+    private function matchingXmlIndex(array $incomplete, array $xml, array $usedXmlIndexes): ?int
+    {
+        $position = (int) $incomplete['__position'];
+
+        if (
+            ! isset($usedXmlIndexes[$position])
+            && isset($xml[$position])
+            && $this->sameTypes($incomplete, $xml[$position])
+        ) {
+            return $position;
+        }
+
+        $matches = [];
+
+        foreach ($xml as $index => $candidate) {
+            if (! isset($usedXmlIndexes[$index]) && $this->sameTypes($incomplete, $candidate)) {
+                $matches[] = $index;
+            }
+        }
+
+        return count($matches) === 1 ? $matches[0] : null;
+    }
+
+    /**
+     * @param  array<string, string|int>  $first
+     * @param  array<string, string|int>  $second
+     */
+    private function sameTypes(array $first, array $second): bool
+    {
+        return $first['relatedIdentifierType'] === $second['relatedIdentifierType']
+            && $first['relationType'] === $second['relationType'];
+    }
+
+    /**
+     * @param  array<string, string|int>  $preferred
+     * @param  array<string, string|int>  $fallback
+     * @return array<string, string|int>
+     */
+    private function supplement(array $preferred, array $fallback): array
+    {
+        if ($this->identifier($preferred) === '') {
+            $preferred['relatedIdentifier'] = $this->identifier($fallback);
+        }
+
+        foreach (self::OPTIONAL_FIELDS as $field) {
+            if ($this->valueIsBlank($preferred[$field] ?? null) && ! $this->valueIsBlank($fallback[$field] ?? null)) {
+                $preferred[$field] = $fallback[$field];
+            }
+        }
+
+        return $preferred;
+    }
+
+    /**
+     * @param  list<array<string, string>>  $merged
+     * @param  array<string, int>  $keyIndexes
+     * @param  array<string, string|int>  $record
+     */
+    private function appendOrSupplement(array &$merged, array &$keyIndexes, array $record): void
+    {
+        $identifier = $this->identifier($record);
+
+        if ($identifier === '') {
+            return;
+        }
+
+        $key = $record['relatedIdentifierType'].'|'
+            .$this->normalizedIdentifier($identifier, (string) $record['relatedIdentifierType']).'|'
+            .$record['relationType'];
+
+        if (isset($keyIndexes[$key])) {
+            $existingIndex = $keyIndexes[$key];
+            /** @var array<string, string|int> $existing */
+            $existing = $merged[$existingIndex];
+            $merged[$existingIndex] = $this->withoutInternalFields($this->supplement($existing, $record));
+
+            return;
+        }
+
+        $keyIndexes[$key] = count($merged);
+        $merged[] = $this->withoutInternalFields($record);
+    }
+
+    /**
+     * @param  array<string, string|int>  $record
+     */
+    private function identifier(array $record): string
+    {
+        return trim((string) ($record['relatedIdentifier'] ?? ''));
+    }
+
+    private function normalizedIdentifier(string $identifier, string $identifierType): string
+    {
+        $identifier = trim($identifier);
+
+        if ($identifierType === 'DOI') {
+            $identifier = preg_replace(
+                '/^(?:doi:\s*|https?:\/\/(?:doi\.org|dx\.doi\.org)\/)/i',
+                '',
+                $identifier,
+            ) ?? $identifier;
+        }
+
+        return mb_strtolower(trim($identifier));
+    }
+
+    private function valueIsBlank(mixed $value): bool
+    {
+        return ! is_scalar($value) || trim((string) $value) === '';
+    }
+
+    /**
+     * @param  array<string, string|int>  $record
+     * @return array<string, string>
+     */
+    private function withoutInternalFields(array $record): array
+    {
+        unset($record['__position']);
+
+        /** @var array<string, string> $record */
+        return $record;
+    }
+}

--- a/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
+++ b/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Xml;
+
+use App\Services\RelatedIdentifierTypeResolverService;
+use App\Support\Xml\XmlElementHelpers;
+use Illuminate\Support\Facades\Log;
+use Saloon\XmlWrangler\XmlReader;
+
+/**
+ * Extracts related identifiers from the original XML embedded in DataCite API responses.
+ */
+final readonly class OriginalDataCiteRelatedIdentifierExtractionService
+{
+    public function __construct(
+        private RelatedIdentifierTypeResolverService $typeResolver,
+    ) {}
+
+    public function decode(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (str_contains($value, '<')) {
+            return $value;
+        }
+
+        $decoded = base64_decode($value, true);
+
+        return is_string($decoded) && str_contains($decoded, '<') ? $decoded : null;
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    public function extract(string $xml, ?string $context = null): array
+    {
+        try {
+            return $this->extractFromReader(XmlReader::fromString($xml), $context);
+        } catch (\Throwable $exception) {
+            Log::warning('Could not parse original DataCite XML related identifiers.', [
+                'context' => $context,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * @return list<array<string, string>>
+     */
+    public function extractFromReader(XmlReader $reader, ?string $context = null): array
+    {
+        try {
+            $elements = $reader
+                ->xpathElement('//*[local-name()="resource"]/*[local-name()="relatedIdentifiers"]/*[local-name()="relatedIdentifier"]')
+                ->get();
+        } catch (\Throwable $exception) {
+            Log::warning('Could not read original DataCite XML related identifiers.', [
+                'context' => $context,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        $relatedIdentifiers = [];
+
+        foreach ($elements as $index => $element) {
+            $identifier = trim((string) (XmlElementHelpers::stringValue($element) ?? ''));
+            $identifierTypeRaw = $element->getAttribute('relatedIdentifierType');
+            $relationTypeRaw = $element->getAttribute('relationType');
+            $identifierType = $this->typeResolver->resolveIdentifierType($identifierTypeRaw);
+            $relationType = $this->typeResolver->resolveRelationType($relationTypeRaw);
+
+            if ($identifier === '' || $identifierType === null || $relationType === null) {
+                Log::warning('Skipping invalid related identifier from original DataCite XML.', [
+                    'context' => $context,
+                    'index' => $index,
+                    'identifier' => $identifier,
+                    'relatedIdentifierType' => $identifierTypeRaw,
+                    'relationType' => $relationTypeRaw,
+                ]);
+
+                continue;
+            }
+
+            $relatedIdentifier = [
+                'relatedIdentifier' => $identifier,
+                'relatedIdentifierType' => $identifierType,
+                'relationType' => $relationType,
+            ];
+
+            $this->copyAttribute($relatedIdentifier, 'resourceTypeGeneral', $element->getAttribute('resourceTypeGeneral'));
+            $this->copyAttribute($relatedIdentifier, 'relationTypeInformation', $element->getAttribute('relationTypeInformation'));
+            $this->copyAttribute($relatedIdentifier, 'relatedMetadataScheme', $element->getAttribute('relatedMetadataScheme'));
+            $this->copyAttribute($relatedIdentifier, 'schemeUri', $element->getAttribute('schemeURI'));
+            $this->copyAttribute($relatedIdentifier, 'schemeType', $element->getAttribute('schemeType'));
+
+            $relatedIdentifiers[] = $relatedIdentifier;
+        }
+
+        return $relatedIdentifiers;
+    }
+
+    /**
+     * @param  array<string, string>  $relatedIdentifier
+     */
+    private function copyAttribute(array &$relatedIdentifier, string $key, mixed $value): void
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return;
+        }
+
+        $relatedIdentifier[$key] = trim($value);
+    }
+}

--- a/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
+++ b/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Log;
 use Saloon\XmlWrangler\XmlReader;
 
 /**
- * Extracts related identifiers from the original XML embedded in DataCite API responses.
+ * Extracts related identifiers from DataCite XML documents.
  */
 final readonly class OriginalDataCiteRelatedIdentifierExtractionService
 {
@@ -43,7 +43,7 @@ final readonly class OriginalDataCiteRelatedIdentifierExtractionService
         try {
             return $this->extractFromReader(XmlReader::fromString($xml), $context);
         } catch (\Throwable $exception) {
-            Log::warning('Could not parse original DataCite XML related identifiers.', [
+            Log::warning('Could not parse XML related identifiers.', [
                 'context' => $context,
                 'error' => $exception->getMessage(),
             ]);
@@ -62,7 +62,7 @@ final readonly class OriginalDataCiteRelatedIdentifierExtractionService
                 ->xpathElement('//*[local-name()="resource"]/*[local-name()="relatedIdentifiers"]/*[local-name()="relatedIdentifier"]')
                 ->get();
         } catch (\Throwable $exception) {
-            Log::warning('Could not read original DataCite XML related identifiers.', [
+            Log::warning('Could not read XML related identifiers.', [
                 'context' => $context,
                 'error' => $exception->getMessage(),
             ]);
@@ -80,7 +80,7 @@ final readonly class OriginalDataCiteRelatedIdentifierExtractionService
             $relationType = $this->typeResolver->resolveRelationType($relationTypeRaw);
 
             if ($identifier === '' || $identifierType === null || $relationType === null) {
-                Log::warning('Skipping invalid related identifier from original DataCite XML.', [
+                Log::warning('Skipping invalid XML related identifier.', [
                     'context' => $context,
                     'index' => $index,
                     'identifier' => $identifier,

--- a/app/Services/Xml/Sections/RelatedWorkAndInstrumentSectionParser.php
+++ b/app/Services/Xml/Sections/RelatedWorkAndInstrumentSectionParser.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Xml\Sections;
 
 use App\Services\Citations\RelatedIdentifierCitationLabelService;
-use App\Services\RelatedIdentifierTypeResolverService;
-use App\Support\Xml\XmlElementHelpers;
-use Illuminate\Support\Facades\Log;
+use App\Services\Xml\OriginalDataCiteRelatedIdentifierExtractionService;
 use Saloon\XmlWrangler\XmlReader;
 
 /**
@@ -19,7 +17,7 @@ use Saloon\XmlWrangler\XmlReader;
 final readonly class RelatedWorkAndInstrumentSectionParser
 {
     public function __construct(
-        private RelatedIdentifierTypeResolverService $typeResolver,
+        private OriginalDataCiteRelatedIdentifierExtractionService $relatedIdentifierExtractor,
         private RelatedIdentifierCitationLabelService $citationLabelService,
     ) {}
 
@@ -31,38 +29,16 @@ final readonly class RelatedWorkAndInstrumentSectionParser
      */
     public function parse(XmlReader $reader, string $filename): array
     {
-        $relatedIdentifierElements = $reader
-            ->xpathElement('//*[local-name()="resource"]/*[local-name()="relatedIdentifiers"]/*[local-name()="relatedIdentifier"]')
-            ->get();
+        $relatedIdentifiers = $this->relatedIdentifierExtractor->extractFromReader($reader, $filename);
 
         $relatedWorks = [];
         $instruments = [];
         $citationResolutionDeadline = microtime(true) + RelatedIdentifierCitationLabelService::DEFAULT_AGGREGATE_TIMEOUT_SECONDS;
 
-        foreach ($relatedIdentifierElements as $index => $element) {
-            $identifier = XmlElementHelpers::stringValue($element);
-            $identifierTypeRaw = $element->getAttribute('relatedIdentifierType');
-            $relationTypeRaw = $element->getAttribute('relationType');
-            $relationTypeInformationRaw = $element->getAttribute('relationTypeInformation');
-
-            if (! is_string($identifier) || $identifier === '') {
-                continue;
-            }
-
-            $identifierType = $this->typeResolver->resolveIdentifierType($identifierTypeRaw);
-            $relationType = $this->typeResolver->resolveRelationType($relationTypeRaw);
-
-            if ($identifierType === null || $relationType === null) {
-                Log::warning('Skipping related identifier with unsupported type values during XML upload', [
-                    'filename' => $filename,
-                    'index' => $index,
-                    'identifier' => $identifier,
-                    'relatedIdentifierType' => $identifierTypeRaw,
-                    'relationType' => $relationTypeRaw,
-                ]);
-
-                continue;
-            }
+        foreach ($relatedIdentifiers as $relatedIdentifier) {
+            $identifier = $relatedIdentifier['relatedIdentifier'];
+            $identifierType = $relatedIdentifier['relatedIdentifierType'];
+            $relationType = $relatedIdentifier['relationType'];
 
             if ($relationType === 'IsCollectedBy' && $identifierType === 'Handle') {
                 $instruments[] = [
@@ -78,7 +54,7 @@ final readonly class RelatedWorkAndInstrumentSectionParser
                 'identifier' => $identifier,
                 'identifier_type' => $identifierType,
                 'relation_type' => $relationType,
-                'relation_type_information' => is_string($relationTypeInformationRaw) && trim($relationTypeInformationRaw) !== '' ? trim($relationTypeInformationRaw) : null,
+                'relation_type_information' => $relatedIdentifier['relationTypeInformation'] ?? null,
                 'citation_label' => $this->citationLabelService->resolveBestEffort($identifier, $identifierType, $citationResolutionDeadline),
                 'position' => count($relatedWorks),
             ];

--- a/composer.lock
+++ b/composer.lock
@@ -725,16 +725,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -833,7 +833,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -849,7 +849,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/database/er-diagram-plantuml.md
+++ b/database/er-diagram-plantuml.md
@@ -414,6 +414,7 @@ entity "related_identifiers" as related_identifiers {
     relation_type_information : VARCHAR //DataCite 4.7//
     citation_label : MEDIUMTEXT
     source : VARCHAR(100) <<nullable>>
+    resource_type_general : VARCHAR(100) <<nullable>>
     related_metadata_scheme : VARCHAR
     scheme_uri : VARCHAR(512)
     scheme_type : VARCHAR(100)

--- a/database/er-diagram.md
+++ b/database/er-diagram.md
@@ -373,6 +373,7 @@ erDiagram
         varchar relation_type_information "nullable, DataCite 4.7"
         mediumtext citation_label "nullable"
         varchar source "100, nullable"
+        varchar resource_type_general "100, nullable"
         varchar related_metadata_scheme
         varchar scheme_uri
         varchar scheme_type

--- a/database/migrations/2026_08_03_000001_add_resource_type_general_to_related_identifiers.php
+++ b/database/migrations/2026_08_03_000001_add_resource_type_general_to_related_identifiers.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('related_identifiers', function (Blueprint $table): void {
+            $table->string('resource_type_general', 100)->nullable()->after('source');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('related_identifiers', function (Blueprint $table): void {
+            $table->dropColumn('resource_type_general');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6247,9 +6247,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10185,9 +10185,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11984,9 +11984,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -14,6 +14,7 @@ use App\Services\DataCiteSyncResult;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\LegacyMetaworksDatacenterLookupService;
+use App\Services\LegacyResourceLookupService;
 use App\Services\MetaworksDownloadUrlService;
 use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
@@ -35,7 +36,8 @@ beforeEach(function () {
     $this->transformer
         ->shouldReceive('prepareDoiData')
         ->zeroOrMoreTimes()
-        ->andReturnUsing(fn (array $doiRecord): array => $doiRecord);
+        ->andReturnUsing(fn (array $doiRecord, array $_legacyRelatedIdentifiers = []): array => $doiRecord)
+        ->byDefault();
     $this->app->instance(DataCiteToResourceTransformer::class, $this->transformer);
 
     // Mock the metaworks service (returns empty result by default)
@@ -51,6 +53,14 @@ beforeEach(function () {
         ->andReturn(['files' => [], 'allPublic' => false])
         ->byDefault();
     $this->app->instance(MetaworksDownloadUrlService::class, $this->metaworksService);
+
+    $this->legacyResourceLookupService = Mockery::mock(LegacyResourceLookupService::class);
+    $this->legacyResourceLookupService
+        ->shouldReceive('relatedIdentifiersByDoi')
+        ->zeroOrMoreTimes()
+        ->andReturn([])
+        ->byDefault();
+    $this->app->instance(LegacyResourceLookupService::class, $this->legacyResourceLookupService);
 
     $this->pendingImportService = Mockery::mock(SumarioPendingResourceImportService::class);
     $this->pendingImportService
@@ -270,6 +280,7 @@ describe('ImportFromDataCiteJob', function () {
 
         // Transformer should not be called for existing DOIs
         $this->transformer->shouldReceive('transform')->never();
+        $this->legacyResourceLookupService->shouldReceive('relatedIdentifiersByDoi')->never();
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
@@ -278,6 +289,91 @@ describe('ImportFromDataCiteJob', function () {
         $status = Cache::get("datacite_import:{$importId}");
         expect($status['skipped'])->toBe(1);
         expect($status['skipped_dois'])->toContain('10.5880/existing');
+    });
+
+    it('passes legacy related identifiers to preparation for new resources', function () {
+        $doiRecord = [
+            'id' => '10.5880/legacy-relations',
+            'attributes' => [
+                'doi' => '10.5880/legacy-relations',
+                'titles' => [['title' => 'Legacy relations']],
+            ],
+        ];
+        $legacyRelatedIdentifiers = [[
+            'identifier' => '10.5880/legacy-related',
+            'identifierType' => 'DOI',
+            'relationType' => 'Cites',
+            'position' => 0,
+        ]];
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(1);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($doiRecord) {
+            yield $doiRecord;
+        })());
+        $this->legacyResourceLookupService
+            ->shouldReceive('relatedIdentifiersByDoi')
+            ->once()
+            ->with('10.5880/legacy-relations')
+            ->andReturn($legacyRelatedIdentifiers);
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->once()
+            ->with($doiRecord, $legacyRelatedIdentifiers)
+            ->andReturn($doiRecord);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->with($doiRecord, $this->user->id)
+            ->andReturn(Resource::factory()->make(['doi' => '10.5880/legacy-relations']));
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(1);
+    });
+
+    it('continues without legacy relations and opens the metaworks circuit breaker after lookup failure', function () {
+        $records = [
+            [
+                'id' => '10.5880/metaworks-failure.1',
+                'attributes' => ['doi' => '10.5880/metaworks-failure.1'],
+            ],
+            [
+                'id' => '10.5880/metaworks-failure.2',
+                'attributes' => ['doi' => '10.5880/metaworks-failure.2'],
+            ],
+        ];
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(2);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($records) {
+            yield from $records;
+        })());
+        $this->legacyResourceLookupService
+            ->shouldReceive('relatedIdentifiersByDoi')
+            ->once()
+            ->with('10.5880/metaworks-failure.1')
+            ->andThrow(new RuntimeException('connection refused'));
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->twice()
+            ->with(Mockery::type('array'), [])
+            ->andReturnUsing(fn (array $record): array => $record);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->twice()
+            ->andReturnUsing(fn (array $record): Resource => Resource::factory()->make([
+                'doi' => $record['attributes']['doi'],
+            ]));
+        $this->metaworksService->shouldReceive('lookupFileEntries')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['imported'])->toBe(2)
+            ->and($status['failed'])->toBe(0);
     });
 
     it('normalizes incoming DOIs before checking for duplicates', function () {

--- a/tests/pest/Feature/Database/AddResourceTypeGeneralToRelatedIdentifiersMigrationTest.php
+++ b/tests/pest/Feature/Database/AddResourceTypeGeneralToRelatedIdentifiersMigrationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\IdentifierType;
+use App\Models\RelationType;
+use App\Models\Resource;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\RelationTypeSeeder;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class)->group('database');
+
+function loadAddResourceTypeGeneralMigration(): Migration
+{
+    /** @var Migration $migration */
+    $migration = require database_path('migrations/2026_08_03_000001_add_resource_type_general_to_related_identifiers.php');
+
+    return $migration;
+}
+
+it('drops and re-adds resource_type_general on related identifiers', function (): void {
+    $migration = loadAddResourceTypeGeneralMigration();
+
+    expect(Schema::hasColumn('related_identifiers', 'resource_type_general'))->toBeTrue();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    expect(Schema::hasColumn('related_identifiers', 'resource_type_general'))->toBeFalse();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(Schema::hasColumn('related_identifiers', 'resource_type_general'))->toBeTrue();
+});
+
+it('preserves existing related identifiers when the migration is reapplied', function (): void {
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+
+    $resource = Resource::factory()->create();
+    $identifierTypeId = IdentifierType::query()->where('slug', 'DOI')->value('id');
+    $relationTypeId = RelationType::query()->where('slug', 'Cites')->value('id');
+
+    expect($identifierTypeId)->toBeInt()
+        ->and($relationTypeId)->toBeInt();
+
+    DB::table('related_identifiers')->insert([
+        'resource_id' => $resource->id,
+        'identifier' => '10.5880/existing.related',
+        'identifier_type_id' => $identifierTypeId,
+        'relation_type_id' => $relationTypeId,
+        'position' => 0,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $migration = loadAddResourceTypeGeneralMigration();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->down();
+
+    /** @phpstan-ignore method.notFound */
+    $migration->up();
+
+    expect(DB::table('related_identifiers')->where('resource_id', $resource->id)->value('resource_type_general'))
+        ->toBeNull();
+});

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerRelatedIdentifiersTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerRelatedIdentifiersTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Services\Citations\RelatedIdentifierCitationLabelService;
+use App\Services\DataCiteToResourceTransformer;
+use Database\Seeders\ContributorTypeSeeder;
+use Database\Seeders\DescriptionTypeSeeder;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\LanguageSeeder;
+use Database\Seeders\PublisherSeeder;
+use Database\Seeders\RelationTypeSeeder;
+use Database\Seeders\ResourceTypeSeeder;
+use Database\Seeders\TitleTypeSeeder;
+
+covers(DataCiteToResourceTransformer::class);
+
+beforeEach(function (): void {
+    test()->seed(ResourceTypeSeeder::class);
+    test()->seed(TitleTypeSeeder::class);
+    test()->seed(DescriptionTypeSeeder::class);
+    test()->seed(ContributorTypeSeeder::class);
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(LanguageSeeder::class);
+    test()->seed(PublisherSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+});
+
+it('imports all related works from issue 1077 when JSON omits their identifiers', function (): void {
+    $citationService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $citationService->shouldReceive('resolveBestEffort')
+        ->times(3)
+        ->andReturnNull();
+    $this->app->instance(RelatedIdentifierCitationLabelService::class, $citationService);
+
+    $originalXml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Dataset">10.5880/CRC1211DB.86</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Dataset">10.5880/CRC1211DB.87</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Dataset">10.5880/CRC1211DB.89</relatedIdentifier>
+  </relatedIdentifiers>
+</resource>
+XML;
+
+    $doiData = [
+        'attributes' => [
+            'doi' => '10.5880/crc1211db.88',
+            'publicationYear' => 2021,
+            'titles' => [['title' => 'Issue 1077 regression fixture']],
+            'creators' => [[
+                'familyName' => 'Regression',
+                'givenName' => 'Test',
+                'nameType' => 'Personal',
+            ]],
+            'relatedIdentifiers' => array_fill(0, 3, [
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'IsSupplementedBy',
+                'resourceTypeGeneral' => 'Dataset',
+            ]),
+            'xml' => base64_encode($originalXml),
+        ],
+    ];
+
+    $resource = (new DataCiteToResourceTransformer)->transform($doiData, User::factory()->create()->id);
+    $relatedIdentifiers = $resource->relatedIdentifiers()
+        ->with(['identifierType', 'relationType'])
+        ->orderBy('position')
+        ->get();
+
+    expect($relatedIdentifiers)->toHaveCount(3)
+        ->and($relatedIdentifiers->pluck('identifier')->all())->toBe([
+            '10.5880/CRC1211DB.86',
+            '10.5880/CRC1211DB.87',
+            '10.5880/CRC1211DB.89',
+        ])
+        ->and($relatedIdentifiers->pluck('identifierType.slug')->unique()->values()->all())->toBe(['DOI'])
+        ->and($relatedIdentifiers->pluck('relationType.slug')->unique()->values()->all())->toBe(['IsSupplementedBy'])
+        ->and($relatedIdentifiers->pluck('resource_type_general')->unique()->values()->all())->toBe(['Dataset']);
+});
+
+it('supplements JSON with XML and legacy relations while preserving JSON values', function (): void {
+    $citationService = Mockery::mock(RelatedIdentifierCitationLabelService::class);
+    $citationService->shouldReceive('resolveBestEffort')->zeroOrMoreTimes()->andReturnNull();
+    $this->app->instance(RelatedIdentifierCitationLabelService::class, $citationService);
+
+    $xml = <<<'XML'
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Cites" resourceTypeGeneral="Dataset">10.5880/shared</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="References">10.5880/xml-only</relatedIdentifier>
+  </relatedIdentifiers>
+</resource>
+XML;
+
+    $prepared = (new DataCiteToResourceTransformer)->prepareDoiData([
+        'attributes' => [
+            'doi' => '10.5880/source-priority',
+            'relatedIdentifiers' => [[
+                'relatedIdentifier' => 'https://doi.org/10.5880/SHARED',
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'Cites',
+                'relationTypeInformation' => 'JSON wins',
+            ]],
+            'xml' => base64_encode($xml),
+        ],
+    ], [
+        [
+            'identifier' => 'doi:10.5880/shared',
+            'identifierType' => 'DOI',
+            'relationType' => 'Cites',
+        ],
+        [
+            'identifier' => '10.5880/legacy-only',
+            'identifierType' => 'DOI',
+            'relationType' => 'IsCitedBy',
+        ],
+    ]);
+
+    expect($prepared['attributes']['relatedIdentifiers'])->toHaveCount(3)
+        ->and($prepared['attributes']['relatedIdentifiers'][0])->toMatchArray([
+            'relatedIdentifier' => 'https://doi.org/10.5880/SHARED',
+            'relationTypeInformation' => 'JSON wins',
+            'resourceTypeGeneral' => 'Dataset',
+        ])
+        ->and(array_column($prepared['attributes']['relatedIdentifiers'], 'relatedIdentifier'))->toBe([
+            'https://doi.org/10.5880/SHARED',
+            '10.5880/xml-only',
+            '10.5880/legacy-only',
+        ]);
+});

--- a/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
@@ -23,11 +23,19 @@ beforeEach(function () {
         $table->id();
         $table->string('identifier')->nullable();
     });
+    Schema::connection('metaworks')->create('relatedidentifier', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('resource_id');
+        $table->string('identifier')->nullable();
+        $table->string('identifiertype')->nullable();
+        $table->string('relationtype')->nullable();
+    });
 
     $this->service = new LegacyResourceLookupService;
 });
 
 afterEach(function () {
+    Schema::connection('metaworks')->dropIfExists('relatedidentifier');
     Schema::connection('metaworks')->dropIfExists('resource');
     DB::disconnect('metaworks');
 });
@@ -50,5 +58,47 @@ describe('LegacyResourceLookupService', function () {
         ]);
 
         expect($this->service->existsByDoi('10.14470/rv968923'))->toBeTrue();
+    });
+
+    it('returns legacy related identifiers case-insensitively and in stable order', function () {
+        $resourceId = DB::connection('metaworks')->table('resource')->insertGetId([
+            'identifier' => '10.5880/CRC1211DB.88',
+        ]);
+
+        DB::connection('metaworks')->table('relatedidentifier')->insert([
+            [
+                'id' => 20,
+                'resource_id' => $resourceId,
+                'identifier' => '10.5880/CRC1211DB.89',
+                'identifiertype' => 'DOI',
+                'relationtype' => 'IsSupplementedBy',
+            ],
+            [
+                'id' => 10,
+                'resource_id' => $resourceId,
+                'identifier' => '10.5880/CRC1211DB.86',
+                'identifiertype' => 'DOI',
+                'relationtype' => 'IsSupplementedBy',
+            ],
+        ]);
+
+        expect($this->service->relatedIdentifiersByDoi('10.5880/crc1211db.88'))->toBe([
+            [
+                'identifier' => '10.5880/CRC1211DB.86',
+                'identifierType' => 'DOI',
+                'relationType' => 'IsSupplementedBy',
+                'position' => 0,
+            ],
+            [
+                'identifier' => '10.5880/CRC1211DB.89',
+                'identifierType' => 'DOI',
+                'relationType' => 'IsSupplementedBy',
+                'position' => 1,
+            ],
+        ]);
+    });
+
+    it('returns an empty relation list when the DOI is absent from legacy storage', function () {
+        expect($this->service->relatedIdentifiersByDoi('10.5880/missing'))->toBe([]);
     });
 });

--- a/tests/pest/Unit/Services/RelatedIdentifierImportMergeServiceTest.php
+++ b/tests/pest/Unit/Services/RelatedIdentifierImportMergeServiceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\RelatedIdentifierImportMergeService;
+
+covers(RelatedIdentifierImportMergeService::class);
+
+beforeEach(function (): void {
+    $this->service = app(RelatedIdentifierImportMergeService::class);
+});
+
+it('merges JSON, XML, and legacy values in priority order without duplicates', function (): void {
+    $merged = $this->service->merge(
+        [
+            [
+                'relatedIdentifier' => 'https://doi.org/10.5880/JSON.WINS',
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'Cites',
+                'relationTypeInformation' => 'JSON information',
+            ],
+        ],
+        [
+            [
+                'relatedIdentifier' => '10.5880/json.wins',
+                'relatedIdentifierType' => 'doi',
+                'relationType' => 'Cites',
+                'relationTypeInformation' => 'XML must not overwrite JSON',
+                'resourceTypeGeneral' => 'Dataset',
+            ],
+            [
+                'relatedIdentifier' => '10.5880/json.wins',
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'IsSupplementedBy',
+            ],
+        ],
+        [
+            [
+                'identifier' => 'doi:10.5880/JSON.WINS',
+                'identifierType' => 'DOI',
+                'relationType' => 'Cites',
+                'citation_label' => 'Legacy citation',
+            ],
+            [
+                'identifier' => 'https://example.org/legacy-only',
+                'identifierType' => 'URL',
+                'relationType' => 'References',
+            ],
+        ],
+    );
+
+    expect($merged)->toHaveCount(3)
+        ->and($merged[0])->toMatchArray([
+            'relatedIdentifier' => 'https://doi.org/10.5880/JSON.WINS',
+            'relatedIdentifierType' => 'DOI',
+            'relationType' => 'Cites',
+            'relationTypeInformation' => 'JSON information',
+            'resourceTypeGeneral' => 'Dataset',
+            'citationLabel' => 'Legacy citation',
+        ])
+        ->and($merged[1]['relationType'])->toBe('IsSupplementedBy')
+        ->and($merged[2]['relatedIdentifier'])->toBe('https://example.org/legacy-only');
+});
+
+it('repairs the three incomplete JSON entries from issue 1077 by XML position', function (): void {
+    $json = array_fill(0, 3, [
+        'relatedIdentifierType' => 'DOI',
+        'relationType' => 'IsSupplementedBy',
+        'resourceTypeGeneral' => 'Dataset',
+    ]);
+
+    $xml = array_map(
+        fn (string $doi): array => [
+            'relatedIdentifier' => $doi,
+            'relatedIdentifierType' => 'DOI',
+            'relationType' => 'IsSupplementedBy',
+            'resourceTypeGeneral' => 'Dataset',
+        ],
+        ['10.5880/CRC1211DB.86', '10.5880/CRC1211DB.87', '10.5880/CRC1211DB.89'],
+    );
+
+    $merged = $this->service->merge($json, $xml);
+
+    expect(array_column($merged, 'relatedIdentifier'))->toBe([
+        '10.5880/CRC1211DB.86',
+        '10.5880/CRC1211DB.87',
+        '10.5880/CRC1211DB.89',
+    ]);
+});
+
+it('uses a unique compatible XML fallback when the positions differ', function (): void {
+    $merged = $this->service->merge(
+        [[
+            'relatedIdentifierType' => 'DOI',
+            'relationType' => 'Cites',
+        ]],
+        [
+            [
+                'relatedIdentifier' => 'https://example.org/other',
+                'relatedIdentifierType' => 'URL',
+                'relationType' => 'References',
+            ],
+            [
+                'relatedIdentifier' => '10.5880/unique',
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'Cites',
+            ],
+        ],
+    );
+
+    expect(array_column($merged, 'relatedIdentifier'))->toBe([
+        '10.5880/unique',
+        'https://example.org/other',
+    ]);
+});
+
+it('drops an ambiguous incomplete JSON shell but retains all complete XML records', function (): void {
+    $merged = $this->service->merge(
+        [[
+            'relatedIdentifierType' => 'DOI',
+            'relationType' => 'Cites',
+        ]],
+        [
+            [
+                'relatedIdentifier' => 'https://example.org/other',
+                'relatedIdentifierType' => 'URL',
+                'relationType' => 'References',
+            ],
+            [
+                'relatedIdentifier' => '10.5880/first',
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'Cites',
+            ],
+            [
+                'relatedIdentifier' => '10.5880/second',
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'Cites',
+            ],
+        ],
+    );
+
+    expect(array_column($merged, 'relatedIdentifier'))->toBe([
+        'https://example.org/other',
+        '10.5880/first',
+        '10.5880/second',
+    ]);
+});
+
+it('skips incomplete lower-priority records and unsupported type values', function (): void {
+    $merged = $this->service->merge(
+        [['relatedIdentifier' => null, 'relatedIdentifierType' => 'DOI', 'relationType' => 'Cites']],
+        [['relatedIdentifier' => '', 'relatedIdentifierType' => 'DOI', 'relationType' => 'Cites']],
+        [
+            ['identifier' => '10.5880/invalid', 'identifierType' => 'unknown', 'relationType' => 'Cites'],
+            ['identifier' => '10.5880/valid', 'identifierType' => 'DOI', 'relationType' => 'Is Cited By'],
+        ],
+    );
+
+    expect($merged)->toBe([[
+        'relatedIdentifier' => '10.5880/valid',
+        'relatedIdentifierType' => 'DOI',
+        'relationType' => 'IsCitedBy',
+    ]]);
+});

--- a/tests/pest/Unit/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionServiceTest.php
+++ b/tests/pest/Unit/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Xml\OriginalDataCiteRelatedIdentifierExtractionService;
+
+covers(OriginalDataCiteRelatedIdentifierExtractionService::class);
+
+beforeEach(function (): void {
+    $this->service = app(OriginalDataCiteRelatedIdentifierExtractionService::class);
+});
+
+it('decodes raw and base64 encoded XML and rejects non XML values', function (): void {
+    $xml = '<resource xmlns="http://datacite.org/schema/kernel-4" />';
+
+    expect($this->service->decode($xml))->toBe($xml)
+        ->and($this->service->decode(base64_encode($xml)))->toBe($xml)
+        ->and($this->service->decode(''))
+        ->toBeNull()
+        ->and($this->service->decode('not XML or base64 XML'))->toBeNull()
+        ->and($this->service->decode(null))->toBeNull();
+});
+
+it('extracts canonical related identifiers and all supported optional attributes', function (): void {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <relatedIdentifiers>
+    <relatedIdentifier
+      relatedIdentifierType="doi"
+      relationType="Is Supplemented By"
+      resourceTypeGeneral="Dataset"
+      relationTypeInformation="Additional measurements"
+      relatedMetadataScheme="DDI"
+      schemeURI="https://example.org/scheme"
+      schemeType="XSD"> 10.5880/CRC1211DB.86 </relatedIdentifier>
+  </relatedIdentifiers>
+</resource>
+XML;
+
+    expect($this->service->extract($xml, 'issue-1077'))->toBe([[
+        'relatedIdentifier' => '10.5880/CRC1211DB.86',
+        'relatedIdentifierType' => 'DOI',
+        'relationType' => 'IsSupplementedBy',
+        'resourceTypeGeneral' => 'Dataset',
+        'relationTypeInformation' => 'Additional measurements',
+        'relatedMetadataScheme' => 'DDI',
+        'schemeUri' => 'https://example.org/scheme',
+        'schemeType' => 'XSD',
+    ]]);
+});
+
+it('extracts all three related works from the issue 1077 XML fixture', function (): void {
+    $xml = <<<'XML'
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Dataset">10.5880/CRC1211DB.86</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Dataset">10.5880/CRC1211DB.87</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementedBy" resourceTypeGeneral="Dataset">10.5880/CRC1211DB.89</relatedIdentifier>
+  </relatedIdentifiers>
+</resource>
+XML;
+
+    $relatedIdentifiers = $this->service->extract($xml, '10.5880/crc1211db.88');
+
+    expect(array_column($relatedIdentifiers, 'relatedIdentifier'))->toBe([
+        '10.5880/CRC1211DB.86',
+        '10.5880/CRC1211DB.87',
+        '10.5880/CRC1211DB.89',
+    ]);
+});
+
+it('skips invalid entries and fails open for malformed XML', function (): void {
+    $xml = <<<'XML'
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="Cites"></relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="unsupported" relationType="Cites">10.5880/unsupported</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="References">https://example.org/valid</relatedIdentifier>
+  </relatedIdentifiers>
+</resource>
+XML;
+
+    expect($this->service->extract($xml))->toBe([[
+        'relatedIdentifier' => 'https://example.org/valid',
+        'relatedIdentifierType' => 'URL',
+        'relationType' => 'References',
+    ]])->and($this->service->extract('<resource><broken>'))->toBe([]);
+});

--- a/tests/pest/Unit/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionServiceTest.php
+++ b/tests/pest/Unit/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Services\Xml\OriginalDataCiteRelatedIdentifierExtractionService;
+use Illuminate\Support\Facades\Log;
 
 covers(OriginalDataCiteRelatedIdentifierExtractionService::class);
 
@@ -12,9 +13,11 @@ beforeEach(function (): void {
 
 it('decodes raw and base64 encoded XML and rejects non XML values', function (): void {
     $xml = '<resource xmlns="http://datacite.org/schema/kernel-4" />';
+    $lineWrappedBase64 = chunk_split(base64_encode($xml), 12, "\r\n");
 
     expect($this->service->decode($xml))->toBe($xml)
         ->and($this->service->decode(base64_encode($xml)))->toBe($xml)
+        ->and($this->service->decode($lineWrappedBase64))->toBe($xml)
         ->and($this->service->decode(''))
         ->toBeNull()
         ->and($this->service->decode('not XML or base64 XML'))->toBeNull()
@@ -71,6 +74,8 @@ XML;
 });
 
 it('skips invalid entries and fails open for malformed XML', function (): void {
+    Log::spy();
+
     $xml = <<<'XML'
 <resource xmlns="http://datacite.org/schema/kernel-4">
   <relatedIdentifiers>
@@ -81,9 +86,18 @@ it('skips invalid entries and fails open for malformed XML', function (): void {
 </resource>
 XML;
 
-    expect($this->service->extract($xml))->toBe([[
+    expect($this->service->extract($xml, 'upload.xml'))->toBe([[
         'relatedIdentifier' => 'https://example.org/valid',
         'relatedIdentifierType' => 'URL',
         'relationType' => 'References',
-    ]])->and($this->service->extract('<resource><broken>'))->toBe([]);
+    ]])->and($this->service->extract('<resource><broken>', 'upload.xml'))->toBe([]);
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Skipping invalid XML related identifier.'
+            && $context['context'] === 'upload.xml')
+        ->twice();
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Could not read XML related identifiers.'
+            && $context['context'] === 'upload.xml')
+        ->once();
 });


### PR DESCRIPTION
This pull request introduces enhancements to the DOI import process, focusing on improved enrichment of related identifiers by integrating legacy, XML, and JSON sources. It also adds better handling and reporting of Metaworks database availability, ensuring the import process is more robust and comprehensive.

**Related Identifier Enrichment:**
- The `DataCiteToResourceTransformer` now merges related identifiers from three sources: JSON, original XML, and legacy database lookups, using the new `relatedIdentifierImportMergeService` and `xmlRelatedIdentifierExtractor` helpers. This ensures more complete and accurate related identifier data during import. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R68-R69) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R124-L163) [[3]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L250-R263)
- The transformer’s `prepareDoiData` and `prepareAttributes` methods were updated to accept and use legacy related identifiers, which are now fetched during the import job. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R124-L163) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L920-R940)

**Metaworks Database Availability Handling:**
- The import job (`ImportFromDataCiteJob.php`) now tracks and propagates Metaworks database availability. If the database is unavailable when fetching legacy related identifiers, the import continues gracefully, and the status is reported accurately in the result. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R891-R892) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L948-R974) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L972-R992) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L982-R1002) [[5]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1003-R1029)

**Legacy Data Integration:**
- A new method `relatedIdentifiersByDoi` was added to `LegacyResourceLookupService`, allowing efficient retrieval of legacy related identifiers for a given DOI.
- The import job now uses this service to enrich records with legacy related identifiers when Metaworks is available. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R19) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L920-R940)

**Data Consistency and Robustness:**
- Related identifier handling was improved to trim and validate identifiers, and to include the `resource_type_general` field when transforming related identifiers for storage. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L1440-R1447) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R1486)
- The transformer’s XML rights extraction now receives the decoded XML directly, improving clarity and reducing redundant decoding logic. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L214-L217) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959L250-R263)

These changes collectively ensure that imported resources have richer metadata, handle legacy and XML data gracefully, and are more resilient to backend service outages.