### PR TITLE
Chore: Update Vitest to v5

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -67,10 +67,6 @@ jobs:
     if: ${{ !cancelled() }}
     needs: vitest-shard
     runs-on: ubuntu-latest
-    env:
-      LARAVEL_BYPASS_ENV_CHECK: 1
-      VITE_APP_URL: ''
-      APP_URL: ''
 
     steps:
       - name: Verify Vitest shards
@@ -95,7 +91,7 @@ jobs:
           merge-multiple: true
 
       - name: Merge Vitest and coverage reports
-        run: npx vitest --merge-reports --coverage
+        run: npx vitest --config vitest.merge.config.ts --merge-reports --coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -67,6 +67,10 @@ jobs:
     if: ${{ !cancelled() }}
     needs: vitest-shard
     runs-on: ubuntu-latest
+    env:
+      LARAVEL_BYPASS_ENV_CHECK: 1
+      VITE_APP_URL: ''
+      APP_URL: ''
 
     steps:
       - name: Verify Vitest shards

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   vitest-shard:
     name: Vitest shard ${{ matrix.shard }}/2

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -9,8 +9,13 @@ on:
       - main
 
 jobs:
-  vitest:
+  vitest-shard:
+    name: Vitest shard ${{ matrix.shard }}/2
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,17 +42,58 @@ jobs:
         run: php artisan wayfinder:generate
 
       - name: TypeScript Check
+        if: matrix.shard == 1
         run: npm run types
 
-      - name: Run Vitest with coverage
+      - name: Run Vitest shard with coverage
         env:
           LARAVEL_BYPASS_ENV_CHECK: 1
-          VITE_APP_URL: ""
-          APP_URL: ""
-        run: npm run test:coverage
+          VITE_APP_URL: ''
+          APP_URL: ''
+        run: npm run test:coverage -- --reporter=blob --coverage.reporter=json-summary --shard=${{ matrix.shard }}/2
+
+      - name: Upload Vitest shard results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vitest-results-${{ matrix.shard }}
+          path: .vitest
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  vitest:
+    name: Vitest
+    if: ${{ !cancelled() }}
+    needs: vitest-shard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify Vitest shards
+        if: ${{ needs.vitest-shard.result != 'success' }}
+        run: exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download Vitest shard results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: .vitest
+          merge-multiple: true
+
+      - name: Merge Vitest and coverage reports
+        run: npx vitest --merge-reports --coverage
 
       - name: Upload coverage to Codecov
-        if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.tmp/
 /bootstrap/ssr
 /coverage
+/.vitest/
 clover.xml
 coverage-serial.xml
 coverage-parallel.xml

--- a/composer.lock
+++ b/composer.lock
@@ -1142,16 +1142,16 @@
         },
         {
             "name": "inertiajs/inertia-laravel",
-            "version": "v3.3.0",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/inertiajs/inertia-laravel.git",
-                "reference": "1e134f607ac6af9a77c35c110714a82cead80c40"
+                "reference": "7bfd75e352938b703180574b943d81963555a0aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/1e134f607ac6af9a77c35c110714a82cead80c40",
-                "reference": "1e134f607ac6af9a77c35c110714a82cead80c40",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/7bfd75e352938b703180574b943d81963555a0aa",
+                "reference": "7bfd75e352938b703180574b943d81963555a0aa",
                 "shasum": ""
             },
             "require": {
@@ -1161,7 +1161,7 @@
                 "symfony/console": "^7.0|^8.0"
             },
             "conflict": {
-                "laravel/boost": "<2.2.0"
+                "laravel/boost": "<2.5.0"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^7.15.2|^8.0",
@@ -1208,22 +1208,22 @@
             ],
             "support": {
                 "issues": "https://github.com/inertiajs/inertia-laravel/issues",
-                "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.3.0"
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v3.3.1"
             },
-            "time": "2026-08-04T09:15:41+00:00"
+            "time": "2026-08-04T21:58:51+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v13.23.0",
+            "version": "v13.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "92a707229148e57f08a249211c8a5a194159c619"
+                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/92a707229148e57f08a249211c8a5a194159c619",
-                "reference": "92a707229148e57f08a249211c8a5a194159c619",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/6d481710375d2aa67656922ef760cdd2b18bcfe0",
+                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0",
                 "shasum": ""
             },
             "require": {
@@ -1243,7 +1243,7 @@
                 "guzzlehttp/guzzle": "^7.8.2",
                 "guzzlehttp/promises": "^2.0.3",
                 "guzzlehttp/uri-template": "^1.0",
-                "laravel/prompts": "^0.3.0",
+                "laravel/prompts": "^0.3.11",
                 "laravel/serializable-closure": "^2.0.10",
                 "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
@@ -1437,20 +1437,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-07-27T14:48:58+00:00"
+            "time": "2026-08-04T15:54:59+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.21",
+            "version": "v0.3.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
+                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
-                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/02b89b39e8972a998db4d5d4ad4719239dd4aee4",
+                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4",
                 "shasum": ""
             },
             "require": {
@@ -1494,9 +1494,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.22"
             },
-            "time": "2026-06-26T00:11:25+00:00"
+            "time": "2026-08-04T14:50:50+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1630,16 +1630,16 @@
         },
         {
             "name": "laravel/wayfinder",
-            "version": "v0.1.20",
+            "version": "v0.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/wayfinder.git",
-                "reference": "91d958a6f99fe9187c6eda84e62aa93d79330be5"
+                "reference": "a85a996cea189f59cac14854f8b13319a29007f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/wayfinder/zipball/91d958a6f99fe9187c6eda84e62aa93d79330be5",
-                "reference": "91d958a6f99fe9187c6eda84e62aa93d79330be5",
+                "url": "https://api.github.com/repos/laravel/wayfinder/zipball/a85a996cea189f59cac14854f8b13319a29007f3",
+                "reference": "a85a996cea189f59cac14854f8b13319a29007f3",
                 "shasum": ""
             },
             "require": {
@@ -1649,6 +1649,9 @@
                 "illuminate/support": "^11.0|^12.0|^13.0",
                 "php": "^8.2",
                 "phpstan/phpdoc-parser": "^2.3"
+            },
+            "conflict": {
+                "laravel/boost": "<2.5.0"
             },
             "require-dev": {
                 "laravel/pint": "^1.21",
@@ -1689,7 +1692,7 @@
                 "issues": "https://github.com/laravel/wayfinder/issues",
                 "source": "https://github.com/laravel/wayfinder"
             },
-            "time": "2026-05-12T01:44:17+00:00"
+            "time": "2026-08-04T21:55:43+00:00"
         },
         {
             "name": "league/commonmark",
@@ -7050,16 +7053,16 @@
         },
         {
             "name": "veewee/xml",
-            "version": "3.7.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/veewee/xml.git",
-                "reference": "6529e0570d9e987c5f9c636d533df7d275f5f898"
+                "reference": "a3e60ccda54a3326f444fe7a30916da3523d3844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/veewee/xml/zipball/6529e0570d9e987c5f9c636d533df7d275f5f898",
-                "reference": "6529e0570d9e987c5f9c636d533df7d275f5f898",
+                "url": "https://api.github.com/repos/veewee/xml/zipball/a3e60ccda54a3326f444fe7a30916da3523d3844",
+                "reference": "a3e60ccda54a3326f444fe7a30916da3523d3844",
                 "shasum": ""
             },
             "require": {
@@ -7118,7 +7121,7 @@
             ],
             "support": {
                 "issues": "https://github.com/veewee/xml/issues",
-                "source": "https://github.com/veewee/xml/tree/3.7.0"
+                "source": "https://github.com/veewee/xml/tree/3.8.0"
             },
             "funding": [
                 {
@@ -7126,7 +7129,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-24T07:53:14+00:00"
+            "time": "2026-07-23T06:36:13+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -7348,16 +7351,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb"
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
-                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a",
                 "shasum": ""
             },
             "require": {
@@ -7417,7 +7420,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.2"
+                "source": "https://github.com/amphp/amp/tree/v3.1.3"
             },
             "funding": [
                 {
@@ -7425,7 +7428,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-21T13:59:44+00:00"
+            "time": "2026-07-19T17:59:20+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -8052,16 +8055,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2"
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/10941bf38de5c585aa2407b2ec4265d806d4eef2",
-                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
+                "reference": "cf2d67696c2015ea7c7fd8f6ec5f8ed7c2d17c17",
                 "shasum": ""
             },
             "require": {
@@ -8107,7 +8110,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.6"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.7"
             },
             "funding": [
                 {
@@ -8115,7 +8118,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-27T16:15:40+00:00"
+            "time": "2026-07-26T14:50:43+00:00"
         },
         {
             "name": "amphp/process",
@@ -9408,16 +9411,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.64.0",
+            "version": "v1.65.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "08cacd3e72d6798df3fa8bd4b5d55d0f7f920625"
+                "reference": "d4b92139858d2a189a6302ca133e494f58afe20b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/08cacd3e72d6798df3fa8bd4b5d55d0f7f920625",
-                "reference": "08cacd3e72d6798df3fa8bd4b5d55d0f7f920625",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/d4b92139858d2a189a6302ca133e494f58afe20b",
+                "reference": "d4b92139858d2a189a6302ca133e494f58afe20b",
                 "shasum": ""
             },
             "require": {
@@ -9467,7 +9470,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-07-17T15:09:35+00:00"
+            "time": "2026-08-03T18:00:17+00:00"
         },
         {
             "name": "league/uri-components",
@@ -10374,16 +10377,16 @@
         },
         {
             "name": "pestphp/pest-plugin-mutate",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-mutate.git",
-                "reference": "fc4a0b3d3bc75bad1148d4c046cf0fa66c508f77"
+                "reference": "ca1e6e6402323353ef4c1dd5bf034e6f4ab17fbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/fc4a0b3d3bc75bad1148d4c046cf0fa66c508f77",
-                "reference": "fc4a0b3d3bc75bad1148d4c046cf0fa66c508f77",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/ca1e6e6402323353ef4c1dd5bf034e6f4ab17fbf",
+                "reference": "ca1e6e6402323353ef4c1dd5bf034e6f4ab17fbf",
                 "shasum": ""
             },
             "require": {
@@ -10396,7 +10399,7 @@
                 "pestphp/pest": "<5.0.0"
             },
             "require-dev": {
-                "pestphp/pest": "^5.0.0",
+                "pestphp/pest": "^5.0.3",
                 "pestphp/pest-dev-tools": "^5.0.0",
                 "pestphp/pest-plugin-type-coverage": "^5.0.0"
             },
@@ -10433,7 +10436,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v5.0.0"
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v5.0.1"
             },
             "funding": [
                 {
@@ -10449,7 +10452,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-21T07:48:56+00:00"
+            "time": "2026-08-04T15:26:47+00:00"
         },
         {
             "name": "pestphp/pest-plugin-phpstan",
@@ -10603,30 +10606,31 @@
         },
         {
             "name": "pestphp/pest-plugin-type-coverage",
-            "version": "v5.0.0",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-type-coverage.git",
-                "reference": "d4b50bf0a813a60e2d24671afe17ec046bb290cd"
+                "reference": "6bcd630c6ee6bc06b0ae54a9d35fef0f4087efd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-type-coverage/zipball/d4b50bf0a813a60e2d24671afe17ec046bb290cd",
-                "reference": "d4b50bf0a813a60e2d24671afe17ec046bb290cd",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-type-coverage/zipball/6bcd630c6ee6bc06b0ae54a9d35fef0f4087efd7",
+                "reference": "6bcd630c6ee6bc06b0ae54a9d35fef0f4087efd7",
                 "shasum": ""
             },
             "require": {
                 "nunomaduro/pokio": "^1.0.1",
                 "pestphp/pest-plugin": "^5.0.0",
                 "php": "^8.4",
-                "phpstan/phpstan": "^2.2.5",
-                "tomasvotruba/type-coverage": "^2.2.2"
+                "phpstan/phpstan": "^2.2.7",
+                "tomasvotruba/type-coverage": "^2.3.0"
             },
             "conflict": {
-                "pestphp/pest": "<5.0.0"
+                "pestphp/pest": "<5.0.0",
+                "phpstan/phpstan": "<2.2.7"
             },
             "require-dev": {
-                "pestphp/pest": "^5.0.0",
+                "pestphp/pest": "^5.0.3",
                 "pestphp/pest-dev-tools": "^5.0.0"
             },
             "type": "library",
@@ -10659,7 +10663,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-type-coverage/tree/v5.0.0"
+                "source": "https://github.com/pestphp/pest-plugin-type-coverage/tree/v5.0.2"
             },
             "funding": [
                 {
@@ -10671,7 +10675,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-21T07:48:56+00:00"
+            "time": "2026-08-04T16:35:23+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10969,11 +10973,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.7",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
-                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -11029,7 +11033,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-29T17:39:32+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -12667,16 +12671,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.1.1",
+            "version": "v8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8e4cdd4311683516be06944f4b85244063cdb886"
+                "reference": "faabdbe998e8c5c599dceffa27aa265b185c0736"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8e4cdd4311683516be06944f4b85244063cdb886",
-                "reference": "8e4cdd4311683516be06944f4b85244063cdb886",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/faabdbe998e8c5c599dceffa27aa265b185c0736",
+                "reference": "faabdbe998e8c5c599dceffa27aa265b185c0736",
                 "shasum": ""
             },
             "require": {
@@ -12719,7 +12723,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.1.1"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.2"
             },
             "funding": [
                 {
@@ -12739,7 +12743,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-09T11:06:24+00:00"
+            "time": "2026-07-22T15:42:13+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -12852,29 +12856,31 @@
         },
         {
             "name": "tomasvotruba/type-coverage",
-            "version": "2.2.2",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TomasVotruba/type-coverage.git",
-                "reference": "25f298265c823e8fb0505169135855e1e6a91021"
+                "reference": "7ba48c1bf3bbb7ffe99caacc7017bae5ee72d644"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TomasVotruba/type-coverage/zipball/25f298265c823e8fb0505169135855e1e6a91021",
-                "reference": "25f298265c823e8fb0505169135855e1e6a91021",
+                "url": "https://api.github.com/repos/TomasVotruba/type-coverage/zipball/7ba48c1bf3bbb7ffe99caacc7017bae5ee72d644",
+                "reference": "7ba48c1bf3bbb7ffe99caacc7017bae5ee72d644",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.4",
-                "phpstan/phpstan": "^2.2"
+                "phpstan/phpstan": "^2.2",
+                "webmozart/assert": "^1.11 || ^2.1"
             },
             "require-dev": {
                 "phpstan/extension-installer": "^1.4",
-                "phpunit/phpunit": "^12.5",
+                "phpunit/phpunit": "^13.2",
                 "rector/jack": "^1.0",
-                "rector/rector": "^2.4",
+                "rector/rector": "^2.5",
                 "shipmonk/composer-dependency-analyser": "^1.8",
-                "symplify/easy-coding-standard": "^13.1",
+                "symfony/dom-crawler": "^8.1",
+                "symplify/easy-coding-standard": "^13.2",
                 "tomasvotruba/unused-public": "^2.2",
                 "tracy/tracy": "^2.12"
             },
@@ -12882,12 +12888,14 @@
             "extra": {
                 "phpstan": {
                     "includes": [
-                        "config/extension.neon"
+                        "config/extension.neon",
+                        "packages/type-perfect/config/extension.neon"
                     ]
                 }
             },
             "autoload": {
                 "psr-4": {
+                    "Rector\\TypePerfect\\": "packages/type-perfect/src",
                     "TomasVotruba\\TypeCoverage\\": "src"
                 }
             },
@@ -12902,7 +12910,7 @@
             ],
             "support": {
                 "issues": "https://github.com/TomasVotruba/type-coverage/issues",
-                "source": "https://github.com/TomasVotruba/type-coverage/tree/2.2.2"
+                "source": "https://github.com/TomasVotruba/type-coverage/tree/2.3.0"
             },
             "funding": [
                 {
@@ -12914,7 +12922,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-07T12:35:00+00:00"
+            "time": "2026-07-29T20:32:37+00:00"
         }
     ],
     "aliases": [],

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,25 +20,25 @@ Run `npm install` once after cloning and again whenever frontend dependencies ch
 
 ## Recommended Commands
 
-| Check | Where to run it | Command | Notes |
-| --- | --- | --- | --- |
-| Pest fast path | Host shell via npm wrapper | `npm run test:php` | Starts backend containers if needed |
-| Pest TIA | Host shell via npm wrapper | `npm run test:php:tia` | Local-only affected-test loop; records a baseline on first use |
-| Pest deprecation details | Host shell via npm wrapper | `npm run test:php:deprecations` | Use this instead of forwarding `--display-*` flags through npm |
-| Pest Agent probe | Host shell via npm wrapper | `npm run test:php:agent -- '<PHP snippet>'` | One-off verification; not a replacement for a regression test |
-| PHPStan | Host shell via npm wrapper | `npm run phpstan:check` | Required before finishing PHP changes |
-| Pest type coverage | Host shell via npm wrapper | `npm run test:php:type-coverage` | Enforces the measured 92% minimum; expensive on a cold cache |
-| MySQL-sensitive Pest slice | Host shell via npm wrapper | `npm run test:php:mysql-sensitive` | Uses isolated `ernie_test` schema |
-| Vitest one-shot | Host shell | `npm run test:run` | Preferred for focused frontend validation |
-| Vitest coverage | Host shell | `npm run test:coverage` | Use only when coverage detail is needed |
-| ESLint check | Host shell | `npm run lint:check` | Non-mutating validation |
-| ESLint auto-fix | Host shell | `npm run lint` | Applies ESLint fixes |
-| TypeScript | Host shell | `npm run types` | Runs app and test TS checks |
-| Playwright dev stack | Host shell | `npm run test:e2e:devstack` | Requires the Docker dev stack |
-| Playwright stage | Host shell | `npm run test:e2e:stage` | Use only for stage-specific bug reproduction |
-| Backend umbrella check | Host shell | `npm run check:backend` | Pest plus PHPStan |
-| Frontend umbrella check | Host shell | `npm run check:frontend` | ESLint plus OpenAPI lint plus TypeScript plus one-shot Vitest |
-| Parity umbrella check | Host shell | `npm run check:parity` | Parity profile plus MySQL slice plus Playwright |
+| Check                      | Where to run it            | Command                                     | Notes                                                          |
+| -------------------------- | -------------------------- | ------------------------------------------- | -------------------------------------------------------------- |
+| Pest fast path             | Host shell via npm wrapper | `npm run test:php`                          | Starts backend containers if needed                            |
+| Pest TIA                   | Host shell via npm wrapper | `npm run test:php:tia`                      | Local-only affected-test loop; records a baseline on first use |
+| Pest deprecation details   | Host shell via npm wrapper | `npm run test:php:deprecations`             | Use this instead of forwarding `--display-*` flags through npm |
+| Pest Agent probe           | Host shell via npm wrapper | `npm run test:php:agent -- '<PHP snippet>'` | One-off verification; not a replacement for a regression test  |
+| PHPStan                    | Host shell via npm wrapper | `npm run phpstan:check`                     | Required before finishing PHP changes                          |
+| Pest type coverage         | Host shell via npm wrapper | `npm run test:php:type-coverage`            | Enforces the measured 92% minimum; expensive on a cold cache   |
+| MySQL-sensitive Pest slice | Host shell via npm wrapper | `npm run test:php:mysql-sensitive`          | Uses isolated `ernie_test` schema                              |
+| Vitest one-shot            | Host shell                 | `npm run test:run`                          | Preferred for focused frontend validation                      |
+| Vitest coverage            | Host shell                 | `npm run test:coverage`                     | Use only when coverage detail is needed                        |
+| ESLint check               | Host shell                 | `npm run lint:check`                        | Non-mutating validation                                        |
+| ESLint auto-fix            | Host shell                 | `npm run lint`                              | Applies ESLint fixes                                           |
+| TypeScript                 | Host shell                 | `npm run types`                             | Runs app and test TS checks                                    |
+| Playwright dev stack       | Host shell                 | `npm run test:e2e:devstack`                 | Requires the Docker dev stack                                  |
+| Playwright stage           | Host shell                 | `npm run test:e2e:stage`                    | Use only for stage-specific bug reproduction                   |
+| Backend umbrella check     | Host shell                 | `npm run check:backend`                     | Pest plus PHPStan                                              |
+| Frontend umbrella check    | Host shell                 | `npm run check:frontend`                    | ESLint plus OpenAPI lint plus TypeScript plus one-shot Vitest  |
+| Parity umbrella check      | Host shell                 | `npm run check:parity`                      | Parity profile plus MySQL slice plus Playwright                |
 
 ## PHP Test Database Strategy
 
@@ -140,6 +140,10 @@ npm run test:run -- tests/vitest/path/to/file.test.tsx --fsModuleCache
 npx vitest --clearCache
 ```
 
+The cache is intentionally not enabled by default. A representative DataCite run took 2:24 without it, 2:29 with a cold cache, and 2:44 with a warm cache; this suite is dominated by DOM interactions rather than module transformation.
+
+The large DataCite form suite is registered through six `datacite-form.part-*.test.tsx` entrypoints. They distribute direct tests while keeping nested `describe` groups intact, allowing Vitest to schedule the formerly serial suite across isolated workers. Keep shared tests and setup in `datacite-form.test-suite.tsx`; do not add that support file to the Vitest include pattern.
+
 If your host cannot start Laravel Artisan locally, start the Docker backend stack before Vitest:
 
 ```bash
@@ -195,6 +199,8 @@ npm run test:e2e:stage
 - Run local coverage only when targeted feedback is needed.
 - Keep day-to-day backend runs on `--no-coverage`.
 - Let CI remain the primary source of complete coverage reporting.
+- CI runs the Vitest coverage suite on two machines with `--shard=1/2` and `--shard=2/2`. Each machine uploads a Vitest blob report; the final `vitest` job merges both test and V8 coverage results before uploading the single complete `coverage/lcov.info` to Codecov.
+- Keep the blob upload and merge job together when changing the workflow. Uploading either shard's partial LCOV report would make the Codecov result incomplete.
 
 ## Suggested Validation Sets
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -121,6 +121,25 @@ npm run types
 npm run test:run
 ```
 
+Vitest 5 can repeat a focused test file to expose flaky behavior without multiplying the complete suite:
+
+```bash
+npm run test:run -- tests/vitest/path/to/file.test.tsx --repeats=5
+```
+
+For slow startup or import-heavy tests, print the import-duration breakdown before changing optimizer settings:
+
+```bash
+npm run test:run -- tests/vitest/path/to/file.test.tsx --experimental.importDurations.print
+```
+
+The persistent filesystem module cache remains an opt-in experiment because Wayfinder and other plugin inputs must be invalidated correctly. It can be compared on focused repeated runs and cleared explicitly:
+
+```bash
+npm run test:run -- tests/vitest/path/to/file.test.tsx --fsModuleCache
+npx vitest --clearCache
+```
+
 If your host cannot start Laravel Artisan locally, start the Docker backend stack before Vitest:
 
 ```bash
@@ -141,6 +160,8 @@ npm run docker:dev:backend:d
 ```bash
 WAYFINDER_COMMAND="php artisan ernie:wayfinder-generate" npm run test:run
 ```
+
+The separate `vitest.browser.config.ts` deliberately contains only browser-test transforms. Laravel HMR and Wayfinder generation stay in the main Vite configuration: Vitest 5 starts multiple browser environments, and generating files from their `buildStart` hooks can repeatedly invalidate the browser test server. Generate Wayfinder sources before introducing or running browser tests that import them.
 
 Why frontend validation stays on the host:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,14 +232,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -352,13 +352,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -404,18 +404,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -423,9 +423,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -613,9 +613,9 @@
       "license": "MIT"
     },
     "node_modules/@devframes/hub": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.8.0.tgz",
-      "integrity": "sha512-0eaxezZG+u/n0GKpf9jVlujBzpOvPKeBbvl/5IWD+p/Yv+1Pr5NaTOQBHvWK3B1M96whylnNdErHwoalcPrHJA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@devframes/hub/-/hub-0.8.1.tgz",
+      "integrity": "sha512-EF1BfqCbVHTDeWmu6TWPN5zrcSajis4E9Xc8qCuqCMDifUOjy2cOJJQ3eEN6K9TwuUKkL+ByBa8Xe3ZGMrnmGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -628,13 +628,13 @@
         "zigpty": "^0.2.1"
       },
       "peerDependencies": {
-        "devframe": "0.8.0"
+        "devframe": "0.8.1"
       }
     },
     "node_modules/@devframes/json-render": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@devframes/json-render/-/json-render-0.8.0.tgz",
-      "integrity": "sha512-nKmLTetl3wbaK2BiN42MKH+/kCfPd6r4FEmwM7DJ5f2QoFt7qxnZJLk4hAl3gWkdhrad7ukp3sOfnsTeFJUNkw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@devframes/json-render/-/json-render-0.8.1.tgz",
+      "integrity": "sha512-eOLYL1dooi87L2UqNNtPueATJ7gxQKJxUSSywDD6iLg5BoRg0n4pkkpDdwSiTb22RrgPMXZZhX7HHcAIFwtwJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -643,8 +643,8 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@devframes/hub": "0.8.0",
-        "devframe": "0.8.0"
+        "@devframes/hub": "0.8.1",
+        "devframe": "0.8.1"
       },
       "peerDependenciesMeta": {
         "@devframes/hub": {
@@ -653,9 +653,9 @@
       }
     },
     "node_modules/@devframes/plugin-inspect": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@devframes/plugin-inspect/-/plugin-inspect-0.8.0.tgz",
-      "integrity": "sha512-ixtI2cW4HX0Wmz89OF0mSFT2aeUV3IjC118DBdhzQFJurzisy/DmJPnXAb4S+P4z519SnHz4W6UtHNiamDxyxQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@devframes/plugin-inspect/-/plugin-inspect-0.8.1.tgz",
+      "integrity": "sha512-UdGNXKnYq3bI/HH+kycUxxuUeLt8jiB54T+2Ks4gg6uKk7JsksZGa2VX9pVZGIc/5SbMWa98va1LMpD8SDo4FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,7 +667,7 @@
         "devframe-inspect": "bin.mjs"
       },
       "peerDependencies": {
-        "devframe": "0.8.0",
+        "devframe": "0.8.1",
         "vite": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@devframes/plugin-messages": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@devframes/plugin-messages/-/plugin-messages-0.8.0.tgz",
-      "integrity": "sha512-Z99f64fs+K5XsvtDCqrPRwftYZHe0W2KifED/BvmZQ62AnKnP2Yx+YCBddS96BB+3JWtUhPHlwNdNSAQAnO+Nw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@devframes/plugin-messages/-/plugin-messages-0.8.1.tgz",
+      "integrity": "sha512-f2pglJhU2IpegszBua5PBFxVAp80zz1zdvrsegGpc4A87sYmbWrw/k1ckBksC+TbT9FrCdjE3Gmwx0Z5F+34Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -690,8 +690,8 @@
         "devframe-messages": "bin.mjs"
       },
       "peerDependencies": {
-        "@devframes/hub": "0.8.0",
-        "devframe": "0.8.0",
+        "@devframes/hub": "0.8.1",
+        "devframe": "0.8.1",
         "vite": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -701,9 +701,9 @@
       }
     },
     "node_modules/@devframes/plugin-terminals": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@devframes/plugin-terminals/-/plugin-terminals-0.8.0.tgz",
-      "integrity": "sha512-BjOnHuTQuzjJyWa7WvsVYrjh4CCMRLTosBfK3ZgzCcdX1F3aejmRdUIsIuYxJvWPdEedlZGdYFZbWiEVSxb81w==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@devframes/plugin-terminals/-/plugin-terminals-0.8.1.tgz",
+      "integrity": "sha512-8nc0/BJOG/tFlmV9ezlsEMnOLueNdNdLzhZlpLVkSVwP1fPW2kEMBorBKVKnoU98pUmoymUDcBxTpQTxKJEdvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -715,7 +715,7 @@
         "devframe-terminals": "bin.mjs"
       },
       "peerDependencies": {
-        "devframe": "0.8.0",
+        "devframe": "0.8.1",
         "vite": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -775,37 +775,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1441,24 +1410,6 @@
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "3.0.0",
@@ -3026,9 +2977,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.43.3",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.43.3.tgz",
-      "integrity": "sha512-c6qQnH7N29FkpBAFDw+7cAsR+F5LXWWuS66BzHuC7zUsqqeZeUVxONRAAZHzwWG/N1zuqXMQZigVIh+ZC4OIFg==",
+      "version": "2.44.1",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.44.1.tgz",
+      "integrity": "sha512-3zyg9oXTmcMZu9attaMRItk9FU7txmQKy6MuWjrksRYCFs66tf8OWdzAzGVm9NCR7ODxt+5b2TPACV5dPL4XZw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4537,16 +4488,6 @@
         }
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4716,9 +4657,9 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4868,9 +4809,9 @@
       "license": "MIT"
     },
     "node_modules/@types/google.maps": {
-      "version": "3.65.3",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.3.tgz",
-      "integrity": "sha512-tqbbx7MUtoDk+RwpZMymPDj6Skez0FhqDZNhLhS5UDmCx4D1dgP+BJOHTebiO/rhjJLa1f8te2p6mJJeFKVFOQ==",
+      "version": "3.65.4",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.4.tgz",
+      "integrity": "sha512-5mvL6keNtWL8jisY5ABjNCpczqGpP9SU9CgYYi7xK+rmy0PSVsDIS+4fM+q6HR1uihDj2k7F1KoHK7kSV5GBpQ==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -5713,9 +5654,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5939,9 +5880,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
-      "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6850,6 +6791,21 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -6996,9 +6952,9 @@
       "license": "MIT"
     },
     "node_modules/devframe": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.8.0.tgz",
-      "integrity": "sha512-kUK/JIYlfb3A4nbIY+cJ/zljyfpCdBzwsR3uY2Y6Tbm6jnNY0w5yLpuDX524XQD7D1Vnmvs8kpC+ILOkCRk5OA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.8.1.tgz",
+      "integrity": "sha512-H+5kAYUfITObKdRuI2LE3OWY3zTEC6YKxlAPkZ1PB0mqTkl6jOxQhMKXKCHL+wGZBgXUmCGi1U6MMlO4oxDnSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7085,9 +7041,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7136,9 +7092,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.395",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
-      "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7149,9 +7105,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -7227,13 +7183,14 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
       "license": "MIT",
       "workspaces": [
         "docs",
-        "benchmarks"
+        "benchmarks",
+        "tests/types"
       ]
     },
     "node_modules/escalade": {
@@ -7668,9 +7625,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -8541,21 +8498,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
-      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.15.1",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^22.14.0 || >=24.0.0"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -9090,14 +9032,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "source-map-js": "^1.2.1"
       }
     },
@@ -9463,9 +9405,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -9526,9 +9468,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9667,23 +9609,7 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
+    "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -9699,12 +9625,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -11308,9 +11237,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11334,9 +11263,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11344,22 +11273,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
-      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.9"
+        "tldts-core": "^7.4.10"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
-      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12298,18 +12227,18 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
+        "@exodus/bytes": "^1.15.1",
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -12406,9 +12335,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12499,6 +12428,19 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zenscroll": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,8 +73,9 @@
         "@types/yaireo__tagify": "^4.27.0",
         "@vitejs/devtools": "^0.4.12",
         "@vitejs/plugin-react": "^6.0.5",
-        "@vitest/browser": "^4.1.10",
-        "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/browser": "^5.0.0-beta.7",
+        "@vitest/browser-playwright": "^5.0.0-beta.7",
+        "@vitest/coverage-v8": "^5.0.0-beta.7",
         "dotenv": "^17.4.2",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
@@ -90,7 +91,7 @@
         "start-server-and-test": "^3.0.12",
         "typescript-eslint": "^8.66.0",
         "vite": "^8.2.0",
-        "vitest": "^4.1.10"
+        "vitest": "^5.0.0-beta.7"
       },
       "engines": {
         "node": ">=26",
@@ -5376,38 +5377,73 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
-      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-5.0.0-beta.7.tgz",
+      "integrity": "sha512-zcO1dsyO5lyX+MhXkyOV+9UjCaUsFnq3LBy7XYLlfWnYQKrlxfNmbgRmgL9KhCRe5fpR3AM05jDlDEbbtaOGdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/utils": "4.1.10",
-        "magic-string": "^0.30.21",
+        "@vitest/mocker": "5.0.0-beta.7",
+        "@vitest/ui": "5.0.0-beta.7",
+        "@vitest/utils": "5.0.0-beta.7",
+        "magic-string": "^1.0.0",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
         "tinyrainbow": "^3.1.0",
-        "ws": "^8.19.0"
+        "ws": "^8.20.1"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.10"
+        "vitest": "5.0.0-beta.7"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-5.0.0-beta.7.tgz",
+      "integrity": "sha512-5YcoQ2FNxk3X37UILQxMjiq7PGziK8IqXSgps9+uj6dLbpCCn6vLKlrkjHJfL4v8W0+uwHrO8RnNjegHT0b72w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "5.0.0-beta.7",
+        "@vitest/mocker": "5.0.0-beta.7",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "5.0.0-beta.7"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/browser/node_modules/magic-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0-beta.7.tgz",
+      "integrity": "sha512-1EiXmCq9KiqB8xAueEZ/hbnVnAl6TuMQyYlQwU4trb+QoGoxAOKQeVWKtho59t4mk2ziEtnJphy/cVFGgkuzTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.10",
-        "ast-v8-to-istanbul": "^1.0.0",
+        "@vitest/utils": "5.0.0-beta.7",
+        "ast-v8-to-istanbul": "^1.0.5",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
@@ -5420,8 +5456,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.10",
-        "vitest": "4.1.10"
+        "@vitest/browser": "5.0.0-beta.7",
+        "vitest": "5.0.0-beta.7"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -5429,34 +5465,17 @@
         }
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0-beta.7.tgz",
+      "integrity": "sha512-SczTGMNh6ksM5r8ogUwAf8zVbQPgbc6yvdZO9xBsTKT2rLUwpHn95Upod0s0Cpm3/bH898iqRBLXovRZSUbJBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0-beta.7",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^1.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5474,10 +5493,20 @@
         }
       }
     },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-5.0.0-beta.7.tgz",
+      "integrity": "sha512-mYUiYNj9BcF4BawuqncdUlR+zNNbWOWBNsp57jJon2Gq5R2fMqTYQJWHpfvkNqkAAgt/lC6bH5+JISjLIhHa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5487,54 +5516,46 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.10",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0-beta.7.tgz",
+      "integrity": "sha512-NiE4frPDnDjFaMvaZaj4ASyxc/c2fvSQU8Fpo7D0YNj9AetE4hcA7ewRxhlrg6dHEOt1JhhCgy67e8SCXDh5VQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-5.0.0-beta.7.tgz",
+      "integrity": "sha512-z2PKZrRvT2W6S7s09cS9xqQf6CzURL0YbGCiaOvksIDQ8w/IS07g/0YujWY5c4CgavEaUmxctaDr/ru++U7aoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "5.0.0-beta.7",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "5.0.0-beta.7"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-5.0.0-beta.7.tgz",
+      "integrity": "sha512-DFjgVac0frIqGUZnQCd8lTGYfWnPJfzUNhOubZuvUMgzb+v0mdJjeMEcpmesujZIPasFOR+SzsQ4dS/BCEWGvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "5.0.0-beta.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -7594,6 +7615,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -11270,11 +11298,14 @@
       "license": "MIT"
     },
     "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.2.tgz",
+      "integrity": "sha512-REdMxUreK3VSUeWcLd5+ijUGNKFyHT8s1trKmYEE/tlYE6ggdOkFOlKba/vI/l1fIqh/NTEEr1Cyw4AwttOicA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -12092,38 +12123,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "5.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0-beta.7.tgz",
+      "integrity": "sha512-YT/AWBSxJW/GHyNVQzVA7lIj39oRcEPEj1AYMi1Oko7l5GwCh8MO0ufavjVZI0oEYXcAoNmthegJhzGA2pkU2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0-beta.7",
+        "chai": "^6.2.2",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.0.0",
         "obug": "^2.1.1",
-        "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
         "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
+        "tinybench": "^6.0.1",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -12131,16 +12155,16 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0-beta.7",
+        "@vitest/browser-preview": "5.0.0-beta.7",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0-beta.7",
+        "@vitest/coverage-v8": "5.0.0-beta.7",
+        "@vitest/ui": "5.0.0-beta.7",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -12179,6 +12203,16 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
+      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -83,8 +83,9 @@
     "@types/yaireo__tagify": "^4.27.0",
     "@vitejs/devtools": "^0.4.12",
     "@vitejs/plugin-react": "^6.0.5",
-    "@vitest/browser": "^4.1.10",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/browser": "^5.0.0-beta.7",
+    "@vitest/browser-playwright": "^5.0.0-beta.7",
+    "@vitest/coverage-v8": "^5.0.0-beta.7",
     "dotenv": "^17.4.2",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
@@ -100,7 +101,7 @@
     "start-server-and-test": "^3.0.12",
     "typescript-eslint": "^8.66.0",
     "vite": "^8.2.0",
-    "vitest": "^4.1.10"
+    "vitest": "^5.0.0-beta.7"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -2,10 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const webStorageFlag = '--no-experimental-webstorage';
-const ignoredStderrLines = new Set(['Could not parse CSS stylesheet', 'Not implemented: navigation to another Document']);
 const hostWayfinderCommand = 'php artisan ernie:wayfinder-generate --with-form';
 const hostWayfinderProbeTimeoutMs = 10_000;
 const dockerWayfinderCommand =
@@ -72,62 +69,6 @@ function canRunHostWayfinder() {
         rmSync(outputPath, { force: true, recursive: true });
     }
 }
-
-function withWebStorageFlag(nodeOptions = '') {
-    const options = nodeOptions.trim();
-
-    if (options.includes('--no-experimental-webstorage') || options.includes('--localstorage-file=')) {
-        return options;
-    }
-
-    return options ? `${options} ${webStorageFlag}` : webStorageFlag;
-}
-
-function filterKnownJsdomNoise(output = '') {
-    const parts = output.split(/(\r?\n)/);
-    let filtered = '';
-
-    for (let index = 0; index < parts.length; index += 2) {
-        const line = parts[index] ?? '';
-        const newline = parts[index + 1] ?? '';
-
-        if (ignoredStderrLines.has(line.trim())) {
-            continue;
-        }
-
-        filtered += `${line}${newline}`;
-    }
-
-    return filtered;
-}
-
-if (!process.execArgv.includes(webStorageFlag)) {
-    const result = spawnSync(process.execPath, [webStorageFlag, fileURLToPath(import.meta.url), ...process.argv.slice(2)], {
-        encoding: 'utf8',
-        env: {
-            ...process.env,
-            NODE_OPTIONS: withWebStorageFlag(process.env.NODE_OPTIONS),
-        },
-        maxBuffer: 100 * 1024 * 1024,
-        stdio: ['inherit', 'inherit', 'pipe'],
-    });
-
-    if (result.stderr) {
-        process.stderr.write(filterKnownJsdomNoise(result.stderr));
-    }
-
-    if (result.error) {
-        throw result.error;
-    }
-
-    if (result.signal) {
-        process.kill(process.pid, result.signal);
-    }
-
-    process.exit(result.status ?? 1);
-}
-
-process.env.NODE_OPTIONS = withWebStorageFlag(process.env.NODE_OPTIONS);
 
 if (!process.env.WAYFINDER_COMMAND && !canRunHostWayfinder()) {
     process.env.WAYFINDER_COMMAND = dockerWayfinderCommand;

--- a/tests/vitest/components/curation/__tests__/datacite-form.part-1.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.part-1.test.tsx
@@ -1,0 +1,6 @@
+process.env.VITEST_DATACITE_TEST_SHARD = '1';
+process.env.VITEST_DATACITE_TEST_SHARD_COUNT = '6';
+
+await import('./datacite-form.test-suite');
+
+export {};

--- a/tests/vitest/components/curation/__tests__/datacite-form.part-2.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.part-2.test.tsx
@@ -1,0 +1,6 @@
+process.env.VITEST_DATACITE_TEST_SHARD = '2';
+process.env.VITEST_DATACITE_TEST_SHARD_COUNT = '6';
+
+await import('./datacite-form.test-suite');
+
+export {};

--- a/tests/vitest/components/curation/__tests__/datacite-form.part-3.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.part-3.test.tsx
@@ -1,0 +1,6 @@
+process.env.VITEST_DATACITE_TEST_SHARD = '3';
+process.env.VITEST_DATACITE_TEST_SHARD_COUNT = '6';
+
+await import('./datacite-form.test-suite');
+
+export {};

--- a/tests/vitest/components/curation/__tests__/datacite-form.part-4.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.part-4.test.tsx
@@ -1,0 +1,6 @@
+process.env.VITEST_DATACITE_TEST_SHARD = '4';
+process.env.VITEST_DATACITE_TEST_SHARD_COUNT = '6';
+
+await import('./datacite-form.test-suite');
+
+export {};

--- a/tests/vitest/components/curation/__tests__/datacite-form.part-5.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.part-5.test.tsx
@@ -1,0 +1,6 @@
+process.env.VITEST_DATACITE_TEST_SHARD = '5';
+process.env.VITEST_DATACITE_TEST_SHARD_COUNT = '6';
+
+await import('./datacite-form.test-suite');
+
+export {};

--- a/tests/vitest/components/curation/__tests__/datacite-form.part-6.test.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.part-6.test.tsx
@@ -1,0 +1,6 @@
+process.env.VITEST_DATACITE_TEST_SHARD = '6';
+process.env.VITEST_DATACITE_TEST_SHARD_COUNT = '6';
+
+await import('./datacite-form.test-suite');
+
+export {};

--- a/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { act, fireEvent, render, screen, waitFor, within } from '@tests/vitest/utils/render';
 import axios from 'axios';
-import { afterAll, afterEach, beforeAll, beforeEach, describe as vitestDescribe, expect, it as vitestIt, type Mock, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, vi, describe as vitestDescribe, it as vitestIt, type Mock } from 'vitest';
 
 import DataCiteForm, { canAddLicense, canAddTitle, type DataCiteFormProps } from '@/components/curation/datacite-form';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
@@ -89,8 +89,33 @@ type TestRegistration = (...args: unknown[]) => unknown;
 // Vitest can schedule the work across workers and CI shards. Direct tests are distributed
 // individually; nested describe blocks stay intact to preserve their hooks and isolation.
 // Importing this module without shard variables retains the original single-file behavior.
-const dataCiteTestShard = Number.parseInt(process.env.VITEST_DATACITE_TEST_SHARD ?? '1', 10);
-const dataCiteTestShardCount = Number.parseInt(process.env.VITEST_DATACITE_TEST_SHARD_COUNT ?? '1', 10);
+const resolveDataCiteTestShard = (): readonly [number, number] => {
+    const shardValue = process.env.VITEST_DATACITE_TEST_SHARD;
+    const shardCountValue = process.env.VITEST_DATACITE_TEST_SHARD_COUNT;
+
+    if (shardValue === undefined && shardCountValue === undefined) {
+        return [1, 1];
+    }
+
+    if (shardValue === undefined || shardCountValue === undefined) {
+        throw new Error('VITEST_DATACITE_TEST_SHARD and VITEST_DATACITE_TEST_SHARD_COUNT must be set together.');
+    }
+
+    const shard = Number(shardValue);
+    const shardCount = Number(shardCountValue);
+
+    if (!Number.isSafeInteger(shard) || shard <= 0 || !Number.isSafeInteger(shardCount) || shardCount <= 0) {
+        throw new Error('DataCite test shard and shard count must be positive integers.');
+    }
+
+    if (shard > shardCount) {
+        throw new Error(`DataCite test shard ${shard} cannot exceed shard count ${shardCount}.`);
+    }
+
+    return [shard, shardCount];
+};
+
+const [dataCiteTestShard, dataCiteTestShardCount] = resolveDataCiteTestShard();
 let dataCiteTestIndex = 0;
 let suiteDepth = 0;
 let assignedSuiteDepth = 0;
@@ -101,7 +126,8 @@ const isAssignedShard = () => {
     return assignedShard === dataCiteTestShard;
 };
 
-const registerTestInAssignedShard = (register: TestRegistration): TestRegistration =>
+const registerTestInAssignedShard =
+    (register: TestRegistration): TestRegistration =>
     (...args: unknown[]) => {
         if (assignedSuiteDepth > 0 || isAssignedShard()) {
             return register(...args);

--- a/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { act, fireEvent, render, screen, waitFor, within } from '@tests/vitest/utils/render';
 import axios from 'axios';
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe as vitestDescribe, expect, it as vitestIt, type Mock, vi } from 'vitest';
 
 import DataCiteForm, { canAddLicense, canAddTitle, type DataCiteFormProps } from '@/components/curation/datacite-form';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';
@@ -81,6 +81,81 @@ vi.mock('@/hooks/use-ror-affiliations', () => ({
         error: null,
     }),
 }));
+
+type TestRegistration = (...args: unknown[]) => unknown;
+
+// This suite takes several minutes when one worker executes all tests serially. The six
+// lightweight *.part-*.test.tsx entrypoints load it with a different shard number so
+// Vitest can schedule the work across workers and CI shards. Direct tests are distributed
+// individually; nested describe blocks stay intact to preserve their hooks and isolation.
+// Importing this module without shard variables retains the original single-file behavior.
+const dataCiteTestShard = Number.parseInt(process.env.VITEST_DATACITE_TEST_SHARD ?? '1', 10);
+const dataCiteTestShardCount = Number.parseInt(process.env.VITEST_DATACITE_TEST_SHARD_COUNT ?? '1', 10);
+let dataCiteTestIndex = 0;
+let suiteDepth = 0;
+let assignedSuiteDepth = 0;
+
+const isAssignedShard = () => {
+    const assignedShard = (dataCiteTestIndex++ % dataCiteTestShardCount) + 1;
+
+    return assignedShard === dataCiteTestShard;
+};
+
+const registerTestInAssignedShard = (register: TestRegistration): TestRegistration =>
+    (...args: unknown[]) => {
+        if (assignedSuiteDepth > 0 || isAssignedShard()) {
+            return register(...args);
+        }
+
+        return undefined;
+    };
+
+const wrapSuiteHandler = (args: unknown[], assigned: boolean): unknown[] => {
+    const wrappedArgs = [...args];
+    const handlerIndex = wrappedArgs.length - 1;
+    const handler = wrappedArgs[handlerIndex] as TestRegistration;
+
+    wrappedArgs[handlerIndex] = (...handlerArgs: unknown[]) => {
+        suiteDepth++;
+        assignedSuiteDepth += assigned ? 1 : 0;
+
+        try {
+            return handler(...handlerArgs);
+        } finally {
+            assignedSuiteDepth -= assigned ? 1 : 0;
+            suiteDepth--;
+        }
+    };
+
+    return wrappedArgs;
+};
+
+const describe = ((...args: unknown[]) => {
+    if (suiteDepth === 0) {
+        return (vitestDescribe as unknown as TestRegistration)(...wrapSuiteHandler(args, false));
+    }
+
+    if (assignedSuiteDepth > 0) {
+        return (vitestDescribe as unknown as TestRegistration)(...wrapSuiteHandler(args, true));
+    }
+
+    if (isAssignedShard()) {
+        return (vitestDescribe as unknown as TestRegistration)(...wrapSuiteHandler(args, true));
+    }
+
+    return undefined;
+}) as typeof vitestDescribe;
+
+const shardedEach = ((...cases: unknown[]) => {
+    const register = Reflect.apply(vitestIt.each as unknown as TestRegistration, vitestIt, cases) as TestRegistration;
+
+    return registerTestInAssignedShard(register);
+}) as typeof vitestIt.each;
+
+const it = Object.assign(registerTestInAssignedShard(vitestIt as unknown as TestRegistration), vitestIt, {
+    each: shardedEach,
+    skip: registerTestInAssignedShard(vitestIt.skip as unknown as TestRegistration),
+}) as typeof vitestIt;
 
 describe('DataCiteForm', () => {
     const originalFetch = global.fetch;

--- a/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { act, fireEvent, render, screen, waitFor, within } from '@tests/vitest/utils/render';
 import axios from 'axios';
-import { afterAll, afterEach, beforeAll, beforeEach, expect, vi, describe as vitestDescribe, it as vitestIt, type Mock } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe as vitestDescribe, expect, it as vitestIt, type Mock, vi } from 'vitest';
 
 import DataCiteForm, { canAddLicense, canAddTitle, type DataCiteFormProps } from '@/components/curation/datacite-form';
 import { useRorAffiliations } from '@/hooks/use-ror-affiliations';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,6 +76,7 @@ export default defineConfig(({ command }) => {
         },
         test: {
             environment: 'jsdom',
+            clearMocks: true,
             environmentOptions: {
                 jsdom: {
                     url: 'http://localhost/',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,6 +76,9 @@ export default defineConfig(({ command }) => {
         },
         test: {
             environment: 'jsdom',
+            // Threads avoid the process startup overhead of the default fork pool.
+            // Both coverage shards are about 25-30% faster with this suite.
+            pool: 'threads',
             clearMocks: true,
             environmentOptions: {
                 jsdom: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,9 +76,9 @@ export default defineConfig(({ command }) => {
         },
         test: {
             environment: 'jsdom',
-            // Threads avoid the process startup overhead of the default fork pool.
-            // Both coverage shards are about 25-30% faster with this suite.
-            pool: 'threads',
+            // Threads are 25-30% faster locally, while GitHub-hosted runners
+            // perform better with the process-isolated fork pool.
+            pool: process.env.CI ? 'forks' : 'threads',
             clearMocks: true,
             environmentOptions: {
                 jsdom: {

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig(() => {
     return {
+        // Keep file-generating Laravel/Wayfinder buildStart hooks out of Vitest's browser environments.
         plugins: [
             react(),
             tailwindcss(),

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,21 +1,13 @@
-import { wayfinder } from '@laravel/vite-plugin-wayfinder';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import laravel from 'laravel-vite-plugin';
+import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig(() => {
     return {
         plugins: [
-            laravel({
-                input: ['resources/css/app.css', 'resources/js/app.tsx'],
-                refresh: true,
-            }),
             react(),
             tailwindcss(),
-            wayfinder({
-                formVariants: true,
-            }),
         ],
         resolve: {
             alias: {
@@ -29,7 +21,7 @@ export default defineConfig(() => {
             include: ['tests/vitest-browser/**/*.{test,spec}.{js,ts,jsx,tsx}'],
             browser: {
                 enabled: true,
-                provider: 'playwright',
+                provider: playwright(),
                 instances: [{ browser: 'chromium' }],
             },
             env: {

--- a/vitest.merge.config.ts
+++ b/vitest.merge.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    // Report merging replays existing Vitest blobs. Loading the application Vite
+    // plugins here would unnecessarily run Laravel and Wayfinder build hooks.
+    test: {
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'json-summary', 'lcov'],
+            reportsDirectory: 'coverage',
+        },
+    },
+});


### PR DESCRIPTION
This pull request introduces major improvements to our frontend test infrastructure, focusing on upgrading to Vitest 5, optimizing test sharding and parallelism in CI, and improving the maintainability and speed of our large DataCite form test suite. The changes update dependencies, restructure the Vitest workflow to use sharded runs, and refactor the DataCite test suite for efficient parallel execution. Documentation is also updated to reflect these changes and provide guidance on new features and best practices.

**Vitest 5 upgrade and workflow improvements:**

- Upgraded `vitest`, `@vitest/browser`, and `@vitest/coverage-v8` to version 5.0.0-beta.7, and added `@vitest/browser-playwright` as a dependency in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L86-R88) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L103-R104)
- Reworked the GitHub Actions workflow (`.github/workflows/vitest.yml`) to run Vitest in two parallel shards, upload their results as artifacts, and merge coverage reports before uploading to Codecov. This increases CI speed and ensures complete coverage reporting. [[1]](diffhunk://#diff-8e5000814be46b2df07a5db6f63d1719b58ae346a025ad694f287418c4896a28L12-R18) [[2]](diffhunk://#diff-8e5000814be46b2df07a5db6f63d1719b58ae346a025ad694f287418c4896a28R45-L50)

**Test suite sharding and parallelism:**

- Refactored the DataCite form test suite by splitting it into six entrypoint files (`datacite-form.part-*.test.tsx`) that each set environment variables to identify their shard and import a shared test suite. A custom sharding mechanism in the shared suite ensures tests are distributed across shards and Vitest workers, greatly reducing runtime. [[1]](diffhunk://#diff-1af2a92d67c6aca73e0c08e8a7cfe76436fb77ca90eeea7c53d4d23808e2afbdR1-R6) [[2]](diffhunk://#diff-696a96f32031b3f608dfa182e04e6ddca11840513080df8cd93fd8dfd9f1750bR1-R6) [[3]](diffhunk://#diff-750ef91a9ad5b8c06e01adc0001ff8ec7a5365931ed5159818c48ee700366fe4R1-R6) [[4]](diffhunk://#diff-e05e4497b6efaecfcfbae87b489e7538a9bf43f02757f83bbd3818e23a27fa8fR1-R6) [[5]](diffhunk://#diff-17b3b899ff6d0d04319146a6a2bd19d02e88bb580fa055d7573afe0252f8f288R1-R6) [[6]](diffhunk://#diff-5b5d3eea7db030e9793457b388c14ca1c827d0a58c7c86f8f1b25d1834a0355cR1-R6) [[7]](diffhunk://#diff-c1dcf58cb1341c0b12d70b8df172eec8c91f7ba412349eec6a45ed87ac567c07L6-R6) [[8]](diffhunk://#diff-c1dcf58cb1341c0b12d70b8df172eec8c91f7ba412349eec6a45ed87ac567c07R85-R159)
- Updated `vite.config.ts` to use process-based pools in CI for better performance, and clarified comments about threading and isolation.

**Configuration and plugin changes:**

- Simplified `vitest.browser.config.ts` to remove Laravel/Wayfinder plugins from browser test runs, added Playwright as the browser provider, and clarified that only browser-specific transforms are included. [[1]](diffhunk://#diff-6109cd8d41607943a9744aa97c2c18e15260b8bc7f724cfe72460caa00bcb95cL1-L18) [[2]](diffhunk://#diff-6109cd8d41607943a9744aa97c2c18e15260b8bc7f724cfe72460caa00bcb95cL32-R25)
- Added a new `vitest.merge.config.ts` to configure report merging without loading unnecessary plugins or build hooks.
- Cleaned up `scripts/run-vitest.mjs` by removing legacy web storage flag handling and noise filtering, as these are no longer needed with Vitest 5. [[1]](diffhunk://#diff-ed13b120e845ec4a2e5e09d8e203d2916983451c7b12a55669a54be8bedeb0d5L5-L8) [[2]](diffhunk://#diff-ed13b120e845ec4a2e5e09d8e203d2916983451c7b12a55669a54be8bedeb0d5L76-L131)

**Documentation updates:**

- Expanded `docs/testing.md` with details on Vitest 5 features (repeat runs, import duration diagnostics, module cache), the new sharding and merging process in CI, and best practices for managing large test suites and browser test environments. [[1]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245L24-R24) [[2]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245R124-R146) [[3]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245R168-R169) [[4]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245R202-R203)

These changes collectively modernize our frontend testing workflow, improve CI efficiency, and provide clearer guidance for contributors.