### PR TITLE
Feature: Improved Handling of the optional Version Field

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -384,6 +384,10 @@
         ],
         "fixes": [
             {
+                "title": "Clearer Optional Version Field",
+                "description": "The Data Editor now displays 'None' only as a placeholder when a resource has no version. The underlying field remains empty, missing or cleared versions continue to be stored as null and omitted from DataCite exports, and genuine version values remain unchanged."
+            },
+            {
                 "title": "Optional Data Language in the Data Editor",
                 "description": "The Data Editor no longer defaults missing resource-language metadata to English or requires curators to select a language. New, uploaded, existing, and legacy resources preserve an explicitly supplied language, while missing values remain unset and existing selections can be cleared without blocking validation."
             },

--- a/resources/js/components/curation/datacite-form.tsx
+++ b/resources/js/components/curation/datacite-form.tsx
@@ -3095,8 +3095,8 @@ export default function DataCiteForm({
                             onValidationBlur={() => markFieldTouched('version')}
                             validationMessages={getFieldState('version').messages}
                             touched={getFieldState('version').touched}
-                            placeholder="1.0"
-                            labelTooltip="Version number (e.g., 1.0, 2.1, 1.0.0)"
+                            placeholder="None"
+                            labelTooltip="Optional version (e.g., 1.0, 2.1, 1.0.0)"
                             maxLength={50}
                             className="min-w-0 md:col-span-2 xl:col-span-1"
                         />

--- a/tests/pest/Feature/Services/ResourceStorageServiceTest.php
+++ b/tests/pest/Feature/Services/ResourceStorageServiceTest.php
@@ -101,6 +101,74 @@ describe('ResourceStorageService', function () {
         expect($description->value)->toBe('Test abstract description.');
     });
 
+    it('stores a missing version as null', function () {
+        $resourceType = ResourceType::firstOrFail();
+
+        [$resource] = $this->service->store([
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'titles' => [
+                [
+                    'title' => 'Resource without a version',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'position' => 0,
+                ],
+            ],
+        ], $this->user->id);
+
+        expect($resource->version)->toBeNull();
+        $this->assertDatabaseHas('resources', [
+            'id' => $resource->id,
+            'version' => null,
+        ]);
+    });
+
+    it('clears a previously stored version to null', function () {
+        $resourceType = ResourceType::firstOrFail();
+        $data = [
+            'year' => 2024,
+            'resourceType' => $resourceType->id,
+            'version' => '1.0',
+            'titles' => [
+                [
+                    'title' => 'Versioned resource',
+                    'titleType' => 'MainTitle',
+                ],
+            ],
+            'authors' => [
+                [
+                    'type' => 'person',
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'position' => 0,
+                ],
+            ],
+        ];
+
+        [$resource] = $this->service->store($data, $this->user->id);
+        expect($resource->version)->toBe('1.0');
+
+        [$updatedResource, $isUpdate] = $this->service->store([
+            ...$data,
+            'resourceId' => $resource->id,
+            'version' => null,
+        ], $this->user->id);
+
+        expect($isUpdate)->toBeTrue()
+            ->and($updatedResource->version)->toBeNull();
+        $this->assertDatabaseHas('resources', [
+            'id' => $resource->id,
+            'version' => null,
+        ]);
+    });
+
     it('stores imported raw rights without a selected catalog license', function () {
         $resourceType = ResourceType::first();
 

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -137,6 +137,39 @@ test.describe('DataCite Form Validation UX', () => {
             expect(await formPage.versionInput.evaluate((input: HTMLInputElement) => input.matches(':placeholder-shown'))).toBe(false);
         });
 
+        test('submits null for a missing version and the entered version string in draft save requests', async ({ page }) => {
+            const submittedVersions: unknown[] = [];
+            const saveDraftButton = page.getByTestId('save-draft-button');
+
+            await page.route(
+                (url) => url.pathname === '/editor/resources/draft',
+                async (route) => {
+                    const payload = route.request().postDataJSON() as { version?: unknown };
+                    submittedVersions.push(payload.version);
+
+                    await route.fulfill({
+                        status: 422,
+                        contentType: 'application/json',
+                        body: JSON.stringify({ message: 'Request intercepted by the version payload test.' }),
+                    });
+                },
+            );
+
+            await formPage.mainTitleInput.fill('Version payload regression test');
+            await expect(formPage.versionInput).toHaveValue('');
+            await expect(saveDraftButton).toBeEnabled();
+
+            await saveDraftButton.click();
+            await expect.poll(() => submittedVersions.length).toBe(1);
+            expect(submittedVersions[0]).toBeNull();
+
+            await expect(saveDraftButton).toBeEnabled();
+            await formPage.versionInput.fill('2.1');
+            await saveDraftButton.click();
+            await expect.poll(() => submittedVersions.length).toBe(2);
+            expect(submittedVersions[1]).toBe('2.1');
+        });
+
         test('validates main title length', async ({ page }) => {
             // Too short (empty)
             await formPage.mainTitleInput.fill('');

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -124,7 +124,7 @@ test.describe('DataCite Form Validation UX', () => {
             await formPage.expectValidationSuccess(formPage.versionInput);
         });
 
-        test('shows a missing version as None without setting a metadata value', async () => {
+        test('shows None as a placeholder while keeping a missing version input empty', async () => {
             await expect(formPage.versionInput).toHaveValue('');
             await expect(formPage.versionInput).toHaveAttribute('placeholder', 'None');
 

--- a/tests/playwright/workflows/07-validation-ux.spec.ts
+++ b/tests/playwright/workflows/07-validation-ux.spec.ts
@@ -124,6 +124,19 @@ test.describe('DataCite Form Validation UX', () => {
             await formPage.expectValidationSuccess(formPage.versionInput);
         });
 
+        test('shows a missing version as None without setting a metadata value', async () => {
+            await expect(formPage.versionInput).toHaveValue('');
+            await expect(formPage.versionInput).toHaveAttribute('placeholder', 'None');
+
+            const placeholderIsShown = await formPage.versionInput.evaluate((input: HTMLInputElement) => input.matches(':placeholder-shown'));
+            expect(placeholderIsShown).toBe(true);
+
+            await formPage.versionInput.fill('2.1');
+
+            await expect(formPage.versionInput).toHaveValue('2.1');
+            expect(await formPage.versionInput.evaluate((input: HTMLInputElement) => input.matches(':placeholder-shown'))).toBe(false);
+        });
+
         test('validates main title length', async ({ page }) => {
             // Too short (empty)
             await formPage.mainTitleInput.fill('');


### PR DESCRIPTION
This pull request improves the handling of the optional "version" field in the DataCite resource form and ensures consistent behavior when the version is missing or cleared. It updates the UI to better reflect the optional nature of the version, adds backend tests for storing and clearing version values, and enhances frontend tests to verify the correct display and storage of version information.

**UI/UX Improvements:**

* Changed the `version` input in `DataCiteForm` to display the placeholder "None" and clarified the tooltip to indicate that the version is optional.

**Backend Logic and Testing:**

* Added tests to `ResourceStorageServiceTest` to verify that missing versions are stored as `null` and that an existing version can be cleared by setting it to `null`.

**Frontend Testing:**

* Enhanced Playwright tests to check that the version input shows "None" as the placeholder when no version is set and does not store a metadata value until a version is entered.