### PR TITLE
Fix: GEOFON Events and Networks Import does not import the right Datacenter

### DIFF
--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -23,6 +23,10 @@ class LegacyMetaworksDatacenterLookupService
 
     public const FID_GEO_DATACENTER = 'FID GEO';
 
+    public const GEOFON_EVENTS_DATACENTER = 'GEOFON Seismic Events';
+
+    public const GEOFON_NETWORKS_DATACENTER = 'GEOFON Seismic Networks';
+
     public const DEFAULT_DATACENTER = 'GFZ German Research Centre for Geosciences';
 
     public const GIPP_DATACENTER = 'GIPP Geophysical Instrument Pool Potsdam';
@@ -60,6 +64,23 @@ class LegacyMetaworksDatacenterLookupService
     public function __construct(
         private readonly DoiSuggestionService $doiSuggestionService,
     ) {}
+
+    /**
+     * Complete DOI patterns for namespaces that cannot be identified reliably
+     * from the suffix alone.
+     *
+     * @var list<array{pattern: string, datacenters: list<string>}>
+     */
+    private const DOI_DATACENTER_RULES = [
+        [
+            'pattern' => '/^10\.14470\/.+$/i',
+            'datacenters' => [self::GEOFON_NETWORKS_DATACENTER],
+        ],
+        [
+            'pattern' => '/^10\.1594\/gfz\.geofon\..+$/i',
+            'datacenters' => [self::GEOFON_EVENTS_DATACENTER],
+        ],
+    ];
 
     /**
      * DOI suffix patterns that identify datacenters in legacy SUMARIO records.
@@ -198,17 +219,16 @@ class LegacyMetaworksDatacenterLookupService
         ));
 
         $candidates = $specializedNames !== [] ? $specializedNames : $names;
-        $idsByName = Datacenter::query()
-            ->whereIn('name', $candidates)
-            ->pluck('id', 'name');
 
-        foreach ($candidates as $candidate) {
-            if ($idsByName->has($candidate)) {
-                return [(int) $idsByName->get($candidate)];
-            }
+        if ($candidates === []) {
+            return [];
         }
 
-        return [];
+        $datacenter = Datacenter::query()->firstOrCreate([
+            'name' => $candidates[0],
+        ]);
+
+        return [(int) $datacenter->id];
     }
 
     public function syncDatacenters(Resource $resource, string $doi): void
@@ -244,13 +264,21 @@ class LegacyMetaworksDatacenterLookupService
      */
     private function resolveDatacenterNamesFromDoiPattern(string $doi): array
     {
+        $datacenters = [];
+
+        foreach (self::DOI_DATACENTER_RULES as $rule) {
+            if (preg_match($rule['pattern'], $doi) !== 1) {
+                continue;
+            }
+
+            array_push($datacenters, ...$rule['datacenters']);
+        }
+
         $suffix = $this->doiSuffix($doi);
 
         if ($suffix === null) {
-            return [];
+            return $this->uniqueDatacenters($datacenters);
         }
-
-        $datacenters = [];
 
         foreach (self::DOI_SUFFIX_DATACENTER_RULES as $rule) {
             if (preg_match($rule['pattern'], $suffix) !== 1) {

--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -224,9 +224,7 @@ class LegacyMetaworksDatacenterLookupService
             return [];
         }
 
-        $datacenter = Datacenter::query()->firstOrCreate([
-            'name' => $candidates[0],
-        ]);
+        $datacenter = $this->resolveCanonicalDatacenter($candidates[0]);
 
         return [(int) $datacenter->id];
     }
@@ -257,6 +255,32 @@ class LegacyMetaworksDatacenterLookupService
             ->table($table)
             ->where('doi', $doi)
             ->exists();
+    }
+
+    private function resolveCanonicalDatacenter(string $canonicalName): Datacenter
+    {
+        $datacenter = Datacenter::query()
+            ->where('name', $canonicalName)
+            ->first();
+
+        if ($datacenter === null) {
+            $datacenter = Datacenter::query()
+                ->whereRaw('LOWER(name) = LOWER(?)', [$canonicalName])
+                ->orderBy('id')
+                ->first();
+        }
+
+        if ($datacenter === null) {
+            return Datacenter::query()->firstOrCreate([
+                'name' => $canonicalName,
+            ]);
+        }
+
+        if ($datacenter->name !== $canonicalName) {
+            $datacenter->forceFill(['name' => $canonicalName])->save();
+        }
+
+        return $datacenter;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9401,9 +9401,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-07-29",
+        "date": "2026-08-13",
         "features": [
             {
                 "title": "Resource Types for Relation Suggestions",
@@ -383,6 +383,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "Correct GEOFON Datacenters for Legacy Imports",
+                "description": "New legacy imports now assign GEOFON seismic-network and seismic-event DOIs to their canonical GEOFON datacenters instead of the general GFZ fallback. Existing datacenter records with different letter casing are reused and normalized, preventing duplicate assignments. Existing imported resources remain unchanged."
+            },
             {
                 "title": "Clearer Optional Version Field",
                 "description": "The Data Editor now displays 'None' only as a placeholder when a resource has no version. The underlying field remains empty, missing or cleared versions continue to be stored as null and omitted from DataCite exports, and genuine version values remain unchanged."

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -5,6 +5,7 @@ use App\Enums\CitationLabelResolutionMode;
 use App\Enums\UserRole;
 use App\Exceptions\IncompleteCitationLabelResolutionException;
 use App\Jobs\ImportFromDataCiteJob;
+use App\Models\Datacenter;
 use App\Models\LandingPage;
 use App\Models\LandingPageDomain;
 use App\Models\LandingPageFile;
@@ -15,14 +16,18 @@ use App\Services\DataCiteImportService;
 use App\Services\DataCiteSyncResult;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
+use App\Services\DoiSuggestionService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
 use App\Services\LegacyResourceLookupService;
 use App\Services\MetaworksDownloadUrlService;
 use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 beforeEach(function () {
@@ -779,6 +784,74 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['skipped'])->toBe(0)
             ->and($status['failed'])->toBe(0);
     });
+
+    it('assigns canonical GEOFON datacenters during single DataCite imports', function (string $doi, string $expectedDatacenter): void {
+        Config::set('database.connections.legacy_metaworks', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+        DB::purge('legacy_metaworks');
+
+        Schema::connection('legacy_metaworks')->create('gipp_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable()->collation('NOCASE');
+        });
+        Schema::connection('legacy_metaworks')->create('sddb_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable()->collation('NOCASE');
+        });
+
+        $this->app->instance(
+            LegacyMetaworksDatacenterLookupService::class,
+            new LegacyMetaworksDatacenterLookupService(app(DoiSuggestionService::class)),
+        );
+
+        $doiRecord = [
+            'id' => $doi,
+            'attributes' => [
+                'doi' => $doi,
+                'titles' => [['title' => 'GEOFON import regression']],
+                'publicationYear' => 2025,
+                'types' => ['resourceTypeGeneral' => 'Dataset'],
+            ],
+        ];
+
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with($doi)
+            ->andReturn($doiRecord);
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->with($doiRecord, $this->user->id)
+            ->andReturnUsing(fn (): Resource => Resource::factory()->create(['doi' => $doi]));
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId, $doi);
+        $job->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $resource = Resource::query()->where('doi', $doi)->firstOrFail();
+        $status = Cache::get("datacite_import:{$importId}");
+
+        expect($status['status'])->toBe('completed')
+            ->and($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(0)
+            ->and($resource->fresh()->datacenter?->name)->toBe($expectedDatacenter)
+            ->and(Datacenter::query()->where('name', $expectedDatacenter)->count())->toBe(1);
+    })->with([
+        'GEOFON seismic network' => [
+            '10.14470/rv968923',
+            LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER,
+        ],
+        'GEOFON seismic event' => [
+            '10.1594/gfz.geofon.gfz2009gibb',
+            LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+        ],
+    ]);
 
     it('fails a single import atomically when a required citation label cannot be resolved', function () {
         $doiRecord = [

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -26,6 +26,8 @@ function legacyImportDatacenterNames(): array
         LegacyMetaworksDatacenterLookupService::DIGIS_DATACENTER,
         LegacyMetaworksDatacenterLookupService::ENMAP_DATACENTER,
         LegacyMetaworksDatacenterLookupService::FID_GEO_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+        LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER,
         LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
         LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER,
         LegacyMetaworksDatacenterLookupService::ICGEM_DATACENTER,
@@ -135,6 +137,22 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             '10.5880/GIPP-MT.202403.1',
             [LegacyMetaworksDatacenterLookupService::GIPP_DATACENTER],
         ],
+        'GEOFON seismic network issue DOI RV968923' => [
+            '10.14470/RV968923',
+            [LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER],
+        ],
+        'GEOFON seismic network issue DOI RR425351' => [
+            '10.14470/RR425351',
+            [LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER],
+        ],
+        'GEOFON seismic event DOI' => [
+            '10.1594/GFZ.GEOFON.GFZ2009GIBB',
+            [LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER],
+        ],
+        'non-GEOFON 10.1594 DOI with a similar suffix' => [
+            '10.1594/GFZ.GEOFONIC.GFZ2009GIBB',
+            [LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER],
+        ],
         'ICGEM DOI inside COST-G namespace' => [
             '10.5880/COST-G.ICGEM_02_L2',
             [LegacyMetaworksDatacenterLookupService::ICGEM_DATACENTER],
@@ -205,15 +223,32 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
         ],
     ]);
 
-    it('normalises DOI URLs and doi scheme before matching datacenter patterns', function (string $doi): void {
+    it('normalises DOI URLs and doi scheme before matching datacenter patterns', function (string $doi, string $expectedDatacenter): void {
         $service = app(LegacyMetaworksDatacenterLookupService::class);
 
         expect($service->resolveDatacenterNames($doi))
-            ->toBe([LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER]);
+            ->toBe([$expectedDatacenter]);
     })->with([
-        'https DOI URL' => ['https://doi.org/10.5880/hA-ArboDat_AK1'],
-        'http dx.doi URL' => ['http://dx.doi.org/10.5880/hA-ArboDat_AK1'],
-        'doi scheme' => ['doi:10.5880/hA-ArboDat_AK1'],
+        'https DOI URL' => [
+            'https://doi.org/10.5880/hA-ArboDat_AK1',
+            LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER,
+        ],
+        'http dx.doi URL' => [
+            'http://dx.doi.org/10.5880/hA-ArboDat_AK1',
+            LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER,
+        ],
+        'doi scheme' => [
+            'doi:10.5880/hA-ArboDat_AK1',
+            LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER,
+        ],
+        'mixed-case GEOFON network DOI URL' => [
+            'https://doi.org/10.14470/RV968923',
+            LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER,
+        ],
+        'GEOFON event doi scheme' => [
+            'doi:10.1594/GFZ.GEOFON.GFZ2009GIBB',
+            LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+        ],
     ]);
 
     it('delegates DOI normalization after stripping the doi scheme prefix', function () {
@@ -276,6 +311,38 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             ->toBe([LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER]);
     });
 
+    it('creates a missing canonical GEOFON datacenter instead of falling back to GFZ', function () {
+        Datacenter::query()
+            ->where('name', LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER)
+            ->delete();
+
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
+        $datacenterIds = $service->resolveDatacenterIds('10.14470/RV968923');
+
+        expect($datacenterIds)->toHaveCount(1)
+            ->and(Datacenter::query()->findOrFail($datacenterIds[0])->name)
+            ->toBe(LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER)
+            ->and(Datacenter::query()
+                ->where('name', LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER)
+                ->count())
+            ->toBe(1);
+    });
+
+    it('keeps the DOI-rule datacenter authoritative when another specialised table also matches', function () {
+        Datacenter::query()
+            ->where('name', LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER)
+            ->delete();
+        DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
+            'doi' => '10.14470/RV968923',
+        ]);
+
+        $service = app(LegacyMetaworksDatacenterLookupService::class);
+        $datacenterIds = $service->resolveDatacenterIds('10.14470/RV968923');
+
+        expect(Datacenter::query()->findOrFail($datacenterIds[0])->name)
+            ->toBe(LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER);
+    });
+
     it('syncs resolved datacenters onto the imported resource', function () {
         DB::connection('legacy_metaworks')->table('gipp_dataset')->insert([
             'doi' => '10.5880/gipp.sync',
@@ -297,4 +364,21 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
         expect($resource->fresh()->datacenter?->name)
             ->toBe(LegacyMetaworksDatacenterLookupService::ARBODAT_DATACENTER);
     });
+
+    it('syncs GEOFON DOI datacenters onto imported resources', function (string $doi, string $expectedDatacenter): void {
+        $resource = Resource::factory()->create(['doi' => $doi]);
+
+        app(LegacyMetaworksDatacenterLookupService::class)->syncDatacenters($resource, $doi);
+
+        expect($resource->fresh()->datacenter?->name)->toBe($expectedDatacenter);
+    })->with([
+        'seismic network' => [
+            '10.14470/RR425351',
+            LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER,
+        ],
+        'seismic event' => [
+            '10.1594/GFZ.GEOFON.GFZ2009GIBB',
+            LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+        ],
+    ]);
 });

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -328,6 +328,41 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             ->toBe(1);
     });
 
+    it('reuses and canonicalises an existing mixed-case GEOFON datacenter', function (
+        string $doi,
+        string $canonicalName,
+        string $mixedCaseName,
+    ): void {
+        Datacenter::query()
+            ->where('name', $canonicalName)
+            ->delete();
+
+        $existingDatacenter = Datacenter::query()->create([
+            'name' => $mixedCaseName,
+        ]);
+
+        $datacenterIds = app(LegacyMetaworksDatacenterLookupService::class)
+            ->resolveDatacenterIds($doi);
+
+        expect($datacenterIds)->toBe([$existingDatacenter->id])
+            ->and($existingDatacenter->refresh()->name)->toBe($canonicalName)
+            ->and(Datacenter::query()
+                ->whereRaw('LOWER(name) = LOWER(?)', [$canonicalName])
+                ->count())
+            ->toBe(1);
+    })->with([
+        'seismic network' => [
+            '10.14470/RV968923',
+            LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER,
+            'Geofon seismic networks',
+        ],
+        'seismic event' => [
+            '10.1594/GFZ.GEOFON.GFZ2009GIBB',
+            LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+            'Geofon seismic events',
+        ],
+    ]);
+
     it('keeps the DOI-rule datacenter authoritative when another specialised table also matches', function () {
         Datacenter::query()
             ->where('name', LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER)

--- a/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
+++ b/tests/pest/Unit/Services/SumarioPendingResourceImportServiceTest.php
@@ -252,6 +252,129 @@ describe('SumarioPendingResourceImportService', function () {
         expect($result['status'])->toBe('imported');
     });
 
+    it('assigns canonical GEOFON datacenters during pending SUMARIO imports', function (
+        int $legacyResourceId,
+        string $storedDoi,
+        string $requestedDoi,
+        string $expectedDoi,
+        string $expectedDatacenter,
+    ) {
+        Config::set('database.connections.legacy_metaworks', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+        DB::purge('legacy_metaworks');
+
+        Schema::connection('legacy_metaworks')->create('gipp_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable()->collation('NOCASE');
+        });
+        Schema::connection('legacy_metaworks')->create('sddb_dataset', function (Blueprint $table): void {
+            $table->id();
+            $table->string('doi')->nullable()->collation('NOCASE');
+        });
+
+        DB::connection('metaworks')->table('resource')->insert([
+            'id' => $legacyResourceId,
+            'publicstatus' => 'pending',
+            'identifier' => $storedDoi,
+            'publicationyear' => 2025,
+            'title' => 'Pending GEOFON Resource',
+        ]);
+
+        $user = User::factory()->create();
+        $editorLoader = Mockery::mock(OldDatasetEditorLoader::class);
+        $editorLoader
+            ->shouldReceive('loadForEditor')
+            ->once()
+            ->with($legacyResourceId)
+            ->andReturn([
+                'doi' => $storedDoi,
+                'year' => '2025',
+                'language' => 'en',
+                'titles' => [
+                    ['title' => 'Pending GEOFON Resource', 'titleType' => 'main-title'],
+                ],
+                'initialRights' => [],
+                'authors' => [],
+                'contributors' => [],
+                'descriptions' => [],
+                'dates' => [],
+                'gcmdKeywords' => [],
+                'freeKeywords' => [],
+                'geoLocations' => [],
+                'relatedWorks' => [],
+                'fundingReferences' => [],
+                'mslLaboratories' => [],
+            ]);
+
+        $resourceStorage = Mockery::mock(ResourceStorageService::class);
+        $resourceStorage
+            ->shouldReceive('store')
+            ->once()
+            ->andReturnUsing(function (array $payload, int $userId) use ($user, $expectedDoi, $expectedDatacenter): array {
+                $datacenter = Datacenter::query()
+                    ->whereKey($payload['datacenter_id'])
+                    ->firstOrFail();
+
+                expect($userId)->toBe($user->id)
+                    ->and($payload['doi'])->toBe($expectedDoi)
+                    ->and($datacenter->name)->toBe($expectedDatacenter);
+
+                return [
+                    Resource::factory()->create([
+                        'doi' => $payload['doi'],
+                        'datacenter_id' => $datacenter->id,
+                    ]),
+                    false,
+                ];
+            });
+
+        $downloadUrlService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $downloadUrlService
+            ->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with($expectedDoi)
+            ->andReturn(['files' => [], 'allPublic' => false]);
+
+        $service = new SumarioPendingResourceImportService(
+            editorLoader: $editorLoader,
+            resourceStorage: $resourceStorage,
+            datacenterLookup: app(LegacyMetaworksDatacenterLookupService::class),
+            downloadUrlService: $downloadUrlService,
+            landingPageImport: new LegacyLandingPageImportService,
+            doiSuggestionService: app(DoiSuggestionService::class),
+        );
+
+        $result = $service->importPendingByDoi($requestedDoi, $user->id);
+        $resource = $result['resource'];
+
+        if (! $resource instanceof Resource) {
+            throw new RuntimeException('Expected the pending GEOFON resource to be imported.');
+        }
+
+        expect($result['status'])->toBe('imported')
+            ->and($resource->fresh()->datacenter?->name)->toBe($expectedDatacenter)
+            ->and(Datacenter::query()->where('name', $expectedDatacenter)->count())->toBe(1);
+    })->with([
+        'GEOFON seismic network' => [
+            61,
+            '10.14470/RV968923',
+            'https://doi.org/10.14470/RV968923',
+            '10.14470/rv968923',
+            LegacyMetaworksDatacenterLookupService::GEOFON_NETWORKS_DATACENTER,
+        ],
+        'GEOFON seismic event' => [
+            62,
+            '10.1594/GFZ.GEOFON.GFZ2009GIBB',
+            '10.1594/GFZ.GEOFON.GFZ2009GIBB',
+            '10.1594/gfz.geofon.gfz2009gibb',
+            LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+        ],
+    ]);
+
     it('skips a pending SUMARIO resource when the DOI already exists in ERNIE', function () {
         DB::connection('metaworks')->table('resource')->insert([
             'id' => 56,


### PR DESCRIPTION
This pull request improves the assignment and normalization of GEOFON datacenters during legacy DOI imports, ensuring that GEOFON seismic-network and seismic-event DOIs are assigned to their canonical datacenters rather than a generic fallback. It also introduces robust handling to prevent duplicate or mis-cased datacenter entries and adds comprehensive tests to verify this behavior.

**Enhancements to GEOFON datacenter assignment and normalization:**

* Introduced new canonical constants for GEOFON seismic events and seismic networks datacenters in `LegacyMetaworksDatacenterLookupService` and added DOI pattern rules to map specific GEOFON DOIs directly to these canonical names. [[1]](diffhunk://#diff-6871331b5e968f086cc56f2bf594987501a753a17e13c45fd4f5b78e2dec5c20R26-R29) [[2]](diffhunk://#diff-6871331b5e968f086cc56f2bf594987501a753a17e13c45fd4f5b78e2dec5c20R68-R84)
* Updated datacenter resolution logic to always return or create the canonical datacenter entry, normalizing case and preventing duplicate datacenters with different casing. [[1]](diffhunk://#diff-6871331b5e968f086cc56f2bf594987501a753a17e13c45fd4f5b78e2dec5c20L201-R229) [[2]](diffhunk://#diff-6871331b5e968f086cc56f2bf594987501a753a17e13c45fd4f5b78e2dec5c20R260-L254)
* Ensured that when a DOI matches a GEOFON pattern, the canonical GEOFON datacenter is considered authoritative, even if other specialized table matches exist.

**Testing improvements:**

* Added and expanded unit and feature tests to cover assignment, normalization, and synchronization of GEOFON datacenters—including mixed-case handling, creation of missing canonical entries, and correct assignment during imports. [[1]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R29-R30) [[2]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R140-R155) [[3]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343L208-R251) [[4]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R314-R380) [[5]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R402-R418) [[6]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR8) [[7]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR19-R30) [[8]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR788-R855)

**Documentation and changelog:**

* Updated the changelog to document the fix: new imports assign GEOFON DOIs to canonical datacenters, existing records are normalized, and legacy resources remain unchanged. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fL4-R4) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR386-R389)