### PR TITLE
Fix: Role import Problem for Person/Institution-only Roles

### DIFF
--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -1,7 +1,7 @@
 [
     {
         "version": "1.0.0",
-        "date": "2026-08-13",
+        "date": "2026-08-14",
         "features": [
             {
                 "title": "Resource Types for Relation Suggestions",
@@ -383,6 +383,10 @@
             }
         ],
         "fixes": [
+            {
+                "title": "Preserved Imported Contributor Roles",
+                "description": "The Data Editor now keeps imported contributor roles visible and unchanged when they are not normally available for that contributor type. These entry-specific roles remain attached when an existing resource is opened and saved, without making them selectable for newly added contributors."
+            },
             {
                 "title": "Correct GEOFON Datacenters for Legacy Imports",
                 "description": "New legacy imports now assign GEOFON seismic-network and seismic-event DOIs to their canonical GEOFON datacenters instead of the general GFZ fallback. Existing datacenter records with different letter casing are reused and normalized, preventing duplicate assignments. Existing imported resources remain unchanged."

--- a/resources/js/components/curation/fields/contributor/contributor-item.tsx
+++ b/resources/js/components/curation/fields/contributor/contributor-item.tsx
@@ -47,6 +47,29 @@ interface ContributorItemProps {
 }
 
 /**
+ * Keep roles already assigned to this contributor valid for Tagify without
+ * exposing them as global options for other contributors of the same type.
+ */
+export const buildContributorRoleOptions = (allowedRoles: readonly string[], assignedRoles: readonly ContributorRoleTag[]) => {
+    const seen = new Set<string>();
+
+    return [...allowedRoles, ...assignedRoles.map((role) => role.value)]
+        .map((role) => role.trim())
+        .filter((role) => role.length > 0)
+        .filter((role) => {
+            const key = role.toLowerCase();
+
+            if (seen.has(key)) {
+                return false;
+            }
+
+            seen.add(key);
+            return true;
+        })
+        .map((value) => ({ value }));
+};
+
+/**
  * ContributorItem - Single contributor entry component with full field implementation
  */
 export default function ContributorItem({
@@ -127,10 +150,11 @@ export default function ContributorItem({
         await handleOrcidSelect(suggestion.orcid);
     };
 
-    // Role options based on type
+    // Role options based on type, plus this entry's existing roles. The latter
+    // prevents Tagify's enforced whitelist from dropping imported legacy roles.
     const roleOptions = useMemo(
-        () => (isPerson ? personRoleOptions : institutionRoleOptions).map((role) => ({ value: role })),
-        [institutionRoleOptions, isPerson, personRoleOptions],
+        () => buildContributorRoleOptions(isPerson ? personRoleOptions : institutionRoleOptions, contributor.roles),
+        [contributor.roles, institutionRoleOptions, isPerson, personRoleOptions],
     );
 
     // Tagify settings for roles

--- a/tests/playwright/workflows/12-legacy-contributor-roles.spec.ts
+++ b/tests/playwright/workflows/12-legacy-contributor-roles.spec.ts
@@ -1,0 +1,100 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { loginAsTestUser } from '../helpers/test-helpers';
+
+const contributors = [
+  { institutionName: 'Geological Survey of Estonia', role: 'Data Collector' },
+  { institutionName: 'GFZ Helmholtz-Zentrum für Geoforschung', role: 'Hosting Institution' },
+  { institutionName: 'GEOFON Data Centre', role: 'Data Manager' },
+] as const;
+
+const buildEditorUrl = () => {
+  const query = new URLSearchParams({
+    'titles[0][title]': 'Legacy contributor roles',
+    'titles[0][titleType]': 'main-title',
+  });
+
+  contributors.forEach((contributor, index) => {
+    query.set(`contributors[${index}][type]`, 'institution');
+    query.set(`contributors[${index}][position]`, String(index));
+    query.set(`contributors[${index}][institutionName]`, contributor.institutionName);
+    query.set(`contributors[${index}][roles][0]`, contributor.role);
+  });
+
+  return `/editor?${query.toString()}`;
+};
+
+const expandContributors = async (page: Page) => {
+  const trigger = page.locator('[data-slot="accordion-trigger"]', { hasText: /Contributors/i }).first();
+  await trigger.waitFor({ state: 'visible' });
+
+  if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  }
+};
+
+const getRoleWhitelist = (page: Page, index: number) =>
+  page.getByTestId(`contributor-${index}-roles-input`).evaluate((input) => {
+    const tagify = (input as HTMLInputElement & {
+      tagify?: { whitelist?: Array<string | { value?: string }> };
+    }).tagify;
+
+    return (tagify?.whitelist ?? [])
+      .map((role) => (typeof role === 'string' ? role : role.value))
+      .filter((role): role is string => Boolean(role));
+  });
+
+test.describe('Legacy contributor roles (Issue #1090)', () => {
+  test('keeps imported institution roles without offering them to a new institution', async ({ page }) => {
+    await loginAsTestUser(page);
+    await page.goto(buildEditorUrl());
+    await expandContributors(page);
+
+    for (const [index, contributor] of contributors.entries()) {
+      await expect(page.getByTestId(`contributor-${index}-roles-input`)).toHaveValue(contributor.role);
+      await expect(page.getByTestId(`contributor-${index}-roles-field`).locator('.tagify__tag-text')).toHaveText(contributor.role);
+    }
+
+    await page.getByRole('button', { name: 'Add another contributor' }).click();
+    const typeField = page.getByTestId('contributor-3-type-field');
+    await typeField.getByRole('combobox').click();
+    await page.getByRole('option', { name: 'Institution', exact: true }).click();
+
+    await expect.poll(() => getRoleWhitelist(page, 3)).not.toContain('Data Collector');
+    await expect.poll(() => getRoleWhitelist(page, 3)).not.toContain('Data Manager');
+
+    const newInstitutionRoleField = page.getByTestId('contributor-3-roles-field');
+    const tagInput = newInstitutionRoleField.locator('.tagify__input');
+    await tagInput.click();
+    await tagInput.fill('Data Collector');
+    await tagInput.press('Enter');
+    await expect(newInstitutionRoleField.locator('.tagify__tag')).toHaveCount(0);
+
+    const draftRequestPromise = page.waitForRequest((request) => request.url().includes('/editor/resources/draft') && request.method() === 'POST');
+    await page.route('**/editor/resources/draft', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        status: 200,
+        body: JSON.stringify({ message: 'Draft saved.', resource: { id: 1090 } }),
+      });
+    });
+
+    await page.getByTestId('save-draft-button').click();
+    const draftRequest = await draftRequestPromise;
+    const payload = draftRequest.postDataJSON() as {
+      contributors: Array<{ institutionName: string; roles: string[] }>;
+    };
+
+    expect(payload.contributors).toEqual(
+      contributors.map((contributor, position) =>
+        expect.objectContaining({
+          type: 'institution',
+          institutionName: contributor.institutionName,
+          roles: [contributor.role],
+          position,
+        }),
+      ),
+    );
+  });
+});

--- a/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
+++ b/tests/vitest/components/curation/__tests__/datacite-form.test-suite.tsx
@@ -6025,6 +6025,57 @@ describe('DataCiteForm', () => {
             expect(data.titles).toEqual([{ title: 'Draft Dataset', titleType: 'main-title', language: null }]);
         });
 
+        it('preserves entry-specific legacy institution roles in the draft payload', { timeout: 60000 }, async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };
+
+            renderDataCiteForm({
+                initialTitles: [{ title: 'Legacy contributor roles', titleType: 'main-title' }],
+                initialContributors: [
+                    {
+                        type: 'institution',
+                        institutionName: 'Geological Survey of Estonia',
+                        roles: ['Data Collector'],
+                    },
+                    {
+                        type: 'institution',
+                        institutionName: 'GFZ Helmholtz-Zentrum für Geoforschung',
+                        roles: ['Hosting Institution'],
+                    },
+                    {
+                        type: 'institution',
+                        institutionName: 'GEOFON Data Centre',
+                        roles: ['Data Manager'],
+                    },
+                ],
+            });
+
+            await user.click(screen.getByTestId('save-draft-button'));
+
+            await waitFor(() => {
+                expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+            });
+
+            const payload = mockedAxios.post.mock.calls[0][1];
+            expect(payload.contributors).toEqual([
+                expect.objectContaining({
+                    type: 'institution',
+                    institutionName: 'Geological Survey of Estonia',
+                    roles: ['Data Collector'],
+                }),
+                expect.objectContaining({
+                    type: 'institution',
+                    institutionName: 'GFZ Helmholtz-Zentrum für Geoforschung',
+                    roles: ['Hosting Institution'],
+                }),
+                expect.objectContaining({
+                    type: 'institution',
+                    institutionName: 'GEOFON Data Centre',
+                    roles: ['Data Manager'],
+                }),
+            ]);
+        });
+
         it('omits an unresolved access level from the draft payload', { timeout: 60000 }, async () => {
             const user = userEvent.setup({ pointerEventsCheck: 0 });
             const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> };

--- a/tests/vitest/components/curation/fields/contributor/contributor-item.test.tsx
+++ b/tests/vitest/components/curation/fields/contributor/contributor-item.test.tsx
@@ -3,11 +3,24 @@
  */
 
 import userEvent from '@testing-library/user-event';
-import { cleanup, render, screen } from '@tests/vitest/utils/render';
+import { cleanup, render, screen, waitFor } from '@tests/vitest/utils/render';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import ContributorItem from '@/components/curation/fields/contributor/contributor-item';
+import ContributorItem, { buildContributorRoleOptions } from '@/components/curation/fields/contributor/contributor-item';
 import type { ContributorEntry } from '@/components/curation/fields/contributor/types';
+
+interface RoleTagifyInput extends HTMLInputElement {
+    tagify?: {
+        addTags: (tags: Array<{ value: string }>) => void;
+        value: Array<{ value?: string }>;
+        whitelist: Array<string | { value?: string }>;
+    };
+}
+
+const getTagifyValues = (input: RoleTagifyInput) => input.tagify?.value.map((role) => role.value) ?? [];
+
+const getWhitelistValues = (input: RoleTagifyInput) =>
+    input.tagify?.whitelist.map((role) => (typeof role === 'string' ? role : role.value)).filter((role): role is string => Boolean(role)) ?? [];
 
 // Mock ORCID Service
 vi.mock('@/services/orcid', () => ({
@@ -136,6 +149,73 @@ describe('ContributorItem Component', () => {
         
         // Roles are shown in tag input
         expect(screen.getByDisplayValue('DataCollector')).toBeInTheDocument();
+    });
+
+    it.each(['Data Collector', 'Data Manager'])('preserves the existing institution role %s outside the institution category', async (role) => {
+        const legacyInstitution: ContributorEntry = {
+            ...mockInstitutionContributor,
+            roles: [{ value: role }],
+            rolesInput: role,
+        };
+
+        render(
+            <ContributorItem
+                contributor={legacyInstitution}
+                {...mockProps}
+                institutionRoleOptions={['Hosting Institution']}
+            />,
+        );
+
+        const input = screen.getByTestId('contributor-0-roles-input') as RoleTagifyInput;
+
+        await waitFor(() => {
+            expect(input).toHaveValue(role);
+            expect(getTagifyValues(input)).toContain(role);
+            expect(getWhitelistValues(input)).toEqual(['Hosting Institution', role]);
+        });
+    });
+
+    it('keeps only regular institution roles available after a legacy role is removed', async () => {
+        const legacyInstitution: ContributorEntry = {
+            ...mockInstitutionContributor,
+            roles: [{ value: 'Data Collector' }],
+            rolesInput: 'Data Collector',
+        };
+        const { rerender } = render(
+            <ContributorItem
+                contributor={legacyInstitution}
+                {...mockProps}
+                institutionRoleOptions={['Hosting Institution']}
+            />,
+        );
+        const input = screen.getByTestId('contributor-0-roles-input') as RoleTagifyInput;
+
+        await waitFor(() => expect(getWhitelistValues(input)).toEqual(['Hosting Institution', 'Data Collector']));
+
+        rerender(
+            <ContributorItem
+                contributor={{ ...legacyInstitution, roles: [], rolesInput: '' }}
+                {...mockProps}
+                institutionRoleOptions={['Hosting Institution']}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(getWhitelistValues(input)).toEqual(['Hosting Institution']);
+            expect(getTagifyValues(input)).toEqual([]);
+        });
+
+        input.tagify?.addTags([{ value: 'Data Collector' }]);
+        expect(getTagifyValues(input)).not.toContain('Data Collector');
+    });
+
+    it('trims and deduplicates regular and entry-specific role options', () => {
+        expect(
+            buildContributorRoleOptions(
+                ['Hosting Institution', ''],
+                [{ value: ' hosting institution ' }, { value: ' Data Collector ' }, { value: 'data collector' }],
+            ),
+        ).toEqual([{ value: 'Hosting Institution' }, { value: 'Data Collector' }]);
     });
 
     it('renders drag handle with correct aria-label', () => {


### PR DESCRIPTION
This pull request improves how contributor roles—especially legacy or entry-specific institution roles—are handled in the curation editor, ensuring that imported roles are preserved for existing contributors but are not offered as selectable options for new contributors. It introduces a utility to build a deduplicated, trimmed list of role options, updates the contributor item component to use this logic, and adds comprehensive tests to verify the new behavior.

**Contributor Role Handling Improvements:**

* Added `buildContributorRoleOptions` utility to combine allowed roles with entry-specific roles, trimming and deduplicating them, so legacy roles are preserved for the contributor but not exposed globally.
* Updated `ContributorItem` to use `buildContributorRoleOptions`, ensuring imported legacy roles are whitelisted only for the relevant contributor and not for new entries.

**Testing and Validation:**

* Added Playwright test `12-legacy-contributor-roles.spec.ts` to verify that imported institution roles are preserved for existing contributors and not offered to new ones, and that they are correctly saved in the draft payload.
* Added Vitest tests to ensure that legacy institution roles are preserved for existing contributors, are removed from the whitelist when deleted, and that role options are trimmed and deduplicated. [[1]](diffhunk://#diff-c94b27cde231d2d6e9ab0393e7ae9fd6073e149fe6c4eb8af88ba3ea8b851544L6-R24) [[2]](diffhunk://#diff-c94b27cde231d2d6e9ab0393e7ae9fd6073e149fe6c4eb8af88ba3ea8b851544R154-R220)
* Added a test in the DataCite form suite to confirm that entry-specific legacy institution roles are preserved in the draft payload.