### PR TITLE
Fix: Import of legacy GCMD Keywords does not import all GCMD Keywords

### DIFF
--- a/app/Http/Controllers/OldDatasetController.php
+++ b/app/Http/Controllers/OldDatasetController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\OldDataset;
-use App\Services\OldDatasetKeywordTransformer;
+use App\Services\LegacyKeywordService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
@@ -30,6 +30,11 @@ class OldDatasetController extends Controller
      * @var list<string>
      */
     private const ALLOWED_SORT_DIRECTIONS = ['asc', 'desc'];
+
+    public function __construct(
+        private readonly LegacyKeywordService $legacyKeywordService,
+    ) {
+    }
 
     /**
      * Display a listing of the datasets.
@@ -410,26 +415,8 @@ class OldDatasetController extends Controller
                 ], 404);
             }
 
-            // Get supported GCMD thesauri
-            $supportedThesauri = OldDatasetKeywordTransformer::getSupportedThesauri();
-
-            // Load keywords from old database with JOIN
-            $oldKeywords = DB::connection(self::DATASET_CONNECTION)
-                ->table('thesauruskeyword as tk')
-                ->join('thesaurusvalue as tv', function ($join) {
-                    $join->on('tk.keyword', '=', 'tv.keyword')
-                        ->on('tk.thesaurus', '=', 'tv.thesaurus');
-                })
-                ->where('tk.resource_id', $id)
-                ->whereIn('tk.thesaurus', $supportedThesauri)
-                ->select('tv.keyword', 'tv.thesaurus', 'tv.uri', 'tv.description')
-                ->get();
-
-            // Transform to new format
-            $transformedKeywords = OldDatasetKeywordTransformer::transformMany($oldKeywords->all());
-
             return response()->json([
-                'keywords' => $transformedKeywords,
+                'keywords' => $this->legacyKeywordService->controlledKeywords($dataset),
             ]);
         } catch (\Throwable $e) {
             $debugInfo = $this->buildConnectionDebugInfo($e);
@@ -459,26 +446,8 @@ class OldDatasetController extends Controller
                 ], 404);
             }
 
-            // Get keywords from the keywords column
-            $keywordsString = $dataset->keywords;
-
-            // Parse comma-separated keywords
-            $keywords = [];
-            if (! empty($keywordsString)) {
-                $keywords = array_map(
-                    fn ($keyword) => trim($keyword),
-                    explode(',', $keywordsString)
-                );
-
-                // Remove empty strings
-                $keywords = array_filter($keywords, fn ($keyword) => $keyword !== '');
-
-                // Re-index array to ensure sequential numeric keys
-                $keywords = array_values($keywords);
-            }
-
             return response()->json([
-                'keywords' => $keywords,
+                'keywords' => $this->legacyKeywordService->freeKeywords($dataset),
             ]);
         } catch (\Throwable $e) {
             $debugInfo = $this->buildConnectionDebugInfo($e);

--- a/app/Http/Controllers/OldDatasetController.php
+++ b/app/Http/Controllers/OldDatasetController.php
@@ -6,6 +6,9 @@ namespace App\Http\Controllers;
 
 use App\Models\OldDataset;
 use App\Services\LegacyKeywordService;
+use App\Services\MslKeywordTransformer;
+use App\Services\MslVocabularyService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
@@ -33,8 +36,7 @@ class OldDatasetController extends Controller
 
     public function __construct(
         private readonly LegacyKeywordService $legacyKeywordService,
-    ) {
-    }
+    ) {}
 
     /**
      * Display a listing of the datasets.
@@ -133,7 +135,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint for loading more datasets (for infinite scrolling).
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function loadMore(Request $request)
     {
@@ -237,7 +239,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get authors for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getAuthors(Request $request, int $id)
     {
@@ -270,7 +272,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get contributors for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getContributors(Request $request, int $id)
     {
@@ -303,7 +305,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get descriptions for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getDescriptions(Request $request, int $id)
     {
@@ -336,7 +338,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get funding references for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getFundingReferences(Request $request, int $id)
     {
@@ -369,7 +371,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get dates for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getDates(Request $request, int $id)
     {
@@ -402,7 +404,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get controlled keywords (GCMD) for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getControlledKeywords(Request $request, int $id)
     {
@@ -433,7 +435,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get free keywords for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getFreeKeywords(Request $request, int $id)
     {
@@ -464,7 +466,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get spatial and temporal coverage entries for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getCoverages(Request $request, int $id)
     {
@@ -498,7 +500,7 @@ class OldDatasetController extends Controller
      * Get related identifiers for a specific old dataset.
      *
      * @param  int  $id  The dataset ID
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getRelatedIdentifiers(Request $request, int $id)
     {
@@ -531,7 +533,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get MSL keywords for a specific old dataset.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getMslKeywords(Request $request, int $id)
     {
@@ -545,7 +547,7 @@ class OldDatasetController extends Controller
             }
 
             // Get supported MSL thesauri
-            $supportedThesauri = \App\Services\MslKeywordTransformer::getSupportedThesauri();
+            $supportedThesauri = MslKeywordTransformer::getSupportedThesauri();
 
             // Load MSL keywords from old database with JOIN
             $oldKeywords = DB::connection(self::DATASET_CONNECTION)
@@ -560,10 +562,10 @@ class OldDatasetController extends Controller
                 ->get();
 
             // Transform to new format
-            $transformedKeywords = \App\Services\MslKeywordTransformer::transformMany($oldKeywords->all());
+            $transformedKeywords = MslKeywordTransformer::transformMany($oldKeywords->all());
 
             // Load current MSL vocabulary to validate keywords
-            $vocabularyService = new \App\Services\MslVocabularyService;
+            $vocabularyService = new MslVocabularyService;
             $currentVocabulary = $vocabularyService->getVocabulary();
 
             // Separate keywords into validated (exist in current vocab) and legacy (don't exist)
@@ -627,7 +629,7 @@ class OldDatasetController extends Controller
     }
 
     /**
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getMslLaboratories(Request $request, int $id)
     {
@@ -757,7 +759,7 @@ class OldDatasetController extends Controller
     /**
      * API endpoint to get available filter options.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getFilterOptions()
     {
@@ -894,7 +896,7 @@ class OldDatasetController extends Controller
      *
      * @param  array<string, mixed>  $debugInfo
      */
-    private function errorResponse(string $message, array $debugInfo = [], int $statusCode = 500): \Illuminate\Http\JsonResponse
+    private function errorResponse(string $message, array $debugInfo = [], int $statusCode = 500): JsonResponse
     {
         $response = ['error' => $message];
 

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -10,6 +10,7 @@ use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteImportService;
 use App\Services\DataCiteLandingPageImportService;
+use App\Services\DataCiteSubjectMergeService;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
@@ -925,16 +926,19 @@ class ImportFromDataCiteJob implements ShouldQueue
                 ];
             }
 
-            $legacyRelatedIdentifiers = [];
+            $legacyMetadata = [
+                'relatedIdentifiers' => [],
+                'subjects' => [],
+            ];
 
             if ($shouldLookupMetaworks) {
                 try {
-                    $legacyRelatedIdentifiers = app(LegacyResourceLookupService::class)
-                        ->relatedIdentifiersByDoi($doi);
+                    $legacyMetadata = app(LegacyResourceLookupService::class)
+                        ->importMetadataByDoi($doi);
                 } catch (\Throwable $exception) {
                     $metaworksUnavailable = true;
 
-                    Log::warning('Metaworks DB unavailable while loading related identifiers; continuing without legacy enrichment.', [
+                    Log::warning('Metaworks DB unavailable while loading legacy metadata; continuing without legacy enrichment.', [
                         'import_id' => $this->importId,
                         'doi' => $doi,
                         'error' => $exception->getMessage(),
@@ -942,9 +946,14 @@ class ImportFromDataCiteJob implements ShouldQueue
                 }
             }
 
+            $doiRecord = app(DataCiteSubjectMergeService::class)->mergeIntoDoiRecord(
+                $doiRecord,
+                $legacyMetadata['subjects'],
+            );
+
             $preparedDoiRecord = $transformer->prepareDoiData(
                 $doiRecord,
-                $legacyRelatedIdentifiers,
+                $legacyMetadata['relatedIdentifiers'],
                 $citationLabelResolutionMode,
             );
 

--- a/app/Services/DataCiteSubjectMergeService.php
+++ b/app/Services/DataCiteSubjectMergeService.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Support\GcmdUriHelper;
+use App\Support\PortalSubjectNormalizer;
+use Normalizer;
+
+/**
+ * Merges DataCite and legacy subjects in source-priority order.
+ *
+ * DataCite subjects remain byte-for-byte intact and in their original order.
+ * Legacy subjects are only appended when no equivalent DataCite or earlier
+ * legacy subject exists.
+ */
+final class DataCiteSubjectMergeService
+{
+    /**
+     * @param  array<string, mixed>  $doiRecord
+     * @param  array<int, mixed>  $legacySubjects
+     * @return array<string, mixed>
+     */
+    public function mergeIntoDoiRecord(array $doiRecord, array $legacySubjects): array
+    {
+        if ($legacySubjects === []) {
+            return $doiRecord;
+        }
+
+        if (is_array($doiRecord['attributes'] ?? null)) {
+            $dataCiteSubjects = is_array($doiRecord['attributes']['subjects'] ?? null)
+                ? $doiRecord['attributes']['subjects']
+                : [];
+            $doiRecord['attributes']['subjects'] = $this->merge($dataCiteSubjects, $legacySubjects);
+
+            return $doiRecord;
+        }
+
+        $dataCiteSubjects = is_array($doiRecord['subjects'] ?? null)
+            ? $doiRecord['subjects']
+            : [];
+        $doiRecord['subjects'] = $this->merge($dataCiteSubjects, $legacySubjects);
+
+        return $doiRecord;
+    }
+
+    /**
+     * @param  array<int, mixed>  $dataCiteSubjects
+     * @param  array<int, mixed>  $legacySubjects
+     * @return list<mixed>
+     */
+    public function merge(array $dataCiteSubjects, array $legacySubjects): array
+    {
+        $merged = array_values($dataCiteSubjects);
+        /** @var array<string, true> $identities */
+        $identities = [];
+
+        foreach ($merged as $subject) {
+            if (! is_array($subject)) {
+                continue;
+            }
+
+            foreach ($this->identities($subject) as $identity) {
+                $identities[$identity] = true;
+            }
+        }
+
+        foreach ($legacySubjects as $subject) {
+            if (! is_array($subject) || $this->stringValue($subject, ['subject']) === null) {
+                continue;
+            }
+
+            $candidateIdentities = $this->identities($subject);
+            if ($candidateIdentities === []) {
+                continue;
+            }
+
+            $isDuplicate = false;
+            foreach ($candidateIdentities as $identity) {
+                if (isset($identities[$identity])) {
+                    $isDuplicate = true;
+                    break;
+                }
+            }
+
+            if ($isDuplicate) {
+                continue;
+            }
+
+            $merged[] = $subject;
+            foreach ($candidateIdentities as $identity) {
+                $identities[$identity] = true;
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * @param  array<string, mixed>  $subject
+     * @return list<string>
+     */
+    private function identities(array $subject): array
+    {
+        $value = $this->stringValue($subject, ['subject']);
+        if ($value === null) {
+            return [];
+        }
+
+        $scheme = $this->stringValue($subject, ['subjectScheme', 'scheme', 'subject_scheme']);
+        $schemeUri = $this->stringValue($subject, ['schemeUri', 'schemeURI', 'scheme_uri']);
+        $valueUri = $this->stringValue($subject, ['valueUri', 'valueURI', 'value_uri', 'id']);
+        $classificationCode = $this->stringValue($subject, ['classificationCode', 'classification_code']);
+        $isControlled = $scheme !== null || $schemeUri !== null || $valueUri !== null || $classificationCode !== null;
+
+        if (! $isControlled) {
+            return ['free|'.$this->normalizeText($value)];
+        }
+
+        $normalizedScheme = $this->normalizeScheme($scheme, $schemeUri, $valueUri);
+        $identities = [];
+
+        if ($valueUri !== null) {
+            $identities[] = 'uri|'.$this->normalizeUri($valueUri);
+        }
+
+        if ($classificationCode !== null && $normalizedScheme !== '') {
+            $identities[] = 'classification|'.$normalizedScheme.'|'.$this->normalizeText($classificationCode);
+        }
+
+        $normalizedPath = $this->normalizeControlledPath($value, $normalizedScheme);
+        if ($normalizedScheme !== '' && $normalizedPath !== '') {
+            $identities[] = 'controlled|'.$normalizedScheme.'|'.$normalizedPath;
+        }
+
+        return array_values(array_unique($identities));
+    }
+
+    /**
+     * @param  array<string, mixed>  $subject
+     * @param  list<string>  $keys
+     */
+    private function stringValue(array $subject, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            if (! isset($subject[$key]) || ! is_scalar($subject[$key])) {
+                continue;
+            }
+
+            $value = trim((string) $subject[$key]);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeScheme(?string $scheme, ?string $schemeUri, ?string $valueUri): string
+    {
+        $normalizedScheme = PortalSubjectNormalizer::normalizeScheme($scheme);
+
+        if ($normalizedScheme === null) {
+            $uri = mb_strtolower(($schemeUri ?? '').' '.($valueUri ?? ''));
+            $normalizedScheme = match (true) {
+                str_contains($uri, 'sciencekeyword') => 'Science Keywords',
+                str_contains($uri, 'platform') => 'Platforms',
+                str_contains($uri, 'instrument') => 'Instruments',
+                default => '',
+            };
+        }
+
+        return $this->normalizeText($normalizedScheme);
+    }
+
+    private function normalizeControlledPath(string $value, string $normalizedScheme): string
+    {
+        $path = PortalSubjectNormalizer::normalizeControlledSubjectValue($value);
+        if ($path === null) {
+            return '';
+        }
+
+        $segments = array_values(array_filter(
+            array_map('trim', explode(PortalSubjectNormalizer::BREADCRUMB_SEPARATOR, $path)),
+            static fn (string $segment): bool => $segment !== '',
+        ));
+
+        if ($segments !== [] && $normalizedScheme !== '') {
+            $firstSegmentScheme = PortalSubjectNormalizer::normalizeScheme($segments[0]);
+            if ($firstSegmentScheme !== null && $this->normalizeText($firstSegmentScheme) === $normalizedScheme) {
+                array_shift($segments);
+            }
+        }
+
+        return $this->normalizeText(implode(PortalSubjectNormalizer::BREADCRUMB_SEPARATOR, $segments));
+    }
+
+    private function normalizeUri(string $uri): string
+    {
+        $uri = trim($uri);
+
+        if (str_contains(mb_strtolower($uri), 'gcmd')) {
+            $uri = GcmdUriHelper::convertToNewUri($uri) ?? $uri;
+        }
+
+        return mb_strtolower(rtrim($uri, '/'));
+    }
+
+    private function normalizeText(string $value): string
+    {
+        if (class_exists(Normalizer::class)) {
+            $value = Normalizer::normalize($value, Normalizer::FORM_C) ?: $value;
+        }
+
+        $value = preg_replace('/\s+/u', ' ', trim($value)) ?? trim($value);
+
+        return mb_strtolower($value);
+    }
+}

--- a/app/Services/LegacyKeywordService.php
+++ b/app/Services/LegacyKeywordService.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\OldDataset;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+final class LegacyKeywordService
+{
+    /**
+     * Load controlled vocabulary keywords for a legacy SUMARIOPMD resource.
+     *
+     * @return list<array<string, string|null>>
+     */
+    public function controlledKeywords(OldDataset $dataset): array
+    {
+        $rows = DB::connection($dataset->getConnectionName())
+            ->table('thesauruskeyword as tk')
+            ->join('thesaurusvalue as tv', function ($join): void {
+                $join->on('tk.keyword', '=', 'tv.keyword')
+                    ->on('tk.thesaurus', '=', 'tv.thesaurus');
+            })
+            ->where('tk.resource_id', $dataset->id)
+            ->whereIn('tk.thesaurus', OldDatasetKeywordTransformer::getSupportedThesauri())
+            ->select('tv.keyword', 'tv.thesaurus', 'tv.uri', 'tv.description')
+            ->orderBy('tk.thesaurus')
+            ->orderBy('tk.keyword')
+            ->get();
+
+        $keywords = [];
+
+        foreach ($rows as $row) {
+            try {
+                $keyword = OldDatasetKeywordTransformer::transform($row);
+            } catch (\Throwable $exception) {
+                Log::warning('Skipping legacy controlled keyword after transformation failure', [
+                    'doi' => $dataset->identifier,
+                    'legacy_resource_id' => $dataset->id,
+                    'keyword' => isset($row->keyword) ? (string) $row->keyword : null,
+                    'thesaurus' => isset($row->thesaurus) ? (string) $row->thesaurus : null,
+                    'error' => $exception->getMessage(),
+                ]);
+
+                continue;
+            }
+
+            if ($keyword === null || trim((string) ($keyword['path'] ?? '')) === '') {
+                Log::warning('Skipping invalid legacy controlled keyword', [
+                    'doi' => $dataset->identifier,
+                    'legacy_resource_id' => $dataset->id,
+                    'keyword' => isset($row->keyword) ? (string) $row->keyword : null,
+                    'thesaurus' => isset($row->thesaurus) ? (string) $row->thesaurus : null,
+                ]);
+
+                continue;
+            }
+
+            $keywords[] = $keyword;
+        }
+
+        return $keywords;
+    }
+
+    /**
+     * Load comma-separated free keywords for a legacy SUMARIOPMD resource.
+     *
+     * @return list<string>
+     */
+    public function freeKeywords(OldDataset $dataset): array
+    {
+        if (! is_string($dataset->keywords) || trim($dataset->keywords) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(
+                static fn (string $keyword): string => trim($keyword),
+                explode(',', $dataset->keywords),
+            ),
+            static fn (string $keyword): bool => $keyword !== '',
+        ));
+    }
+
+    /**
+     * Convert all supported legacy keywords to canonical DataCite subjects.
+     * Controlled subjects are returned before free subjects.
+     *
+     * @return list<array<string, string>>
+     */
+    public function dataCiteSubjects(OldDataset $dataset): array
+    {
+        $subjects = [];
+
+        foreach ($this->controlledKeywords($dataset) as $keyword) {
+            $subject = trim((string) $keyword['path']);
+            $subjectScheme = trim((string) $keyword['scheme']);
+            $schemeUri = trim((string) ($keyword['schemeURI'] ?? ''));
+            $valueUri = trim((string) $keyword['id']);
+
+            $controlledSubject = [
+                'subject' => $subject,
+                'subjectScheme' => $subjectScheme,
+                'valueUri' => $valueUri,
+                'lang' => 'en',
+            ];
+
+            if ($schemeUri !== '') {
+                $controlledSubject['schemeUri'] = $schemeUri;
+            }
+
+            $subjects[] = $controlledSubject;
+        }
+
+        foreach ($this->freeKeywords($dataset) as $keyword) {
+            $subjects[] = ['subject' => $keyword];
+        }
+
+        return $subjects;
+    }
+}

--- a/app/Services/LegacyResourceLookupService.php
+++ b/app/Services/LegacyResourceLookupService.php
@@ -8,6 +8,10 @@ use App\Models\OldDataset;
 
 class LegacyResourceLookupService
 {
+    public function __construct(
+        private ?LegacyKeywordService $legacyKeywordService = null,
+    ) {}
+
     public function existsByDoi(string $doi): bool
     {
         return OldDataset::query()
@@ -20,10 +24,43 @@ class LegacyResourceLookupService
      */
     public function relatedIdentifiersByDoi(string $doi): array
     {
-        $resource = OldDataset::query()
-            ->whereRaw('LOWER(identifier) = ?', [strtolower(trim($doi))])
-            ->first();
+        $resource = $this->findByDoi($doi);
 
         return $resource?->getRelatedIdentifiers() ?? [];
+    }
+
+    /**
+     * @return array{
+     *     relatedIdentifiers: list<array{identifier: string, identifierType: string, relationType: string, position: int}>,
+     *     subjects: list<array<string, string>>
+     * }
+     */
+    public function importMetadataByDoi(string $doi): array
+    {
+        $resource = $this->findByDoi($doi);
+
+        if ($resource === null) {
+            return [
+                'relatedIdentifiers' => [],
+                'subjects' => [],
+            ];
+        }
+
+        return [
+            'relatedIdentifiers' => array_values($resource->getRelatedIdentifiers()),
+            'subjects' => $this->keywordService()->dataCiteSubjects($resource),
+        ];
+    }
+
+    private function findByDoi(string $doi): ?OldDataset
+    {
+        return OldDataset::query()
+            ->whereRaw('LOWER(identifier) = ?', [mb_strtolower(trim($doi))])
+            ->first();
+    }
+
+    private function keywordService(): LegacyKeywordService
+    {
+        return $this->legacyKeywordService ??= app(LegacyKeywordService::class);
     }
 }

--- a/app/Services/OldDatasetEditorLoader.php
+++ b/app/Services/OldDatasetEditorLoader.php
@@ -16,6 +16,10 @@ class OldDatasetEditorLoader
 {
     private const DATASET_CONNECTION = 'metaworks';
 
+    public function __construct(
+        private ?LegacyKeywordService $legacyKeywordService = null,
+    ) {}
+
     /**
      * Normalize a name for comparison (lowercase, trim, replace umlauts).
      *
@@ -795,25 +799,11 @@ class OldDatasetEditorLoader
      */
     private function loadControlledKeywords(int $id): array
     {
-        // Get supported GCMD thesauri
-        $supportedThesauri = OldDatasetKeywordTransformer::getSupportedThesauri();
+        $dataset = OldDataset::find($id);
 
-        // Load keywords from old database
-        $oldKeywords = DB::connection(self::DATASET_CONNECTION)
-            ->table('thesauruskeyword as tk')
-            ->join('thesaurusvalue as tv', function ($join) {
-                $join->on('tk.keyword', '=', 'tv.keyword')
-                    ->on('tk.thesaurus', '=', 'tv.thesaurus');
-            })
-            ->where('tk.resource_id', $id)
-            ->whereIn('tk.thesaurus', $supportedThesauri)
-            ->select('tv.keyword', 'tv.thesaurus', 'tv.uri', 'tv.description')
-            ->get();
-
-        // Transform to new format
-        $keywords = OldDatasetKeywordTransformer::transformMany($oldKeywords->all());
-
-        return array_values($keywords);
+        return $dataset === null
+            ? []
+            : $this->keywordService()->controlledKeywords($dataset);
     }
 
     /**
@@ -823,21 +813,12 @@ class OldDatasetEditorLoader
      */
     private function loadFreeKeywords(OldDataset $dataset): array
     {
-        $keywordsString = $dataset->keywords;
+        return $this->keywordService()->freeKeywords($dataset);
+    }
 
-        if (empty($keywordsString)) {
-            return [];
-        }
-
-        $keywords = array_map(
-            fn ($keyword) => trim($keyword),
-            explode(',', $keywordsString)
-        );
-
-        // Remove empty strings
-        $keywords = array_filter($keywords, fn ($keyword) => $keyword !== '');
-
-        return array_values($keywords);
+    private function keywordService(): LegacyKeywordService
+    {
+        return $this->legacyKeywordService ??= app(LegacyKeywordService::class);
     }
 
     /**

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -384,6 +384,10 @@
         ],
         "fixes": [
             {
+                "title": "Complete Legacy GCMD Keyword Enrichment for DataCite Imports",
+                "description": "New legacy resource imports now enrich DataCite metadata with all controlled GCMD keywords and free keywords from SUMARIOPMD. Existing DataCite subjects keep their original order, equivalent legacy subjects are omitted, and unavailable legacy metadata no longer blocks the import. Existing imported resources remain unchanged."
+            },
+            {
                 "title": "Preserved Imported Contributor Roles",
                 "description": "The Data Editor now keeps imported contributor roles visible and unchanged when they are not normally available for that contributor type. These entry-specific roles remain attached when an existing resource is opened and saved, without making them selectable for newly added contributors."
             },

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -67,9 +67,12 @@ beforeEach(function () {
 
     $this->legacyResourceLookupService = Mockery::mock(LegacyResourceLookupService::class);
     $this->legacyResourceLookupService
-        ->shouldReceive('relatedIdentifiersByDoi')
+        ->shouldReceive('importMetadataByDoi')
         ->zeroOrMoreTimes()
-        ->andReturn([])
+        ->andReturn([
+            'relatedIdentifiers' => [],
+            'subjects' => [],
+        ])
         ->byDefault();
     $this->app->instance(LegacyResourceLookupService::class, $this->legacyResourceLookupService);
 
@@ -272,7 +275,15 @@ describe('ImportFromDataCiteJob', function () {
 
     it('skips existing DOIs', function () {
         // Create existing resource
-        Resource::factory()->create(['doi' => '10.5880/existing']);
+        $existingResource = Resource::factory()->create(['doi' => '10.5880/existing']);
+        $existingResource->subjects()->create([
+            'value' => 'Existing keyword',
+            'subject_scheme' => null,
+            'scheme_uri' => null,
+            'value_uri' => null,
+            'classification_code' => null,
+            'language' => null,
+        ]);
 
         $this->importService
             ->shouldReceive('getTotalDoiCount')
@@ -291,7 +302,7 @@ describe('ImportFromDataCiteJob', function () {
 
         // Transformer should not be called for existing DOIs
         $this->transformer->shouldReceive('transform')->never();
-        $this->legacyResourceLookupService->shouldReceive('relatedIdentifiersByDoi')->never();
+        $this->legacyResourceLookupService->shouldReceive('importMetadataByDoi')->never();
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
@@ -300,14 +311,18 @@ describe('ImportFromDataCiteJob', function () {
         $status = Cache::get("datacite_import:{$importId}");
         expect($status['skipped'])->toBe(1);
         expect($status['skipped_dois'])->toContain('10.5880/existing');
+        expect($existingResource->fresh()->subjects()->pluck('value')->all())->toBe(['Existing keyword']);
     });
 
-    it('passes legacy related identifiers to preparation for new resources', function () {
+    it('merges legacy subjects and passes related identifiers to preparation for new resources', function () {
         $doiRecord = [
             'id' => '10.5880/legacy-relations',
             'attributes' => [
                 'doi' => '10.5880/legacy-relations',
                 'titles' => [['title' => 'Legacy relations']],
+                'subjects' => [[
+                    'subject' => 'DataCite keyword',
+                ]],
             ],
         ];
         $legacyRelatedIdentifiers = [[
@@ -316,25 +331,45 @@ describe('ImportFromDataCiteJob', function () {
             'relationType' => 'Cites',
             'position' => 0,
         ]];
+        $legacySubjects = [
+            ['subject' => 'DataCite keyword'],
+            [
+                'subject' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+                'subjectScheme' => 'Science Keywords',
+                'schemeUri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+                'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/legacy-tectonics',
+                'lang' => 'en',
+            ],
+            ['subject' => 'Legacy free keyword'],
+        ];
+        $mergedDoiRecord = $doiRecord;
+        $mergedDoiRecord['attributes']['subjects'] = [
+            ['subject' => 'DataCite keyword'],
+            $legacySubjects[1],
+            $legacySubjects[2],
+        ];
 
         $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(1);
         $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($doiRecord) {
             yield $doiRecord;
         })());
         $this->legacyResourceLookupService
-            ->shouldReceive('relatedIdentifiersByDoi')
+            ->shouldReceive('importMetadataByDoi')
             ->once()
             ->with('10.5880/legacy-relations')
-            ->andReturn($legacyRelatedIdentifiers);
+            ->andReturn([
+                'relatedIdentifiers' => $legacyRelatedIdentifiers,
+                'subjects' => $legacySubjects,
+            ]);
         $this->transformer
             ->shouldReceive('prepareDoiData')
             ->once()
-            ->with($doiRecord, $legacyRelatedIdentifiers, CitationLabelResolutionMode::BEST_EFFORT)
-            ->andReturn($doiRecord);
+            ->with($mergedDoiRecord, $legacyRelatedIdentifiers, CitationLabelResolutionMode::BEST_EFFORT)
+            ->andReturn($mergedDoiRecord);
         $this->transformer
             ->shouldReceive('transform')
             ->once()
-            ->with($doiRecord, $this->user->id)
+            ->with($mergedDoiRecord, $this->user->id)
             ->andReturn(Resource::factory()->make(['doi' => '10.5880/legacy-relations']));
 
         $importId = Str::uuid()->toString();
@@ -344,7 +379,7 @@ describe('ImportFromDataCiteJob', function () {
         expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(1);
     });
 
-    it('continues without legacy relations and opens the metaworks circuit breaker after lookup failure', function () {
+    it('continues without legacy metadata and opens the metaworks circuit breaker after lookup failure', function () {
         $records = [
             [
                 'id' => '10.5880/metaworks-failure.1',
@@ -361,7 +396,7 @@ describe('ImportFromDataCiteJob', function () {
             yield from $records;
         })());
         $this->legacyResourceLookupService
-            ->shouldReceive('relatedIdentifiersByDoi')
+            ->shouldReceive('importMetadataByDoi')
             ->once()
             ->with('10.5880/metaworks-failure.1')
             ->andThrow(new RuntimeException('connection refused'));

--- a/tests/pest/Feature/Services/DataCiteLegacyKeywordImportTest.php
+++ b/tests/pest/Feature/Services/DataCiteLegacyKeywordImportTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Services\DataCiteSubjectMergeService;
+use App\Services\DataCiteToResourceTransformer;
+use App\Services\Editor\EditorDataTransformer;
+use App\Services\LegacyKeywordService;
+use App\Services\LegacyResourceLookupService;
+use Database\Seeders\ContributorTypeSeeder;
+use Database\Seeders\DescriptionTypeSeeder;
+use Database\Seeders\IdentifierTypeSeeder;
+use Database\Seeders\LanguageSeeder;
+use Database\Seeders\PublisherSeeder;
+use Database\Seeders\RelationTypeSeeder;
+use Database\Seeders\ResourceTypeSeeder;
+use Database\Seeders\TitleTypeSeeder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    test()->seed(ResourceTypeSeeder::class);
+    test()->seed(TitleTypeSeeder::class);
+    test()->seed(DescriptionTypeSeeder::class);
+    test()->seed(ContributorTypeSeeder::class);
+    test()->seed(IdentifierTypeSeeder::class);
+    test()->seed(LanguageSeeder::class);
+    test()->seed(PublisherSeeder::class);
+    test()->seed(RelationTypeSeeder::class);
+
+    Config::set('database.connections.metaworks', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+    DB::purge('metaworks');
+
+    Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+        $table->id();
+        $table->string('identifier')->nullable();
+        $table->text('keywords')->nullable();
+    });
+    Schema::connection('metaworks')->create('relatedidentifier', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('resource_id');
+        $table->string('identifier')->nullable();
+        $table->string('identifiertype')->nullable();
+        $table->string('relationtype')->nullable();
+    });
+    Schema::connection('metaworks')->create('thesauruskeyword', function (Blueprint $table): void {
+        $table->unsignedBigInteger('resource_id');
+        $table->string('keyword');
+        $table->string('thesaurus');
+    });
+    Schema::connection('metaworks')->create('thesaurusvalue', function (Blueprint $table): void {
+        $table->string('keyword');
+        $table->string('thesaurus');
+        $table->string('uri')->nullable();
+        $table->text('description')->nullable();
+    });
+});
+
+afterEach(function (): void {
+    Schema::connection('metaworks')->dropIfExists('thesaurusvalue');
+    Schema::connection('metaworks')->dropIfExists('thesauruskeyword');
+    Schema::connection('metaworks')->dropIfExists('relatedidentifier');
+    Schema::connection('metaworks')->dropIfExists('resource');
+    DB::disconnect('metaworks');
+});
+
+it('persists the Issue 1091 keyword pattern and exposes it in the editor shape', function (): void {
+    $doi = '10.5880/GFZ.LKUT.2026.004';
+    $thesaurus = 'NASA/GCMD Earth Science Keywords';
+    $legacyKeywords = [
+        [
+            'path' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'uuid' => '11111111-1111-4111-8111-111111111111',
+        ],
+        [
+            'path' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+            'uuid' => '22222222-2222-4222-8222-222222222222',
+        ],
+        [
+            'path' => 'EARTH SCIENCE > SOLID EARTH > CRUSTAL DYNAMICS',
+            'uuid' => '33333333-3333-4333-8333-333333333333',
+        ],
+    ];
+    $legacyResourceId = DB::connection('metaworks')->table('resource')->insertGetId([
+        'identifier' => $doi,
+        'keywords' => 'GNSS, Crustal deformation',
+    ]);
+
+    foreach ($legacyKeywords as $keyword) {
+        DB::connection('metaworks')->table('thesauruskeyword')->insert([
+            'resource_id' => $legacyResourceId,
+            'keyword' => $keyword['path'],
+            'thesaurus' => $thesaurus,
+        ]);
+        DB::connection('metaworks')->table('thesaurusvalue')->insert([
+            'keyword' => $keyword['path'],
+            'thesaurus' => $thesaurus,
+            'uri' => "http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/{$keyword['uuid']}",
+            'description' => null,
+        ]);
+    }
+
+    $doiRecord = [
+        'id' => mb_strtolower($doi),
+        'attributes' => [
+            'doi' => mb_strtolower($doi),
+            'publicationYear' => 2026,
+            'titles' => [['title' => 'Issue 1091 regression dataset']],
+            'creators' => [[
+                'familyName' => 'Importer',
+                'givenName' => 'Test',
+                'nameType' => 'Personal',
+            ]],
+            'subjects' => [[
+                // DataCite wins, while the matching legacy subject must not be appended again.
+                'subject' => $legacyKeywords[0]['path'],
+                'subjectScheme' => 'Science Keywords',
+                'schemeUri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+                'valueUri' => "https://gcmd.earthdata.nasa.gov/kms/concept/{$legacyKeywords[0]['uuid']}",
+                'lang' => 'en',
+            ]],
+        ],
+    ];
+
+    $lookup = new LegacyResourceLookupService(new LegacyKeywordService);
+    $legacyMetadata = $lookup->importMetadataByDoi(mb_strtolower($doi));
+    $mergedRecord = (new DataCiteSubjectMergeService)->mergeIntoDoiRecord(
+        $doiRecord,
+        $legacyMetadata['subjects'],
+    );
+    $resource = (new DataCiteToResourceTransformer)->transform(
+        $mergedRecord,
+        User::factory()->create()->id,
+    );
+
+    $subjects = $resource->subjects()->orderBy('id')->get();
+    expect($subjects)->toHaveCount(5)
+        ->and($subjects->whereNotNull('subject_scheme'))->toHaveCount(3)
+        ->and($subjects->whereNull('subject_scheme'))->toHaveCount(2)
+        ->and($subjects->whereNotNull('subject_scheme')->pluck('value')->all())->toBe([
+            'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'EARTH SCIENCE > SOLID EARTH > CRUSTAL DYNAMICS',
+            'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+        ])
+        ->and($subjects->whereNotNull('subject_scheme')->pluck('subject_scheme')->unique()->values()->all())->toBe([
+            'Science Keywords',
+        ])
+        ->and($subjects->whereNotNull('subject_scheme')->pluck('scheme_uri')->unique()->values()->all())->toBe([
+            'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+        ])
+        ->and($subjects->whereNull('subject_scheme')->pluck('value')->all())->toBe([
+            'GNSS',
+            'Crustal deformation',
+        ]);
+
+    $resource->load('subjects');
+    $editorTransformer = new EditorDataTransformer;
+    $editorControlledKeywords = $editorTransformer->transformGcmdKeywords($resource);
+
+    expect($editorControlledKeywords)->toHaveCount(3)
+        ->and(array_column($editorControlledKeywords, 'text'))->toBe([
+            'SEISMOLOGY',
+            'CRUSTAL DYNAMICS',
+            'TECTONICS',
+        ])
+        ->and(array_column($editorControlledKeywords, 'path'))->toBe([
+            'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'EARTH SCIENCE > SOLID EARTH > CRUSTAL DYNAMICS',
+            'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+        ])
+        ->and($editorTransformer->transformFreeKeywords($resource))->toBe([
+            'GNSS',
+            'Crustal deformation',
+        ]);
+});

--- a/tests/pest/Feature/Services/LegacyKeywordConsumersTest.php
+++ b/tests/pest/Feature/Services/LegacyKeywordConsumersTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\OldDatasetController;
+use App\Models\OldDataset;
+use App\Services\LegacyKeywordService;
+use App\Services\OldDatasetEditorLoader;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    Config::set('database.connections.metaworks', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+    DB::purge('metaworks');
+
+    Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
+        $table->id();
+        $table->string('identifier')->nullable();
+        $table->text('keywords')->nullable();
+    });
+    Schema::connection('metaworks')->create('thesauruskeyword', function (Blueprint $table): void {
+        $table->unsignedBigInteger('resource_id');
+        $table->string('keyword');
+        $table->string('thesaurus');
+    });
+    Schema::connection('metaworks')->create('thesaurusvalue', function (Blueprint $table): void {
+        $table->string('keyword');
+        $table->string('thesaurus');
+        $table->string('uri')->nullable();
+        $table->text('description')->nullable();
+    });
+
+    $this->resourceId = DB::connection('metaworks')->table('resource')->insertGetId([
+        'identifier' => '10.5880/GFZ.LKUT.2026.004',
+        'keywords' => 'GNSS, , Crustal deformation',
+    ]);
+    DB::connection('metaworks')->table('thesauruskeyword')->insert([
+        'resource_id' => $this->resourceId,
+        'keyword' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+        'thesaurus' => 'NASA/GCMD Earth Science Keywords',
+    ]);
+    DB::connection('metaworks')->table('thesaurusvalue')->insert([
+        'keyword' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+        'thesaurus' => 'NASA/GCMD Earth Science Keywords',
+        'uri' => 'http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/11111111-1111-4111-8111-111111111111',
+        'description' => null,
+    ]);
+});
+
+afterEach(function (): void {
+    Schema::connection('metaworks')->dropIfExists('thesaurusvalue');
+    Schema::connection('metaworks')->dropIfExists('thesauruskeyword');
+    Schema::connection('metaworks')->dropIfExists('resource');
+    DB::disconnect('metaworks');
+});
+
+it('uses the shared keyword service in the old dataset editor loader', function (): void {
+    $loader = new OldDatasetEditorLoader(new LegacyKeywordService);
+    $reflection = new ReflectionClass($loader);
+    $loadControlledKeywords = $reflection->getMethod('loadControlledKeywords');
+    $loadFreeKeywords = $reflection->getMethod('loadFreeKeywords');
+    $dataset = OldDataset::findOrFail($this->resourceId);
+
+    $controlledKeywords = $loadControlledKeywords->invoke($loader, $this->resourceId);
+
+    expect($controlledKeywords)->toHaveCount(1)
+        ->and($controlledKeywords[0])->toMatchArray([
+            'path' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'scheme' => 'Science Keywords',
+            'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/11111111-1111-4111-8111-111111111111',
+        ])
+        ->and($loadFreeKeywords->invoke($loader, $dataset))->toBe([
+            'GNSS',
+            'Crustal deformation',
+        ])
+        ->and($loadControlledKeywords->invoke($loader, 999999))->toBe([]);
+});
+
+it('uses the shared keyword service in both legacy keyword endpoints', function (): void {
+    $controller = new OldDatasetController(new LegacyKeywordService);
+    $request = Request::create('/old-datasets/keywords', 'GET');
+
+    $controlledResponse = $controller->getControlledKeywords($request, $this->resourceId);
+    $freeResponse = $controller->getFreeKeywords($request, $this->resourceId);
+
+    expect($controlledResponse->getStatusCode())->toBe(200)
+        ->and($controlledResponse->getData(true)['keywords'])->toHaveCount(1)
+        ->and($controlledResponse->getData(true)['keywords'][0])->toMatchArray([
+            'path' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'scheme' => 'Science Keywords',
+        ])
+        ->and($freeResponse->getStatusCode())->toBe(200)
+        ->and($freeResponse->getData(true))->toBe([
+            'keywords' => ['GNSS', 'Crustal deformation'],
+        ]);
+});
+
+it('keeps both legacy keyword endpoints at 404 for missing resources', function (): void {
+    $controller = new OldDatasetController(new LegacyKeywordService);
+    $request = Request::create('/old-datasets/keywords', 'GET');
+
+    expect($controller->getControlledKeywords($request, 999999)->getStatusCode())->toBe(404)
+        ->and($controller->getFreeKeywords($request, 999999)->getStatusCode())->toBe(404);
+});

--- a/tests/pest/Unit/Services/DataCiteSubjectMergeServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteSubjectMergeServiceTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DataCiteSubjectMergeService;
+
+covers(DataCiteSubjectMergeService::class);
+
+beforeEach(function (): void {
+    $this->service = new DataCiteSubjectMergeService;
+});
+
+it('adds all three Issue 1091 legacy subjects when DataCite has none', function (): void {
+    $legacySubjects = [
+        ['subject' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY', 'subjectScheme' => 'Science Keywords'],
+        ['subject' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS', 'subjectScheme' => 'Science Keywords'],
+        ['subject' => 'EARTH SCIENCE > SOLID EARTH > CRUSTAL DYNAMICS', 'subjectScheme' => 'Science Keywords'],
+    ];
+
+    expect($this->service->merge([], $legacySubjects))->toBe($legacySubjects);
+});
+
+it('preserves DataCite subjects and appends missing legacy subjects in source order', function (): void {
+    $dataCiteSubjects = [
+        ['subject' => 'DataCite free keyword', 'lang' => 'de'],
+        [
+            'subject' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'subjectScheme' => 'Science Keywords',
+            'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/02acb399-a247-5e23-ab4f-63d001267e22',
+        ],
+    ];
+    $legacySubjects = [
+        ['subject' => 'Legacy free keyword'],
+        [
+            'subject' => 'Platforms > Aircraft',
+            'subjectScheme' => 'Platforms',
+            'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/6848f19a-1a5f-5f80-b2e1-6178362f50b7',
+        ],
+    ];
+
+    expect($this->service->merge($dataCiteSubjects, $legacySubjects))->toBe([
+        ...$dataCiteSubjects,
+        ...$legacySubjects,
+    ]);
+});
+
+it('deduplicates old and current GCMD value URI formats', function (): void {
+    $uuid = '02acb399-a247-5e23-ab4f-63d001267e22';
+    $dataCiteSubject = [
+        'subject' => 'SEISMOLOGY',
+        'subjectScheme' => 'GCMD Science Keywords',
+        'valueUri' => "http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/{$uuid}",
+    ];
+    $legacySubject = [
+        'subject' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+        'subjectScheme' => 'Science Keywords',
+        'valueUri' => "https://gcmd.earthdata.nasa.gov/kms/concept/{$uuid}",
+    ];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([$dataCiteSubject]);
+});
+
+it('deduplicates controlled paths across scheme aliases, encoded separators, and a synthetic scheme root', function (): void {
+    $dataCiteSubject = [
+        'subject' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+        'subjectScheme' => 'NASA/GCMD Earth Science Keywords',
+    ];
+    $legacySubject = [
+        'subject' => ' Science Keywords &gt; earth science  > solid earth > tectonics ',
+        'subjectScheme' => 'Science Keywords',
+    ];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([$dataCiteSubject]);
+});
+
+it('deduplicates controlled subjects by classification code and normalized scheme', function (): void {
+    $dataCiteSubject = [
+        'subject' => 'A DataCite label',
+        'subjectScheme' => 'GCMD Platforms',
+        'classificationCode' => 'PLATFORM-42',
+    ];
+    $legacySubject = [
+        'subject' => 'A different legacy path',
+        'subjectScheme' => 'Platforms',
+        'classification_code' => ' platform-42 ',
+    ];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([$dataCiteSubject]);
+});
+
+it('normalizes Unicode, whitespace, and casing when deduplicating free subjects', function (): void {
+    $dataCiteSubject = ['subject' => "Caf\u{00E9}   au lait"];
+    $legacySubject = ['subject' => " cafe\u{0301} au LAIT "];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([$dataCiteSubject]);
+});
+
+it('keeps controlled and free subjects with identical visible text separate', function (): void {
+    $freeSubject = ['subject' => 'SEISMOLOGY'];
+    $controlledSubject = [
+        'subject' => 'SEISMOLOGY',
+        'subjectScheme' => 'Science Keywords',
+        'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/02acb399-a247-5e23-ab4f-63d001267e22',
+    ];
+
+    expect($this->service->merge([$freeSubject], [$controlledSubject]))->toBe([
+        $freeSubject,
+        $controlledSubject,
+    ]);
+});
+
+it('does not deduplicate distinct URI-only controlled subjects by their label', function (): void {
+    $dataCiteSubject = [
+        'subject' => 'Shared label',
+        'valueUri' => 'https://vocabulary.example.test/concept/datacite',
+    ];
+    $legacySubject = [
+        'subject' => 'Shared label',
+        'valueUri' => 'https://vocabulary.example.test/concept/legacy',
+    ];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([
+        $dataCiteSubject,
+        $legacySubject,
+    ]);
+});
+
+it('deduplicates repeated legacy subjects while preserving the first representation', function (): void {
+    $firstLegacySubject = ['subject' => '  Arctic   research '];
+    $secondLegacySubject = ['subject' => 'arctic research'];
+
+    expect($this->service->merge([], [$firstLegacySubject, $secondLegacySubject]))->toBe([
+        $firstLegacySubject,
+    ]);
+});
+
+it('ignores malformed legacy subjects without changing malformed DataCite input', function (): void {
+    $dataCiteSubjects = ['unchanged', ['unexpected' => 'DataCite value']];
+
+    expect($this->service->merge($dataCiteSubjects, [
+        'not-an-array',
+        [],
+        ['subject' => '   '],
+        [
+            'subject' => 'Controlled value without a usable identity',
+            'schemeUri' => 'https://vocabulary.example.test/unknown-scheme',
+        ],
+    ]))->toBe($dataCiteSubjects);
+});
+
+it('merges subjects into wrapped and flat DOI records', function (): void {
+    $legacySubject = ['subject' => 'Legacy keyword'];
+    $wrapped = [
+        'id' => '10.5880/wrapped',
+        'attributes' => [
+            'doi' => '10.5880/wrapped',
+            'subjects' => [['subject' => 'DataCite keyword']],
+        ],
+    ];
+    $flat = [
+        'doi' => '10.5880/flat',
+        'subjects' => [['subject' => 'DataCite keyword']],
+    ];
+
+    expect($this->service->mergeIntoDoiRecord($wrapped, [$legacySubject]))->toBe([
+        'id' => '10.5880/wrapped',
+        'attributes' => [
+            'doi' => '10.5880/wrapped',
+            'subjects' => [
+                ['subject' => 'DataCite keyword'],
+                $legacySubject,
+            ],
+        ],
+    ])->and($this->service->mergeIntoDoiRecord($flat, [$legacySubject]))->toBe([
+        'doi' => '10.5880/flat',
+        'subjects' => [
+            ['subject' => 'DataCite keyword'],
+            $legacySubject,
+        ],
+    ]);
+});
+
+it('replaces malformed subject containers only when legacy enrichment is available', function (): void {
+    $legacySubject = ['subject' => 'Legacy keyword'];
+
+    expect($this->service->mergeIntoDoiRecord([
+        'attributes' => [
+            'doi' => '10.5880/wrapped-malformed',
+            'subjects' => 'not-an-array',
+        ],
+    ], [$legacySubject]))->toBe([
+        'attributes' => [
+            'doi' => '10.5880/wrapped-malformed',
+            'subjects' => [$legacySubject],
+        ],
+    ])->and($this->service->mergeIntoDoiRecord([
+        'doi' => '10.5880/flat-malformed',
+        'subjects' => 'not-an-array',
+    ], [$legacySubject]))->toBe([
+        'doi' => '10.5880/flat-malformed',
+        'subjects' => [$legacySubject],
+    ]);
+});
+
+it('returns the exact DOI record when no legacy subjects are available', function (): void {
+    $record = [
+        'id' => '10.5880/unchanged',
+        'attributes' => [
+            'doi' => '10.5880/unchanged',
+            'subjects' => 'malformed-but-unchanged',
+        ],
+    ];
+
+    expect($this->service->mergeIntoDoiRecord($record, []))->toBe($record);
+});

--- a/tests/pest/Unit/Services/LegacyKeywordServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyKeywordServiceTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\OldDataset;
+use App\Services\LegacyKeywordService;
+use App\Services\SubjectBreadcrumbPathResolverService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+covers(LegacyKeywordService::class);
+
+beforeEach(function (): void {
+    Config::set('database.connections.metaworks', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+
+    DB::purge('metaworks');
+
+    Schema::connection('metaworks')->create('thesauruskeyword', function (Blueprint $table): void {
+        $table->unsignedBigInteger('resource_id');
+        $table->string('keyword');
+        $table->string('thesaurus');
+    });
+    Schema::connection('metaworks')->create('thesaurusvalue', function (Blueprint $table): void {
+        $table->string('keyword');
+        $table->string('thesaurus');
+        $table->string('uri')->nullable();
+        $table->text('description')->nullable();
+    });
+
+    $this->service = new LegacyKeywordService;
+    $this->dataset = new OldDataset;
+    $this->dataset->forceFill([
+        'id' => 9663,
+        'identifier' => '10.5880/GFZ.LKUT.2026.004',
+        'keywords' => null,
+    ]);
+    $this->dataset->exists = true;
+});
+
+afterEach(function (): void {
+    Schema::connection('metaworks')->dropIfExists('thesaurusvalue');
+    Schema::connection('metaworks')->dropIfExists('thesauruskeyword');
+    DB::disconnect('metaworks');
+});
+
+it('loads and transforms controlled keywords in deterministic order', function (): void {
+    $thesaurus = 'NASA/GCMD Earth Science Keywords';
+    DB::connection('metaworks')->table('thesauruskeyword')->insert([
+        ['resource_id' => 9663, 'keyword' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS', 'thesaurus' => $thesaurus],
+        ['resource_id' => 9663, 'keyword' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY', 'thesaurus' => $thesaurus],
+        ['resource_id' => 9999, 'keyword' => 'SHOULD NOT MATCH', 'thesaurus' => $thesaurus],
+        ['resource_id' => 9663, 'keyword' => 'UNSUPPORTED', 'thesaurus' => 'Unrelated thesaurus'],
+    ]);
+    DB::connection('metaworks')->table('thesaurusvalue')->insert([
+        [
+            'keyword' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+            'thesaurus' => $thesaurus,
+            'uri' => 'http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/11111111-1111-4111-8111-111111111111',
+            'description' => 'Tectonics description',
+        ],
+        [
+            'keyword' => 'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'thesaurus' => $thesaurus,
+            'uri' => 'http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/22222222-2222-4222-8222-222222222222',
+            'description' => 'Seismology description',
+        ],
+        [
+            'keyword' => 'SHOULD NOT MATCH',
+            'thesaurus' => $thesaurus,
+            'uri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/33333333-3333-4333-8333-333333333333',
+            'description' => null,
+        ],
+        [
+            'keyword' => 'UNSUPPORTED',
+            'thesaurus' => 'Unrelated thesaurus',
+            'uri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/44444444-4444-4444-8444-444444444444',
+            'description' => null,
+        ],
+    ]);
+
+    $keywords = $this->service->controlledKeywords($this->dataset);
+
+    expect($keywords)->toHaveCount(2)
+        ->and(array_column($keywords, 'path'))->toBe([
+            'EARTH SCIENCE > SOLID EARTH > SEISMOLOGY',
+            'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+        ])
+        ->and($keywords[0])->toMatchArray([
+            'id' => 'https://gcmd.earthdata.nasa.gov/kms/concept/22222222-2222-4222-8222-222222222222',
+            'scheme' => 'Science Keywords',
+            'schemeURI' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+            'uuid' => '22222222-2222-4222-8222-222222222222',
+            'description' => 'Seismology description',
+        ]);
+});
+
+it('splits, trims, and filters comma-separated free keywords', function (): void {
+    $this->dataset->keywords = '  GNSS, , Crustal deformation ,,Seismology  ';
+
+    expect($this->service->freeKeywords($this->dataset))->toBe([
+        'GNSS',
+        'Crustal deformation',
+        'Seismology',
+    ]);
+});
+
+it('returns no free keywords for null, blank, or non-string values', function (mixed $keywords): void {
+    $this->dataset->setRawAttributes([
+        'id' => 9663,
+        'identifier' => '10.5880/GFZ.LKUT.2026.004',
+        'keywords' => $keywords,
+    ]);
+
+    expect($this->service->freeKeywords($this->dataset))->toBe([]);
+})->with([null, '', '   ', 123]);
+
+it('converts controlled and free keywords to canonical DataCite subjects', function (): void {
+    $thesaurus = 'NASA/GCMD Earth Science Keywords';
+    $keyword = 'EARTH SCIENCE > SOLID EARTH > TECTONICS';
+    DB::connection('metaworks')->table('thesauruskeyword')->insert([
+        'resource_id' => 9663,
+        'keyword' => $keyword,
+        'thesaurus' => $thesaurus,
+    ]);
+    DB::connection('metaworks')->table('thesaurusvalue')->insert([
+        'keyword' => $keyword,
+        'thesaurus' => $thesaurus,
+        'uri' => 'http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/11111111-1111-4111-8111-111111111111',
+        'description' => null,
+    ]);
+    $this->dataset->keywords = 'GNSS, Crustal deformation';
+
+    expect($this->service->dataCiteSubjects($this->dataset))->toBe([
+        [
+            'subject' => $keyword,
+            'subjectScheme' => 'Science Keywords',
+            'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/11111111-1111-4111-8111-111111111111',
+            'lang' => 'en',
+            'schemeUri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+        ],
+        ['subject' => 'GNSS'],
+        ['subject' => 'Crustal deformation'],
+    ]);
+});
+
+it('skips invalid controlled keywords and records enough context for diagnosis', function (): void {
+    Log::spy();
+    $thesaurus = 'NASA/GCMD Earth Science Keywords';
+    DB::connection('metaworks')->table('thesauruskeyword')->insert([
+        'resource_id' => 9663,
+        'keyword' => '',
+        'thesaurus' => $thesaurus,
+    ]);
+    DB::connection('metaworks')->table('thesaurusvalue')->insert([
+        'keyword' => '',
+        'thesaurus' => $thesaurus,
+        'uri' => null,
+        'description' => null,
+    ]);
+
+    expect($this->service->controlledKeywords($this->dataset))->toBe([]);
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Skipping invalid legacy controlled keyword'
+            && $context['doi'] === '10.5880/GFZ.LKUT.2026.004'
+            && $context['legacy_resource_id'] === 9663
+            && $context['thesaurus'] === $thesaurus);
+});
+
+it('continues after an individual controlled keyword transformation throws', function (): void {
+    Log::spy();
+    $thesaurus = 'NASA/GCMD Earth Science Keywords';
+    DB::connection('metaworks')->table('thesauruskeyword')->insert([
+        'resource_id' => 9663,
+        'keyword' => 'BROKEN KEYWORD',
+        'thesaurus' => $thesaurus,
+    ]);
+    DB::connection('metaworks')->table('thesaurusvalue')->insert([
+        'keyword' => 'BROKEN KEYWORD',
+        'thesaurus' => $thesaurus,
+        'uri' => null,
+        'description' => null,
+    ]);
+    $this->app->bind(
+        SubjectBreadcrumbPathResolverService::class,
+        static fn (): never => throw new RuntimeException('Vocabulary storage unavailable'),
+    );
+
+    expect($this->service->controlledKeywords($this->dataset))->toBe([]);
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Skipping legacy controlled keyword after transformation failure'
+            && $context['doi'] === '10.5880/GFZ.LKUT.2026.004'
+            && $context['legacy_resource_id'] === 9663
+            && $context['keyword'] === 'BROKEN KEYWORD'
+            && $context['error'] === 'Vocabulary storage unavailable');
+});
+
+it('returns an empty subject list when no legacy keywords exist', function (): void {
+    expect($this->service->dataCiteSubjects($this->dataset))->toBe([]);
+});

--- a/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyResourceLookupServiceTest.php
@@ -22,6 +22,7 @@ beforeEach(function () {
     Schema::connection('metaworks')->create('resource', function (Blueprint $table): void {
         $table->id();
         $table->string('identifier')->nullable();
+        $table->text('keywords')->nullable();
     });
     Schema::connection('metaworks')->create('relatedidentifier', function (Blueprint $table): void {
         $table->id();
@@ -30,11 +31,24 @@ beforeEach(function () {
         $table->string('identifiertype')->nullable();
         $table->string('relationtype')->nullable();
     });
+    Schema::connection('metaworks')->create('thesauruskeyword', function (Blueprint $table): void {
+        $table->unsignedBigInteger('resource_id');
+        $table->string('keyword');
+        $table->string('thesaurus');
+    });
+    Schema::connection('metaworks')->create('thesaurusvalue', function (Blueprint $table): void {
+        $table->string('keyword');
+        $table->string('thesaurus');
+        $table->string('uri')->nullable();
+        $table->text('description')->nullable();
+    });
 
     $this->service = new LegacyResourceLookupService;
 });
 
 afterEach(function () {
+    Schema::connection('metaworks')->dropIfExists('thesaurusvalue');
+    Schema::connection('metaworks')->dropIfExists('thesauruskeyword');
     Schema::connection('metaworks')->dropIfExists('relatedidentifier');
     Schema::connection('metaworks')->dropIfExists('resource');
     DB::disconnect('metaworks');
@@ -100,5 +114,56 @@ describe('LegacyResourceLookupService', function () {
 
     it('returns an empty relation list when the DOI is absent from legacy storage', function () {
         expect($this->service->relatedIdentifiersByDoi('10.5880/missing'))->toBe([]);
+    });
+
+    it('returns related identifiers and both keyword types as import metadata', function () {
+        $resourceId = DB::connection('metaworks')->table('resource')->insertGetId([
+            'identifier' => '10.5880/GFZ.LKUT.2026.004',
+            'keywords' => 'GNSS, Crustal deformation',
+        ]);
+        DB::connection('metaworks')->table('relatedidentifier')->insert([
+            'resource_id' => $resourceId,
+            'identifier' => '10.5880/GFZ.LKUT.2026.003',
+            'identifiertype' => 'DOI',
+            'relationtype' => 'IsNewVersionOf',
+        ]);
+        DB::connection('metaworks')->table('thesauruskeyword')->insert([
+            'resource_id' => $resourceId,
+            'keyword' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+            'thesaurus' => 'NASA/GCMD Earth Science Keywords',
+        ]);
+        DB::connection('metaworks')->table('thesaurusvalue')->insert([
+            'keyword' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+            'thesaurus' => 'NASA/GCMD Earth Science Keywords',
+            'uri' => 'http://gcmdservices.gsfc.nasa.gov/kms/concepts/concept_scheme/sciencekeywords/11111111-1111-4111-8111-111111111111',
+            'description' => null,
+        ]);
+
+        expect($this->service->importMetadataByDoi('10.5880/gfz.lkut.2026.004'))->toBe([
+            'relatedIdentifiers' => [[
+                'identifier' => '10.5880/GFZ.LKUT.2026.003',
+                'identifierType' => 'DOI',
+                'relationType' => 'IsNewVersionOf',
+                'position' => 0,
+            ]],
+            'subjects' => [
+                [
+                    'subject' => 'EARTH SCIENCE > SOLID EARTH > TECTONICS',
+                    'subjectScheme' => 'Science Keywords',
+                    'valueUri' => 'https://gcmd.earthdata.nasa.gov/kms/concept/11111111-1111-4111-8111-111111111111',
+                    'lang' => 'en',
+                    'schemeUri' => 'https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords',
+                ],
+                ['subject' => 'GNSS'],
+                ['subject' => 'Crustal deformation'],
+            ],
+        ]);
+    });
+
+    it('returns empty import metadata when the DOI is absent from legacy storage', function () {
+        expect($this->service->importMetadataByDoi('10.5880/missing'))->toBe([
+            'relatedIdentifiers' => [],
+            'subjects' => [],
+        ]);
     });
 });


### PR DESCRIPTION
This pull request introduces a new service for merging DataCite and legacy subjects, refactors the `OldDatasetController` to use dependency injection for keyword services, and improves type consistency for JSON responses. The most significant changes are summarized below.

### Subject Merging and Import Improvements

* Added a new `DataCiteSubjectMergeService` that merges DataCite and legacy subjects, ensuring no duplicates and preserving source-priority order. This service is now used during DataCite import to enrich DOI records with legacy subjects when available. [[1]](diffhunk://#diff-e7d4dfb8d7687aafdd888243ce56202b76d689a9557687a6a0798fd4628470f1R1-R220) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R13) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L928-R956)

### Controller Refactoring and Dependency Injection

* Refactored `OldDatasetController` to inject `LegacyKeywordService` via the constructor, replacing direct usage of `OldDatasetKeywordTransformer` for controlled and free keyword retrieval. This centralizes keyword logic and improves testability. [[1]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L8-R11) [[2]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49R37-R40) [[3]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L413-R421) [[4]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L462-R452)

### Consistent JSON Response Typing

* Updated all relevant controller method docblocks and type hints to use `JsonResponse` instead of `\Illuminate\Http\JsonResponse`, ensuring consistency and clarity in return types. [[1]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L131-R138) [[2]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L235-R242) [[3]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L268-R275) [[4]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L301-R308) [[5]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L334-R341) [[6]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L367-R374) [[7]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L400-R407) [[8]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L449-R438) [[9]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L498-R469) [[10]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L532-R503) [[11]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L565-R536) [[12]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L661-R632) [[13]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L791-R762) [[14]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L928-R899)

### Minor Code Cleanups

* Simplified static class references for MSL keyword and vocabulary services in `OldDatasetController` for consistency and readability. [[1]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L579-R550) [[2]](diffhunk://#diff-ce563f3724dd5a3e00838a6b6dca29f0bedfabff1db9a32a3b06d91d3dff1c49L594-R568)

These changes improve maintainability, code clarity, and data enrichment during import processes.