### PR TITLE
Fix: Gate Landing Page publishing on findable DOI State

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -916,7 +916,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
                 if ($shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
-                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
+                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $doiRecord, $metaworksService);
                 }
 
                 return [
@@ -984,7 +984,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
                 if ($existingResource !== null && $shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
-                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
+                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $doiRecord, $metaworksService);
                 }
 
                 return [
@@ -1008,7 +1008,7 @@ class ImportFromDataCiteJob implements ShouldQueue
             $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
             if ($shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $importedResource->id)->exists()) {
-                $legacyDownloadSync = $this->syncLegacyDownloadLinks($importedResource, $doi, $metaworksService);
+                $legacyDownloadSync = $this->syncLegacyDownloadLinks($importedResource, $doi, $doiRecord, $metaworksService);
             }
 
             $this->syncDataCiteMetadataIfAllowed($importedResource);
@@ -1039,7 +1039,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
                 if ($existingResource !== null && $shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
-                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $metaworksService);
+                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $doiRecord, $metaworksService);
                 }
 
                 return [
@@ -1096,6 +1096,7 @@ class ImportFromDataCiteJob implements ShouldQueue
     private function syncLegacyDownloadLinks(
         Resource $resource,
         string $doi,
+        array $doiRecord,
         MetaworksDownloadUrlService $metaworksService,
     ): array {
         /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound?: bool} $fileResult */
@@ -1121,7 +1122,8 @@ class ImportFromDataCiteJob implements ShouldQueue
             $syncResult = app(LegacyLandingPageImportService::class)->syncMissingFileEntries(
                 resource: $resource,
                 fileEntries: $fileResult['files'],
-                isPublished: $fileResult['files'] !== [] && $fileResult['allPublic'],
+                isPublished: $this->isFindableDoiRecord($doiRecord)
+                    && ($fileResult['files'] === [] || $fileResult['allPublic']),
                 createWhenEmpty: $fileResult['resourceFound'] === true,
             );
         } catch (\Throwable $exception) {
@@ -1138,6 +1140,18 @@ class ImportFromDataCiteJob implements ShouldQueue
             'changed' => $syncResult['changed'],
             'metaworks_unavailable' => false,
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $doiRecord
+     */
+    private function isFindableDoiRecord(array $doiRecord): bool
+    {
+        $attributes = is_array($doiRecord['attributes'] ?? null)
+            ? $doiRecord['attributes']
+            : $doiRecord;
+
+        return strtolower(trim((string) ($attributes['state'] ?? ''))) === 'findable';
     }
 
     /**

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -1091,6 +1091,7 @@ class ImportFromDataCiteJob implements ShouldQueue
     }
 
     /**
+     * @param  array<string, mixed>  $doiRecord
      * @return array{changed: bool, metaworks_unavailable: bool}
      */
     private function syncLegacyDownloadLinks(

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -1100,8 +1100,8 @@ class ImportFromDataCiteJob implements ShouldQueue
         array $doiRecord,
         MetaworksDownloadUrlService $metaworksService,
     ): array {
-        /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound?: bool} $fileResult */
-        $fileResult = ['files' => [], 'allPublic' => false, 'resourceFound' => false];
+        /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound?: bool, hasFileRows?: bool} $fileResult */
+        $fileResult = ['files' => [], 'allPublic' => false, 'resourceFound' => false, 'hasFileRows' => false];
 
         try {
             $fileResult = $metaworksService->lookupFileEntries($doi);
@@ -1117,14 +1117,17 @@ class ImportFromDataCiteJob implements ShouldQueue
             ];
         }
 
-        $fileResult += ['resourceFound' => false];
+        $fileResult += [
+            'resourceFound' => false,
+            'hasFileRows' => $fileResult['files'] !== [],
+        ];
 
         try {
             $syncResult = app(LegacyLandingPageImportService::class)->syncMissingFileEntries(
                 resource: $resource,
                 fileEntries: $fileResult['files'],
                 isPublished: $this->isFindableDoiRecord($doiRecord)
-                    && ($fileResult['files'] === [] || $fileResult['allPublic']),
+                    && (! $fileResult['hasFileRows'] || $fileResult['allPublic']),
                 createWhenEmpty: $fileResult['resourceFound'] === true,
             );
         } catch (\Throwable $exception) {

--- a/app/Services/LegacyLandingPageImportService.php
+++ b/app/Services/LegacyLandingPageImportService.php
@@ -154,7 +154,7 @@ class LegacyLandingPageImportService
         $resource->loadMissing('titles.titleType');
 
         $primaryFile = $fileEntries[0] ?? null;
-        $shouldPublish = $isPublished && $primaryFile !== null;
+        $shouldPublish = $isPublished;
 
         $landingPage = new LandingPage([
             'resource_id' => $resource->id,

--- a/app/Services/MetaworksDownloadUrlService.php
+++ b/app/Services/MetaworksDownloadUrlService.php
@@ -51,7 +51,7 @@ class MetaworksDownloadUrlService
      * entries are imported as landing page additional links, using the legacy
      * file name first and the description as fallback label.
      *
-     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound: bool}
+     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound: bool, hasFileRows: bool}
      */
     public function lookupFileEntries(string $doi): array
     {
@@ -63,7 +63,7 @@ class MetaworksDownloadUrlService
             ->first();
 
         if ($oldResource === null) {
-            return ['files' => [], 'allPublic' => false, 'resourceFound' => false];
+            return ['files' => [], 'allPublic' => false, 'resourceFound' => false, 'hasFileRows' => false];
         }
 
         // Get all file records for that resource (public and non-public)
@@ -74,7 +74,7 @@ class MetaworksDownloadUrlService
             ->get(['url', 'name', 'description', 'visible']);
 
         if ($files->isEmpty()) {
-            return ['files' => [], 'allPublic' => false, 'resourceFound' => true];
+            return ['files' => [], 'allPublic' => false, 'resourceFound' => true, 'hasFileRows' => false];
         }
 
         // Determine if all files are publicly visible
@@ -109,7 +109,7 @@ class MetaworksDownloadUrlService
             ];
         }
 
-        return ['files' => $entries, 'allPublic' => $allPublic, 'resourceFound' => true];
+        return ['files' => $entries, 'allPublic' => $allPublic, 'resourceFound' => true, 'hasFileRows' => true];
     }
 
     private function isValidDownloadUrl(string $doi, string $url): bool

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -424,6 +424,10 @@
                 "description": "DataCite registration, metadata updates, and JSON/XML exports now preserve logical description line breaks using DataCite's allowed <br> representation. JSON API payloads emit literal <br> markers and XML exports emit real <br/> child elements, while all other landing-page HTML remains excluded. Existing resources require no migration."
             },
             {
+                "title": "Safe Legacy Landing Page Publication and Review Links",
+                "description": "Findable legacy resource imports now publish a download-free landing page only when the legacy resource truly has no file rows. Non-public rows can no longer be mistaken for no files after invalid URLs are filtered, and Review status links now open the landing-page review URL instead of the DOI."
+            },
+            {
                 "title": "Legacy Resource Download Links Import",
                 "description": "Legacy resource imports from /resources now persist SUMARIO download URLs and additional legacy download links from the queue worker. Re-running the single or bulk import for an already imported DOI can backfill missing landing page download links without overwriting curator-provided values, and the import summary now reports when existing resources had legacy links added."
             },

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -1541,6 +1541,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                 'files' => [],
                 'allPublic' => false,
                 'resourceFound' => true,
+                'hasFileRows' => false,
             ]);
 
         $importId = Str::uuid()->toString();
@@ -1557,6 +1558,58 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($landingPage->is_published)->toBeTrue()
             ->and($landingPage->published_at)->not->toBeNull()
             ->and(LandingPageDomain::count())->toBe(0);
+    });
+
+    it('keeps a findable landing page in review when non-public legacy rows have no valid URLs', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/invalid.private.001',
+                    'attributes' => [
+                        'doi' => '10.5880/invalid.private.001',
+                        'state' => 'findable',
+                        'titles' => [['title' => 'Invalid Private File Dataset']],
+                        'publicationYear' => 2024,
+                        'types' => ['resourceTypeGeneral' => 'Dataset'],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/invalid.private.001']));
+
+        $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $metaworksService->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/invalid.private.001')
+            ->andReturn([
+                'files' => [],
+                'allPublic' => false,
+                'resourceFound' => true,
+                'hasFileRows' => true,
+            ]);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $metaworksService);
+
+        $resource = Resource::where('doi', '10.5880/invalid.private.001')->firstOrFail();
+        $landingPage = $resource->fresh(['landingPage'])->landingPage;
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->downloads_unavailable)->toBeTrue()
+            ->and($landingPage->is_published)->toBeFalse()
+            ->and($landingPage->published_at)->toBeNull();
     });
 
     it('ignores old DataCite data services URLs and imports SUMARIO file URLs instead', function () {

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -1281,6 +1281,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     'id' => '10.5880/lp.sample.001',
                     'attributes' => [
                         'doi' => '10.5880/lp.sample.001',
+                        'state' => 'findable',
                         'titles' => [['title' => 'Test Dataset Title']],
                         'publicationYear' => 2024,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
@@ -1339,6 +1340,62 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         expect(Cache::get(CacheKey::LANDING_PAGE_DOWNLOAD_URL_SUGGESTIONS->key()))->toBeNull();
     });
 
+    it('keeps a landing page in review when public files belong to a non-findable DOI', function () {
+        $this->importService
+            ->shouldReceive('getTotalDoiCount')
+            ->once()
+            ->andReturn(1);
+
+        $this->importService
+            ->shouldReceive('fetchAllDois')
+            ->once()
+            ->andReturn((function () {
+                yield [
+                    'id' => '10.5880/lp.registered.001',
+                    'attributes' => [
+                        'doi' => '10.5880/lp.registered.001',
+                        'state' => 'registered',
+                        'titles' => [['title' => 'Registered Dataset']],
+                        'publicationYear' => 2024,
+                        'types' => ['resourceTypeGeneral' => 'Dataset'],
+                    ],
+                ];
+            })());
+
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/lp.registered.001']));
+
+        $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
+        $metaworksService->shouldReceive('lookupFileEntries')
+            ->with('10.5880/lp.registered.001')
+            ->once()
+            ->andReturn([
+                'files' => [
+                    [
+                        'url' => 'https://datapub.gfz.de/download/public-file.zip',
+                        'label' => 'Public package',
+                        'visible' => 'public',
+                    ],
+                ],
+                'allPublic' => true,
+            ]);
+
+        $importId = Str::uuid()->toString();
+        $job = new ImportFromDataCiteJob($this->user->id, $importId);
+        $job->handle($this->importService, $this->transformer, $metaworksService);
+
+        $landingPage = Resource::where('doi', '10.5880/lp.registered.001')
+            ->firstOrFail()
+            ->fresh(['landingPage'])
+            ->landingPage;
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->is_published)->toBeFalse()
+            ->and($landingPage->published_at)->toBeNull();
+    });
+
     it('creates unpublished landing page when metaworks files are non-public', function () {
         $this->importService
             ->shouldReceive('getTotalDoiCount')
@@ -1353,6 +1410,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     'id' => '10.5880/lp.nonpub.001',
                     'attributes' => [
                         'doi' => '10.5880/lp.nonpub.001',
+                        'state' => 'findable',
                         'titles' => [['title' => 'Non-Public Files Dataset']],
                         'publicationYear' => 2024,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
@@ -1447,12 +1505,28 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     'attributes' => [
                         'doi' => '10.5880/gfz.dekorp.ktb8401.001',
                         'url' => 'https://dataservices.gfz.de/dekorp/showshort.php?id=493dcc02-011c-11ed-9531-ca1f3ed77ce8',
+                        'state' => 'findable',
                         'titles' => [['title' => 'DEKORP No Files Dataset']],
                         'publicationYear' => 2022,
                         'types' => ['resourceTypeGeneral' => 'Dataset'],
                     ],
                 ];
             })());
+
+        // The real transformer strips read-only DataCite fields such as state.
+        // The publication decision must therefore use the original API record.
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->once()
+            ->andReturn([
+                'id' => '10.5880/gfz.dekorp.ktb8401.001',
+                'attributes' => [
+                    'doi' => '10.5880/gfz.dekorp.ktb8401.001',
+                    'titles' => [['title' => 'DEKORP No Files Dataset']],
+                    'publicationYear' => 2022,
+                    'types' => ['resourceTypeGeneral' => 'Dataset'],
+                ],
+            ]);
 
         $this->transformer
             ->shouldReceive('transform')
@@ -1480,7 +1554,8 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($landingPage->template)->toBe('default_gfz')
             ->and($landingPage->ftp_url)->toBeNull()
             ->and($landingPage->downloads_unavailable)->toBeTrue()
-            ->and($landingPage->is_published)->toBeFalse()
+            ->and($landingPage->is_published)->toBeTrue()
+            ->and($landingPage->published_at)->not->toBeNull()
             ->and(LandingPageDomain::count())->toBe(0);
     });
 
@@ -1620,7 +1695,10 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->andReturn((function () {
                 yield [
                     'id' => '10.5880/skip.backfill',
-                    'attributes' => ['doi' => '10.5880/skip.backfill'],
+                    'attributes' => [
+                        'doi' => '10.5880/skip.backfill',
+                        'state' => 'findable',
+                    ],
                 ];
             })());
 

--- a/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageImportServiceTest.php
@@ -70,6 +70,23 @@ describe('LegacyLandingPageImportService', function () {
             ->and($resource->fresh(['landingPage'])->publicStatus())->toBe('review');
     });
 
+    it('publishes a landing page without downloads when the import marks it as published', function () {
+        $resource = Resource::factory()->create(['doi' => '10.5880/landing.empty.published']);
+
+        $landingPage = (new LegacyLandingPageImportService)->createForResource(
+            resource: $resource,
+            fileEntries: [],
+            isPublished: true,
+            createWhenEmpty: true,
+        );
+
+        expect($landingPage)->not->toBeNull()
+            ->and($landingPage->ftp_url)->toBeNull()
+            ->and($landingPage->downloads_unavailable)->toBeTrue()
+            ->and($landingPage->is_published)->toBeTrue()
+            ->and($landingPage->published_at)->not->toBeNull();
+    });
+
     it('clears downloads unavailable when legacy files are synced later', function () {
         $resource = Resource::factory()->create(['doi' => '10.5880/landing.empty.then.files']);
         $landingPage = LandingPage::factory()->downloadsUnavailable()->draft()->create([

--- a/tests/pest/Unit/Services/MetaworksDownloadUrlServiceTest.php
+++ b/tests/pest/Unit/Services/MetaworksDownloadUrlServiceTest.php
@@ -260,8 +260,63 @@ describe('MetaworksDownloadUrlService', function () {
             ->and($result['allPublic'])->toBeTrue();
     });
 
+    it('distinguishes a legacy resource without file rows from filtered file entries', function () {
+        $resourceQuery = Mockery::mock();
+        $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.no.rows')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 90]);
+
+        $fileQuery = Mockery::mock();
+        $fileQuery->shouldReceive('where')->with('resource_id', 90)->andReturnSelf();
+        $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect());
+
+        $connection = Mockery::mock();
+        $connection->shouldReceive('table')->with('resource')->andReturn($resourceQuery);
+        $connection->shouldReceive('table')->with('file')->andReturn($fileQuery);
+
+        DB::shouldReceive('connection')->with('metaworks')->andReturn($connection);
+
+        $service = new MetaworksDownloadUrlService;
+        $result = $service->lookupFileEntries('10.5880/GFZ.no.rows');
+
+        expect($result['files'])->toBe([])
+            ->and($result['allPublic'])->toBeFalse()
+            ->and($result['resourceFound'])->toBeTrue()
+            ->and($result['hasFileRows'])->toBeFalse();
+    });
+
+    it('preserves file row presence when a non-public URL is filtered out', function () {
+        $resourceQuery = Mockery::mock();
+        $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.invalid.private')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 91]);
+
+        $fileQuery = Mockery::mock();
+        $fileQuery->shouldReceive('where')->with('resource_id', 91)->andReturnSelf();
+        $fileQuery->shouldReceive('orderBy')->with('id')->andReturnSelf();
+        $fileQuery->shouldReceive('get')->with(['url', 'name', 'description', 'visible'])->andReturn(collect([
+            (object) ['url' => 'javascript:alert(1)', 'visible' => 'private'],
+        ]));
+
+        $connection = Mockery::mock();
+        $connection->shouldReceive('table')->with('resource')->andReturn($resourceQuery);
+        $connection->shouldReceive('table')->with('file')->andReturn($fileQuery);
+
+        DB::shouldReceive('connection')->with('metaworks')->andReturn($connection);
+        Log::shouldReceive('warning')->once();
+
+        $service = new MetaworksDownloadUrlService;
+        $result = $service->lookupFileEntries('10.5880/GFZ.invalid.private');
+
+        expect($result['files'])->toBe([])
+            ->and($result['allPublic'])->toBeFalse()
+            ->and($result['resourceFound'])->toBeTrue()
+            ->and($result['hasFileRows'])->toBeTrue();
+    });
+
     it('filters out URLs exceeding 2048 characters', function () {
-        $longUrl = 'https://datapub.gfz.de/download/' . str_repeat('a', 2048);
+        $longUrl = 'https://datapub.gfz.de/download/'.str_repeat('a', 2048);
 
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.long.test')->andReturnSelf();

--- a/tests/playwright/workflows/09-doi-registration.spec.ts
+++ b/tests/playwright/workflows/09-doi-registration.spec.ts
@@ -140,7 +140,7 @@ test.describe('DOI Registration Workflow', () => {
     test('review status opens the tokenized landing-page preview instead of the DOI', async ({ page }) => {
         await page.goto('/resources');
 
-        const reviewRow = page.locator('tbody tr').filter({ hasText: 'Playwright: Review Resource' });
+        const reviewRow = page.locator('tbody tr').filter({ hasText: '10.1234/playwright-qa' });
         await expect(reviewRow).toBeVisible();
 
         const reviewBadge = reviewRow.getByRole('button', { name: /Review - Click to open preview page/i });

--- a/tests/playwright/workflows/09-doi-registration.spec.ts
+++ b/tests/playwright/workflows/09-doi-registration.spec.ts
@@ -137,23 +137,27 @@ test.describe('DOI Registration Workflow', () => {
         }
     });
 
-    test('status badge is clickable for review resources', async ({ page }) => {
-        // Navigate to resources
+    test('review status opens the tokenized landing-page preview instead of the DOI', async ({ page }) => {
         await page.goto('/resources');
 
-        // Find review resource
-        const reviewBadge = page.getByText('Review').first();
+        const reviewRow = page.locator('tbody tr').filter({ hasText: 'Playwright: Review Resource' });
+        await expect(reviewRow).toBeVisible();
 
-        if ((await reviewBadge.count()) > 0) {
-            await expect(reviewBadge).toBeVisible();
+        const reviewBadge = reviewRow.getByRole('button', { name: /Review - Click to open preview page/i });
+        await expect(reviewBadge).toHaveCSS('cursor', 'pointer');
 
-            // Badge should have button role or be clickable
-            const badgeElement = reviewBadge.locator('..');
-            await expect(badgeElement).toHaveAttribute('role', 'button');
+        const popupPromise = page.waitForEvent('popup');
+        await reviewBadge.click();
+        const previewPage = await popupPromise;
 
-            // Should have hover effect
-            await expect(badgeElement).toHaveCSS('cursor', 'pointer');
-        }
+        await previewPage.waitForURL((url) => url.searchParams.has('preview'));
+
+        const previewUrl = new URL(previewPage.url());
+        expect(previewUrl.hostname).not.toBe('doi.org');
+        expect(previewUrl.searchParams.get('preview')).toBeTruthy();
+        expect(previewUrl.pathname).toContain('/10.1234/playwright-qa/');
+
+        await previewPage.close();
     });
 
     test('status badge is not clickable for curation resources', async ({ page }) => {


### PR DESCRIPTION
This pull request updates the DataCite import workflow to ensure that landing pages are only published when the associated DOI is in the "findable" state, regardless of file visibility. It introduces a new helper to check DOI state, adjusts the logic for publishing landing pages, and adds comprehensive tests to verify these behaviors. Additionally, minor improvements were made to the Playwright test to better reflect the UI's review status badge behavior.

**Landing page publication logic:**

- Landing pages are now published only if the DOI's `state` is "findable", even when all files are public. This prevents premature publication of landing pages for DOIs that are only "registered" or not yet findable. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1124-R1127) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R1146-R1157)
- The `syncLegacyDownloadLinks` method now receives the full DOI record, enabling it to check the DOI state before deciding publication status. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L919-R919) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L987-R987) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1011-R1011) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1042-R1042) [[5]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R1094-R1100)
- The `isPublished` flag in `createDefaultLandingPage` is now passed directly, without requiring a primary file to exist.

**Testing improvements:**

- New and updated feature tests in `ImportFromDataCiteJobTest.php` verify that landing pages remain in review if the DOI is not "findable", and that pages without downloads are published only when appropriate. [[1]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR1343-R1398) [[2]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR1413) [[3]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR1508-R1530) [[4]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dL1483-R1558) [[5]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dL1623-R1701)
- Added a unit test to confirm that landing pages without downloads are published if the import marks them as published.

**UI test update:**

- The Playwright workflow test was updated to ensure that clicking the "Review" status badge opens the tokenized landing-page preview, not the DOI URL, and verifies the preview behavior.