### PR TITLE
Fix: SDDB Datacenter Mapping for ICDP Imports is wrong

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -753,6 +753,7 @@ class ImportFromDataCiteJob implements ShouldQueue
         }
 
         ['doi' => $doi, 'doiRecord' => $doiRecord] = $this->normalizeDoiRecord($doi, $doiRecord);
+        $portalDatacenterNames = $this->portalDatacenterNamesForSingleImport($doi);
 
         try {
             $result = $this->processDoiRecord(
@@ -760,6 +761,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                 doiRecord: $doiRecord,
                 transformer: $transformer,
                 metaworksService: $metaworksService,
+                portalDatacenterNames: $portalDatacenterNames,
                 citationLabelResolutionMode: CitationLabelResolutionMode::REQUIRED,
             );
         } catch (\Exception $exception) {
@@ -791,6 +793,26 @@ class ImportFromDataCiteJob implements ShouldQueue
             'completed_at' => now()->toIso8601String(),
             'current_prefix' => null,
         ]);
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function portalDatacenterNamesForSingleImport(string $doi): ?array
+    {
+        try {
+            $names = app(GfzDataServicesPortalService::class)->datacenterNamesForDoi($doi);
+
+            return $names !== [] ? $names : null;
+        } catch (\Throwable $exception) {
+            Log::warning('GFZ Data Services portal lookup failed during single DOI import; using legacy datacenter fallback.', [
+                'import_id' => $this->importId,
+                'doi' => $doi,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
     }
 
     private function markSingleImportAsFailed(string $doi, string $error, string $startedAt): void

--- a/app/Services/GfzDataServicesPortalService.php
+++ b/app/Services/GfzDataServicesPortalService.php
@@ -57,6 +57,57 @@ class GfzDataServicesPortalService
     }
 
     /**
+     * @return list<string>
+     */
+    public function datacenterNamesForDoi(string $doi): array
+    {
+        $normalizedDoi = $this->doiSuggestionService->normalizeDoi($doi);
+
+        if ($normalizedDoi === '' || ! $this->doiSuggestionService->isValidDoiFormat($normalizedDoi)) {
+            return [];
+        }
+
+        $response = $this->postQuery([
+            'q' => 'doi:'.$this->escapeSolrTerm($normalizedDoi),
+            'rows' => 10,
+            'fl' => 'doi,datacentre_facet',
+            'json.nl' => 'map',
+            'fq' => '-type:text',
+        ]);
+        $payload = $this->jsonPayload($response);
+        $responseData = $payload['response'] ?? null;
+
+        if (! is_array($responseData)) {
+            throw new RuntimeException('The GFZ Data Services portal returned an invalid DOI response.');
+        }
+
+        $total = $responseData['numFound'] ?? null;
+        $documents = $responseData['docs'] ?? null;
+
+        if (! is_numeric($total) || ! is_array($documents)) {
+            throw new RuntimeException('The GFZ Data Services portal DOI response is incomplete.');
+        }
+
+        $names = [];
+
+        foreach ($documents as $document) {
+            if (! is_array($document) || ! is_string($document['doi'] ?? null)) {
+                continue;
+            }
+
+            $documentDoi = $this->doiSuggestionService->normalizeDoi($document['doi']);
+
+            if (! hash_equals($normalizedDoi, $documentDoi)) {
+                continue;
+            }
+
+            array_push($names, ...$this->datacenterNamesFromDocument($document));
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
      * @return array{
      *     datacenter: array{id: string, name: string, resource_count: int},
      *     resources: array<string, list<string>>
@@ -307,6 +358,15 @@ class GfzDataServicesPortalService
             ['\\\\', '\\"'],
             $value,
         );
+    }
+
+    private function escapeSolrTerm(string $value): string
+    {
+        return preg_replace(
+            '/(&&|\|\||[+\-!(){}\[\]^"~*?:\\\\\/])/',
+            '\\\\$1',
+            $value,
+        ) ?? $value;
     }
 
     /**

--- a/app/Services/LegacyMetaworksDatacenterLookupService.php
+++ b/app/Services/LegacyMetaworksDatacenterLookupService.php
@@ -145,6 +145,10 @@ class LegacyMetaworksDatacenterLookupService
             'datacenters' => [self::RIESGOS_DATACENTER],
         ],
         [
+            'pattern' => '/^icdp(?:[.\/_-]|$)/',
+            'datacenters' => [self::SDDB_DATACENTER],
+        ],
+        [
             'pattern' => '/(?:^|[.\/_-])sddb(?:[.\/_-]|$)/',
             'datacenters' => [self::SDDB_DATACENTER],
         ],

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -412,6 +412,10 @@
                 "description": "New legacy imports now assign GEOFON seismic-network and seismic-event DOIs to their canonical GEOFON datacenters instead of the general GFZ fallback. Existing datacenter records with different letter casing are reused and normalized, preventing duplicate assignments. Existing imported resources remain unchanged."
             },
             {
+                "title": "Correct SDDB Datacenters for ICDP Legacy Imports",
+                "description": "New single-resource imports now use the authoritative GFZ Data Services portal datacenter assignment when available, so ICDP legacy DOIs are assigned to SDDB Scientific Drilling Database instead of the general GFZ fallback. A dedicated ICDP DOI rule keeps the assignment correct when the portal is unavailable. Existing imported resources remain unchanged."
+            },
+            {
                 "title": "Clearer Optional Version Field",
                 "description": "The Data Editor now displays 'None' only as a placeholder when a resource has no version. The underlying field remains empty, missing or cleared versions continue to be stored as null and omitted from DataCite exports, and genuine version values remain unchanged."
             },

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -17,6 +17,7 @@ use App\Services\DataCiteSyncResult;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
+use App\Services\GfzDataServicesPortalService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
 use App\Services\LegacyResourceLookupService;
 use App\Services\MetaworksDownloadUrlService;
@@ -27,6 +28,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -121,6 +123,14 @@ beforeEach(function () {
         ->andReturnNull()
         ->byDefault();
     $this->app->instance(LegacyMetaworksDatacenterLookupService::class, $this->datacenterLookupService);
+
+    $this->portalService = Mockery::mock(GfzDataServicesPortalService::class);
+    $this->portalService
+        ->shouldReceive('datacenterNamesForDoi')
+        ->zeroOrMoreTimes()
+        ->andReturn([])
+        ->byDefault();
+    $this->app->instance(GfzDataServicesPortalService::class, $this->portalService);
 });
 
 afterEach(function () {
@@ -818,6 +828,182 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['imported'])->toBe(1)
             ->and($status['skipped'])->toBe(0)
             ->and($status['failed'])->toBe(0);
+    });
+
+    it('prefers a specialized portal datacenter during a single DOI import', function () {
+        $doi = '10.5880/icdp.5069.001';
+        $doiRecord = [
+            'id' => $doi,
+            'attributes' => [
+                'doi' => $doi,
+                'titles' => [['title' => 'SDDB portal assignment']],
+                'publicationYear' => 2026,
+                'types' => ['resourceTypeGeneral' => 'Dataset'],
+            ],
+        ];
+
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with($doi)
+            ->andReturn($doiRecord);
+        $this->portalService
+            ->shouldReceive('datacenterNamesForDoi')
+            ->once()
+            ->with($doi)
+            ->andReturn([
+                LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER,
+                LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER,
+            ]);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->with($doiRecord, $this->user->id)
+            ->andReturnUsing(fn (): Resource => Resource::factory()->create(['doi' => $doi]));
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, $doi))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $resource = Resource::query()->where('doi', $doi)->firstOrFail();
+
+        expect(Cache::get("datacite_import:{$importId}"))
+            ->toMatchArray([
+                'status' => 'completed',
+                'imported' => 1,
+                'failed' => 0,
+            ])
+            ->and($resource->fresh()->datacenter?->name)
+            ->toBe(LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER);
+    });
+
+    it('uses the legacy datacenter fallback when the portal has no DOI assignment', function () {
+        $doi = '10.5880/icdp.5068.002';
+        $doiRecord = [
+            'id' => $doi,
+            'attributes' => [
+                'doi' => $doi,
+                'titles' => [['title' => 'SDDB fallback assignment']],
+                'publicationYear' => 2026,
+                'types' => ['resourceTypeGeneral' => 'Dataset'],
+            ],
+        ];
+
+        $this->importService->shouldReceive('fetchSingleDoi')->once()->with($doi)->andReturn($doiRecord);
+        $this->portalService->shouldReceive('datacenterNamesForDoi')->once()->with($doi)->andReturn([]);
+        $this->datacenterLookupService
+            ->shouldReceive('syncDatacenters')
+            ->once()
+            ->withArgs(fn (Resource $resource, string $resolvedDoi): bool => $resource->doi === $doi && $resolvedDoi === $doi)
+            ->andReturnUsing(function (Resource $resource): void {
+                $datacenter = Datacenter::query()->firstOrCreate([
+                    'name' => LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER,
+                ]);
+                $resource->update(['datacenter_id' => $datacenter->id]);
+            });
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn (): Resource => Resource::factory()->create(['doi' => $doi]));
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, $doi))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Resource::query()->where('doi', $doi)->firstOrFail()->datacenter?->name)
+            ->toBe(LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER)
+            ->and(Cache::get("datacite_import:{$importId}")['status'])
+            ->toBe('completed');
+    });
+
+    it('logs a portal failure and completes a single import through the legacy fallback', function () {
+        Log::spy();
+
+        $doi = '10.5880/icdp.5065.001';
+        $doiRecord = [
+            'id' => $doi,
+            'attributes' => [
+                'doi' => $doi,
+                'titles' => [['title' => 'SDDB unavailable portal fallback']],
+                'publicationYear' => 2026,
+                'types' => ['resourceTypeGeneral' => 'Dataset'],
+            ],
+        ];
+
+        $this->importService->shouldReceive('fetchSingleDoi')->once()->with($doi)->andReturn($doiRecord);
+        $this->portalService
+            ->shouldReceive('datacenterNamesForDoi')
+            ->once()
+            ->with($doi)
+            ->andThrow(new RuntimeException('Portal unavailable'));
+        $this->datacenterLookupService
+            ->shouldReceive('syncDatacenters')
+            ->once()
+            ->andReturnNull();
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->andReturnUsing(fn (): Resource => Resource::factory()->create(['doi' => $doi]));
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, $doi))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}"))
+            ->toMatchArray([
+                'status' => 'completed',
+                'imported' => 1,
+                'failed' => 0,
+            ]);
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->with(
+                'GFZ Data Services portal lookup failed during single DOI import; using legacy datacenter fallback.',
+                [
+                    'import_id' => $importId,
+                    'doi' => $doi,
+                    'error' => 'Portal unavailable',
+                ],
+            );
+    });
+
+    it('keeps an existing resource datacenter unchanged during a repeated single DOI import', function () {
+        $doi = '10.5880/icdp.5069.001';
+        $existingDatacenter = Datacenter::query()->create(['name' => 'Existing manual assignment']);
+        $existingResource = Resource::factory()->create([
+            'doi' => $doi,
+            'datacenter_id' => $existingDatacenter->id,
+        ]);
+        $doiRecord = [
+            'id' => $doi,
+            'attributes' => [
+                'doi' => $doi,
+                'titles' => [['title' => 'Existing SDDB resource']],
+            ],
+        ];
+
+        $this->importService->shouldReceive('fetchSingleDoi')->once()->with($doi)->andReturn($doiRecord);
+        $this->portalService
+            ->shouldReceive('datacenterNamesForDoi')
+            ->once()
+            ->with($doi)
+            ->andReturn([LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER]);
+        $this->transformer->shouldReceive('transform')->never();
+        $this->datacenterLookupService->shouldReceive('syncDatacenters')->never();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, $doi))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}"))
+            ->toMatchArray([
+                'status' => 'completed',
+                'imported' => 0,
+                'skipped' => 1,
+            ])
+            ->and($existingResource->fresh()->datacenter_id)
+            ->toBe($existingDatacenter->id);
     });
 
     it('assigns canonical GEOFON datacenters during single DataCite imports', function (string $doi, string $expectedDatacenter): void {

--- a/tests/pest/Unit/Services/GfzDataServicesPortalServiceTest.php
+++ b/tests/pest/Unit/Services/GfzDataServicesPortalServiceTest.php
@@ -131,6 +131,108 @@ it('paginates resources and keeps all portal datacenter assignments', function (
     });
 });
 
+it('resolves all canonical portal datacenters for one normalized DOI', function (): void {
+    Http::fake([
+        'portal.example.test/*' => Http::response([
+            'response' => [
+                'numFound' => 3,
+                'docs' => [
+                    [
+                        'doi' => '10.5880/ICDP.5069.001',
+                        'datacentre_facet' => [
+                            'DOIDB.SDDB - SDDB Scientific Drilling Database',
+                            'DOIDB.GFZ - GFZ German Research Centre for Geosciences',
+                            'DOIDB.SDDB - SDDB Scientific Drilling Database',
+                        ],
+                    ],
+                    [
+                        'doi' => 'https://doi.org/10.5880/ICDP.5069.001',
+                        'datacentre_facet' => 'DOIDB.SDDB - SDDB Scientific Drilling Database',
+                    ],
+                    [
+                        'doi' => '10.5880/ICDP.5068.002',
+                        'datacentre_facet' => 'DOIDB.OTHER - Other Datacenter',
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+
+    expect(app(GfzDataServicesPortalService::class)
+        ->datacenterNamesForDoi('https://doi.org/10.5880/ICDP.5069.001'))
+        ->toBe([
+            'SDDB Scientific Drilling Database',
+            'GFZ German Research Centre for Geosciences',
+        ]);
+
+    Http::assertSent(function (Request $request): bool {
+        parse_str((string) $request->data()['query'], $query);
+
+        return $query['q'] === 'doi:10.5880\\/icdp.5069.001'
+            && $query['rows'] === '10'
+            && $query['fl'] === 'doi,datacentre_facet'
+            && $query['fq'] === '-type:text';
+    });
+});
+
+it('returns no datacenters for invalid absent or facet-free DOI records', function (string $doi, array $response): void {
+    Http::fake([
+        'portal.example.test/*' => Http::response($response),
+    ]);
+
+    expect(app(GfzDataServicesPortalService::class)->datacenterNamesForDoi($doi))->toBe([]);
+
+    if ($doi === 'not-a-doi') {
+        Http::assertNothingSent();
+    } else {
+        Http::assertSentCount(1);
+    }
+})->with([
+    'invalid DOI without a request' => [
+        'not-a-doi',
+        [],
+    ],
+    'absent DOI' => [
+        '10.5880/missing',
+        [
+            'response' => [
+                'numFound' => 0,
+                'docs' => [],
+            ],
+        ],
+    ],
+    'matching DOI without a datacenter facet' => [
+        '10.5880/facet-free',
+        [
+            'response' => [
+                'numFound' => 1,
+                'docs' => [
+                    ['doi' => '10.5880/FACET-FREE'],
+                ],
+            ],
+        ],
+    ],
+]);
+
+it('rejects malformed DOI lookup responses', function (array $response, string $message): void {
+    Http::fake([
+        'portal.example.test/*' => Http::response($response),
+    ]);
+
+    expect(fn () => app(GfzDataServicesPortalService::class)
+        ->datacenterNamesForDoi('10.5880/icdp.5069.001'))
+        ->toThrow(RuntimeException::class, $message);
+})->with([
+    'missing response object' => [
+        ['unexpected' => []],
+        'invalid DOI response',
+    ],
+    'incomplete response object' => [
+        ['response' => ['numFound' => 1]],
+        'DOI response is incomplete',
+    ],
+]);
+
 it('rejects a datacenter id that is not in the portal list', function (): void {
     Http::fake([
         'portal.example.test/*' => Http::response(portalFacetResponse([

--- a/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyMetaworksDatacenterLookupServiceTest.php
@@ -185,6 +185,22 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
             '10.1594/GFZ.SDDB.1003',
             [LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER],
         ],
+        'SDDB ICDP 5069 DOI' => [
+            '10.5880/icdp.5069.001',
+            [LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER],
+        ],
+        'SDDB ICDP 5068 DOI' => [
+            '10.5880/icdp.5068.002',
+            [LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER],
+        ],
+        'SDDB ICDP 5065 DOI' => [
+            '10.5880/icdp.5065.001',
+            [LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER],
+        ],
+        'non-SDDB DOI with a similar ICDPX prefix' => [
+            '10.5880/ICDPX.5069.001',
+            [LegacyMetaworksDatacenterLookupService::DEFAULT_DATACENTER],
+        ],
         'SFB806 DOI' => [
             '10.5880/SFB806.2024.001',
             [LegacyMetaworksDatacenterLookupService::SFB806_DATACENTER],
@@ -248,6 +264,10 @@ describe('LegacyMetaworksDatacenterLookupService', function () {
         'GEOFON event doi scheme' => [
             'doi:10.1594/GFZ.GEOFON.GFZ2009GIBB',
             LegacyMetaworksDatacenterLookupService::GEOFON_EVENTS_DATACENTER,
+        ],
+        'mixed-case SDDB ICDP DOI URL' => [
+            'https://doi.org/10.5880/ICDP.5069.001',
+            LegacyMetaworksDatacenterLookupService::SDDB_DATACENTER,
         ],
     ]);
 


### PR DESCRIPTION
This pull request improves the accuracy of datacenter assignment for single DOI imports, especially for ICDP legacy DOIs, by integrating authoritative lookups from the GFZ Data Services portal. If the portal is unavailable or has no assignment, a new dedicated rule ensures correct fallback to the SDDB Scientific Drilling Database. The changes also add robust error handling, expand test coverage, and update documentation accordingly.

**Datacenter assignment improvements:**

* Single DOI imports now query the GFZ Data Services portal to determine the authoritative datacenter assignment, ensuring ICDP legacy DOIs are assigned to the SDDB Scientific Drilling Database when appropriate. If the portal lookup fails or returns no assignment, a dedicated ICDP rule provides a correct fallback, replacing the previous generic GFZ fallback. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R756-R764) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R798-R817) [[3]](diffhunk://#diff-ba00990ee13bbe86eff291c7ed4e4f3eb3f2afe2fff9a01c9426b0f6264150aeR59-R109) [[4]](diffhunk://#diff-6871331b5e968f086cc56f2bf594987501a753a17e13c45fd4f5b78e2dec5c20R147-R150)

**GFZ Data Services portal integration:**

* Added the `datacenterNamesForDoi` method to `GfzDataServicesPortalService`, which queries the portal, normalizes DOIs, and extracts canonical datacenter names. Also introduced robust error handling and Solr query escaping. [[1]](diffhunk://#diff-ba00990ee13bbe86eff291c7ed4e4f3eb3f2afe2fff9a01c9426b0f6264150aeR59-R109) [[2]](diffhunk://#diff-ba00990ee13bbe86eff291c7ed4e4f3eb3f2afe2fff9a01c9426b0f6264150aeR363-R371)

**Testing enhancements:**

* Expanded and updated feature and unit tests to verify the new portal-based datacenter assignment logic, fallback mechanisms, error logging, and to ensure that existing resource assignments remain unchanged. [[1]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR20) [[2]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR31) [[3]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR126-R133) [[4]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR833-R1008) [[5]](diffhunk://#diff-911763290551fa45ea43e964d9ccae31eebd521e45ab2b27d0bbada618728adeR134-R235) [[6]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R188-R203) [[7]](diffhunk://#diff-e4e2e8e990becb3fcfadf25fd75498684ed959e98f68e4e5abab6a7293911343R268-R271)

**Documentation:**

* Updated the changelog to describe the improved SDDB datacenter assignment for ICDP legacy imports and clarify that existing resources remain unchanged.