### PR TITLE
Feature: Datacenter Filter for Resources List

### DIFF
--- a/app/Http/Controllers/ResourceFilterController.php
+++ b/app/Http/Controllers/ResourceFilterController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Resource\LoadMoreResourcesRequest;
 use App\Http\Resources\FilterOptionsResource;
 use App\Http\Resources\ResourceListItemResource;
+use App\Models\Datacenter;
 use App\Models\Resource;
 use App\Models\ResourceType;
 use App\Models\User;
@@ -63,6 +64,7 @@ class ResourceFilterController extends Controller
     {
         return (new FilterOptionsResource([
             'resource_types' => $this->loadResourceTypes(),
+            'datacenters' => $this->loadDatacenters(),
             'curators' => $this->loadCurators(),
             'year_range' => $this->loadYearRange(),
             // Single source of truth: the same allow-list that
@@ -72,6 +74,37 @@ class ResourceFilterController extends Controller
             // trait (PHPStan rejects `Trait::CONST` access).
             'statuses' => LoadMoreResourcesRequest::ALLOWED_STATUSES,
         ]))->response();
+    }
+
+    /**
+     * Return datacenters assigned to at least one non-IGSN resource.
+     *
+     * @return array<int, array{id:int, name:string}>
+     */
+    private function loadDatacenters(): array
+    {
+        try {
+            return Datacenter::query()
+                ->whereHas('resources', function ($resourceQuery): void {
+                    $resourceQuery->whereDoesntHave('resourceType', function ($typeQuery): void {
+                        $typeQuery->where('slug', 'physical-object');
+                    });
+                })
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(fn (Datacenter $datacenter): array => [
+                    'id' => $datacenter->id,
+                    'name' => $datacenter->name,
+                ])
+                ->all();
+        } catch (Throwable $e) {
+            Log::warning('Failed to load datacenter filter options', [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
     }
 
     /**

--- a/app/Http/Requests/Resource/Concerns/ResolvesResourceListing.php
+++ b/app/Http/Requests/Resource/Concerns/ResolvesResourceListing.php
@@ -89,6 +89,9 @@ trait ResolvesResourceListing
             'status' => ['nullable', 'array'],
             'status.*' => ['nullable', 'string', Rule::in(self::ALLOWED_STATUSES)],
 
+            'datacenter_id' => ['nullable', 'integer', 'exists:datacenters,id', 'prohibited_if:without_datacenter,1'],
+            'without_datacenter' => ['nullable', 'boolean'],
+
             'year_from' => ['nullable', 'integer', 'between:1000,9999'],
             'year_to' => ['nullable', 'integer', 'between:1000,9999'],
 
@@ -148,6 +151,15 @@ trait ResolvesResourceListing
         $filters = $this->collectMultiValueFilter($filters, 'resource_type');
         $filters = $this->collectMultiValueFilter($filters, 'curator');
         $filters = $this->collectMultiValueFilter($filters, 'status');
+
+        if ($this->boolean('without_datacenter')) {
+            $filters['without_datacenter'] = true;
+        } else {
+            $datacenterId = $this->input('datacenter_id');
+            if ($datacenterId !== null && $datacenterId !== '' && is_numeric($datacenterId)) {
+                $filters['datacenter_id'] = (int) $datacenterId;
+            }
+        }
 
         $yearFrom = $this->input('year_from');
         if ($yearFrom !== null && $yearFrom !== '' && is_numeric($yearFrom)) {

--- a/app/Http/Resources/FilterOptionsResource.php
+++ b/app/Http/Resources/FilterOptionsResource.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *
  * Wraps a plain associative array with keys:
  *  - resource_types: list<array{name: string, slug: string}>
+ *  - datacenters: list<array{id: int, name: string}>
  *  - curators: list<string>
  *  - year_range: array{min: int, max: int}
  *  - statuses: list<string>
@@ -43,6 +44,7 @@ final class FilterOptionsResource extends JsonResource
 
         return [
             'resource_types' => $payload['resource_types'] ?? [],
+            'datacenters' => $payload['datacenters'] ?? [],
             'curators' => $payload['curators'] ?? [],
             'year_range' => $payload['year_range'] ?? ['min' => $currentYear, 'max' => $currentYear],
             'statuses' => $payload['statuses'] ?? [],

--- a/app/Services/Resources/ResourceQueryBuilder.php
+++ b/app/Services/Resources/ResourceQueryBuilder.php
@@ -163,6 +163,12 @@ final readonly class ResourceQueryBuilder
             });
         }
 
+        if (! empty($filters['without_datacenter'])) {
+            $query->whereNull('datacenter_id');
+        } elseif (isset($filters['datacenter_id'])) {
+            $query->where('datacenter_id', $filters['datacenter_id']);
+        }
+
         // Status filter - keep semantics in sync with Resource::publicStatus():
         // - draft: missing mandatory fields (type, year, creators, rights, main title or abstract)
         // - curation: complete + no DOI OR (has DOI but no landing page)

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-08-20",
         "features": [
             {
+                "title": "Resources List Datacenter Filter",
+                "description": "The Resources list now includes a Datacenter dropdown for showing resources assigned to one selected datacenter. Its options include only datacenters used by regular resources, while the new \"Without Datacenter\" choice finds resources that still need an assignment. The filter remains active while sorting or loading more results and can be removed from the active filter badges."
+            },
+            {
                 "title": "Bulk Resource Review Invitations",
                 "description": "Admins, Group Leaders, and Curators can now send tokenized landing-page review links directly from the Resources bulk Actions menu. The action accepts up to 100 selected resources when every item is in Review and has a preview link. Each ContactPerson contributor with a valid email address receives a separate invitation per resource, with the GFZ Data Services contact address in Cc and Reply-To. Invalid recipients or resources without a valid ContactPerson are reported as partial failures while other eligible invitations continue to be queued."
             },

--- a/resources/js/components/resources-filters.tsx
+++ b/resources/js/components/resources-filters.tsx
@@ -64,6 +64,9 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
 
     // Local states for Select components to ensure proper synchronization
     const [resourceTypeValue, setResourceTypeValue] = useState(filters.resource_type?.[0] || 'all');
+    const [datacenterValue, setDatacenterValue] = useState(
+        filters.without_datacenter ? 'without' : filters.datacenter_id ? String(filters.datacenter_id) : 'all',
+    );
     const [statusValue, setStatusValue] = useState(filters.status?.[0] || 'all');
     const [curatorValue, setCuratorValue] = useState(filters.curator?.[0] || 'all');
     const {
@@ -86,9 +89,10 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
     // Sync Select values when filters change externally
     useEffect(() => {
         setResourceTypeValue(filters.resource_type?.[0] || 'all');
+        setDatacenterValue(filters.without_datacenter ? 'without' : filters.datacenter_id ? String(filters.datacenter_id) : 'all');
         setStatusValue(filters.status?.[0] || 'all');
         setCuratorValue(filters.curator?.[0] || 'all');
-    }, [filters.resource_type, filters.status, filters.curator]);
+    }, [filters.resource_type, filters.datacenter_id, filters.without_datacenter, filters.status, filters.curator]);
 
     // Debounced search handler
     const handleSearchChange = useCallback(
@@ -177,6 +181,23 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
         [filters, onFilterChange],
     );
 
+    const handleDatacenterChange = useCallback(
+        (value: string) => {
+            const newFilters = { ...filters };
+            delete newFilters.datacenter_id;
+            delete newFilters.without_datacenter;
+
+            if (value === 'without') {
+                newFilters.without_datacenter = true;
+            } else if (value && value !== 'all') {
+                newFilters.datacenter_id = Number(value);
+            }
+
+            onFilterChange(newFilters);
+        },
+        [filters, onFilterChange],
+    );
+
     const handleCuratorChange = useCallback(
         (value: string) => {
             const newFilters = { ...filters };
@@ -248,6 +269,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                 resource_type: 'Type',
                 status: 'Status',
                 curator: 'Curator',
+                datacenter_id: 'Datacenter',
                 search: 'Search',
                 year_from: 'Year from',
                 year_to: 'Year to',
@@ -269,6 +291,15 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                     return `${label}: ${names.join(', ')}`;
                 }
                 return `${label}: ${value.join(', ')}`;
+            }
+
+            if (key === 'datacenter_id' && filterOptions?.datacenters) {
+                const datacenter = filterOptions.datacenters.find((option) => option.id === value);
+                return `${label}: ${datacenter?.name || String(value)}`;
+            }
+
+            if (key === 'without_datacenter') {
+                return 'Datacenter: Without Datacenter';
             }
 
             return `${label}: ${String(value)}`;
@@ -305,6 +336,22 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                         {filterOptions?.resource_types?.map((type) => (
                             <SelectItem key={type.slug} value={type.slug}>
                                 {type.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+
+                {/* Datacenter Select */}
+                <Select value={datacenterValue} onValueChange={handleDatacenterChange} disabled={isLoading || !filterOptions}>
+                    <SelectTrigger size="sm" className="w-full sm:w-[180px]" aria-label="Filter by datacenter">
+                        <SelectValue placeholder="Datacenter" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="all">All Datacenters</SelectItem>
+                        <SelectItem value="without">Without Datacenter</SelectItem>
+                        {filterOptions?.datacenters?.map((datacenter) => (
+                            <SelectItem key={datacenter.id} value={String(datacenter.id)}>
+                                {datacenter.name}
                             </SelectItem>
                         ))}
                     </SelectContent>
@@ -413,13 +460,7 @@ export function ResourcesFilters({ filters, onFilterChange, filterOptions, resul
                                     Apply
                                 </Button>
                                 {hasYearRangeInput && (
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="sm"
-                                        onClick={clearYearRange}
-                                        disabled={isLoading}
-                                    >
+                                    <Button type="button" variant="ghost" size="sm" onClick={clearYearRange} disabled={isLoading}>
                                         <X className="mr-1 h-3 w-3" />
                                         Clear
                                     </Button>

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -2045,6 +2045,16 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             individually with the checkbox in the leftmost column, or use the header checkbox to select all currently visible
                             resources. The bulk actions toolbar sits directly below the filter row and shows how many resources are selected.
                         </p>
+
+                        <h4>Filtering by Datacenter</h4>
+                        <p>
+                            Use the <strong>Datacenter</strong> dropdown to show resources assigned to one datacenter. The dropdown lists only
+                            datacenters assigned to at least one regular resource; datacenters used exclusively by physical-sample IGSNs and unused
+                            datacenters are omitted. Choose <strong>Without Datacenter</strong> to find resources that still need a datacenter
+                            assignment, or <strong>All Datacenters</strong> to remove the filter. The selected value appears with the other active
+                            filter badges and remains applied when you change the sorting or load more results.
+                        </p>
+
                         <p>
                             Click anywhere else on a resource row to open that resource in the Data Editor in a new browser tab. Existing row controls
                             keep their own behavior: the checkbox selects the row, and a clickable published status badge opens and copies the DOI.

--- a/resources/js/pages/resources.tsx
+++ b/resources/js/pages/resources.tsx
@@ -633,6 +633,21 @@ const formatValue = (key: string, value: unknown): string => {
     return '-';
 };
 
+const appendResourceFilters = (params: URLSearchParams, filters: ResourceFilterState): void => {
+    Object.entries(filters).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === '') {
+            return;
+        }
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => params.append(`${key}[]`, String(item)));
+            return;
+        }
+
+        params.append(key, typeof value === 'boolean' ? (value ? '1' : '0') : String(value));
+    });
+};
+
 const breadcrumbs: BreadcrumbItem[] = [
     {
         title: 'Resources',
@@ -720,16 +735,7 @@ function ResourcesPage({
                 sort_direction: sortState.direction,
             });
 
-            // Add filters
-            Object.entries(filters).forEach(([key, value]) => {
-                if (value !== undefined && value !== null && value !== '') {
-                    if (Array.isArray(value)) {
-                        value.forEach((v) => params.append(`${key}[]`, String(v)));
-                    } else {
-                        params.append(key, String(value));
-                    }
-                }
-            });
+            appendResourceFilters(params, filters);
 
             const response = await axios.get('/resources/load-more', { params });
 
@@ -804,16 +810,7 @@ function ResourcesPage({
                 sort_direction: newState.direction,
             });
 
-            // Add current filters
-            Object.entries(filters).forEach(([filterKey, value]) => {
-                if (value !== undefined && value !== null && value !== '') {
-                    if (Array.isArray(value)) {
-                        value.forEach((v) => params.append(`${filterKey}[]`, String(v)));
-                    } else {
-                        params.append(filterKey, String(value));
-                    }
-                }
-            });
+            appendResourceFilters(params, filters);
 
             // Navigate to same page with new query params
             router.visit(`/resources?${params.toString()}`, {
@@ -834,16 +831,7 @@ function ResourcesPage({
                 sort_direction: sortState.direction,
             });
 
-            // Add filters to params
-            Object.entries(newFilters).forEach(([key, value]) => {
-                if (value !== undefined && value !== null && value !== '') {
-                    if (Array.isArray(value)) {
-                        value.forEach((v) => params.append(`${key}[]`, String(v)));
-                    } else {
-                        params.append(key, String(value));
-                    }
-                }
-            });
+            appendResourceFilters(params, newFilters);
 
             // Navigate to same page with new query params
             router.visit(`/resources?${params.toString()}`, {

--- a/resources/js/types/resources.ts
+++ b/resources/js/types/resources.ts
@@ -23,6 +23,8 @@ export interface ResourceFilterState {
     year_to?: number;
     curator?: string[];
     status?: string[];
+    datacenter_id?: number;
+    without_datacenter?: boolean;
     created_from?: string;
     created_to?: string;
     updated_from?: string;
@@ -34,6 +36,7 @@ export interface ResourceFilterState {
  */
 export interface ResourceFilterOptions {
     resource_types: Array<{ name: string; slug: string }>;
+    datacenters: Array<{ id: number; name: string }>;
     curators: string[];
     year_range: {
         min: number;

--- a/resources/js/utils/filter-parser.ts
+++ b/resources/js/utils/filter-parser.ts
@@ -150,7 +150,20 @@ function parseFiltersFromUrl<T extends ResourceFilterState | FilterState>(search
  * ```
  */
 export function parseResourceFiltersFromUrl(search: string): ResourceFilterState {
-    return parseFiltersFromUrl<ResourceFilterState>(search);
+    const filters = parseFiltersFromUrl<ResourceFilterState>(search);
+    const params = new URLSearchParams(search);
+    const datacenterId = parsePositiveInt(params, 'datacenter_id');
+
+    if (datacenterId !== undefined) {
+        filters.datacenter_id = datacenterId;
+    }
+
+    if (params.get('without_datacenter') === '1') {
+        filters.without_datacenter = true;
+        delete filters.datacenter_id;
+    }
+
+    return filters;
 }
 
 /**

--- a/tests/pest/Feature/Resources/ResourceControllerFilterTest.php
+++ b/tests/pest/Feature/Resources/ResourceControllerFilterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\AccessLevel;
+use App\Models\Datacenter;
 use App\Models\Description;
 use App\Models\DescriptionType;
 use App\Models\LandingPage;
@@ -310,6 +311,97 @@ describe('Status Filter', function (): void {
                 ->component('resources')
                 ->has('resources', 2)
             );
+    });
+});
+
+describe('Datacenter Filter', function (): void {
+    it('filters resources by one datacenter', function (): void {
+        $resourceType = ResourceType::factory()->create(['slug' => 'dataset']);
+        $language = Language::factory()->create();
+        $selectedDatacenter = Datacenter::factory()->create(['name' => 'Selected Datacenter']);
+        $otherDatacenter = Datacenter::factory()->create(['name' => 'Other Datacenter']);
+
+        $selectedResource = Resource::factory()->create([
+            'resource_type_id' => $resourceType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => $selectedDatacenter->id,
+        ]);
+        Resource::factory()->create([
+            'resource_type_id' => $resourceType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => $otherDatacenter->id,
+        ]);
+        Resource::factory()->create([
+            'resource_type_id' => $resourceType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => null,
+        ]);
+
+        get(route('resources', ['datacenter_id' => $selectedDatacenter->id]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('resources')
+                ->has('resources', 1)
+                ->where('resources.0.id', $selectedResource->id)
+            );
+    });
+
+    it('filters resources without a datacenter', function (): void {
+        $resourceType = ResourceType::factory()->create(['slug' => 'dataset']);
+        $language = Language::factory()->create();
+        $datacenter = Datacenter::factory()->create();
+
+        Resource::factory()->create([
+            'resource_type_id' => $resourceType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => $datacenter->id,
+        ]);
+        $resourceWithoutDatacenter = Resource::factory()->create([
+            'resource_type_id' => $resourceType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => null,
+        ]);
+
+        get(route('resources', ['without_datacenter' => 1]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('resources')
+                ->has('resources', 1)
+                ->where('resources.0.id', $resourceWithoutDatacenter->id)
+            );
+    });
+
+    it('only exposes datacenters used by non-IGSN resources in filter options', function (): void {
+        $datasetType = ResourceType::factory()->create(['slug' => 'dataset']);
+        $physicalObjectType = ResourceType::factory()->create(['slug' => 'physical-object']);
+        $language = Language::factory()->create();
+        $alphaDatacenter = Datacenter::factory()->create(['name' => 'Alpha Datacenter']);
+        $betaDatacenter = Datacenter::factory()->create(['name' => 'Beta Datacenter']);
+        $igsnOnlyDatacenter = Datacenter::factory()->create(['name' => 'IGSN Only Datacenter']);
+        Datacenter::factory()->create(['name' => 'Unused Datacenter']);
+
+        Resource::factory()->create([
+            'resource_type_id' => $datasetType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => $betaDatacenter->id,
+        ]);
+        Resource::factory()->create([
+            'resource_type_id' => $datasetType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => $alphaDatacenter->id,
+        ]);
+        Resource::factory()->create([
+            'resource_type_id' => $physicalObjectType->id,
+            'language_id' => $language->id,
+            'datacenter_id' => $igsnOnlyDatacenter->id,
+        ]);
+
+        get(route('resources.filter-options'))
+            ->assertOk()
+            ->assertJsonPath('datacenters', [
+                ['id' => $alphaDatacenter->id, 'name' => 'Alpha Datacenter'],
+                ['id' => $betaDatacenter->id, 'name' => 'Beta Datacenter'],
+            ]);
     });
 });
 

--- a/tests/pest/Unit/Http/Requests/Resource/ResourceListingRequestsTest.php
+++ b/tests/pest/Unit/Http/Requests/Resource/ResourceListingRequestsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Requests\Resource\IndexResourcesRequest;
 use App\Http\Requests\Resource\LoadMoreResourcesRequest;
+use App\Models\Datacenter;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Route;
@@ -128,6 +129,40 @@ it('accepts a single status string and normalises it to an array filter', functi
         ->getJson('/_test/index-resources?status=draft')
         ->assertOk()
         ->assertJsonPath('filters.status', ['draft']);
+});
+
+it('extracts a datacenter id filter', function (): void {
+    $user = User::factory()->create();
+    $datacenter = Datacenter::factory()->create();
+
+    $this->actingAs($user)
+        ->getJson('/_test/index-resources?datacenter_id='.$datacenter->id)
+        ->assertOk()
+        ->assertJsonPath('filters.datacenter_id', $datacenter->id);
+});
+
+it('extracts the without datacenter filter', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->getJson('/_test/index-resources?without_datacenter=1')
+        ->assertOk()
+        ->assertJsonPath('filters.without_datacenter', true);
+});
+
+it('rejects unknown datacenters and mutually exclusive datacenter filters', function (): void {
+    $user = User::factory()->create();
+    $datacenter = Datacenter::factory()->create();
+
+    $this->actingAs($user)
+        ->getJson('/_test/index-resources?datacenter_id=999999')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['datacenter_id']);
+
+    $this->actingAs($user)
+        ->getJson('/_test/index-resources?datacenter_id='.$datacenter->id.'&without_datacenter=1')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['datacenter_id']);
 });
 
 it('extracts year_from / year_to as integers and trims search', function (): void {

--- a/tests/vitest/components/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/__tests__/resources-filters.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { render, screen } from '@tests/vitest/utils/render';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ResourcesFilters } from '@/components/resources-filters';

--- a/tests/vitest/components/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/__tests__/resources-filters.test.tsx
@@ -10,6 +10,10 @@ const defaultFilterOptions: ResourceFilterOptions = {
         { slug: 'dataset', name: 'Dataset' },
         { slug: 'text', name: 'Text' },
     ],
+    datacenters: [
+        { id: 7, name: 'Alpha Datacenter' },
+        { id: 9, name: 'Beta Datacenter' },
+    ],
     statuses: ['draft', 'registered', 'findable'],
     curators: ['Alice', 'Bob'],
     year_range: { min: 2020, max: 2025 },
@@ -42,8 +46,65 @@ describe('ResourcesFilters', () => {
         );
 
         expect(screen.getByLabelText('Filter by resource type')).toBeInTheDocument();
+        expect(screen.getByLabelText('Filter by datacenter')).toBeInTheDocument();
         expect(screen.getByLabelText('Filter by publication status')).toBeInTheDocument();
         expect(screen.getByLabelText('Filter by curator')).toBeInTheDocument();
+    });
+
+    it('filters by a single datacenter', async () => {
+        const user = userEvent.setup();
+        const onFilterChange = vi.fn();
+
+        render(
+            <ResourcesFilters
+                filters={{}}
+                onFilterChange={onFilterChange}
+                filterOptions={defaultFilterOptions}
+                resultCount={10}
+                totalCount={10}
+            />,
+        );
+
+        await user.click(screen.getByLabelText('Filter by datacenter'));
+        await user.click(screen.getByText('Alpha Datacenter'));
+
+        expect(onFilterChange).toHaveBeenCalledWith({ datacenter_id: 7 });
+    });
+
+    it('offers and labels resources without a datacenter', async () => {
+        const user = userEvent.setup();
+        const onFilterChange = vi.fn();
+
+        render(
+            <ResourcesFilters
+                filters={{ without_datacenter: true }}
+                onFilterChange={onFilterChange}
+                filterOptions={defaultFilterOptions}
+                resultCount={2}
+                totalCount={10}
+            />,
+        );
+
+        expect(screen.getByText('Datacenter: Without Datacenter')).toBeInTheDocument();
+
+        await user.click(screen.getByLabelText('Filter by datacenter'));
+        await user.click(screen.getByText('All Datacenters'));
+
+        expect(onFilterChange).toHaveBeenCalledWith({});
+    });
+
+    it('shows the selected datacenter name in the active filter badge', () => {
+        render(
+            <ResourcesFilters
+                filters={{ datacenter_id: 9 }}
+                onFilterChange={vi.fn()}
+                filterOptions={defaultFilterOptions}
+                resultCount={4}
+                totalCount={10}
+            />,
+        );
+
+        expect(screen.getByText('Datacenter: Beta Datacenter')).toBeInTheDocument();
     });
 
     it('shows total count when not filtered', () => {

--- a/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
+++ b/tests/vitest/components/filters/__tests__/resources-filters.test.tsx
@@ -43,6 +43,10 @@ describe('ResourcesFilters Component', () => {
                 { slug: 'dataset', name: 'Dataset' },
                 { slug: 'collection', name: 'Collection' },
             ],
+            datacenters: [
+                { id: 1, name: 'Alpha Datacenter' },
+                { id: 2, name: 'Beta Datacenter' },
+            ],
             statuses: ['curation', 'review', 'published'],
             curators: ['Alice', 'Bob'],
             year_range: { min: 2000, max: 2025 },

--- a/tests/vitest/test-helpers/factories.ts
+++ b/tests/vitest/test-helpers/factories.ts
@@ -151,6 +151,9 @@ export function createMockResourceFilterOptions(overrides?: Partial<ResourceFilt
             { name: 'Software', slug: 'software' },
             { name: 'Text', slug: 'text' },
         ],
+        datacenters: [
+            { id: 1, name: 'GFZ German Research Centre for Geosciences' },
+        ],
         curators: ['Admin User', 'Test Curator'],
         year_range: { min: 2020, max: 2026 },
         statuses: ['draft', 'registered', 'findable'],

--- a/tests/vitest/utils/filter-parser.test.ts
+++ b/tests/vitest/utils/filter-parser.test.ts
@@ -50,6 +50,27 @@ describe('parseResourceFiltersFromUrl', () => {
         });
     });
 
+    it('should parse a datacenter id', () => {
+        const result = parseResourceFiltersFromUrl('?datacenter_id=12');
+        expect(result).toEqual({
+            datacenter_id: 12,
+        });
+    });
+
+    it('should parse the without datacenter option', () => {
+        const result = parseResourceFiltersFromUrl('?without_datacenter=1');
+        expect(result).toEqual({
+            without_datacenter: true,
+        });
+    });
+
+    it('should prefer the without datacenter option over a datacenter id', () => {
+        const result = parseResourceFiltersFromUrl('?datacenter_id=12&without_datacenter=1');
+        expect(result).toEqual({
+            without_datacenter: true,
+        });
+    });
+
     it('should parse year_from as number', () => {
         const result = parseResourceFiltersFromUrl('?year_from=2020');
         expect(result).toEqual({


### PR DESCRIPTION
This pull request adds a new Datacenter filter to the Resources list, allowing users to filter resources by their assigned datacenter or to find resources without a datacenter assignment. The filter integrates with both the backend and frontend, ensuring options are accurate and the filter state persists across sorting and pagination. Documentation and the changelog have also been updated to reflect this feature.

**Backend changes: Datacenter filter support**
- Added a new `datacenter_id` and `without_datacenter` filter to resource listing and validation, including extraction and application logic for these filters in the backend (`ResolvesResourceListing.php`, `ResourceQueryBuilder.php`). [[1]](diffhunk://#diff-ca64321545a8ecd2a9f2db2edd739b747d3f3ace87c8e07ea3877311e7461932R92-R94) [[2]](diffhunk://#diff-ca64321545a8ecd2a9f2db2edd739b747d3f3ace87c8e07ea3877311e7461932R155-R163) [[3]](diffhunk://#diff-101164254a7ac882bec9382987b506e070e09b7aa9d72736dc7049c7cab53fa2R166-R171)
- Implemented `loadDatacenters()` in `ResourceFilterController.php` to provide a list of datacenters assigned to at least one non-IGSN resource for the filter options (`ResourceFilterController.php`). [[1]](diffhunk://#diff-703c30b61ed1a57654d308bc05aaab3014e0d5708c6ce489c5cf7de1b14bcea8R10) [[2]](diffhunk://#diff-703c30b61ed1a57654d308bc05aaab3014e0d5708c6ce489c5cf7de1b14bcea8R67) [[3]](diffhunk://#diff-703c30b61ed1a57654d308bc05aaab3014e0d5708c6ce489c5cf7de1b14bcea8R79-R109)

**Frontend changes: Filter UI and state management**
- Added a Datacenter dropdown to the resources filter UI, with options for all, specific datacenters, and "Without Datacenter". Updated filter badge rendering and filter state handling to support the new filter (`resources-filters.tsx`). [[1]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R67-R69) [[2]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R92-R95) [[3]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R184-R200) [[4]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R272) [[5]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R296-R304) [[6]](diffhunk://#diff-1f6a7bee61dd056f18864760c9d20f3605619cf328c9ee78c81cfa1e48dd6cd2R344-R359)
- Updated filter state types and filter options to include datacenter fields (`resources.ts`, `types/resources.ts`). [[1]](diffhunk://#diff-4ab2fb32555d5e2d9a45e8cda602cc15d1b12518d1552868ff3ac83b930888a7R26-R27) [[2]](diffhunk://#diff-4ab2fb32555d5e2d9a45e8cda602cc15d1b12518d1552868ff3ac83b930888a7R39)
- Improved filter query parameter handling and parsing to support the new filters (`resources.tsx`, `filter-parser.ts`). [[1]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934R636-R650) [[2]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L723-R738) [[3]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L807-R813) [[4]](diffhunk://#diff-61b7f847c80b175b7b00b91b62e686a8223bba3bcc5db5e6d0f74be2fb012934L837-R834) [[5]](diffhunk://#diff-b9175e3118f1193039364cc18d3549225239af6c29a2e25900f0670c3cf3ba81L153-R166)

**Documentation and changelog**
- Added documentation for the Datacenter filter to the resources page and updated the changelog with a feature entry (`docs.tsx`, `changelog.json`). [[1]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR2048-R2057) [[2]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR6-R9)