### PR TITLE
Feature: DataCite Sync for IGSNs after Import

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -124,7 +124,8 @@ ORCID_SEARCH_URL=https://pub.orcid.org/v3.0/search
 # =============================================================================
 # DataCite API Credentials for DOI management
 # =============================================================================
-# Always use test mode in development!
+# Always use test mode in development. Eligible imports still create their local
+# landing pages, but no import-triggered metadata is written to DataCite.
 DATACITE_TEST_MODE=true
 DATACITE_TEST_USERNAME=
 DATACITE_TEST_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,10 @@ ORCID_SEARCH_URL=https://pub.orcid.org/v3.0/search
 # DataCite API Credentials for DOI management
 # USERNAME should be your Repository ID (e.g., "gfz.ernie" or "datacite.datacite")
 # PASSWORD is your repository password from DataCite Fabrica
-# Test credentials are completely separate from production credentials
+# Test credentials are completely separate from production credentials.
+# Import behavior: true creates/publishes eligible landing pages locally without
+# any DataCite write; false also updates the production DOI metadata and URL.
+# DATACITE_TEST_MODE is the only switch for automatic post-import DataCite sync.
 # Get test account at: https://doi.test.datacite.org/
 DATACITE_TEST_MODE=true
 DATACITE_TEST_USERNAME=

--- a/app/Http/Controllers/DataCiteImportController.php
+++ b/app/Http/Controllers/DataCiteImportController.php
@@ -11,6 +11,8 @@ use App\Models\Resource;
 use App\Models\User;
 use App\Services\DoiImportEligibilityService;
 use App\Services\GfzDataServicesPortalService;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -241,6 +243,37 @@ class DataCiteImportController extends Controller
         ]);
     }
 
+    public function retrySync(
+        Request $request,
+        string $importId,
+        ImportedResourceDataCiteSyncDispatcher $dispatcher,
+    ): JsonResponse {
+        $this->authorize('importFromDataCite', Resource::class);
+
+        if (! Str::isUuid($importId)) {
+            return response()->json(['error' => 'Invalid import ID format'], 400);
+        }
+
+        $progress = Cache::get("datacite_import:{$importId}");
+        if (! is_array($progress)) {
+            return response()->json(['error' => 'Import not found'], 404);
+        }
+
+        if (config('datacite.test_mode') !== false) {
+            return response()->json(['error' => 'DataCite synchronization is disabled in test mode.'], 400);
+        }
+
+        if (($progress['status'] ?? null) === 'running') {
+            return response()->json(['error' => 'A synchronization is already running.'], 409);
+        }
+
+        if (! $dispatcher->retryFailures(ImportProgressService::TYPE_RESOURCE, $importId)) {
+            return response()->json(['error' => 'There are no failed synchronizations to retry.'], 400);
+        }
+
+        return response()->json(['message' => 'DataCite synchronization retry started.'], 202);
+    }
+
     private function initializeProgress(string $importId, int $total): void
     {
         Cache::put("datacite_import:{$importId}", [
@@ -252,6 +285,14 @@ class DataCiteImportController extends Controller
             'failed' => 0,
             'skipped_dois' => [],
             'failed_dois' => [],
+            'phase' => 'importing',
+            'sync_total' => 0,
+            'sync_processed' => 0,
+            'sync_succeeded' => 0,
+            'sync_failed' => 0,
+            'sync_errors' => [],
+            'sync_skipped_test_mode' => false,
+            'sync_retry_available' => false,
             'started_at' => now()->toIso8601String(),
             'completed_at' => null,
         ], now()->addHours(24));

--- a/app/Http/Controllers/DataCiteImportController.php
+++ b/app/Http/Controllers/DataCiteImportController.php
@@ -11,7 +11,7 @@ use App\Models\Resource;
 use App\Models\User;
 use App\Services\DoiImportEligibilityService;
 use App\Services\GfzDataServicesPortalService;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
@@ -246,7 +246,7 @@ class DataCiteImportController extends Controller
     public function retrySync(
         Request $request,
         string $importId,
-        ImportedResourceDataCiteSyncDispatcher $dispatcher,
+        ImportedResourceDataCiteSyncDispatcherService $dispatcher,
     ): JsonResponse {
         $this->authorize('importFromDataCite', Resource::class);
 

--- a/app/Http/Controllers/IgsnImportController.php
+++ b/app/Http/Controllers/IgsnImportController.php
@@ -10,7 +10,7 @@ use App\Jobs\ImportIgsnsFromDataCiteJob;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\IgsnImportService;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use App\Services\LegacyIgsnPortalService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -220,7 +220,7 @@ class IgsnImportController extends Controller
     public function retrySync(
         Request $request,
         string $importId,
-        ImportedResourceDataCiteSyncDispatcher $dispatcher,
+        ImportedResourceDataCiteSyncDispatcherService $dispatcher,
     ): JsonResponse {
         $this->authorize('importFromDataCite', Resource::class);
 

--- a/app/Http/Controllers/IgsnImportController.php
+++ b/app/Http/Controllers/IgsnImportController.php
@@ -10,6 +10,8 @@ use App\Jobs\ImportIgsnsFromDataCiteJob;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\IgsnImportService;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
 use App\Services\LegacyIgsnPortalService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Client\RequestException;
@@ -215,6 +217,37 @@ class IgsnImportController extends Controller
         return response()->json(['message' => 'Import cancelled']);
     }
 
+    public function retrySync(
+        Request $request,
+        string $importId,
+        ImportedResourceDataCiteSyncDispatcher $dispatcher,
+    ): JsonResponse {
+        $this->authorize('importFromDataCite', Resource::class);
+
+        if (! Str::isUuid($importId)) {
+            return response()->json(['error' => 'Invalid import ID format'], 400);
+        }
+
+        $progress = Cache::get("igsn_import:{$importId}");
+        if (! is_array($progress)) {
+            return response()->json(['error' => 'Import not found'], 404);
+        }
+
+        if (config('datacite.test_mode') !== false) {
+            return response()->json(['error' => 'DataCite synchronization is disabled in test mode.'], 400);
+        }
+
+        if (($progress['status'] ?? null) === 'running') {
+            return response()->json(['error' => 'A synchronization is already running.'], 409);
+        }
+
+        if (! $dispatcher->retryFailures(ImportProgressService::TYPE_IGSN, $importId)) {
+            return response()->json(['error' => 'There are no failed synchronizations to retry.'], 400);
+        }
+
+        return response()->json(['message' => 'DataCite synchronization retry started.'], 202);
+    }
+
     /**
      * @param  array{id: string, name: string, legacy_name: string, resource_count: int}|null  $datacenter
      */
@@ -237,6 +270,14 @@ class IgsnImportController extends Controller
             'unassigned' => 0,
             'unassigned_dois' => [],
             'warnings' => [],
+            'phase' => 'importing',
+            'sync_total' => 0,
+            'sync_processed' => 0,
+            'sync_succeeded' => 0,
+            'sync_failed' => 0,
+            'sync_errors' => [],
+            'sync_skipped_test_mode' => false,
+            'sync_retry_available' => false,
             'started_at' => now()->toIso8601String(),
             'completed_at' => null,
         ], now()->addHours(24));

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -11,10 +11,11 @@ use App\Models\Resource;
 use App\Services\DataCiteImportService;
 use App\Services\DataCiteLandingPageImportService;
 use App\Services\DataCiteSubjectMergeService;
-use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
 use App\Services\GfzDataServicesPortalService;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
 use App\Services\LegacyLandingPageDecisionService;
 use App\Services\LegacyLandingPageImportService;
 use App\Services\LegacyMetaworksDatacenterLookupService;
@@ -58,6 +59,9 @@ class ImportFromDataCiteJob implements ShouldQueue
 
     /** @var array<string, int> */
     private array $portalDatacenterIds = [];
+
+    /** @var list<int> */
+    private array $resourceIdsForDataCiteSync = [];
 
     /**
      * Create a new job instance.
@@ -309,7 +313,8 @@ class ImportFromDataCiteJob implements ShouldQueue
             $finalStatus = $this->determineFinalStatus();
 
             $this->updateProgress([
-                'status' => $finalStatus,
+                'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+                'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
                 'total' => $total,
                 'processed' => $processed,
                 'imported' => $imported,
@@ -320,9 +325,13 @@ class ImportFromDataCiteJob implements ShouldQueue
                 'enriched_dois' => $enrichedDois,
                 'failed_dois' => $failedDois,
                 'started_at' => $startTime->toIso8601String(),
-                'completed_at' => now()->toIso8601String(),
+                'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
                 'current_prefix' => null,
             ]);
+
+            if ($finalStatus !== 'cancelled') {
+                $this->finishDataCiteSyncPhase();
+            }
 
             Log::info('DataCite import completed', [
                 'import_id' => $this->importId,
@@ -632,7 +641,8 @@ class ImportFromDataCiteJob implements ShouldQueue
         $finalStatus = $this->determineFinalStatus();
 
         $this->updateProgress([
-            'status' => $finalStatus,
+            'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+            'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
             'total' => $total,
             'processed' => $processed,
             'imported' => $imported,
@@ -645,9 +655,13 @@ class ImportFromDataCiteJob implements ShouldQueue
             'warnings' => $warnings,
             'datacenter' => $datacenter,
             'started_at' => $startedAt,
-            'completed_at' => now()->toIso8601String(),
+            'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
             'current_prefix' => null,
         ]);
+
+        if ($finalStatus !== 'cancelled') {
+            $this->finishDataCiteSyncPhase();
+        }
 
         Log::info('Datacenter DataCite import completed', [
             'import_id' => $this->importId,
@@ -778,8 +792,11 @@ class ImportFromDataCiteJob implements ShouldQueue
         $wasSkipped = $result['status'] === 'skipped';
         $wasEnriched = $result['enriched'];
 
+        $finalStatus = $this->determineFinalStatus();
+
         $this->updateProgress([
-            'status' => $this->determineFinalStatus(),
+            'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+            'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
             'total' => 1,
             'processed' => 1,
             'imported' => $wasSkipped ? 0 : 1,
@@ -790,9 +807,13 @@ class ImportFromDataCiteJob implements ShouldQueue
             'enriched_dois' => $wasEnriched ? [$doi] : [],
             'failed_dois' => [],
             'started_at' => $startedAt,
-            'completed_at' => now()->toIso8601String(),
+            'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
             'current_prefix' => null,
         ]);
+
+        if ($this->determineFinalStatus() !== 'cancelled') {
+            $this->finishDataCiteSyncPhase();
+        }
     }
 
     /**
@@ -856,9 +877,12 @@ class ImportFromDataCiteJob implements ShouldQueue
             return;
         }
 
+        $finalStatus = $this->determineFinalStatus();
+
         if ($result['status'] === 'imported') {
             $this->updateProgress([
-                'status' => $this->determineFinalStatus(),
+                'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+                'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
                 'total' => 1,
                 'processed' => 1,
                 'imported' => 1,
@@ -869,16 +893,21 @@ class ImportFromDataCiteJob implements ShouldQueue
                 'enriched_dois' => [],
                 'failed_dois' => [],
                 'started_at' => $startedAt,
-                'completed_at' => now()->toIso8601String(),
+                'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
                 'current_prefix' => null,
             ]);
+
+            if ($finalStatus !== 'cancelled') {
+                $this->finishDataCiteSyncPhase();
+            }
 
             return;
         }
 
         if ($result['status'] === 'skipped') {
             $this->updateProgress([
-                'status' => $this->determineFinalStatus(),
+                'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+                'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
                 'total' => 1,
                 'processed' => 1,
                 'imported' => 0,
@@ -889,9 +918,13 @@ class ImportFromDataCiteJob implements ShouldQueue
                 'enriched_dois' => [],
                 'failed_dois' => [],
                 'started_at' => $startedAt,
-                'completed_at' => now()->toIso8601String(),
+                'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
                 'current_prefix' => null,
             ]);
+
+            if ($finalStatus !== 'cancelled') {
+                $this->finishDataCiteSyncPhase();
+            }
 
             return;
         }
@@ -935,16 +968,11 @@ class ImportFromDataCiteJob implements ShouldQueue
                 Log::debug('Skipping existing DOI', ['doi' => $doi]);
 
                 $dataCiteLandingPageSync = $this->syncDataCiteLandingPageIfAllowed($existingResource, $doi, $doiRecord);
-                $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
-
-                if ($shouldLookupMetaworks && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
-                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $doiRecord, $metaworksService);
-                }
 
                 return [
                     'status' => 'skipped',
-                    'metaworks_unavailable' => $legacyDownloadSync['metaworks_unavailable'],
-                    'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
+                    'metaworks_unavailable' => false,
+                    'enriched' => $dataCiteLandingPageSync['changed'],
                 ];
             }
 
@@ -1003,16 +1031,11 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $dataCiteLandingPageSync = $existingResource !== null
                     ? $this->syncDataCiteLandingPageIfAllowed($existingResource, $doi, $preparedDoiRecord)
                     : $this->emptyDataCiteLandingPageSyncResult();
-                $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
-
-                if ($existingResource !== null && $shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
-                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $doiRecord, $metaworksService);
-                }
 
                 return [
                     'status' => 'skipped',
-                    'metaworks_unavailable' => $metaworksUnavailable || $legacyDownloadSync['metaworks_unavailable'],
-                    'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
+                    'metaworks_unavailable' => $metaworksUnavailable,
+                    'enriched' => $dataCiteLandingPageSync['changed'],
                 ];
             }
 
@@ -1025,7 +1048,7 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $portalDatacenterNames,
             );
 
-            $this->syncDataCiteLandingPageIfAllowed($importedResource, $doi, $preparedDoiRecord);
+            $dataCiteLandingPageSync = $this->syncDataCiteLandingPageIfAllowed($importedResource, $doi, $preparedDoiRecord);
 
             $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
 
@@ -1033,7 +1056,9 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $legacyDownloadSync = $this->syncLegacyDownloadLinks($importedResource, $doi, $doiRecord, $metaworksService);
             }
 
-            $this->syncDataCiteMetadataIfAllowed($importedResource);
+            if ($dataCiteLandingPageSync['sync_eligible'] || $legacyDownloadSync['sync_eligible']) {
+                $this->resourceIdsForDataCiteSync[] = (int) $importedResource->id;
+            }
 
             Log::debug('Imported DOI', ['doi' => $doi]);
 
@@ -1058,16 +1083,11 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $dataCiteLandingPageSync = $existingResource !== null
                     ? $this->syncDataCiteLandingPageIfAllowed($existingResource, $doi, $doiRecord)
                     : $this->emptyDataCiteLandingPageSyncResult();
-                $legacyDownloadSync = $this->emptyLegacyDownloadSyncResult();
-
-                if ($existingResource !== null && $shouldLookupMetaworks && ! $metaworksUnavailable && ! LandingPage::where('resource_id', $existingResource->id)->exists()) {
-                    $legacyDownloadSync = $this->syncLegacyDownloadLinks($existingResource, $doi, $doiRecord, $metaworksService);
-                }
 
                 return [
                     'status' => 'skipped',
-                    'metaworks_unavailable' => $metaworksUnavailable || $legacyDownloadSync['metaworks_unavailable'],
-                    'enriched' => $dataCiteLandingPageSync['changed'] || $legacyDownloadSync['changed'],
+                    'metaworks_unavailable' => $metaworksUnavailable,
+                    'enriched' => $dataCiteLandingPageSync['changed'],
                 ];
             }
 
@@ -1077,7 +1097,7 @@ class ImportFromDataCiteJob implements ShouldQueue
 
     /**
      * @param  array<string, mixed>  $doiRecord
-     * @return array{changed: bool}
+     * @return array{changed: bool, sync_eligible: bool}
      */
     private function syncDataCiteLandingPageIfAllowed(Resource $resource, string $doi, array $doiRecord): array
     {
@@ -1092,7 +1112,11 @@ class ImportFromDataCiteJob implements ShouldQueue
         try {
             $result = app(DataCiteLandingPageImportService::class)->createExternalForResource($resource, $attributes);
 
-            return ['changed' => $result['changed']];
+            return [
+                'changed' => $result['changed'],
+                'sync_eligible' => $result['created']
+                    && $result['landing_page']?->is_published === true,
+            ];
         } catch (\Throwable $exception) {
             Log::warning('Failed to import external DataCite landing page URL', [
                 'doi' => $resource->doi,
@@ -1105,16 +1129,16 @@ class ImportFromDataCiteJob implements ShouldQueue
     }
 
     /**
-     * @return array{changed: bool}
+     * @return array{changed: bool, sync_eligible: bool}
      */
     private function emptyDataCiteLandingPageSyncResult(): array
     {
-        return ['changed' => false];
+        return ['changed' => false, 'sync_eligible' => false];
     }
 
     /**
      * @param  array<string, mixed>  $doiRecord
-     * @return array{changed: bool, metaworks_unavailable: bool}
+     * @return array{changed: bool, metaworks_unavailable: bool, sync_eligible: bool}
      */
     private function syncLegacyDownloadLinks(
         Resource $resource,
@@ -1122,8 +1146,8 @@ class ImportFromDataCiteJob implements ShouldQueue
         array $doiRecord,
         MetaworksDownloadUrlService $metaworksService,
     ): array {
-        /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound?: bool, hasFileRows?: bool} $fileResult */
-        $fileResult = ['files' => [], 'allPublic' => false, 'resourceFound' => false, 'hasFileRows' => false];
+        /** @var array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound?: bool, hasFileRows?: bool, resourcePublicStatus?: string|null} $fileResult */
+        $fileResult = ['files' => [], 'allPublic' => false, 'resourceFound' => false, 'hasFileRows' => false, 'resourcePublicStatus' => null];
 
         try {
             $fileResult = $metaworksService->lookupFileEntries($doi);
@@ -1136,21 +1160,34 @@ class ImportFromDataCiteJob implements ShouldQueue
             return [
                 'changed' => false,
                 'metaworks_unavailable' => true,
+                'sync_eligible' => false,
             ];
         }
 
         $fileResult += [
             'resourceFound' => false,
             'hasFileRows' => $fileResult['files'] !== [],
+            'resourcePublicStatus' => null,
         ];
+
+        $attributes = is_array($doiRecord['attributes'] ?? null)
+            ? $doiRecord['attributes']
+            : $doiRecord;
+        $decision = app(LegacyLandingPageDecisionService::class)->internalLandingPageDecision(
+            $fileResult['resourcePublicStatus'],
+            isset($attributes['state']) ? (string) $attributes['state'] : null,
+        );
+
+        if (! $decision['should_create']) {
+            return $this->emptyLegacyDownloadSyncResult();
+        }
 
         try {
             $syncResult = app(LegacyLandingPageImportService::class)->syncMissingFileEntries(
                 resource: $resource,
                 fileEntries: $fileResult['files'],
-                isPublished: $this->isFindableDoiRecord($doiRecord)
-                    && (! $fileResult['hasFileRows'] || $fileResult['allPublic']),
-                createWhenEmpty: $fileResult['resourceFound'] === true,
+                isPublished: $decision['should_publish'],
+                createWhenEmpty: true,
             );
         } catch (\Throwable $exception) {
             Log::warning('Failed to sync landing page with download links', [
@@ -1165,29 +1202,17 @@ class ImportFromDataCiteJob implements ShouldQueue
         return [
             'changed' => $syncResult['changed'],
             'metaworks_unavailable' => false,
+            'sync_eligible' => $syncResult['created'] && $decision['should_sync'],
         ];
     }
 
-    /**
-     * @param  array<string, mixed>  $doiRecord
-     */
-    private function isFindableDoiRecord(array $doiRecord): bool
-    {
-        $attributes = is_array($doiRecord['attributes'] ?? null)
-            ? $doiRecord['attributes']
-            : $doiRecord;
-
-        return strtolower(trim((string) ($attributes['state'] ?? ''))) === 'findable';
-    }
-
-    /**
-     * @return array{changed: bool, metaworks_unavailable: bool}
-     */
+    /** @return array{changed: bool, metaworks_unavailable: bool, sync_eligible: bool} */
     private function emptyLegacyDownloadSyncResult(): array
     {
         return [
             'changed' => false,
             'metaworks_unavailable' => false,
+            'sync_eligible' => false,
         ];
     }
 
@@ -1277,17 +1302,17 @@ class ImportFromDataCiteJob implements ShouldQueue
         )));
     }
 
-    private function syncDataCiteMetadataIfAllowed(Resource $resource): void
+    private function finishDataCiteSyncPhase(): void
     {
-        if (
-            config('datacite.test_mode') !== false
-            || ! (bool) config('datacite.sync_after_import', false)
-            || ! $resource->exists
-        ) {
+        if ($this->determineFinalStatus() === 'cancelled') {
             return;
         }
 
-        app(DataCiteSyncService::class)->syncIfRegistered($resource->fresh() ?? $resource);
+        app(ImportedResourceDataCiteSyncDispatcher::class)->dispatch(
+            ImportProgressService::TYPE_RESOURCE,
+            $this->importId,
+            $this->resourceIdsForDataCiteSync,
+        );
     }
 
     /**

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -14,7 +14,7 @@ use App\Services\DataCiteSubjectMergeService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
 use App\Services\GfzDataServicesPortalService;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use App\Services\LegacyLandingPageDecisionService;
 use App\Services\LegacyLandingPageImportService;
@@ -1308,7 +1308,7 @@ class ImportFromDataCiteJob implements ShouldQueue
             return;
         }
 
-        app(ImportedResourceDataCiteSyncDispatcher::class)->dispatch(
+        app(ImportedResourceDataCiteSyncDispatcherService::class)->dispatch(
             ImportProgressService::TYPE_RESOURCE,
             $this->importId,
             $this->resourceIdsForDataCiteSync,

--- a/app/Jobs/ImportIgsnsFromDataCiteJob.php
+++ b/app/Jobs/ImportIgsnsFromDataCiteJob.php
@@ -1174,6 +1174,10 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
 
     private function finishDataCiteSyncPhase(): void
     {
+        if ($this->isCancelled()) {
+            return;
+        }
+
         app(ImportedResourceDataCiteSyncDispatcherService::class)->dispatch(
             ImportProgressService::TYPE_IGSN,
             $this->importId,

--- a/app/Jobs/ImportIgsnsFromDataCiteJob.php
+++ b/app/Jobs/ImportIgsnsFromDataCiteJob.php
@@ -12,7 +12,7 @@ use App\Services\DataCiteToIgsnTransformer;
 use App\Services\IgsnChildDiscoveryService;
 use App\Services\IgsnEnrichmentService;
 use App\Services\IgsnImportService;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use App\Services\LegacyIgsnPortalService;
 use App\Support\IgsnIdentifier;
@@ -1174,7 +1174,7 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
 
     private function finishDataCiteSyncPhase(): void
     {
-        app(ImportedResourceDataCiteSyncDispatcher::class)->dispatch(
+        app(ImportedResourceDataCiteSyncDispatcherService::class)->dispatch(
             ImportProgressService::TYPE_IGSN,
             $this->importId,
             $this->resourceIdsForDataCiteSync,

--- a/app/Jobs/ImportIgsnsFromDataCiteJob.php
+++ b/app/Jobs/ImportIgsnsFromDataCiteJob.php
@@ -7,10 +7,13 @@ namespace App\Jobs;
 use App\Models\Datacenter;
 use App\Models\IgsnMetadata;
 use App\Models\Resource;
+use App\Services\AutomaticIgsnLandingPageService;
 use App\Services\DataCiteToIgsnTransformer;
 use App\Services\IgsnChildDiscoveryService;
 use App\Services\IgsnEnrichmentService;
 use App\Services\IgsnImportService;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
 use App\Services\LegacyIgsnPortalService;
 use App\Support\IgsnIdentifier;
 use Illuminate\Bus\Queueable;
@@ -40,6 +43,9 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
     public int $timeout = 14400;
 
     public int $tries = 1;
+
+    /** @var list<int> */
+    private array $resourceIdsForDataCiteSync = [];
 
     /**
      * @param  int  $userId  The user who initiated the import
@@ -268,7 +274,8 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
             $finalStatus = $wasCancelled ? 'cancelled' : 'completed';
 
             $this->updateProgress([
-                'status' => $finalStatus,
+                'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+                'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
                 'total' => $total,
                 'processed' => $processed,
                 'imported' => $imported,
@@ -281,8 +288,12 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
                 'unassigned_dois' => $unassignedDois,
                 'warnings' => $warnings,
                 'started_at' => $startTime->toIso8601String(),
-                'completed_at' => now()->toIso8601String(),
+                'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
             ]);
+
+            if ($finalStatus !== 'cancelled') {
+                $this->finishDataCiteSyncPhase();
+            }
 
             Log::info('IGSN import completed', [
                 'import_id' => $this->importId,
@@ -483,8 +494,11 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
             $this->resolveParentRelationships($handles);
         }
 
+        $finalStatus = $this->determineFinalStatus();
+
         $this->updateProgress([
-            'status' => $this->determineFinalStatus(),
+            'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+            'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
             'total' => $total,
             'processed' => $processed,
             'imported' => $imported,
@@ -498,8 +512,12 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
             'unassigned_dois' => [],
             'warnings' => [],
             'started_at' => $startedAt,
-            'completed_at' => now()->toIso8601String(),
+            'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
         ]);
+
+        if ($finalStatus !== 'cancelled') {
+            $this->finishDataCiteSyncPhase();
+        }
     }
 
     private function handleSingleImport(
@@ -693,8 +711,11 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
             $this->resolveParentRelationships($targetHandles);
         }
 
+        $finalStatus = $this->determineFinalStatus();
+
         $this->updateProgress([
-            'status' => $this->determineFinalStatus(),
+            'status' => $finalStatus === 'cancelled' ? 'cancelled' : 'running',
+            'phase' => $finalStatus === 'cancelled' ? 'completed' : 'syncing',
             'total' => $total,
             'processed' => $processed,
             'imported' => $imported,
@@ -709,8 +730,12 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
             'unassigned_dois' => $unassignedDois,
             'warnings' => $warnings,
             'started_at' => $startedAt,
-            'completed_at' => now()->toIso8601String(),
+            'completed_at' => $finalStatus === 'cancelled' ? now()->toIso8601String() : null,
         ]);
+
+        if ($finalStatus !== 'cancelled') {
+            $this->finishDataCiteSyncPhase();
+        }
 
         Log::info('Single IGSN import completed', [
             'import_id' => $this->importId,
@@ -917,6 +942,13 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
                     'error' => $e->getMessage(),
                 ]);
             }
+        }
+
+        $landingPageResult = app(AutomaticIgsnLandingPageService::class)
+            ->createPublished($importedResource);
+
+        if ($landingPageResult['created']) {
+            $this->resourceIdsForDataCiteSync[] = (int) $importedResource->id;
         }
 
         return [
@@ -1138,6 +1170,15 @@ class ImportIgsnsFromDataCiteJob implements ShouldQueue
     private function determineFinalStatus(): string
     {
         return $this->isCancelled() ? 'cancelled' : 'completed';
+    }
+
+    private function finishDataCiteSyncPhase(): void
+    {
+        app(ImportedResourceDataCiteSyncDispatcher::class)->dispatch(
+            ImportProgressService::TYPE_IGSN,
+            $this->importId,
+            $this->resourceIdsForDataCiteSync,
+        );
     }
 
     public function failed(?\Throwable $exception): void

--- a/app/Jobs/SyncImportedResourcesWithDataCiteJob.php
+++ b/app/Jobs/SyncImportedResourcesWithDataCiteJob.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Resource;
+use App\Services\DataCiteSyncService;
+use App\Services\ImportProgressService;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class SyncImportedResourcesWithDataCiteJob implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 1800;
+
+    public int $tries = 1;
+
+    /** @param list<int> $resourceIds */
+    public function __construct(
+        private readonly string $importType,
+        private readonly string $importId,
+        private readonly array $resourceIds,
+    ) {}
+
+    public function handle(DataCiteSyncService $syncService, ImportProgressService $progressService): void
+    {
+        // This is the hard safety boundary: no import-triggered write may reach
+        // either DataCite API while test mode is enabled.
+        if (config('datacite.test_mode') !== false) {
+            return;
+        }
+
+        foreach ($this->resourceIds as $resourceId) {
+            if ($this->batch()?->cancelled() === true) {
+                return;
+            }
+
+            $progress = $progressService->get($this->importType, $this->importId);
+            if (($progress['status'] ?? null) === 'cancelled') {
+                return;
+            }
+
+            $resource = Resource::query()->with('landingPage')->find($resourceId);
+
+            if ($resource === null) {
+                $progressService->recordSyncFailure(
+                    $this->importType,
+                    $this->importId,
+                    $resourceId,
+                    null,
+                    'The imported resource no longer exists.',
+                );
+
+                continue;
+            }
+
+            try {
+                $result = $syncService->syncIfRegistered($resource);
+
+                if ($result->hasFailed()) {
+                    $progressService->recordSyncFailure(
+                        $this->importType,
+                        $this->importId,
+                        $resourceId,
+                        $result->doi,
+                        $result->errorMessage ?? 'DataCite synchronization failed.',
+                    );
+                } else {
+                    $progressService->recordSyncSuccess($this->importType, $this->importId, $resourceId);
+                }
+            } catch (\Throwable $exception) {
+                Log::error('Unexpected import DataCite sync failure', [
+                    'import_type' => $this->importType,
+                    'import_id' => $this->importId,
+                    'resource_id' => $resourceId,
+                    'doi' => $resource->doi,
+                    'error' => $exception->getMessage(),
+                ]);
+
+                $progressService->recordSyncFailure(
+                    $this->importType,
+                    $this->importId,
+                    $resourceId,
+                    $resource->doi,
+                    $exception->getMessage(),
+                );
+            }
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Enums\UserRole;
 use App\Jobs\CreateDatabaseDumpJob;
 use App\Jobs\DiscoverRelationsJob;
 use App\Jobs\ImportFromDataCiteJob;
+use App\Jobs\ImportIgsnsFromDataCiteJob;
 use App\Jobs\UpdatePidJob;
 use App\Jobs\UpdateThesaurusJob;
 use App\Listeners\MarkContactMessageAsSent;
@@ -95,6 +96,7 @@ class AppServiceProvider extends ServiceProvider
         // Route jobs to dedicated queues to prevent long-running imports
         // from blocking shorter vocabulary/PID update tasks
         Queue::route(ImportFromDataCiteJob::class, queue: 'imports');
+        Queue::route(ImportIgsnsFromDataCiteJob::class, queue: 'imports');
         Queue::route(UpdatePidJob::class, queue: 'vocabularies');
         Queue::route(UpdateThesaurusJob::class, queue: 'vocabularies');
         Queue::route(CreateDatabaseDumpJob::class, queue: 'database-dumps');

--- a/app/Services/AutomaticIgsnLandingPageService.php
+++ b/app/Services/AutomaticIgsnLandingPageService.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\LandingPage;
+use App\Models\Resource;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+class AutomaticIgsnLandingPageService
+{
+    /**
+     * Create the published internal landing page for a newly imported IGSN.
+     *
+     * A null template id deliberately preserves automatic datacenter template
+     * inheritance, with the built-in IGSN template as the persisted fallback.
+     *
+     * @return array{landing_page: LandingPage, created: bool}
+     */
+    public function createPublished(Resource $resource): array
+    {
+        $resource->loadMissing('titles.titleType');
+
+        try {
+            $result = DB::transaction(function () use ($resource): array {
+                $existing = LandingPage::query()
+                    ->where('resource_id', $resource->id)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($existing !== null) {
+                    return ['landing_page' => $existing, 'created' => false];
+                }
+
+                $landingPage = new LandingPage([
+                    'resource_id' => $resource->id,
+                    'template' => 'default_gfz_igsn',
+                    'landing_page_template_id' => null,
+                    'ftp_url' => null,
+                    'downloads_unavailable' => true,
+                    'is_published' => true,
+                    'published_at' => now(),
+                ]);
+                $landingPage->setRelation('resource', $resource);
+                $landingPage->save();
+
+                return ['landing_page' => $landingPage, 'created' => true];
+            });
+        } catch (QueryException $exception) {
+            // A concurrent import can win the unique resource_id insert. Treat
+            // that as an idempotent success while preserving all other errors.
+            $landingPage = LandingPage::query()->where('resource_id', $resource->id)->first();
+
+            if ($landingPage === null) {
+                throw $exception;
+            }
+
+            $result = ['landing_page' => $landingPage, 'created' => false];
+        }
+
+        return $result;
+    }
+}

--- a/app/Services/ImportProgressService.php
+++ b/app/Services/ImportProgressService.php
@@ -4,10 +4,21 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use Closure;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class ImportProgressService
 {
+    private const LOCK_TTL_SECONDS = 15;
+
+    private const LOCK_WAIT_SECONDS = 5;
+
+    /** @var list<int> */
+    private const LOCK_RETRY_BACKOFF_MILLISECONDS = [100, 250];
+
     public const TYPE_RESOURCE = 'resource';
 
     public const TYPE_IGSN = 'igsn';
@@ -25,7 +36,7 @@ class ImportProgressService
     {
         $key = $this->progressKey($type, $importId);
 
-        Cache::lock($key.':lock', 10)->block(5, function () use ($key, $values): void {
+        $this->withProgressLock($type, $importId, 'update', function () use ($key, $values): void {
             $progress = Cache::get($key, []);
 
             foreach ($values as $name => $value) {
@@ -116,7 +127,7 @@ class ImportProgressService
     {
         $key = $this->progressKey($type, $importId);
 
-        Cache::lock($key.':lock', 10)->block(5, function () use ($key, $type, $importId): void {
+        $this->withProgressLock($type, $importId, 'finalize_sync', function () use ($key, $type, $importId): void {
             $progress = Cache::get($key);
 
             if (! is_array($progress) || ($progress['status'] ?? null) === 'cancelled') {
@@ -207,7 +218,7 @@ class ImportProgressService
     ): void {
         $key = $this->progressKey($type, $importId);
 
-        Cache::lock($key.':lock', 10)->block(5, function () use ($key, $type, $importId, $resourceId, $doi, $error): void {
+        $this->withProgressLock($type, $importId, 'record_sync_result', function () use ($key, $type, $importId, $resourceId, $doi, $error): void {
             $progress = Cache::get($key, []);
 
             if (($progress['status'] ?? null) === 'cancelled') {
@@ -251,11 +262,38 @@ class ImportProgressService
             if ((int) $progress['sync_processed'] >= (int) ($progress['sync_total'] ?? 0)) {
                 $progress['status'] = 'completed';
                 $progress['phase'] = 'completed';
-                $progress['sync_retry_available'] = (int) ($progress['sync_failed'] ?? 0) > 0;
+                $progress['sync_retry_available'] = (int) ($progress['sync_failed'] ?? 0) > 0
+                    && config('datacite.test_mode') === false;
                 $progress['completed_at'] = now()->toIso8601String();
             }
 
             Cache::put($key, $progress, now()->addHours(24));
         });
+    }
+
+    private function withProgressLock(
+        string $type,
+        string $importId,
+        string $operation,
+        Closure $callback,
+    ): void {
+        $lockKey = $this->progressKey($type, $importId).':lock';
+
+        try {
+            retry(
+                self::LOCK_RETRY_BACKOFF_MILLISECONDS,
+                static fn (): mixed => Cache::lock($lockKey, self::LOCK_TTL_SECONDS)
+                    ->block(self::LOCK_WAIT_SECONDS, $callback),
+                when: static fn (Throwable $exception): bool => $exception instanceof LockTimeoutException,
+            );
+        } catch (LockTimeoutException $exception) {
+            Log::warning('Import progress update skipped after repeated lock timeouts', [
+                'import_type' => $type,
+                'import_id' => $importId,
+                'operation' => $operation,
+                'lock_key' => $lockKey,
+                'attempts' => count(self::LOCK_RETRY_BACKOFF_MILLISECONDS) + 1,
+            ]);
+        }
     }
 }

--- a/app/Services/ImportProgressService.php
+++ b/app/Services/ImportProgressService.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+
+class ImportProgressService
+{
+    public const TYPE_RESOURCE = 'resource';
+
+    public const TYPE_IGSN = 'igsn';
+
+    /** @return array<string, mixed>|null */
+    public function get(string $type, string $importId): ?array
+    {
+        $progress = Cache::get($this->progressKey($type, $importId));
+
+        return is_array($progress) ? $progress : null;
+    }
+
+    /** @param array<string, mixed> $values */
+    public function update(string $type, string $importId, array $values): void
+    {
+        $key = $this->progressKey($type, $importId);
+
+        Cache::lock($key.':lock', 10)->block(5, function () use ($key, $values): void {
+            $progress = Cache::get($key, []);
+
+            foreach ($values as $name => $value) {
+                $progress[$name] = $value;
+            }
+
+            Cache::put($key, $progress, now()->addHours(24));
+        });
+    }
+
+    /**
+     * @param  list<int>  $resourceIds
+     */
+    public function beginSync(string $type, string $importId, array $resourceIds, bool $retry = false): void
+    {
+        $resourceIds = array_values(array_unique(array_map('intval', $resourceIds)));
+
+        if ($retry) {
+            Cache::put($this->failureIdsKey($type, $importId), [], now()->addHours(24));
+        } else {
+            Cache::forget($this->failureIdsKey($type, $importId));
+        }
+        Cache::put($this->pendingIdsKey($type, $importId), $resourceIds, now()->addHours(24));
+
+        $this->update($type, $importId, [
+            'status' => 'running',
+            'phase' => 'syncing',
+            'sync_total' => count($resourceIds),
+            'sync_processed' => 0,
+            'sync_succeeded' => 0,
+            'sync_failed' => 0,
+            'sync_errors' => [],
+            'sync_skipped_test_mode' => false,
+            'sync_retry_available' => false,
+            'sync_retry' => $retry,
+            'completed_at' => null,
+        ]);
+    }
+
+    public function markSyncSkipped(string $type, string $importId, int $eligibleCount): void
+    {
+        $this->update($type, $importId, [
+            'status' => 'completed',
+            'phase' => 'completed',
+            'sync_total' => $eligibleCount,
+            'sync_processed' => 0,
+            'sync_succeeded' => 0,
+            'sync_failed' => 0,
+            'sync_errors' => [],
+            'sync_skipped_test_mode' => $eligibleCount > 0,
+            'sync_retry_available' => false,
+            'completed_at' => now()->toIso8601String(),
+        ]);
+    }
+
+    public function markCompletedWithoutSync(string $type, string $importId): void
+    {
+        $this->update($type, $importId, [
+            'status' => 'completed',
+            'phase' => 'completed',
+            'sync_total' => 0,
+            'sync_processed' => 0,
+            'sync_succeeded' => 0,
+            'sync_failed' => 0,
+            'sync_errors' => [],
+            'sync_skipped_test_mode' => false,
+            'sync_retry_available' => false,
+            'completed_at' => now()->toIso8601String(),
+        ]);
+    }
+
+    public function recordSyncSuccess(string $type, string $importId, int $resourceId): void
+    {
+        $this->recordSyncResult($type, $importId, $resourceId, null, null);
+    }
+
+    public function recordSyncFailure(
+        string $type,
+        string $importId,
+        int $resourceId,
+        ?string $doi,
+        string $error,
+    ): void {
+        $this->recordSyncResult($type, $importId, $resourceId, $doi, $error);
+    }
+
+    public function finalizeSync(string $type, string $importId): void
+    {
+        $key = $this->progressKey($type, $importId);
+
+        Cache::lock($key.':lock', 10)->block(5, function () use ($key, $type, $importId): void {
+            $progress = Cache::get($key);
+
+            if (! is_array($progress) || ($progress['status'] ?? null) === 'cancelled') {
+                return;
+            }
+
+            $pendingKey = $this->pendingIdsKey($type, $importId);
+            $pendingIds = Cache::get($pendingKey, []);
+            $pendingIds = is_array($pendingIds)
+                ? array_values(array_unique(array_map('intval', $pendingIds)))
+                : [];
+
+            if ($pendingIds !== []) {
+                $progress['sync_processed'] = (int) ($progress['sync_processed'] ?? 0) + count($pendingIds);
+                $progress['sync_failed'] = (int) ($progress['sync_failed'] ?? 0) + count($pendingIds);
+                $errors = is_array($progress['sync_errors'] ?? null) ? $progress['sync_errors'] : [];
+
+                foreach ($pendingIds as $resourceId) {
+                    if (count($errors) >= 100) {
+                        break;
+                    }
+
+                    $errors[] = [
+                        'resource_id' => $resourceId,
+                        'doi' => null,
+                        'error' => 'The DataCite synchronization job did not complete.',
+                    ];
+                }
+
+                $progress['sync_errors'] = $errors;
+                $failureKey = $this->failureIdsKey($type, $importId);
+                $failureIds = Cache::get($failureKey, []);
+                $failureIds = is_array($failureIds) ? $failureIds : [];
+                Cache::put(
+                    $failureKey,
+                    array_values(array_unique(array_merge(array_map('intval', $failureIds), $pendingIds))),
+                    now()->addHours(24),
+                );
+            }
+
+            Cache::forget($pendingKey);
+            $progress['status'] = 'completed';
+            $progress['phase'] = 'completed';
+            $progress['sync_retry_available'] = (int) ($progress['sync_failed'] ?? 0) > 0
+                && config('datacite.test_mode') === false;
+            $progress['completed_at'] = now()->toIso8601String();
+            Cache::put($key, $progress, now()->addHours(24));
+        });
+    }
+
+    /** @return list<int> */
+    public function failedResourceIds(string $type, string $importId): array
+    {
+        $ids = Cache::get($this->failureIdsKey($type, $importId), []);
+
+        if (! is_array($ids)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_map('intval', $ids)));
+    }
+
+    public function progressKey(string $type, string $importId): string
+    {
+        return match ($type) {
+            self::TYPE_RESOURCE => "datacite_import:{$importId}",
+            self::TYPE_IGSN => "igsn_import:{$importId}",
+            default => throw new \InvalidArgumentException("Unsupported import type: {$type}"),
+        };
+    }
+
+    private function failureIdsKey(string $type, string $importId): string
+    {
+        return "import_datacite_sync_failures:{$type}:{$importId}";
+    }
+
+    private function pendingIdsKey(string $type, string $importId): string
+    {
+        return "import_datacite_sync_pending:{$type}:{$importId}";
+    }
+
+    private function recordSyncResult(
+        string $type,
+        string $importId,
+        int $resourceId,
+        ?string $doi,
+        ?string $error,
+    ): void {
+        $key = $this->progressKey($type, $importId);
+
+        Cache::lock($key.':lock', 10)->block(5, function () use ($key, $type, $importId, $resourceId, $doi, $error): void {
+            $progress = Cache::get($key, []);
+
+            if (($progress['status'] ?? null) === 'cancelled') {
+                return;
+            }
+
+            $progress['sync_processed'] = (int) ($progress['sync_processed'] ?? 0) + 1;
+            $pendingKey = $this->pendingIdsKey($type, $importId);
+            $pendingIds = Cache::get($pendingKey, []);
+
+            if (is_array($pendingIds)) {
+                $pendingIds = array_values(array_filter(
+                    array_map('intval', $pendingIds),
+                    static fn (int $id): bool => $id !== $resourceId,
+                ));
+                Cache::put($pendingKey, $pendingIds, now()->addHours(24));
+            }
+
+            if ($error === null) {
+                $progress['sync_succeeded'] = (int) ($progress['sync_succeeded'] ?? 0) + 1;
+            } else {
+                $progress['sync_failed'] = (int) ($progress['sync_failed'] ?? 0) + 1;
+                $errors = is_array($progress['sync_errors'] ?? null) ? $progress['sync_errors'] : [];
+
+                if (count($errors) < 100) {
+                    $errors[] = [
+                        'resource_id' => $resourceId,
+                        'doi' => $doi,
+                        'error' => $error,
+                    ];
+                }
+
+                $progress['sync_errors'] = $errors;
+                $failureKey = $this->failureIdsKey($type, $importId);
+                $failureIds = Cache::get($failureKey, []);
+                $failureIds = is_array($failureIds) ? $failureIds : [];
+                $failureIds[] = $resourceId;
+                Cache::put($failureKey, array_values(array_unique($failureIds)), now()->addHours(24));
+            }
+
+            if ((int) $progress['sync_processed'] >= (int) ($progress['sync_total'] ?? 0)) {
+                $progress['status'] = 'completed';
+                $progress['phase'] = 'completed';
+                $progress['sync_retry_available'] = (int) ($progress['sync_failed'] ?? 0) > 0;
+                $progress['completed_at'] = now()->toIso8601String();
+            }
+
+            Cache::put($key, $progress, now()->addHours(24));
+        });
+    }
+}

--- a/app/Services/ImportedResourceDataCiteSyncDispatcher.php
+++ b/app/Services/ImportedResourceDataCiteSyncDispatcher.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CacheKey;
+use App\Jobs\SyncImportedResourcesWithDataCiteJob;
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class ImportedResourceDataCiteSyncDispatcher
+{
+    private const CHUNK_SIZE = 25;
+
+    public function __construct(
+        private readonly ImportProgressService $progressService,
+    ) {}
+
+    /**
+     * Complete a test-mode import locally, or dispatch production DataCite
+     * updates in bounded parallel queue jobs.
+     *
+     * @param  list<int>  $resourceIds
+     */
+    public function dispatch(string $type, string $importId, array $resourceIds, bool $retry = false): void
+    {
+        $resourceIds = array_values(array_unique(array_map('intval', $resourceIds)));
+
+        if ($resourceIds !== [] && ! $retry) {
+            app(PortalKeywordCacheInvalidationService::class)->scheduleAfterCommit();
+            CacheKey::PORTAL_RESOURCE_TYPE_FACETS->forget();
+            CacheKey::PORTAL_DATACENTER_FACETS->forget();
+        }
+
+        if (config('datacite.test_mode') !== false) {
+            $this->progressService->markSyncSkipped($type, $importId, count($resourceIds));
+
+            return;
+        }
+
+        if ($resourceIds === []) {
+            $this->progressService->markCompletedWithoutSync($type, $importId);
+
+            return;
+        }
+
+        $this->progressService->beginSync($type, $importId, $resourceIds, $retry);
+
+        $jobs = array_map(
+            static fn (array $ids): SyncImportedResourcesWithDataCiteJob => new SyncImportedResourcesWithDataCiteJob(
+                $type,
+                $importId,
+                $ids,
+            ),
+            array_chunk($resourceIds, self::CHUNK_SIZE),
+        );
+
+        Bus::batch($jobs)
+            ->name("DataCite import sync {$type} {$importId}")
+            ->allowFailures()
+            ->onQueue('imports')
+            ->finally(static function (Batch $batch) use ($type, $importId): void {
+                app(ImportProgressService::class)->finalizeSync($type, $importId);
+            })
+            ->catch(static function (Batch $batch, Throwable $exception) use ($type, $importId): void {
+                Log::error('Import DataCite sync batch failed', [
+                    'import_type' => $type,
+                    'import_id' => $importId,
+                    'batch_id' => $batch->id,
+                    'error' => $exception->getMessage(),
+                ]);
+            })
+            ->dispatch();
+    }
+
+    public function retryFailures(string $type, string $importId): bool
+    {
+        if (config('datacite.test_mode') !== false) {
+            return false;
+        }
+
+        $resourceIds = $this->progressService->failedResourceIds($type, $importId);
+
+        if ($resourceIds === []) {
+            return false;
+        }
+
+        $this->dispatch($type, $importId, $resourceIds, true);
+
+        return true;
+    }
+}

--- a/app/Services/ImportedResourceDataCiteSyncDispatcherService.php
+++ b/app/Services/ImportedResourceDataCiteSyncDispatcherService.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
-class ImportedResourceDataCiteSyncDispatcher
+class ImportedResourceDataCiteSyncDispatcherService
 {
     private const CHUNK_SIZE = 25;
 

--- a/app/Services/ImportedResourceDataCiteSyncDispatcherService.php
+++ b/app/Services/ImportedResourceDataCiteSyncDispatcherService.php
@@ -29,6 +29,10 @@ class ImportedResourceDataCiteSyncDispatcherService
     {
         $resourceIds = array_values(array_unique(array_map('intval', $resourceIds)));
 
+        if (($this->progressService->get($type, $importId)['status'] ?? null) === 'cancelled') {
+            return;
+        }
+
         if ($resourceIds !== [] && ! $retry) {
             app(PortalKeywordCacheInvalidationService::class)->scheduleAfterCommit();
             CacheKey::PORTAL_RESOURCE_TYPE_FACETS->forget();

--- a/app/Services/LegacyLandingPageDecisionService.php
+++ b/app/Services/LegacyLandingPageDecisionService.php
@@ -7,6 +7,29 @@ namespace App\Services;
 class LegacyLandingPageDecisionService
 {
     /**
+     * Decide whether a newly imported legacy resource receives an internal
+     * landing page and whether that page may be published/synchronised.
+     *
+     * File visibility is intentionally not part of this decision. The legacy
+     * resource publication status and the DataCite DOI state are authoritative.
+     *
+     * @return array{should_create: bool, should_publish: bool, should_sync: bool}
+     */
+    public function internalLandingPageDecision(?string $legacyPublicStatus, ?string $dataCiteState): array
+    {
+        $legacyPublicStatus = strtolower(trim((string) $legacyPublicStatus));
+        $dataCiteState = strtolower(trim((string) $dataCiteState));
+        $shouldCreate = in_array($legacyPublicStatus, ['published', 'pending'], true);
+        $shouldPublish = $legacyPublicStatus === 'published' && $dataCiteState === 'findable';
+
+        return [
+            'should_create' => $shouldCreate,
+            'should_publish' => $shouldPublish,
+            'should_sync' => $shouldPublish,
+        ];
+    }
+
+    /**
      * Legacy test/delete DOIs should never create ERNIE resources.
      */
     public function shouldSkipLegacyDoi(string $doi): bool

--- a/app/Services/MetaworksDownloadUrlService.php
+++ b/app/Services/MetaworksDownloadUrlService.php
@@ -22,9 +22,9 @@ class MetaworksDownloadUrlService
     /**
      * Look up file download URLs for a given DOI from the old metaworks database.
      *
-     * Returns all file URLs (public and non-public) along with a flag indicating
-     * whether all files have public visibility. The caller uses this to determine
-     * whether the resulting landing page should be published immediately.
+     * Returns all file URLs (public and non-public) along with a compatibility
+     * flag indicating whether every file is public. Landing-page publication is
+     * deliberately decided from the legacy resource status, not file visibility.
      *
      * DOI format in metaworks uses "/" (e.g. "10.5880/GFZ.5.4.2013.001"),
      * same format as DataCite.
@@ -51,7 +51,7 @@ class MetaworksDownloadUrlService
      * entries are imported as landing page additional links, using the legacy
      * file name first and the description as fallback label.
      *
-     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound: bool, hasFileRows: bool}
+     * @return array{files: list<array{url: string, label: string|null, visible: string|null}>, allPublic: bool, resourceFound: bool, hasFileRows: bool, resourcePublicStatus: string|null}
      */
     public function lookupFileEntries(string $doi): array
     {
@@ -59,12 +59,16 @@ class MetaworksDownloadUrlService
         $oldResource = DB::connection(self::CONNECTION)
             ->table('resource')
             ->where('identifier', $doi)
-            ->select('id')
+            ->select('id', 'publicstatus')
             ->first();
 
         if ($oldResource === null) {
-            return ['files' => [], 'allPublic' => false, 'resourceFound' => false, 'hasFileRows' => false];
+            return ['files' => [], 'allPublic' => false, 'resourceFound' => false, 'hasFileRows' => false, 'resourcePublicStatus' => null];
         }
+
+        $resourcePublicStatus = isset($oldResource->publicstatus)
+            ? trim((string) $oldResource->publicstatus)
+            : null;
 
         // Get all file records for that resource (public and non-public)
         $files = DB::connection(self::CONNECTION)
@@ -74,7 +78,7 @@ class MetaworksDownloadUrlService
             ->get(['url', 'name', 'description', 'visible']);
 
         if ($files->isEmpty()) {
-            return ['files' => [], 'allPublic' => false, 'resourceFound' => true, 'hasFileRows' => false];
+            return ['files' => [], 'allPublic' => false, 'resourceFound' => true, 'hasFileRows' => false, 'resourcePublicStatus' => $resourcePublicStatus];
         }
 
         // Determine if all files are publicly visible
@@ -109,7 +113,7 @@ class MetaworksDownloadUrlService
             ];
         }
 
-        return ['files' => $entries, 'allPublic' => $allPublic, 'resourceFound' => true, 'hasFileRows' => true];
+        return ['files' => $entries, 'allPublic' => $allPublic, 'resourceFound' => true, 'hasFileRows' => true, 'resourcePublicStatus' => $resourcePublicStatus];
     }
 
     private function isValidDownloadUrl(string $doi, string $url): bool

--- a/config/datacite.php
+++ b/config/datacite.php
@@ -15,18 +15,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | DataCite Sync After Import
-    |--------------------------------------------------------------------------
-    |
-    | When true and test_mode is false, imported DataCite resources are synced
-    | back to DataCite after legacy enrichment. Keep this opt-in for bulk imports
-    | because direct API updates can add significant runtime and hit rate limits.
-    |
-    */
-    'sync_after_import' => env('DATACITE_SYNC_AFTER_IMPORT', false),
-
-    /*
-    |--------------------------------------------------------------------------
     | Required Citation Label Resolution
     |--------------------------------------------------------------------------
     |

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -163,6 +163,14 @@ npm run docker:dev:parity
 - The npm Docker wrappers always pass `--env-file .env.docker` so Compose and Laravel use the same source of truth.
 - Docker-managed `node_modules` live in the named Docker volume, not in your host checkout.
 
+### DataCite import mode
+
+Keep `DATACITE_TEST_MODE=true` for local development and Stage. Eligible imported resources and every newly imported IGSN receive their local landing page, but the import never writes metadata to either DataCite API in this mode.
+
+With `DATACITE_TEST_MODE=false` on Production, the same local landing pages are created and the newly imported, published records enter a separate DataCite synchronization phase. That phase exports the complete ERNIE metadata and changes the DOI target URL to the new landing page. Failed updates do not roll back the import or landing page and can be retried from the completed import dialog.
+
+There is no separate post-import sync flag: `DATACITE_TEST_MODE` is the only switch. The queue worker must consume the `imports` queue so the bounded synchronization jobs can complete.
+
 ## Troubleshooting
 
 ### `419 Page Expired`

--- a/resources/js/components/igsns/modals/ImportIgsnsModal.tsx
+++ b/resources/js/components/igsns/modals/ImportIgsnsModal.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, CheckCircle2, Download, XCircle } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
+import { dataCiteSyncProgressLabel, type ImportDataCiteSyncProgress, ImportDataCiteSyncStatus } from '@/components/imports/ImportDataCiteSyncStatus';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -14,7 +15,7 @@ import { Progress } from '@/components/ui/progress';
 import { Spinner } from '@/components/ui/spinner';
 import { buildCsrfHeaders } from '@/lib/csrf-token';
 
-interface ImportProgress {
+interface ImportProgress extends ImportDataCiteSyncProgress {
     status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
     total: number;
     processed: number;
@@ -246,7 +247,10 @@ export default function ImportIgsnsModal({ isOpen, onClose, onSuccess, mode = 'a
         }
     }, [importId, isCancelling]);
 
-    const progressPercent = progress && progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
+    const isSyncing = progress?.phase === 'syncing';
+    const progressCurrent = isSyncing ? (progress.sync_processed ?? 0) : (progress?.processed ?? 0);
+    const progressTotal = isSyncing ? (progress?.sync_total ?? 0) : (progress?.total ?? 0);
+    const progressPercent = progressTotal > 0 ? Math.round((progressCurrent / progressTotal) * 100) : 0;
 
     const formatDuration = (startedAt?: string, completedAt?: string): string => {
         if (!startedAt) return '';
@@ -298,7 +302,7 @@ export default function ImportIgsnsModal({ isOpen, onClose, onSuccess, mode = 'a
                             (isDatacenterMode
                                 ? 'Import all IGSNs assigned to one datacenter in the legacy GFZ catalogue.'
                                 : 'Import all registered IGSNs from the DataCite production API and enrich them with legacy metadata.')}
-                        {modalState === 'running' && 'Import is in progress...'}
+                        {modalState === 'running' && (dataCiteSyncProgressLabel(progress ?? {}) ?? 'Import is in progress...')}
                         {modalState === 'completed' && 'Import completed successfully.'}
                         {modalState === 'cancelled' && 'Import was cancelled.'}
                         {modalState === 'failed' && 'Import failed.'}
@@ -382,10 +386,10 @@ export default function ImportIgsnsModal({ isOpen, onClose, onSuccess, mode = 'a
                                 <div className="flex items-center justify-between text-sm">
                                     <span className="flex items-center gap-2">
                                         <Spinner size="sm" />
-                                        Processing...
+                                        {isSyncing ? 'Updating DataCite metadata...' : 'Processing...'}
                                     </span>
                                     <span className="text-muted-foreground">
-                                        {progress.processed} / {progress.total || '?'} IGSNs
+                                        {progressCurrent} / {progressTotal || '?'} {isSyncing ? 'updates' : 'IGSNs'}
                                     </span>
                                 </div>
                                 <Progress value={progressPercent} className="h-2" />
@@ -434,6 +438,12 @@ export default function ImportIgsnsModal({ isOpen, onClose, onSuccess, mode = 'a
                                     {formatDuration(progress.started_at, progress.completed_at)}.
                                 </AlertDescription>
                             </Alert>
+
+                            <ImportDataCiteSyncStatus
+                                progress={progress}
+                                retryUrl={`/igsns/import/${importId}/retry-sync`}
+                                onRetryStarted={() => setModalState('running')}
+                            />
 
                             {(progress.warnings ?? []).map((warning) => (
                                 <Alert key={warning} className="border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950">

--- a/resources/js/components/igsns/modals/ImportSingleIgsnModal.tsx
+++ b/resources/js/components/igsns/modals/ImportSingleIgsnModal.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, Download, XCircle } 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
+import { dataCiteSyncProgressLabel, type ImportDataCiteSyncProgress, ImportDataCiteSyncStatus } from '@/components/imports/ImportDataCiteSyncStatus';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -16,7 +17,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { buildCsrfHeaders } from '@/lib/csrf-token';
 import { normalizeIgsnInput } from '@/lib/igsn-validation';
 
-interface ImportProgress {
+interface ImportProgress extends ImportDataCiteSyncProgress {
     status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
     total: number;
     processed: number;
@@ -253,7 +254,10 @@ export default function ImportSingleIgsnModal({ isOpen, igsnPrefix = '10.60510',
         onClose();
     }, [modalState, onClose]);
 
-    const progressPercent = progress && progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
+    const isSyncing = progress?.phase === 'syncing';
+    const progressCurrent = isSyncing ? (progress.sync_processed ?? 0) : (progress?.processed ?? 0);
+    const progressTotal = isSyncing ? (progress?.sync_total ?? 0) : (progress?.total ?? 0);
+    const progressPercent = progressTotal > 0 ? Math.round((progressCurrent / progressTotal) * 100) : 0;
     const relatedIgsnCount = progress?.discovered_children?.length ?? 0;
     const isAlreadyImported = progress?.imported === 0 && progress?.skipped === progress?.total && progress?.failed === 0;
 
@@ -267,7 +271,7 @@ export default function ImportSingleIgsnModal({ isOpen, igsnPrefix = '10.60510',
                     </DialogTitle>
                     <DialogDescription>
                         {modalState === 'confirm' && 'Enter one IGSN to import it from DataCite into ERNIE.'}
-                        {modalState === 'running' && `Importing ${submittedIgsn ?? 'IGSN'}...`}
+                        {modalState === 'running' && (dataCiteSyncProgressLabel(progress ?? {}) ?? `Importing ${submittedIgsn ?? 'IGSN'}...`)}
                         {modalState === 'completed' && (isAlreadyImported ? 'This IGSN already exists in ERNIE.' : 'Import completed successfully.')}
                         {modalState === 'cancelled' && 'Import was cancelled.'}
                         {modalState === 'failed' && 'Single IGSN import failed.'}
@@ -311,10 +315,10 @@ export default function ImportSingleIgsnModal({ isOpen, igsnPrefix = '10.60510',
                                 <div className="flex items-center justify-between text-sm">
                                     <span className="flex items-center gap-2">
                                         <Spinner size="sm" />
-                                        Processing...
+                                        {isSyncing ? 'Updating DataCite metadata...' : 'Processing...'}
                                     </span>
                                     <span className="text-muted-foreground">
-                                        {progress.processed} / {progress.total || '?'} IGSNs
+                                        {progressCurrent} / {progressTotal || '?'} {isSyncing ? 'updates' : 'IGSNs'}
                                     </span>
                                 </div>
                                 <Progress value={progressPercent} className="h-2" />
@@ -360,6 +364,14 @@ export default function ImportSingleIgsnModal({ isOpen, igsnPrefix = '10.60510',
                                           : `${submittedIgsn ?? progress.requested_igsn ?? 'The IGSN'} import finished with ${progress.imported} imported and ${progress.enriched} enriched.`}
                                 </AlertDescription>
                             </Alert>
+
+                            {modalState === 'completed' && (
+                                <ImportDataCiteSyncStatus
+                                    progress={progress}
+                                    retryUrl={`/igsns/import/${importId}/retry-sync`}
+                                    onRetryStarted={() => setModalState('running')}
+                                />
+                            )}
 
                             {(progress.warnings ?? []).map((warning) => (
                                 <Alert key={warning} className="border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950">

--- a/resources/js/components/imports/ImportDataCiteSyncStatus.tsx
+++ b/resources/js/components/imports/ImportDataCiteSyncStatus.tsx
@@ -1,0 +1,107 @@
+import axios, { isAxiosError } from 'axios';
+import { AlertTriangle, CheckCircle2, RefreshCw, ShieldCheck } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { buildCsrfHeaders } from '@/lib/csrf-token';
+
+export interface ImportDataCiteSyncProgress {
+    phase?: 'importing' | 'syncing' | 'completed';
+    sync_total?: number;
+    sync_processed?: number;
+    sync_succeeded?: number;
+    sync_failed?: number;
+    sync_errors?: Array<{ resource_id: number; doi: string | null; error: string }>;
+    sync_skipped_test_mode?: boolean;
+    sync_retry_available?: boolean;
+}
+
+interface ImportDataCiteSyncStatusProps {
+    progress: ImportDataCiteSyncProgress;
+    retryUrl: string;
+    onRetryStarted: () => void;
+}
+
+export function ImportDataCiteSyncStatus({ progress, retryUrl, onRetryStarted }: ImportDataCiteSyncStatusProps) {
+    const [isRetrying, setIsRetrying] = useState(false);
+    const total = progress.sync_total ?? 0;
+    const succeeded = progress.sync_succeeded ?? 0;
+    const failed = progress.sync_failed ?? 0;
+
+    if (total === 0 && !progress.sync_skipped_test_mode) {
+        return null;
+    }
+
+    const retry = async () => {
+        setIsRetrying(true);
+
+        try {
+            await axios.post(retryUrl, {}, { headers: buildCsrfHeaders() });
+            toast.info('DataCite retry started');
+            onRetryStarted();
+        } catch (error) {
+            const message = isAxiosError(error)
+                ? (error.response?.data?.error ?? error.response?.data?.message ?? error.message)
+                : 'The DataCite retry could not be started.';
+            toast.error(message);
+        } finally {
+            setIsRetrying(false);
+        }
+    };
+
+    if (progress.sync_skipped_test_mode) {
+        return (
+            <Alert>
+                <ShieldCheck className="size-4" />
+                <AlertTitle>DataCite update skipped</AlertTitle>
+                <AlertDescription>Test mode is active. Landing pages were created locally, and no metadata was written to DataCite.</AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (failed === 0) {
+        return (
+            <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950">
+                <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
+                <AlertTitle>DataCite metadata updated</AlertTitle>
+                <AlertDescription>
+                    {succeeded} {succeeded === 1 ? 'record now points' : 'records now point'} to the new landing page.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <Alert variant="destructive">
+            <AlertTriangle className="size-4" />
+            <AlertTitle>DataCite update incomplete</AlertTitle>
+            <AlertDescription className="space-y-3">
+                <p>
+                    {failed} of {total} metadata {total === 1 ? 'update' : 'updates'} failed. The imported records and their published landing pages
+                    were kept.
+                </p>
+                {progress.sync_errors?.[0] && (
+                    <p className="text-xs">
+                        {progress.sync_errors[0].doi ?? `Resource ${progress.sync_errors[0].resource_id}`}: {progress.sync_errors[0].error}
+                    </p>
+                )}
+                {progress.sync_retry_available && (
+                    <Button type="button" variant="outline" size="sm" disabled={isRetrying} onClick={() => void retry()}>
+                        <RefreshCw className={isRetrying ? 'animate-spin' : undefined} />
+                        Retry failed updates
+                    </Button>
+                )}
+            </AlertDescription>
+        </Alert>
+    );
+}
+
+export function dataCiteSyncProgressLabel(progress: ImportDataCiteSyncProgress): string | null {
+    if (progress.phase !== 'syncing') {
+        return null;
+    }
+
+    return `Updating DataCite metadata… ${progress.sync_processed ?? 0} / ${progress.sync_total ?? 0}`;
+}

--- a/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
+++ b/resources/js/components/resources/modals/ImportFromDataCiteModal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { DataCiteIcon } from '@/components/icons/datacite-icon';
+import { dataCiteSyncProgressLabel, type ImportDataCiteSyncProgress, ImportDataCiteSyncStatus } from '@/components/imports/ImportDataCiteSyncStatus';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -15,7 +16,7 @@ import { Progress } from '@/components/ui/progress';
 import { Spinner } from '@/components/ui/spinner';
 import { buildCsrfHeaders } from '@/lib/csrf-token';
 
-interface ImportProgress {
+interface ImportProgress extends ImportDataCiteSyncProgress {
     status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
     total: number;
     processed: number;
@@ -239,7 +240,10 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess, mo
         onClose();
     }, [onClose]);
 
-    const progressPercent = progress && progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
+    const isSyncing = progress?.phase === 'syncing';
+    const progressCurrent = isSyncing ? (progress.sync_processed ?? 0) : (progress?.processed ?? 0);
+    const progressTotal = isSyncing ? (progress?.sync_total ?? 0) : (progress?.total ?? 0);
+    const progressPercent = progressTotal > 0 ? Math.round((progressCurrent / progressTotal) * 100) : 0;
     const enrichedCount = progress?.enriched ?? 0;
 
     const formatDuration = (startedAt?: string, completedAt?: string): string => {
@@ -348,7 +352,7 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess, mo
                             (isDatacenterMode
                                 ? 'Import legacy resources for one GFZ Data Services datacenter into ERNIE.'
                                 : 'Import all registered GFZ legacy resources from the DataCite production API into ERNIE.')}
-                        {modalState === 'running' && 'Import is in progress...'}
+                        {modalState === 'running' && (dataCiteSyncProgressLabel(progress ?? {}) ?? 'Import is in progress...')}
                         {modalState === 'completed' && 'Import completed successfully.'}
                         {modalState === 'failed' && 'Import failed.'}
                     </DialogDescription>
@@ -448,10 +452,10 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess, mo
                                 <div className="flex items-center justify-between text-sm">
                                     <span className="flex items-center gap-2">
                                         <Spinner size="sm" />
-                                        Processing...
+                                        {isSyncing ? 'Updating DataCite metadata...' : 'Processing...'}
                                     </span>
                                     <span className="text-muted-foreground">
-                                        {progress.processed} / {progress.total || '?'} DOIs
+                                        {progressCurrent} / {progressTotal || '?'} {isSyncing ? 'updates' : 'DOIs'}
                                     </span>
                                 </div>
                                 <Progress value={progressPercent} className="h-2" />
@@ -474,6 +478,11 @@ export default function ImportFromDataCiteModal({ isOpen, onClose, onSuccess, mo
 
                     {modalState === 'completed' && progress && (
                         <div className="space-y-4">
+                            <ImportDataCiteSyncStatus
+                                progress={progress}
+                                retryUrl={`/datacite/import/${importId}/retry-sync`}
+                                onRetryStarted={() => setModalState('running')}
+                            />
                             <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950">
                                 <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
                                 <AlertTitle className="text-green-800 dark:text-green-200">Import Complete</AlertTitle>

--- a/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
+++ b/resources/js/components/resources/modals/ImportSingleOldResourceModal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { DataCiteIcon } from '@/components/icons/datacite-icon';
+import { dataCiteSyncProgressLabel, type ImportDataCiteSyncProgress, ImportDataCiteSyncStatus } from '@/components/imports/ImportDataCiteSyncStatus';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -16,7 +17,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { buildCsrfHeaders } from '@/lib/csrf-token';
 import { normalizeDOI, validateDOIFormat } from '@/lib/doi-validation';
 
-interface ImportProgress {
+interface ImportProgress extends ImportDataCiteSyncProgress {
     status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
     total: number;
     processed: number;
@@ -215,7 +216,10 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
         onClose();
     }, [onClose]);
 
-    const progressPercent = progress && progress.total > 0 ? Math.round((progress.processed / progress.total) * 100) : 0;
+    const isSyncing = progress?.phase === 'syncing';
+    const progressCurrent = isSyncing ? (progress.sync_processed ?? 0) : (progress?.processed ?? 0);
+    const progressTotal = isSyncing ? (progress?.sync_total ?? 0) : (progress?.total ?? 0);
+    const progressPercent = progressTotal > 0 ? Math.round((progressCurrent / progressTotal) * 100) : 0;
     const wasEnriched = (progress?.enriched ?? 0) > 0;
     const isAlreadyImported = progress?.skipped === 1 && !wasEnriched;
 
@@ -229,7 +233,7 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
                     </DialogTitle>
                     <DialogDescription>
                         {modalState === 'confirm' && 'Enter a GFZ DataCite or SUMARIO legacy DOI to import it into ERNIE.'}
-                        {modalState === 'running' && `Importing ${submittedDoi ?? 'resource'}...`}
+                        {modalState === 'running' && (dataCiteSyncProgressLabel(progress ?? {}) ?? `Importing ${submittedDoi ?? 'resource'}...`)}
                         {modalState === 'completed' &&
                             (wasEnriched
                                 ? 'Missing legacy download links were added.'
@@ -289,10 +293,10 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
                                 <div className="flex items-center justify-between text-sm">
                                     <span className="flex items-center gap-2">
                                         <Spinner size="sm" />
-                                        Processing {submittedDoi ?? 'resource'}...
+                                        {isSyncing ? 'Updating DataCite metadata...' : `Processing ${submittedDoi ?? 'resource'}...`}
                                     </span>
                                     <span className="text-muted-foreground">
-                                        {progress.processed} / {progress.total} resource
+                                        {progressCurrent} / {progressTotal} {isSyncing ? 'update' : 'resource'}
                                     </span>
                                 </div>
                                 <Progress value={progressPercent} className="h-2" />
@@ -301,21 +305,30 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
                     )}
 
                     {modalState === 'completed' && progress && (
-                        <Alert className={isAlreadyImported ? undefined : 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950'}>
-                            {isAlreadyImported ? (
-                                <AlertCircle className="size-4" />
-                            ) : (
-                                <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
-                            )}
-                            <AlertTitle>{wasEnriched ? 'Legacy links added' : isAlreadyImported ? 'Already imported' : 'Import complete'}</AlertTitle>
-                            <AlertDescription>
-                                {wasEnriched
-                                    ? `${submittedDoi ?? 'This DOI'} already existed in ERNIE. Missing legacy download links were added.`
-                                    : isAlreadyImported
-                                      ? `${submittedDoi ?? 'This DOI'} already exists in ERNIE and was not imported again.`
-                                      : `${submittedDoi ?? 'The DOI'} was imported successfully.`}
-                            </AlertDescription>
-                        </Alert>
+                        <div className="space-y-4">
+                            <Alert className={isAlreadyImported ? undefined : 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950'}>
+                                {isAlreadyImported ? (
+                                    <AlertCircle className="size-4" />
+                                ) : (
+                                    <CheckCircle2 className="size-4 text-green-600 dark:text-green-400" />
+                                )}
+                                <AlertTitle>
+                                    {wasEnriched ? 'Legacy links added' : isAlreadyImported ? 'Already imported' : 'Import complete'}
+                                </AlertTitle>
+                                <AlertDescription>
+                                    {wasEnriched
+                                        ? `${submittedDoi ?? 'This DOI'} already existed in ERNIE. Missing legacy download links were added.`
+                                        : isAlreadyImported
+                                          ? `${submittedDoi ?? 'This DOI'} already exists in ERNIE and was not imported again.`
+                                          : `${submittedDoi ?? 'The DOI'} was imported successfully.`}
+                                </AlertDescription>
+                            </Alert>
+                            <ImportDataCiteSyncStatus
+                                progress={progress}
+                                retryUrl={`/datacite/import/${importId}/retry-sync`}
+                                onRetryStarted={() => setModalState('running')}
+                            />
+                        </div>
                     )}
 
                     {modalState === 'failed' && (
@@ -357,4 +370,3 @@ export default function ImportSingleOldResourceModal({ isOpen, onClose, onSucces
         </Dialog>
     );
 }
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -466,6 +466,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::post('datacite/import/{importId}/cancel', [DataCiteImportController::class, 'cancel'])
         ->name('datacite.import.cancel');
+    Route::post('datacite/import/{importId}/retry-sync', [DataCiteImportController::class, 'retrySync'])
+        ->name('datacite.import.retry-sync');
 
     // Landing Page Management (Admin)
     Route::post('resources/{resource}/landing-page', [LandingPageController::class, 'store'])
@@ -554,6 +556,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('igsns.import.status');
     Route::post('igsns/import/{importId}/cancel', [IgsnImportController::class, 'cancel'])
         ->name('igsns.import.cancel');
+    Route::post('igsns/import/{importId}/retry-sync', [IgsnImportController::class, 'retrySync'])
+        ->name('igsns.import.retry-sync');
     // Batch operations must be defined before routes with {resource} parameter
     Route::delete('igsns/batch', [BatchIgsnController::class, 'destroy'])
         ->name('igsns.batch.destroy');

--- a/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
@@ -3,12 +3,49 @@
 use App\Enums\UserRole;
 use App\Models\Resource;
 use App\Models\User;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 
 beforeEach(function () {
     $this->adminUser = User::factory()->create(['role' => UserRole::ADMIN]);
     $this->groupLeader = User::factory()->create(['role' => UserRole::GROUP_LEADER]);
     $this->curator = User::factory()->create(['role' => UserRole::CURATOR]);
     $this->beginner = User::factory()->create(['role' => UserRole::BEGINNER]);
+});
+
+it('retries failed resource DataCite synchronizations in production', function (): void {
+    Config::set('datacite.test_mode', false);
+    $importId = Str::uuid()->toString();
+    Cache::put("datacite_import:{$importId}", [
+        'status' => 'completed',
+        'sync_failed' => 1,
+        'sync_retry_available' => true,
+    ]);
+
+    $dispatcher = Mockery::mock(ImportedResourceDataCiteSyncDispatcher::class);
+    $dispatcher->shouldReceive('retryFailures')
+        ->once()
+        ->with(ImportProgressService::TYPE_RESOURCE, $importId)
+        ->andReturnTrue();
+    $this->app->instance(ImportedResourceDataCiteSyncDispatcher::class, $dispatcher);
+
+    $this->actingAs($this->adminUser)
+        ->postJson("/datacite/import/{$importId}/retry-sync")
+        ->assertAccepted();
+});
+
+it('rejects resource DataCite retries in test mode', function (): void {
+    Config::set('datacite.test_mode', true);
+    $importId = Str::uuid()->toString();
+    Cache::put("datacite_import:{$importId}", ['status' => 'completed']);
+
+    $this->actingAs($this->adminUser)
+        ->postJson("/datacite/import/{$importId}/retry-sync")
+        ->assertBadRequest()
+        ->assertJsonPath('error', 'DataCite synchronization is disabled in test mode.');
 });
 
 describe('DataCiteImportController', function () {
@@ -161,7 +198,7 @@ describe('ResourceController canImportFromDataCite', function () {
 
 describe('ResourceController destroy authorization', function () {
     it('allows admin to delete draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create([
+        $resource = App\Models\Resource::factory()->create([
             'doi' => null,
         ]);
 
@@ -169,11 +206,11 @@ describe('ResourceController destroy authorization', function () {
             ->delete("/resources/{$resource->id}");
 
         $response->assertRedirect('/resources');
-        expect(\App\Models\Resource::find($resource->id))->toBeNull();
+        expect(App\Models\Resource::find($resource->id))->toBeNull();
     });
 
     it('allows group leader to delete draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create([
+        $resource = App\Models\Resource::factory()->create([
             'doi' => null,
         ]);
 
@@ -181,11 +218,11 @@ describe('ResourceController destroy authorization', function () {
             ->delete("/resources/{$resource->id}");
 
         $response->assertRedirect('/resources');
-        expect(\App\Models\Resource::find($resource->id))->toBeNull();
+        expect(App\Models\Resource::find($resource->id))->toBeNull();
     });
 
     it('allows curator to delete draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create([
+        $resource = App\Models\Resource::factory()->create([
             'doi' => null,
         ]);
 
@@ -193,11 +230,11 @@ describe('ResourceController destroy authorization', function () {
             ->delete("/resources/{$resource->id}");
 
         $response->assertRedirect('/resources');
-        expect(\App\Models\Resource::find($resource->id))->toBeNull();
+        expect(App\Models\Resource::find($resource->id))->toBeNull();
     });
 
     it('denies beginner from deleting draft resources', function () {
-        $resource = \App\Models\Resource::factory()->create([
+        $resource = App\Models\Resource::factory()->create([
             'doi' => null,
         ]);
 
@@ -206,6 +243,6 @@ describe('ResourceController destroy authorization', function () {
 
         $response->assertForbidden();
         // Resource should still exist
-        expect(\App\Models\Resource::find($resource->id))->not->toBeNull();
+        expect(App\Models\Resource::find($resource->id))->not->toBeNull();
     });
 });

--- a/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
+++ b/tests/pest/Feature/DataCiteImport/DataCiteImportControllerTest.php
@@ -3,7 +3,7 @@
 use App\Enums\UserRole;
 use App\Models\Resource;
 use App\Models\User;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
@@ -25,12 +25,12 @@ it('retries failed resource DataCite synchronizations in production', function (
         'sync_retry_available' => true,
     ]);
 
-    $dispatcher = Mockery::mock(ImportedResourceDataCiteSyncDispatcher::class);
+    $dispatcher = Mockery::mock(ImportedResourceDataCiteSyncDispatcherService::class);
     $dispatcher->shouldReceive('retryFailures')
         ->once()
         ->with(ImportProgressService::TYPE_RESOURCE, $importId)
         ->andReturnTrue();
-    $this->app->instance(ImportedResourceDataCiteSyncDispatcher::class, $dispatcher);
+    $this->app->instance(ImportedResourceDataCiteSyncDispatcherService::class, $dispatcher);
 
     $this->actingAs($this->adminUser)
         ->postJson("/datacite/import/{$importId}/retry-sync")

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -13,7 +13,6 @@ use App\Models\LandingPageLink;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\DataCiteImportService;
-use App\Services\DataCiteSyncResult;
 use App\Services\DataCiteSyncService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\DoiSuggestionService;
@@ -25,6 +24,7 @@ use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
@@ -1242,9 +1242,9 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['skipped_dois'])->toBe(['10.5880/pending.skip']);
     });
 
-    it('syncs imported DataCite resources after enrichment when production sync after import is enabled', function () {
+    it('syncs newly imported published DataCite resources after enrichment in production', function () {
         Config::set('datacite.test_mode', false);
-        Config::set('datacite.sync_after_import', true);
+        Bus::fake();
 
         $this->importService
             ->shouldReceive('getTotalDoiCount')
@@ -1259,6 +1259,7 @@ describe('ImportFromDataCiteJob', function () {
                     'id' => '10.5880/sync.production',
                     'attributes' => [
                         'doi' => '10.5880/sync.production',
+                        'state' => 'findable',
                         'titles' => [['title' => 'Production Sync Dataset']],
                     ],
                 ];
@@ -1282,35 +1283,25 @@ describe('ImportFromDataCiteJob', function () {
                     ],
                 ],
                 'allPublic' => true,
+                'resourceFound' => true,
+                'resourcePublicStatus' => 'published',
             ]);
-
-        $syncService = Mockery::mock(DataCiteSyncService::class);
-        $syncService
-            ->shouldReceive('syncIfRegistered')
-            ->once()
-            ->withArgs(function (Resource $resource): bool {
-                $resource->loadMissing('landingPage');
-
-                return $resource->doi === '10.5880/sync.production'
-                    && $resource->landingPage !== null
-                    && $resource->landingPage->ftp_url === 'https://datapub.gfz.de/download/10.5880/sync.production/data.zip';
-            })
-            ->andReturn(DataCiteSyncResult::succeeded('10.5880/sync.production'));
-        $this->app->instance(DataCiteSyncService::class, $syncService);
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
         $job->handle($this->importService, $this->transformer, $this->metaworksService);
 
         $status = Cache::get("datacite_import:{$importId}");
-        expect($status['status'])->toBe('completed')
+        expect($status['status'])->toBe('running')
+            ->and($status['phase'])->toBe('syncing')
             ->and($status['imported'])->toBe(1)
-            ->and($status['failed'])->toBe(0);
+            ->and($status['failed'])->toBe(0)
+            ->and($status['sync_total'])->toBe(1);
+        Bus::assertBatched(fn ($batch): bool => $batch->jobs->count() === 1);
     });
 
-    it('does not sync imported DataCite resources when production sync after import is disabled', function () {
-        Config::set('datacite.test_mode', false);
-        Config::set('datacite.sync_after_import', false);
+    it('does not call DataCite when test mode is enabled', function () {
+        Config::set('datacite.test_mode', true);
 
         $this->importService
             ->shouldReceive('getTotalDoiCount')
@@ -1325,6 +1316,7 @@ describe('ImportFromDataCiteJob', function () {
                     'id' => '10.5880/sync.disabled',
                     'attributes' => [
                         'doi' => '10.5880/sync.disabled',
+                        'state' => 'findable',
                         'titles' => [['title' => 'Sync Disabled Dataset']],
                     ],
                 ];
@@ -1334,6 +1326,18 @@ describe('ImportFromDataCiteJob', function () {
             ->shouldReceive('transform')
             ->once()
             ->andReturnUsing(fn () => Resource::factory()->create(['doi' => '10.5880/sync.disabled']));
+
+        $this->metaworksService
+            ->shouldReceive('lookupFileEntries')
+            ->once()
+            ->with('10.5880/sync.disabled')
+            ->andReturn([
+                'files' => [],
+                'allPublic' => false,
+                'resourceFound' => true,
+                'hasFileRows' => false,
+                'resourcePublicStatus' => 'published',
+            ]);
 
         $syncService = Mockery::mock(DataCiteSyncService::class);
         $syncService
@@ -1348,7 +1352,9 @@ describe('ImportFromDataCiteJob', function () {
         $status = Cache::get("datacite_import:{$importId}");
         expect($status['status'])->toBe('completed')
             ->and($status['imported'])->toBe(1)
-            ->and($status['failed'])->toBe(0);
+            ->and($status['failed'])->toBe(0)
+            ->and($status['sync_skipped_test_mode'])->toBeTrue()
+            ->and($status['sync_total'])->toBe(1);
     });
 
     it('marks single import as failed when the DOI transform throws an exception', function () {
@@ -1500,6 +1506,8 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     ],
                 ],
                 'allPublic' => true,
+                'resourceFound' => true,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();
@@ -1566,6 +1574,8 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     ],
                 ],
                 'allPublic' => true,
+                'resourceFound' => true,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();
@@ -1582,7 +1592,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and($landingPage->published_at)->toBeNull();
     });
 
-    it('creates unpublished landing page when metaworks files are non-public', function () {
+    it('publishes a landing page regardless of legacy file visibility', function () {
         $this->importService
             ->shouldReceive('getTotalDoiCount')
             ->once()
@@ -1623,18 +1633,20 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     ],
                 ],
                 'allPublic' => false,
+                'resourceFound' => true,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
         $job->handle($this->importService, $this->transformer, $metaworksService);
 
-        // Verify landing page was created but NOT published
+        // File visibility is not a publication criterion.
         $resource = Resource::where('doi', '10.5880/lp.nonpub.001')->first();
         $landingPage = LandingPage::where('resource_id', $resource->id)->first();
         expect($landingPage)->not->toBeNull()
-            ->and($landingPage->is_published)->toBeFalse()
-            ->and($landingPage->published_at)->toBeNull();
+            ->and($landingPage->is_published)->toBeTrue()
+            ->and($landingPage->published_at)->not->toBeNull();
 
         expect($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/internal-file.zip')
             ->and(LandingPageLink::where('landing_page_id', $landingPage->id)->count())->toBe(0)
@@ -1728,6 +1740,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                 'allPublic' => false,
                 'resourceFound' => true,
                 'hasFileRows' => false,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();
@@ -1746,7 +1759,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
             ->and(LandingPageDomain::count())->toBe(0);
     });
 
-    it('keeps a findable landing page in review when non-public legacy rows have no valid URLs', function () {
+    it('publishes a findable landing page even when non-public legacy rows have no valid URLs', function () {
         $this->importService
             ->shouldReceive('getTotalDoiCount')
             ->once()
@@ -1782,6 +1795,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                 'allPublic' => false,
                 'resourceFound' => true,
                 'hasFileRows' => true,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();
@@ -1794,8 +1808,8 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         expect($landingPage)->not->toBeNull()
             ->and($landingPage->ftp_url)->toBeNull()
             ->and($landingPage->downloads_unavailable)->toBeTrue()
-            ->and($landingPage->is_published)->toBeFalse()
-            ->and($landingPage->published_at)->toBeNull();
+            ->and($landingPage->is_published)->toBeTrue()
+            ->and($landingPage->published_at)->not->toBeNull();
     });
 
     it('ignores old DataCite data services URLs and imports SUMARIO file URLs instead', function () {
@@ -1840,6 +1854,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                 ],
                 'allPublic' => true,
                 'resourceFound' => true,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();
@@ -1920,7 +1935,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         expect(LandingPage::count())->toBe(0);
     });
 
-    it('backfills legacy download links for skipped existing resources', function () {
+    it('does not backfill or synchronize skipped existing resources', function () {
         $resource = Resource::factory()->create(['doi' => '10.5880/skip.backfill']);
 
         $this->importService
@@ -1944,19 +1959,7 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         $this->transformer->shouldReceive('transform')->never();
 
         $metaworksService = Mockery::mock(MetaworksDownloadUrlService::class);
-        $metaworksService->shouldReceive('lookupFileEntries')
-            ->once()
-            ->with('10.5880/skip.backfill')
-            ->andReturn([
-                'files' => [
-                    [
-                        'url' => 'https://datapub.gfz.de/download/10.5880.skip.backfill',
-                        'label' => 'Download data',
-                        'visible' => 'public',
-                    ],
-                ],
-                'allPublic' => true,
-            ]);
+        $metaworksService->shouldNotReceive('lookupFileEntries');
 
         $importId = Str::uuid()->toString();
         $job = new ImportFromDataCiteJob($this->user->id, $importId);
@@ -1966,14 +1969,12 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
         expect($status['status'])->toBe('completed')
             ->and($status['imported'])->toBe(0)
             ->and($status['skipped'])->toBe(1)
-            ->and($status['enriched'])->toBe(1)
+            ->and($status['enriched'])->toBe(0)
             ->and($status['skipped_dois'])->toBe(['10.5880/skip.backfill'])
-            ->and($status['enriched_dois'])->toBe(['10.5880/skip.backfill']);
+            ->and($status['enriched_dois'])->toBe([]);
 
         $landingPage = $resource->fresh(['landingPage'])->landingPage;
-        expect($landingPage)->not->toBeNull()
-            ->and($landingPage->ftp_url)->toBe('https://datapub.gfz.de/download/10.5880.skip.backfill')
-            ->and($landingPage->is_published)->toBeTrue();
+        expect($landingPage)->toBeNull();
     });
 
     it('creates an external landing page from DataCite url before metaworks lookup', function () {
@@ -2248,6 +2249,8 @@ describe('ImportFromDataCiteJob download URL enrichment', function () {
                     ],
                 ],
                 'allPublic' => true,
+                'resourceFound' => true,
+                'resourcePublicStatus' => 'published',
             ]);
 
         $importId = Str::uuid()->toString();

--- a/tests/pest/Feature/DataCiteImport/ImportedResourceDataCiteSyncTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportedResourceDataCiteSyncTest.php
@@ -7,7 +7,7 @@ use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Services\DataCiteSyncResult;
 use App\Services\DataCiteSyncService;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
@@ -102,7 +102,7 @@ it('finishes locally without dispatching DataCite jobs in test mode', function (
     Config::set('datacite.test_mode', true);
     Bus::fake();
 
-    app(ImportedResourceDataCiteSyncDispatcher::class)->dispatch(
+    app(ImportedResourceDataCiteSyncDispatcherService::class)->dispatch(
         ImportProgressService::TYPE_RESOURCE,
         $this->importId,
         [123],

--- a/tests/pest/Feature/DataCiteImport/ImportedResourceDataCiteSyncTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportedResourceDataCiteSyncTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\SyncImportedResourcesWithDataCiteJob;
+use App\Models\LandingPage;
+use App\Models\Resource;
+use App\Services\DataCiteSyncResult;
+use App\Services\DataCiteSyncService;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+beforeEach(function (): void {
+    $this->importId = Str::uuid()->toString();
+    Cache::put("datacite_import:{$this->importId}", [
+        'status' => 'completed',
+        'imported' => 1,
+    ]);
+});
+
+it('has a hard test-mode guard in the queued sync job', function (): void {
+    Config::set('datacite.test_mode', true);
+    $resource = Resource::factory()->create(['doi' => '10.5880/test-mode']);
+    LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldNotReceive('syncIfRegistered');
+
+    (new SyncImportedResourcesWithDataCiteJob(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        [$resource->id],
+    ))->handle($syncService, app(ImportProgressService::class));
+});
+
+it('records successful synchronization separately from import counts', function (): void {
+    Config::set('datacite.test_mode', false);
+    $resource = Resource::factory()->create(['doi' => '10.5880/success']);
+    LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+    $progress = app(ImportProgressService::class);
+    $progress->beginSync(ImportProgressService::TYPE_RESOURCE, $this->importId, [$resource->id]);
+
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldReceive('syncIfRegistered')
+        ->once()
+        ->andReturn(DataCiteSyncResult::succeeded('10.5880/success'));
+
+    (new SyncImportedResourcesWithDataCiteJob(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        [$resource->id],
+    ))->handle($syncService, $progress);
+
+    expect($progress->get(ImportProgressService::TYPE_RESOURCE, $this->importId))
+        ->toMatchArray([
+            'status' => 'completed',
+            'phase' => 'completed',
+            'imported' => 1,
+            'sync_processed' => 1,
+            'sync_succeeded' => 1,
+            'sync_failed' => 0,
+        ]);
+});
+
+it('keeps local data and exposes retryable synchronization failures', function (): void {
+    Config::set('datacite.test_mode', false);
+    $resource = Resource::factory()->create(['doi' => '10.5880/failure']);
+    LandingPage::factory()->published()->create(['resource_id' => $resource->id]);
+    $progress = app(ImportProgressService::class);
+    $progress->beginSync(ImportProgressService::TYPE_RESOURCE, $this->importId, [$resource->id]);
+
+    $syncService = Mockery::mock(DataCiteSyncService::class);
+    $syncService->shouldReceive('syncIfRegistered')
+        ->once()
+        ->andReturn(DataCiteSyncResult::failed('10.5880/failure', 'DataCite unavailable'));
+
+    (new SyncImportedResourcesWithDataCiteJob(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        [$resource->id],
+    ))->handle($syncService, $progress);
+
+    $state = $progress->get(ImportProgressService::TYPE_RESOURCE, $this->importId);
+    expect($state)->toMatchArray([
+        'status' => 'completed',
+        'sync_failed' => 1,
+        'sync_retry_available' => true,
+    ])->and($state['sync_errors'][0])->toMatchArray([
+        'resource_id' => $resource->id,
+        'doi' => '10.5880/failure',
+        'error' => 'DataCite unavailable',
+    ])->and($progress->failedResourceIds(ImportProgressService::TYPE_RESOURCE, $this->importId))
+        ->toBe([$resource->id])
+        ->and(Resource::find($resource->id))->not->toBeNull();
+});
+
+it('finishes locally without dispatching DataCite jobs in test mode', function (): void {
+    Config::set('datacite.test_mode', true);
+    Bus::fake();
+
+    app(ImportedResourceDataCiteSyncDispatcher::class)->dispatch(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        [123],
+    );
+
+    Bus::assertNothingBatched();
+    expect(Cache::get("datacite_import:{$this->importId}"))->toMatchArray([
+        'status' => 'completed',
+        'phase' => 'completed',
+        'sync_total' => 1,
+        'sync_processed' => 0,
+        'sync_skipped_test_mode' => true,
+    ]);
+});
+
+it('turns unprocessed batch items into retryable failures during finalization', function (): void {
+    Config::set('datacite.test_mode', false);
+    $progress = app(ImportProgressService::class);
+    $progress->beginSync(ImportProgressService::TYPE_RESOURCE, $this->importId, [41, 42]);
+
+    $progress->finalizeSync(ImportProgressService::TYPE_RESOURCE, $this->importId);
+
+    expect($progress->get(ImportProgressService::TYPE_RESOURCE, $this->importId))->toMatchArray([
+        'status' => 'completed',
+        'sync_processed' => 2,
+        'sync_failed' => 2,
+        'sync_retry_available' => true,
+    ])->and($progress->failedResourceIds(ImportProgressService::TYPE_RESOURCE, $this->importId))
+        ->toBe([41, 42]);
+});

--- a/tests/pest/Feature/DataCiteImport/ImportedResourceDataCiteSyncTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportedResourceDataCiteSyncTest.php
@@ -9,9 +9,12 @@ use App\Services\DataCiteSyncResult;
 use App\Services\DataCiteSyncService;
 use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
+use Illuminate\Contracts\Cache\Lock as LockContract;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 beforeEach(function (): void {
@@ -133,3 +136,112 @@ it('turns unprocessed batch items into retryable failures during finalization', 
     ])->and($progress->failedResourceIds(ImportProgressService::TYPE_RESOURCE, $this->importId))
         ->toBe([41, 42]);
 });
+
+it('does not expose synchronization retries when test mode becomes active before completion', function (): void {
+    Config::set('datacite.test_mode', false);
+    $progress = app(ImportProgressService::class);
+    $progress->beginSync(ImportProgressService::TYPE_RESOURCE, $this->importId, [41]);
+
+    Config::set('datacite.test_mode', true);
+    $progress->recordSyncFailure(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        41,
+        '10.5880/test-mode-failure',
+        'DataCite unavailable',
+    );
+
+    expect($progress->get(ImportProgressService::TYPE_RESOURCE, $this->importId))->toMatchArray([
+        'status' => 'completed',
+        'sync_failed' => 1,
+        'sync_retry_available' => false,
+    ]);
+});
+
+it('retries a timed-out progress lock before applying the update', function (): void {
+    $timedOutLock = Mockery::mock(LockContract::class);
+    $acquiredLock = Mockery::mock(LockContract::class);
+    $progressKey = "datacite_import:{$this->importId}";
+
+    $timedOutLock->shouldReceive('block')
+        ->once()
+        ->with(5, Mockery::type(Closure::class))
+        ->andThrow(new LockTimeoutException);
+    $acquiredLock->shouldReceive('block')
+        ->once()
+        ->with(5, Mockery::type(Closure::class))
+        ->andReturnUsing(static fn (int $seconds, Closure $callback): mixed => $callback());
+
+    Cache::shouldReceive('lock')
+        ->twice()
+        ->with("{$progressKey}:lock", 15)
+        ->andReturn($timedOutLock, $acquiredLock);
+    Cache::shouldReceive('get')
+        ->once()
+        ->with($progressKey, [])
+        ->andReturn(['status' => 'running']);
+    Cache::shouldReceive('put')
+        ->once()
+        ->withArgs(fn (string $key, array $progress, mixed $ttl): bool => $key === $progressKey
+            && $progress['processed'] === 1
+            && $ttl instanceof DateTimeInterface)
+        ->andReturnTrue();
+
+    app(ImportProgressService::class)->update(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        ['processed' => 1],
+    );
+});
+
+it('logs and continues when a progress lock repeatedly times out', function (): void {
+    $lock = Mockery::mock(LockContract::class);
+    $progressKey = "datacite_import:{$this->importId}";
+
+    $lock->shouldReceive('block')
+        ->times(3)
+        ->with(5, Mockery::type(Closure::class))
+        ->andThrow(new LockTimeoutException);
+    Cache::shouldReceive('lock')
+        ->times(3)
+        ->with("{$progressKey}:lock", 15)
+        ->andReturn($lock);
+    Log::shouldReceive('warning')
+        ->once()
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Import progress update skipped after repeated lock timeouts'
+            && $context['import_type'] === ImportProgressService::TYPE_RESOURCE
+            && $context['import_id'] === $this->importId
+            && $context['operation'] === 'update'
+            && $context['lock_key'] === "{$progressKey}:lock"
+            && $context['attempts'] === 3);
+
+    expect(fn () => app(ImportProgressService::class)->update(
+        ImportProgressService::TYPE_RESOURCE,
+        $this->importId,
+        ['processed' => 1],
+    ))->not->toThrow(LockTimeoutException::class);
+});
+
+it('does not dispatch synchronization for a cancelled import', function (string $type, string $progressKey): void {
+    Config::set('datacite.test_mode', false);
+    Bus::fake();
+    Cache::put("{$progressKey}:{$this->importId}", [
+        'status' => 'cancelled',
+        'phase' => 'completed',
+    ]);
+
+    app(ImportedResourceDataCiteSyncDispatcherService::class)->dispatch(
+        $type,
+        $this->importId,
+        [123],
+    );
+
+    Bus::assertNothingBatched();
+    expect(Cache::get("{$progressKey}:{$this->importId}"))->toBe([
+        'status' => 'cancelled',
+        'phase' => 'completed',
+    ]);
+})->with([
+    'resource import' => [ImportProgressService::TYPE_RESOURCE, 'datacite_import'],
+    'IGSN import' => [ImportProgressService::TYPE_IGSN, 'igsn_import'],
+]);

--- a/tests/pest/Feature/IgsnImport/AutomaticIgsnLandingPageServiceTest.php
+++ b/tests/pest/Feature/IgsnImport/AutomaticIgsnLandingPageServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\LandingPage;
+use App\Models\Resource;
+use App\Services\AutomaticIgsnLandingPageService;
+
+it('creates a published internal IGSN landing page with automatic template inheritance', function (): void {
+    $resource = Resource::factory()->create(['doi' => '10.60510/gftest001']);
+
+    $result = app(AutomaticIgsnLandingPageService::class)->createPublished($resource);
+
+    expect($result['created'])->toBeTrue()
+        ->and($result['landing_page']->template)->toBe('default_gfz_igsn')
+        ->and($result['landing_page']->landing_page_template_id)->toBeNull()
+        ->and($result['landing_page']->is_published)->toBeTrue()
+        ->and($result['landing_page']->published_at)->not->toBeNull()
+        ->and($result['landing_page']->downloads_unavailable)->toBeTrue()
+        ->and($result['landing_page']->ftp_url)->toBeNull();
+});
+
+it('is idempotent and preserves an existing landing page', function (): void {
+    $resource = Resource::factory()->create(['doi' => '10.60510/gftest002']);
+    $existing = LandingPage::factory()->draft()->create([
+        'resource_id' => $resource->id,
+        'template' => 'default_gfz_igsn',
+    ]);
+
+    $result = app(AutomaticIgsnLandingPageService::class)->createPublished($resource);
+
+    expect($result['created'])->toBeFalse()
+        ->and($result['landing_page']->is($existing))->toBeTrue()
+        ->and($result['landing_page']->is_published)->toBeFalse()
+        ->and(LandingPage::where('resource_id', $resource->id)->count())->toBe(1);
+});

--- a/tests/pest/Feature/IgsnImport/IgsnImportControllerTest.php
+++ b/tests/pest/Feature/IgsnImport/IgsnImportControllerTest.php
@@ -3,7 +3,7 @@
 use App\Enums\UserRole;
 use App\Jobs\ImportIgsnsFromDataCiteJob;
 use App\Models\User;
-use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportedResourceDataCiteSyncDispatcherService;
 use App\Services\ImportProgressService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
@@ -37,12 +37,12 @@ it('retries failed IGSN DataCite synchronizations in production', function (): v
         'sync_retry_available' => true,
     ]);
 
-    $dispatcher = Mockery::mock(ImportedResourceDataCiteSyncDispatcher::class);
+    $dispatcher = Mockery::mock(ImportedResourceDataCiteSyncDispatcherService::class);
     $dispatcher->shouldReceive('retryFailures')
         ->once()
         ->with(ImportProgressService::TYPE_IGSN, $importId)
         ->andReturnTrue();
-    $this->app->instance(ImportedResourceDataCiteSyncDispatcher::class, $dispatcher);
+    $this->app->instance(ImportedResourceDataCiteSyncDispatcherService::class, $dispatcher);
 
     $this->actingAs($this->adminUser)
         ->postJson("/igsns/import/{$importId}/retry-sync")

--- a/tests/pest/Feature/IgsnImport/IgsnImportControllerTest.php
+++ b/tests/pest/Feature/IgsnImport/IgsnImportControllerTest.php
@@ -3,9 +3,13 @@
 use App\Enums\UserRole;
 use App\Jobs\ImportIgsnsFromDataCiteJob;
 use App\Models\User;
+use App\Services\ImportedResourceDataCiteSyncDispatcher;
+use App\Services\ImportProgressService;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
 
 beforeEach(function () {
     $this->adminUser = User::factory()->create(['role' => UserRole::ADMIN]);
@@ -22,6 +26,27 @@ beforeEach(function () {
         'igsn_prefix' => '10.60510',
         'igsn_client_id' => 'gfz.igsn',
     ]);
+});
+
+it('retries failed IGSN DataCite synchronizations in production', function (): void {
+    Config::set('datacite.test_mode', false);
+    $importId = Str::uuid()->toString();
+    Cache::put("igsn_import:{$importId}", [
+        'status' => 'completed',
+        'sync_failed' => 1,
+        'sync_retry_available' => true,
+    ]);
+
+    $dispatcher = Mockery::mock(ImportedResourceDataCiteSyncDispatcher::class);
+    $dispatcher->shouldReceive('retryFailures')
+        ->once()
+        ->with(ImportProgressService::TYPE_IGSN, $importId)
+        ->andReturnTrue();
+    $this->app->instance(ImportedResourceDataCiteSyncDispatcher::class, $dispatcher);
+
+    $this->actingAs($this->adminUser)
+        ->postJson("/igsns/import/{$importId}/retry-sync")
+        ->assertAccepted();
 });
 
 describe('IgsnImportController', function () {

--- a/tests/pest/Feature/IgsnImport/ImportIgsnsFromDataCiteJobTest.php
+++ b/tests/pest/Feature/IgsnImport/ImportIgsnsFromDataCiteJobTest.php
@@ -3,6 +3,7 @@
 use App\Enums\UserRole;
 use App\Jobs\ImportIgsnsFromDataCiteJob;
 use App\Models\IgsnMetadata;
+use App\Models\LandingPage;
 use App\Models\Resource;
 use App\Models\User;
 use App\Services\DataCiteToIgsnTransformer;
@@ -11,7 +12,9 @@ use App\Services\IgsnEnrichmentService;
 use App\Services\IgsnImportService;
 use App\Services\LegacyIgsnPortalService;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 
 beforeEach(function () {
@@ -101,6 +104,10 @@ describe('ImportIgsnsFromDataCiteJob', function () {
         expect($status['imported'])->toBe(2);
         expect($status['enriched'])->toBe(2);
         expect($status['failed'])->toBe(0);
+        expect(LandingPage::query()->count())->toBe(2);
+        expect(LandingPage::query()->where('template', 'default_gfz_igsn')->count())->toBe(2);
+        expect(LandingPage::query()->where('is_published', true)->count())->toBe(2);
+        expect($status['sync_skipped_test_mode'])->toBeTrue();
     });
 
     it('skips existing DOIs', function () {
@@ -131,6 +138,43 @@ describe('ImportIgsnsFromDataCiteJob', function () {
         $status = Cache::get("igsn_import:{$importId}");
         expect($status['skipped'])->toBe(1);
         expect($status['skipped_dois'])->toContain('10.60510/existing001');
+        expect(LandingPage::query()->count())->toBe(0);
+    });
+
+    it('queues a full DataCite metadata update for a newly imported IGSN in production', function (): void {
+        Config::set('datacite.test_mode', false);
+        Bus::fake();
+        $this->importService->shouldReceive('getTotalIgsnCount')->once()->andReturn(1);
+        $this->importService->shouldReceive('fetchAllIgsns')->once()->andReturn((function () {
+            yield [
+                'id' => '10.60510/GFPRODSYNC001',
+                'attributes' => [
+                    'doi' => '10.60510/GFPRODSYNC001',
+                    'titles' => [['title' => 'Production IGSN Sync']],
+                ],
+            ];
+        })());
+        $this->transformer->shouldReceive('transform')->once()->andReturnUsing(
+            fn (): Resource => createMockResourceWithIgsn('10.60510/gfprodsync001'),
+        );
+        $this->enrichmentService->shouldReceive('enrich')->once()->andReturn(false);
+
+        $importId = Str::uuid()->toString();
+        (new ImportIgsnsFromDataCiteJob($this->user->id, $importId))->handle(
+            $this->importService,
+            $this->transformer,
+            $this->enrichmentService,
+        );
+
+        expect(Cache::get("igsn_import:{$importId}"))->toMatchArray([
+            'status' => 'running',
+            'phase' => 'syncing',
+            'sync_total' => 1,
+        ]);
+        $landingPage = Resource::where('doi', '10.60510/gfprodsync001')->firstOrFail()->landingPage;
+        expect($landingPage?->template)->toBe('default_gfz_igsn')
+            ->and($landingPage?->is_published)->toBeTrue();
+        Bus::assertBatched(fn ($batch): bool => $batch->jobs->count() === 1);
     });
 
     it('tracks enrichment counter separately from imported', function () {

--- a/tests/pest/Unit/Services/LegacyLandingPageDecisionServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyLandingPageDecisionServiceTest.php
@@ -4,6 +4,37 @@ declare(strict_types=1);
 
 use App\Services\LegacyLandingPageDecisionService;
 
+it('derives internal landing page publication solely from legacy and DataCite status', function (
+    ?string $publicStatus,
+    ?string $dataCiteState,
+    array $expected,
+): void {
+    $service = new LegacyLandingPageDecisionService;
+
+    expect($service->internalLandingPageDecision($publicStatus, $dataCiteState))->toBe($expected);
+})->with([
+    'published and findable' => [
+        'published',
+        'findable',
+        ['should_create' => true, 'should_publish' => true, 'should_sync' => true],
+    ],
+    'published but registered' => [
+        'published',
+        'registered',
+        ['should_create' => true, 'should_publish' => false, 'should_sync' => false],
+    ],
+    'pending remains draft' => [
+        'pending',
+        'findable',
+        ['should_create' => true, 'should_publish' => false, 'should_sync' => false],
+    ],
+    'unknown status creates nothing' => [
+        null,
+        'findable',
+        ['should_create' => false, 'should_publish' => false, 'should_sync' => false],
+    ],
+]);
+
 it('skips legacy dois marked as test or delete', function (string $doi): void {
     $service = new LegacyLandingPageDecisionService;
 

--- a/tests/pest/Unit/Services/MetaworksDownloadUrlServiceTest.php
+++ b/tests/pest/Unit/Services/MetaworksDownloadUrlServiceTest.php
@@ -13,7 +13,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('identifier', '10.5880/unknown.doi')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('select')
-            ->with('id')
+            ->with('id', 'publicstatus')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('first')
             ->andReturnNull();
@@ -40,7 +40,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('identifier', '10.5880/GFZ.1.2.2024.001')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('select')
-            ->with('id')
+            ->with('id', 'publicstatus')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('first')
             ->andReturn((object) ['id' => 42]);
@@ -85,7 +85,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('identifier', '10.5880/GFZ.dup.test')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('select')
-            ->with('id')
+            ->with('id', 'publicstatus')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('first')
             ->andReturn((object) ['id' => 99]);
@@ -131,7 +131,7 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('identifier', '10.5880/GFZ.multi.test')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('select')
-            ->with('id')
+            ->with('id', 'publicstatus')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('first')
             ->andReturn((object) ['id' => 55]);
@@ -177,10 +177,10 @@ describe('MetaworksDownloadUrlService', function () {
             ->with('identifier', '10.5880/GFZ.labels.test')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('select')
-            ->with('id')
+            ->with('id', 'publicstatus')
             ->andReturnSelf();
         $resourceQuery->shouldReceive('first')
-            ->andReturn((object) ['id' => 56]);
+            ->andReturn((object) ['id' => 56, 'publicstatus' => 'published']);
 
         $fileQuery = Mockery::mock();
         $fileQuery->shouldReceive('where')
@@ -224,13 +224,14 @@ describe('MetaworksDownloadUrlService', function () {
         expect($result['files'])->toHaveCount(2)
             ->and($result['files'][0]['label'])->toBe('Name Label')
             ->and($result['files'][1]['label'])->toBe('Description Fallback')
-            ->and($result['allPublic'])->toBeTrue();
+            ->and($result['allPublic'])->toBeTrue()
+            ->and($result['resourcePublicStatus'])->toBe('published');
     });
 
     it('filters out non-HTTP URLs from legacy data', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.xss.test')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 77]);
 
         $fileQuery = Mockery::mock();
@@ -263,7 +264,7 @@ describe('MetaworksDownloadUrlService', function () {
     it('distinguishes a legacy resource without file rows from filtered file entries', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.no.rows')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 90]);
 
         $fileQuery = Mockery::mock();
@@ -289,7 +290,7 @@ describe('MetaworksDownloadUrlService', function () {
     it('preserves file row presence when a non-public URL is filtered out', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.invalid.private')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 91]);
 
         $fileQuery = Mockery::mock();
@@ -320,7 +321,7 @@ describe('MetaworksDownloadUrlService', function () {
 
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.long.test')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 88]);
 
         $fileQuery = Mockery::mock();
@@ -349,7 +350,7 @@ describe('MetaworksDownloadUrlService', function () {
     it('returns allPublic false when any file is non-public', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.mixed.vis')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 33]);
 
         $fileQuery = Mockery::mock();
@@ -376,7 +377,7 @@ describe('MetaworksDownloadUrlService', function () {
     it('returns allPublic false when all files are non-public', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.all.priv')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 44]);
 
         $fileQuery = Mockery::mock();
@@ -403,7 +404,7 @@ describe('MetaworksDownloadUrlService', function () {
     it('filters out URLs without a host component', function () {
         $resourceQuery = Mockery::mock();
         $resourceQuery->shouldReceive('where')->with('identifier', '10.5880/GFZ.nohost.test')->andReturnSelf();
-        $resourceQuery->shouldReceive('select')->with('id')->andReturnSelf();
+        $resourceQuery->shouldReceive('select')->with('id', 'publicstatus')->andReturnSelf();
         $resourceQuery->shouldReceive('first')->andReturn((object) ['id' => 66]);
 
         $fileQuery = Mockery::mock();

--- a/tests/vitest/components/imports/ImportDataCiteSyncStatus.test.tsx
+++ b/tests/vitest/components/imports/ImportDataCiteSyncStatus.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+
+import { ImportDataCiteSyncStatus } from '@/components/imports/ImportDataCiteSyncStatus';
+
+vi.mock('axios', () => ({
+    default: { post: vi.fn() },
+    isAxiosError: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/csrf-token', () => ({
+    buildCsrfHeaders: () => ({ 'X-CSRF-TOKEN': 'test-token' }),
+}));
+
+vi.mock('sonner', () => ({
+    toast: { info: vi.fn(), error: vi.fn() },
+}));
+
+describe('ImportDataCiteSyncStatus', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('explains that test mode kept the operation local', () => {
+        render(<ImportDataCiteSyncStatus progress={{ sync_total: 2, sync_skipped_test_mode: true }} retryUrl="/retry" onRetryStarted={vi.fn()} />);
+
+        expect(screen.getByText('DataCite update skipped')).toBeInTheDocument();
+        expect(screen.getByText(/no metadata was written to DataCite/i)).toBeInTheDocument();
+    });
+
+    it('shows successful production updates', () => {
+        render(
+            <ImportDataCiteSyncStatus progress={{ sync_total: 2, sync_succeeded: 2, sync_failed: 0 }} retryUrl="/retry" onRetryStarted={vi.fn()} />,
+        );
+
+        expect(screen.getByText('DataCite metadata updated')).toBeInTheDocument();
+        expect(screen.getByText(/2 records now point/i)).toBeInTheDocument();
+    });
+
+    it('starts a retry for failed updates without discarding local data', async () => {
+        const onRetryStarted = vi.fn();
+        (axios.post as Mock).mockResolvedValue({ data: { message: 'started' } });
+
+        render(
+            <ImportDataCiteSyncStatus
+                progress={{
+                    sync_total: 2,
+                    sync_succeeded: 1,
+                    sync_failed: 1,
+                    sync_retry_available: true,
+                    sync_errors: [{ resource_id: 7, doi: '10.60510/test', error: 'API unavailable' }],
+                }}
+                retryUrl="/igsns/import/import-id/retry-sync"
+                onRetryStarted={onRetryStarted}
+            />,
+        );
+
+        expect(screen.getByText(/published landing pages were kept/i)).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('button', { name: /retry failed updates/i }));
+
+        await waitFor(() => {
+            expect(axios.post).toHaveBeenCalledWith('/igsns/import/import-id/retry-sync', {}, { headers: { 'X-CSRF-TOKEN': 'test-token' } });
+            expect(onRetryStarted).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/tests/vitest/components/imports/ImportDataCiteSyncStatus.test.tsx
+++ b/tests/vitest/components/imports/ImportDataCiteSyncStatus.test.tsx
@@ -38,6 +38,7 @@ describe('ImportDataCiteSyncStatus', () => {
     });
 
     it('starts a retry for failed updates without discarding local data', async () => {
+        const user = userEvent.setup();
         const onRetryStarted = vi.fn();
         (axios.post as Mock).mockResolvedValue({ data: { message: 'started' } });
 
@@ -56,7 +57,7 @@ describe('ImportDataCiteSyncStatus', () => {
         );
 
         expect(screen.getByText(/published landing pages were kept/i)).toBeInTheDocument();
-        await userEvent.click(screen.getByRole('button', { name: /retry failed updates/i }));
+        await user.click(screen.getByRole('button', { name: /retry failed updates/i }));
 
         await waitFor(() => {
             expect(axios.post).toHaveBeenCalledWith('/igsns/import/import-id/retry-sync', {}, { headers: { 'X-CSRF-TOKEN': 'test-token' } });


### PR DESCRIPTION
This pull request introduces significant improvements to the import and synchronization workflow for DataCite and IGSN imports. The main changes include a new retry mechanism for failed DataCite synchronizations, enhanced progress tracking with more granular status fields, and better separation of test mode behavior. Additionally, the logic for determining which resources need DataCite sync has been refined, and the documentation for configuration has been clarified.

**Import/Sync Workflow Enhancements:**

* Added a new `retrySync` endpoint to both `DataCiteImportController` and `IgsnImportController`, allowing users to retry failed DataCite synchronizations after an import, with appropriate error handling and test mode checks. [[1]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6R246-R276) [[2]](diffhunk://#diff-92e2498ae5095b4a1b2494aed2d2f0fcd05f818e192b575acd583751c891f05dR220-R250)
* Improved progress tracking by introducing new fields such as `phase`, `sync_total`, `sync_processed`, `sync_succeeded`, `sync_failed`, `sync_errors`, `sync_skipped_test_mode`, and `sync_retry_available` in both DataCite and IGSN import controllers. [[1]](diffhunk://#diff-4f5fc89f1b20ee09ff72e86823d76d1c737744eac04d544ad7e55ccba1ff12f6R288-R295) [[2]](diffhunk://#diff-92e2498ae5095b4a1b2494aed2d2f0fcd05f818e192b575acd583751c891f05dR273-R280)
* Updated job handling logic (`ImportFromDataCiteJob`) to set more granular status and phase fields, and to only mark imports as completed when appropriate. The job now also triggers the sync phase only if the import was not cancelled. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L312-R317) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L323-R335) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L635-R645) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L648-R665) [[5]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R795-R799) [[6]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L793-R816) [[7]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R880-R885) [[8]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L872-R910) [[9]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L892-R928)

**DataCite Sync Eligibility and Logic:**

* Changed the logic for determining which resources require DataCite synchronization: now, only resources where either the landing page or legacy download sync is eligible are queued for sync, and this is tracked in a dedicated array.
* Updated the return type and logic of `syncDataCiteLandingPageIfAllowed` to include a `sync_eligible` flag, and removed legacy download sync from enrichment checks for skipped records. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L938-R975) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1006-R1038) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1061-R1090) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528L1080-R1100)

**Configuration and Documentation:**

* Improved `.env.example` and `.env.docker.example` documentation for `DATACITE_TEST_MODE`, clarifying its effect on import and synchronization behavior. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL92-R95) [[2]](diffhunk://#diff-2f1bab5147b0fd2b6e6ff8dc6163c62e9c706f1539229e8d4e88358db076bc9dL127-R128)

These changes collectively improve the reliability, transparency, and user control of the import and DataCite synchronization processes.