### PR TITLE
Fix: Preserve original DataCite Subjects

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -23,6 +23,7 @@ use App\Services\LegacyResourceLookupService;
 use App\Services\MetaworksDownloadUrlService;
 use App\Services\SumarioPendingResourceImportService;
 use App\Services\SumarioPmdContactEnrichmentService;
+use App\Services\Xml\OriginalDataCiteSubjectExtractionService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
@@ -975,6 +976,9 @@ class ImportFromDataCiteJob implements ShouldQueue
                     'enriched' => $dataCiteLandingPageSync['changed'],
                 ];
             }
+
+            $doiRecord = app(OriginalDataCiteSubjectExtractionService::class)
+                ->preferOriginalSubjects($doiRecord, $doi);
 
             $legacyMetadata = [
                 'relatedIdentifiers' => [],

--- a/app/Services/DataCiteSubjectMergeService.php
+++ b/app/Services/DataCiteSubjectMergeService.php
@@ -11,9 +11,8 @@ use Normalizer;
 /**
  * Merges DataCite and legacy subjects in source-priority order.
  *
- * DataCite subjects remain byte-for-byte intact and in their original order.
- * Legacy subjects are only appended when no equivalent DataCite or earlier
- * legacy subject exists.
+ * DataCite subjects remain in their original order. Equivalent legacy subjects
+ * only fill missing metadata; genuinely new legacy subjects are appended.
  */
 final class DataCiteSubjectMergeService
 {
@@ -53,16 +52,16 @@ final class DataCiteSubjectMergeService
     public function merge(array $dataCiteSubjects, array $legacySubjects): array
     {
         $merged = array_values($dataCiteSubjects);
-        /** @var array<string, true> $identities */
-        $identities = [];
+        /** @var array<string, int> $identityIndexes */
+        $identityIndexes = [];
 
-        foreach ($merged as $subject) {
+        foreach ($merged as $index => $subject) {
             if (! is_array($subject)) {
                 continue;
             }
 
             foreach ($this->identities($subject) as $identity) {
-                $identities[$identity] = true;
+                $identityIndexes[$identity] ??= $index;
             }
         }
 
@@ -76,25 +75,61 @@ final class DataCiteSubjectMergeService
                 continue;
             }
 
-            $isDuplicate = false;
+            $matchingIndex = null;
             foreach ($candidateIdentities as $identity) {
-                if (isset($identities[$identity])) {
-                    $isDuplicate = true;
+                if (isset($identityIndexes[$identity])) {
+                    $matchingIndex = $identityIndexes[$identity];
                     break;
                 }
             }
 
-            if ($isDuplicate) {
+            if ($matchingIndex !== null && is_array($merged[$matchingIndex])) {
+                $merged[$matchingIndex] = $this->enrichMissingMetadata($merged[$matchingIndex], $subject);
+
+                foreach ($this->identities($merged[$matchingIndex]) as $identity) {
+                    $identityIndexes[$identity] ??= $matchingIndex;
+                }
+
                 continue;
             }
 
             $merged[] = $subject;
+            $newIndex = count($merged) - 1;
             foreach ($candidateIdentities as $identity) {
-                $identities[$identity] = true;
+                $identityIndexes[$identity] ??= $newIndex;
             }
         }
 
         return $merged;
+    }
+
+    /**
+     * @param  array<string, mixed>  $existing
+     * @param  array<string, mixed>  $legacy
+     * @return array<string, mixed>
+     */
+    private function enrichMissingMetadata(array $existing, array $legacy): array
+    {
+        $fieldAliases = [
+            'subjectScheme' => ['subjectScheme', 'scheme', 'subject_scheme'],
+            'schemeUri' => ['schemeUri', 'schemeURI', 'scheme_uri'],
+            'valueUri' => ['valueUri', 'valueURI', 'value_uri', 'id'],
+            'classificationCode' => ['classificationCode', 'classification_code'],
+            'lang' => ['lang', 'language', 'xml:lang'],
+        ];
+
+        foreach ($fieldAliases as $targetKey => $aliases) {
+            if ($this->stringValue($existing, $aliases) !== null) {
+                continue;
+            }
+
+            $legacyValue = $this->stringValue($legacy, $aliases);
+            if ($legacyValue !== null) {
+                $existing[$targetKey] = $legacyValue;
+            }
+        }
+
+        return $existing;
     }
 
     /**

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -44,6 +44,7 @@ use App\Services\Xml\OriginalDataCiteRelatedIdentifierExtractionService;
 use App\Services\Xml\Sections\RightsSectionParser;
 use App\Support\DataCiteDateNormalizer;
 use App\Support\OrcidNormalizer;
+use App\Support\PortalSubjectNormalizer;
 use App\Support\SubjectBreadcrumbPath;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -1274,7 +1275,9 @@ class DataCiteToResourceTransformer
 
             $rawSubjectValue = is_string($value) ? $value : null;
             $subjectValue = $rawSubjectValue !== null ? (SubjectBreadcrumbPath::normalize($rawSubjectValue) ?? $value) : $value;
-            $subjectScheme = $subjectData['subjectScheme'] ?? null;
+            $subjectScheme = PortalSubjectNormalizer::normalizeScheme(
+                is_string($subjectData['subjectScheme'] ?? null) ? $subjectData['subjectScheme'] : null,
+            );
             $schemeUri = $this->filledString($subjectData['schemeUri'] ?? null);
             $valueUri = $this->filledString($subjectData['valueUri'] ?? null);
             $classificationCode = $subjectData['classificationCode'] ?? null;

--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -43,8 +43,8 @@ use App\Services\Rights\ResourceRightsStorageService;
 use App\Services\Xml\OriginalDataCiteRelatedIdentifierExtractionService;
 use App\Services\Xml\Sections\RightsSectionParser;
 use App\Support\DataCiteDateNormalizer;
+use App\Support\GemetVocabularyParser;
 use App\Support\OrcidNormalizer;
-use App\Support\PortalSubjectNormalizer;
 use App\Support\SubjectBreadcrumbPath;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -60,6 +60,11 @@ use Saloon\XmlWrangler\XmlReader;
 class DataCiteToResourceTransformer
 {
     private const PREPARED_MARKER = '__citation_labels_prepared';
+
+    /** @var array<string, string> */
+    private const IMPORTED_SUBJECT_SCHEME_ALIASES = [
+        'GEMET - INSPIRE themes, version 1.0' => GemetVocabularyParser::SCHEME_TITLE,
+    ];
 
     public function __construct(
         private ?RelatedIdentifierCitationLabelService $relatedIdentifierCitationLabelService = null,
@@ -1275,9 +1280,10 @@ class DataCiteToResourceTransformer
 
             $rawSubjectValue = is_string($value) ? $value : null;
             $subjectValue = $rawSubjectValue !== null ? (SubjectBreadcrumbPath::normalize($rawSubjectValue) ?? $value) : $value;
-            $subjectScheme = PortalSubjectNormalizer::normalizeScheme(
-                is_string($subjectData['subjectScheme'] ?? null) ? $subjectData['subjectScheme'] : null,
-            );
+            $subjectScheme = $subjectData['subjectScheme'] ?? null;
+            if (is_string($subjectScheme)) {
+                $subjectScheme = self::IMPORTED_SUBJECT_SCHEME_ALIASES[$subjectScheme] ?? $subjectScheme;
+            }
             $schemeUri = $this->filledString($subjectData['schemeUri'] ?? null);
             $valueUri = $this->filledString($subjectData['valueUri'] ?? null);
             $classificationCode = $subjectData['classificationCode'] ?? null;

--- a/app/Services/OldDatasetKeywordTransformer.php
+++ b/app/Services/OldDatasetKeywordTransformer.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Support\GcmdUriHelper;
+use App\Support\GemetVocabularyParser;
 
 class OldDatasetKeywordTransformer
 {
     /**
      * Maps old thesaurus names to scheme names.
-     * Supports both legacy ELMO format and current NASA/GCMD naming conventions.
+     * Supports legacy GEMET plus old and current NASA/GCMD naming conventions.
      */
     private const SCHEME_MAP = [
         // Science Keywords - single standard format
@@ -22,6 +23,8 @@ class OldDatasetKeywordTransformer
         // Instruments - support both legacy and current ELMO formats
         'NASA/GCMD Instruments' => 'Instruments',
         'GCMD Instruments' => 'Instruments',
+        // GEMET - legacy DataCite scheme title
+        'GEMET - INSPIRE themes, version 1.0' => GemetVocabularyParser::SCHEME_TITLE,
     ];
 
     /**
@@ -70,9 +73,14 @@ class OldDatasetKeywordTransformer
         $keyword = trim((string) ($oldKeyword->keyword ?? ''));
         $schemeUri = self::schemeUriForScheme($scheme);
 
-        // Extract UUID from old URI
-        $uuid = self::extractUuidFromOldUri($oldKeyword->uri ?? null);
-        $newUri = $uuid ? self::constructNewUri($uuid) : null;
+        if ($scheme === GemetVocabularyParser::SCHEME_TITLE) {
+            $uuid = null;
+            $newUri = self::normalizeGemetConceptUri($oldKeyword->uri ?? null);
+        } else {
+            // Extract UUID from old GCMD URI
+            $uuid = self::extractUuidFromOldUri($oldKeyword->uri ?? null);
+            $newUri = $uuid ? self::constructNewUri($uuid) : null;
+        }
 
         if ($newUri === null && $keyword !== '') {
             $resolvedKeyword = app(SubjectBreadcrumbPathResolverService::class)
@@ -80,7 +88,9 @@ class OldDatasetKeywordTransformer
 
             if ($resolvedKeyword !== null) {
                 $newUri = $resolvedKeyword['id'];
-                $uuid = self::extractUuidFromOldUri($newUri);
+                $uuid = $scheme === GemetVocabularyParser::SCHEME_TITLE
+                    ? null
+                    : self::extractUuidFromOldUri($newUri);
                 $scheme = $resolvedKeyword['scheme'];
                 $schemeUri = $resolvedKeyword['schemeURI'] ?? self::schemeUriForScheme($scheme);
             }
@@ -123,7 +133,7 @@ class OldDatasetKeywordTransformer
     }
 
     /**
-     * Get list of supported GCMD thesaurus names from old database.
+     * Get list of supported controlled-vocabulary names from the old database.
      *
      * @return array<int, string>
      */
@@ -135,5 +145,22 @@ class OldDatasetKeywordTransformer
     private static function schemeUriForScheme(string $scheme): ?string
     {
         return app(SubjectBreadcrumbPathResolverService::class)->resolveSchemeUri($scheme);
+    }
+
+    private static function normalizeGemetConceptUri(mixed $uri): ?string
+    {
+        if (! is_string($uri)) {
+            return null;
+        }
+
+        if (preg_match(
+            '~^https?://(?:www\.)?eionet\.europa\.eu/gemet/concept/([^/?#\s]+)/?(?:[?#].*)?$~i',
+            trim($uri),
+            $matches,
+        ) !== 1) {
+            return null;
+        }
+
+        return 'http://www.eionet.europa.eu/gemet/concept/'.$matches[1];
     }
 }

--- a/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
+++ b/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
@@ -16,23 +16,12 @@ final readonly class OriginalDataCiteRelatedIdentifierExtractionService
 {
     public function __construct(
         private RelatedIdentifierTypeResolverService $typeResolver,
+        private OriginalDataCiteXmlDecoder $xmlDecoder,
     ) {}
 
     public function decode(mixed $value): ?string
     {
-        if (! is_string($value) || trim($value) === '') {
-            return null;
-        }
-
-        $value = trim($value);
-
-        if (str_contains($value, '<')) {
-            return $value;
-        }
-
-        $decoded = base64_decode($value, true);
-
-        return is_string($decoded) && str_contains($decoded, '<') ? $decoded : null;
+        return $this->xmlDecoder->decode($value);
     }
 
     /**

--- a/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
+++ b/app/Services/Xml/OriginalDataCiteRelatedIdentifierExtractionService.php
@@ -16,7 +16,7 @@ final readonly class OriginalDataCiteRelatedIdentifierExtractionService
 {
     public function __construct(
         private RelatedIdentifierTypeResolverService $typeResolver,
-        private OriginalDataCiteXmlDecoder $xmlDecoder,
+        private OriginalDataCiteXmlDecoderService $xmlDecoder,
     ) {}
 
     public function decode(mixed $value): ?string

--- a/app/Services/Xml/OriginalDataCiteSubjectExtractionService.php
+++ b/app/Services/Xml/OriginalDataCiteSubjectExtractionService.php
@@ -14,7 +14,7 @@ use Saloon\XmlWrangler\XmlReader;
 final readonly class OriginalDataCiteSubjectExtractionService
 {
     public function __construct(
-        private OriginalDataCiteXmlDecoder $xmlDecoder,
+        private OriginalDataCiteXmlDecoderService $xmlDecoder,
     ) {}
 
     /**

--- a/app/Services/Xml/OriginalDataCiteSubjectExtractionService.php
+++ b/app/Services/Xml/OriginalDataCiteSubjectExtractionService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Xml;
+
+use App\Support\Xml\XmlElementHelpers;
+use Illuminate\Support\Facades\Log;
+use Saloon\XmlWrangler\XmlReader;
+
+/**
+ * Extracts subjects from the original DataCite XML embedded in API records.
+ */
+final readonly class OriginalDataCiteSubjectExtractionService
+{
+    public function __construct(
+        private OriginalDataCiteXmlDecoder $xmlDecoder,
+    ) {}
+
+    /**
+     * Replaces REST-derived subjects when valid original XML is available.
+     *
+     * @param  array<string, mixed>  $doiRecord
+     * @return array<string, mixed>
+     */
+    public function preferOriginalSubjects(array $doiRecord, ?string $context = null): array
+    {
+        $isWrappedRecord = is_array($doiRecord['attributes'] ?? null);
+        $attributes = $isWrappedRecord ? $doiRecord['attributes'] : $doiRecord;
+        $subjects = $this->extractEncoded($attributes['xml'] ?? null, $context);
+
+        if ($subjects === null) {
+            return $doiRecord;
+        }
+
+        if ($isWrappedRecord) {
+            $doiRecord['attributes']['subjects'] = $subjects;
+        } else {
+            $doiRecord['subjects'] = $subjects;
+        }
+
+        return $doiRecord;
+    }
+
+    /**
+     * Returns null when no usable XML is available, and an empty list when a
+     * valid XML document intentionally contains no subjects.
+     *
+     * @return list<array<string, string>>|null
+     */
+    public function extractEncoded(mixed $value, ?string $context = null): ?array
+    {
+        $xml = $this->xmlDecoder->decode($value);
+
+        return $xml === null ? null : $this->extract($xml, $context);
+    }
+
+    /**
+     * @return list<array<string, string>>|null
+     */
+    public function extract(string $xml, ?string $context = null): ?array
+    {
+        try {
+            $elements = XmlReader::fromString($xml)
+                ->xpathElement('//*[local-name()="resource"]/*[local-name()="subjects"]/*[local-name()="subject"]')
+                ->get();
+        } catch (\Throwable $exception) {
+            Log::warning('Could not read XML subjects.', [
+                'context' => $context,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $subjects = [];
+
+        foreach ($elements as $element) {
+            $value = trim((string) (XmlElementHelpers::stringValue($element) ?? ''));
+
+            if ($value === '') {
+                continue;
+            }
+
+            $subject = ['subject' => $value];
+
+            $this->copyAttribute($subject, 'subjectScheme', $element->getAttribute('subjectScheme'));
+            $this->copyAttribute($subject, 'schemeUri', $element->getAttribute('schemeURI'));
+            $this->copyAttribute($subject, 'valueUri', $element->getAttribute('valueURI'));
+            $this->copyAttribute($subject, 'classificationCode', $element->getAttribute('classificationCode'));
+            $this->copyAttribute($subject, 'lang', $element->getAttribute('xml:lang'));
+
+            $subjects[] = $subject;
+        }
+
+        return $subjects;
+    }
+
+    /**
+     * @param  array<string, string>  $subject
+     */
+    private function copyAttribute(array &$subject, string $key, mixed $value): void
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return;
+        }
+
+        $subject[$key] = trim($value);
+    }
+}

--- a/app/Services/Xml/OriginalDataCiteXmlDecoder.php
+++ b/app/Services/Xml/OriginalDataCiteXmlDecoder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Xml;
+
+/**
+ * Decodes the original DataCite XML embedded in API records.
+ */
+final class OriginalDataCiteXmlDecoder
+{
+    public function decode(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (str_contains($value, '<')) {
+            return $value;
+        }
+
+        $decoded = base64_decode($value, true);
+
+        return is_string($decoded) && str_contains($decoded, '<') ? $decoded : null;
+    }
+}

--- a/app/Services/Xml/OriginalDataCiteXmlDecoderService.php
+++ b/app/Services/Xml/OriginalDataCiteXmlDecoderService.php
@@ -7,7 +7,7 @@ namespace App\Services\Xml;
 /**
  * Decodes the original DataCite XML embedded in API records.
  */
-final class OriginalDataCiteXmlDecoder
+final class OriginalDataCiteXmlDecoderService
 {
     public function decode(mixed $value): ?string
     {

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -404,6 +404,10 @@
         ],
         "fixes": [
             {
+                "title": "Reliable Legacy Subject Imports",
+                "description": "New legacy DataCite imports now use the embedded original XML subjects when the REST representation differs and enrich matching GEMET terms with stable identifiers from SUMARIOPMD. REST-only additions are no longer imported, GEMET selections reopen correctly in the Data Editor, and unrelated DataCite subject scheme names remain unchanged during import and re-export. Existing imported resources remain unchanged."
+            },
+            {
                 "title": "Complete Legacy GCMD Keyword Enrichment for DataCite Imports",
                 "description": "New legacy resource imports now enrich DataCite metadata with all controlled GCMD keywords and free keywords from SUMARIOPMD. Existing DataCite subjects keep their original order, equivalent legacy subjects are omitted, and unavailable legacy metadata no longer blocks the import. Existing imported resources remain unchanged."
             },

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -830,6 +830,57 @@ describe('ImportFromDataCiteJob', function () {
             ->and($status['failed'])->toBe(0);
     });
 
+    it('uses the nine original XML subjects instead of the extra Issue 1123 REST subject', function () {
+        $doi = '10.5880/trr228db.398';
+        $xmlSubjects = array_map(
+            static fn (int $number): array => ['subject' => "Original keyword {$number}"],
+            range(1, 9),
+        );
+        $xml = '<resource xmlns="http://datacite.org/schema/kernel-4"><subjects>'
+            .implode('', array_map(
+                static fn (array $subject): string => '<subject>'.htmlspecialchars($subject['subject'], ENT_XML1).'</subject>',
+                $xmlSubjects,
+            ))
+            .'</subjects></resource>';
+        $doiRecord = [
+            'id' => $doi,
+            'attributes' => [
+                'doi' => $doi,
+                'xml' => base64_encode($xml),
+                'subjects' => [
+                    ...$xmlSubjects,
+                    ['subject' => 'FOS: Biological sciences'],
+                ],
+            ],
+        ];
+        $expectedRecord = $doiRecord;
+        $expectedRecord['attributes']['subjects'] = $xmlSubjects;
+
+        $this->importService
+            ->shouldReceive('fetchSingleDoi')
+            ->once()
+            ->with($doi)
+            ->andReturn($doiRecord);
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->once()
+            ->with($expectedRecord, [], CitationLabelResolutionMode::REQUIRED)
+            ->andReturn($expectedRecord);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->with($expectedRecord, $this->user->id)
+            ->andReturn(Resource::factory()->make(['doi' => $doi]));
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId, $doi))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['failed_dois'])->toBe([])
+            ->and($status['imported'])->toBe(1);
+    });
+
     it('prefers a specialized portal datacenter during a single DOI import', function () {
         $doi = '10.5880/icdp.5069.001';
         $doiRecord = [

--- a/tests/pest/Feature/Services/DataCiteLegacyKeywordImportTest.php
+++ b/tests/pest/Feature/Services/DataCiteLegacyKeywordImportTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Services\DataCiteJsonExporter;
 use App\Services\DataCiteSubjectMergeService;
 use App\Services\DataCiteToResourceTransformer;
 use App\Services\Editor\EditorDataTransformer;
@@ -343,4 +344,43 @@ it('persists only the nine Issue 1123 original XML subjects', function (): void 
     expect($resource->subjects()->count())->toBe(9)
         ->and($resource->subjects()->orderBy('id')->pluck('value')->all())->toBe($originalSubjects)
         ->and($resource->subjects()->where('value', 'FOS: Biological sciences')->exists())->toBeFalse();
+});
+
+it('preserves arbitrary DataCite subject scheme names during import and re-export', function (): void {
+    $schemes = [
+        'Research Instrument Taxonomy',
+        'Offshore Platform Classification',
+        'Local GEMET-derived Vocabulary',
+    ];
+    $doiRecord = [
+        'id' => '10.5880/custom-subject-schemes',
+        'attributes' => [
+            'doi' => '10.5880/custom-subject-schemes',
+            'publicationYear' => 2026,
+            'titles' => [['title' => 'Custom subject schemes']],
+            'creators' => [[
+                'familyName' => 'Importer',
+                'givenName' => 'Test',
+                'nameType' => 'Personal',
+            ]],
+            'subjects' => array_map(
+                static fn (string $scheme, int $index): array => [
+                    'subject' => "Custom subject {$index}",
+                    'subjectScheme' => $scheme,
+                    'schemeUri' => "https://example.test/schemes/{$index}",
+                ],
+                $schemes,
+                array_keys($schemes),
+            ),
+        ],
+    ];
+
+    $resource = (new DataCiteToResourceTransformer)->transform(
+        $doiRecord,
+        User::factory()->create()->id,
+    );
+    $exportedSubjects = (new DataCiteJsonExporter)->export($resource->fresh())['data']['attributes']['subjects'];
+
+    expect($resource->subjects()->orderBy('id')->pluck('subject_scheme')->all())->toBe($schemes)
+        ->and(array_column($exportedSubjects, 'subjectScheme'))->toBe($schemes);
 });

--- a/tests/pest/Feature/Services/DataCiteLegacyKeywordImportTest.php
+++ b/tests/pest/Feature/Services/DataCiteLegacyKeywordImportTest.php
@@ -8,6 +8,7 @@ use App\Services\DataCiteToResourceTransformer;
 use App\Services\Editor\EditorDataTransformer;
 use App\Services\LegacyKeywordService;
 use App\Services\LegacyResourceLookupService;
+use App\Services\Xml\OriginalDataCiteSubjectExtractionService;
 use Database\Seeders\ContributorTypeSeeder;
 use Database\Seeders\DescriptionTypeSeeder;
 use Database\Seeders\IdentifierTypeSeeder;
@@ -20,6 +21,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 
 beforeEach(function (): void {
     test()->seed(ResourceTypeSeeder::class);
@@ -180,4 +182,165 @@ it('persists the Issue 1091 keyword pattern and exposes it in the editor shape',
             'GNSS',
             'Crustal deformation',
         ]);
+});
+
+it('enriches and persists all Issue 1115 GEMET subjects with editor-selectable IDs', function (): void {
+    Storage::fake('local');
+
+    $doi = '10.5880/igets.bu.l1.001';
+    $legacyThesaurus = 'GEMET - INSPIRE themes, version 1.0';
+    $canonicalScheme = 'GEMET - GEneral Multilingual Environmental Thesaurus';
+    $concepts = [
+        'geodesy' => '3638',
+        'geophysics' => '3655',
+        'hydrology' => '4118',
+    ];
+    Storage::disk('local')->put('gemet-thesaurus.json', json_encode([
+        'data' => [[
+            'id' => 'http://www.eionet.europa.eu/gemet/supergroup/1',
+            'text' => 'Earth sciences',
+            'scheme' => $canonicalScheme,
+            'schemeURI' => 'http://www.eionet.europa.eu/gemet/concept/',
+            'children' => array_map(
+                static fn (string $label, string $conceptId): array => [
+                    'id' => "http://www.eionet.europa.eu/gemet/concept/{$conceptId}",
+                    'text' => $label,
+                    'scheme' => 'GEMET - GEneral Multilingual Environmental Thesaurus',
+                    'schemeURI' => 'http://www.eionet.europa.eu/gemet/concept/',
+                    'children' => [],
+                ],
+                array_keys($concepts),
+                array_values($concepts),
+            ),
+        ]],
+    ], JSON_THROW_ON_ERROR));
+
+    $legacyResourceId = DB::connection('metaworks')->table('resource')->insertGetId([
+        'identifier' => $doi,
+        'keywords' => null,
+    ]);
+    foreach ($concepts as $keyword => $conceptId) {
+        DB::connection('metaworks')->table('thesauruskeyword')->insert([
+            'resource_id' => $legacyResourceId,
+            'keyword' => $keyword,
+            'thesaurus' => $legacyThesaurus,
+        ]);
+        DB::connection('metaworks')->table('thesaurusvalue')->insert([
+            'keyword' => $keyword,
+            'thesaurus' => $legacyThesaurus,
+            'uri' => "http://www.eionet.europa.eu/gemet/concept/{$conceptId}",
+            'description' => null,
+        ]);
+    }
+
+    $xmlSubjects = implode('', array_map(
+        static fn (string $keyword): string => '<subject subjectScheme="GEMET - INSPIRE themes, version 1.0">'.$keyword.'</subject>',
+        array_keys($concepts),
+    ));
+    $doiRecord = [
+        'id' => $doi,
+        'attributes' => [
+            'doi' => $doi,
+            'publicationYear' => 2025,
+            'titles' => [['title' => 'Issue 1115 regression dataset']],
+            'creators' => [[
+                'familyName' => 'Importer',
+                'givenName' => 'Test',
+                'nameType' => 'Personal',
+            ]],
+            'xml' => base64_encode(
+                '<resource xmlns="http://datacite.org/schema/kernel-4"><subjects>'.$xmlSubjects.'</subjects></resource>',
+            ),
+            'subjects' => array_map(
+                static fn (string $keyword): array => [
+                    'subject' => $keyword,
+                    'subjectScheme' => 'GEMET - INSPIRE themes, version 1.0',
+                ],
+                array_keys($concepts),
+            ),
+        ],
+    ];
+
+    $sourceRecord = app(OriginalDataCiteSubjectExtractionService::class)
+        ->preferOriginalSubjects($doiRecord, $doi);
+    $legacyMetadata = (new LegacyResourceLookupService(new LegacyKeywordService))
+        ->importMetadataByDoi($doi);
+    $mergedRecord = (new DataCiteSubjectMergeService)->mergeIntoDoiRecord(
+        $sourceRecord,
+        $legacyMetadata['subjects'],
+    );
+    $resource = (new DataCiteToResourceTransformer)->transform(
+        $mergedRecord,
+        User::factory()->create()->id,
+    );
+
+    $subjects = $resource->subjects()->orderBy('value')->get();
+    expect($subjects)->toHaveCount(3)
+        ->and($subjects->pluck('subject_scheme')->unique()->values()->all())->toBe([$canonicalScheme])
+        ->and($subjects->pluck('value_uri')->all())->toBe([
+            'http://www.eionet.europa.eu/gemet/concept/3638',
+            'http://www.eionet.europa.eu/gemet/concept/3655',
+            'http://www.eionet.europa.eu/gemet/concept/4118',
+        ])
+        ->and($subjects->pluck('breadcrumb_path')->all())->toBe([
+            'Earth sciences > geodesy',
+            'Earth sciences > geophysics',
+            'Earth sciences > hydrology',
+        ]);
+
+    $resource->load('subjects');
+    $editorKeywords = (new EditorDataTransformer)->transformGemetKeywords($resource);
+
+    expect(array_column($editorKeywords, 'id'))->toBe([
+        'http://www.eionet.europa.eu/gemet/concept/3638',
+        'http://www.eionet.europa.eu/gemet/concept/3655',
+        'http://www.eionet.europa.eu/gemet/concept/4118',
+    ])->and(array_column($editorKeywords, 'text'))->toBe([
+        'geodesy',
+        'geophysics',
+        'hydrology',
+    ]);
+});
+
+it('persists only the nine Issue 1123 original XML subjects', function (): void {
+    $doi = '10.5880/TRR228DB.398';
+    $originalSubjects = array_map(
+        static fn (int $number): string => "Original keyword {$number}",
+        range(1, 9),
+    );
+    $xmlSubjects = implode('', array_map(
+        static fn (string $keyword): string => '<subject>'.$keyword.'</subject>',
+        $originalSubjects,
+    ));
+    $doiRecord = [
+        'id' => $doi,
+        'attributes' => [
+            'doi' => $doi,
+            'publicationYear' => 2024,
+            'titles' => [['title' => 'Issue 1123 regression dataset']],
+            'creators' => [[
+                'familyName' => 'Importer',
+                'givenName' => 'Test',
+                'nameType' => 'Personal',
+            ]],
+            'xml' => base64_encode(
+                '<resource xmlns="http://datacite.org/schema/kernel-4"><subjects>'.$xmlSubjects.'</subjects></resource>',
+            ),
+            'subjects' => [
+                ...array_map(static fn (string $keyword): array => ['subject' => $keyword], $originalSubjects),
+                ['subject' => 'FOS: Biological sciences'],
+            ],
+        ],
+    ];
+
+    $sourceRecord = app(OriginalDataCiteSubjectExtractionService::class)
+        ->preferOriginalSubjects($doiRecord, $doi);
+    $resource = (new DataCiteToResourceTransformer)->transform(
+        $sourceRecord,
+        User::factory()->create()->id,
+    );
+
+    expect($resource->subjects()->count())->toBe(9)
+        ->and($resource->subjects()->orderBy('id')->pluck('value')->all())->toBe($originalSubjects)
+        ->and($resource->subjects()->where('value', 'FOS: Biological sciences')->exists())->toBeFalse();
 });

--- a/tests/pest/Unit/Services/DataCiteSubjectMergeServiceTest.php
+++ b/tests/pest/Unit/Services/DataCiteSubjectMergeServiceTest.php
@@ -73,6 +73,46 @@ it('deduplicates controlled paths across scheme aliases, encoded separators, and
     expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([$dataCiteSubject]);
 });
 
+it('enriches an equivalent Issue 1115 GEMET subject with missing legacy metadata', function (): void {
+    $dataCiteSubject = [
+        'subject' => 'geodesy',
+        'subjectScheme' => 'GEMET - INSPIRE themes, version 1.0',
+    ];
+    $legacySubject = [
+        'subject' => 'geodesy',
+        'subjectScheme' => 'GEMET - GEneral Multilingual Environmental Thesaurus',
+        'schemeUri' => 'http://www.eionet.europa.eu/gemet/concept/',
+        'valueUri' => 'http://www.eionet.europa.eu/gemet/concept/3638',
+        'lang' => 'en',
+    ];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([[
+        ...$dataCiteSubject,
+        'schemeUri' => 'http://www.eionet.europa.eu/gemet/concept/',
+        'valueUri' => 'http://www.eionet.europa.eu/gemet/concept/3638',
+        'lang' => 'en',
+    ]]);
+});
+
+it('never overwrites existing metadata while enriching an equivalent subject', function (): void {
+    $dataCiteSubject = [
+        'subject' => 'geodesy',
+        'subjectScheme' => 'GEMET',
+        'scheme_uri' => 'https://example.test/original-scheme',
+        'valueURI' => 'http://www.eionet.europa.eu/gemet/concept/3638',
+        'language' => 'de',
+    ];
+    $legacySubject = [
+        'subject' => 'geodesy',
+        'subjectScheme' => 'GEMET - GEneral Multilingual Environmental Thesaurus',
+        'schemeUri' => 'http://www.eionet.europa.eu/gemet/concept/',
+        'valueUri' => 'http://www.eionet.europa.eu/gemet/concept/3638',
+        'lang' => 'en',
+    ];
+
+    expect($this->service->merge([$dataCiteSubject], [$legacySubject]))->toBe([$dataCiteSubject]);
+});
+
 it('deduplicates controlled subjects by classification code and normalized scheme', function (): void {
     $dataCiteSubject = [
         'subject' => 'A DataCite label',

--- a/tests/pest/Unit/Services/LegacyKeywordServiceTest.php
+++ b/tests/pest/Unit/Services/LegacyKeywordServiceTest.php
@@ -102,6 +102,42 @@ it('loads and transforms controlled keywords in deterministic order', function (
         ]);
 });
 
+it('loads all three Issue 1115 GEMET keywords from the legacy database', function (): void {
+    $thesaurus = 'GEMET - INSPIRE themes, version 1.0';
+    $concepts = [
+        'geodesy' => '3638',
+        'geophysics' => '3655',
+        'hydrology' => '4118',
+    ];
+
+    foreach ($concepts as $keyword => $conceptId) {
+        DB::connection('metaworks')->table('thesauruskeyword')->insert([
+            'resource_id' => 9663,
+            'keyword' => $keyword,
+            'thesaurus' => $thesaurus,
+        ]);
+        DB::connection('metaworks')->table('thesaurusvalue')->insert([
+            'keyword' => $keyword,
+            'thesaurus' => $thesaurus,
+            'uri' => "http://www.eionet.europa.eu/gemet/concept/{$conceptId}",
+            'description' => null,
+        ]);
+    }
+
+    $subjects = $this->service->dataCiteSubjects($this->dataset);
+
+    expect($subjects)->toHaveCount(3)
+        ->and(array_column($subjects, 'subject'))->toBe(['geodesy', 'geophysics', 'hydrology'])
+        ->and(array_column($subjects, 'valueUri'))->toBe([
+            'http://www.eionet.europa.eu/gemet/concept/3638',
+            'http://www.eionet.europa.eu/gemet/concept/3655',
+            'http://www.eionet.europa.eu/gemet/concept/4118',
+        ])
+        ->and(array_unique(array_column($subjects, 'subjectScheme')))->toBe([
+            'GEMET - GEneral Multilingual Environmental Thesaurus',
+        ]);
+});
+
 it('splits, trims, and filters comma-separated free keywords', function (): void {
     $this->dataset->keywords = '  GNSS, , Crustal deformation ,,Seismology  ';
 

--- a/tests/pest/Unit/Services/OldDatasetKeywordTransformerTest.php
+++ b/tests/pest/Unit/Services/OldDatasetKeywordTransformerTest.php
@@ -61,6 +61,35 @@ describe('transform', function () {
             ->and($result['scheme'])->toBe('Instruments');
     });
 
+    it('transforms and canonicalizes a legacy GEMET keyword', function () {
+        $old = (object) [
+            'keyword' => 'geodesy',
+            'thesaurus' => 'GEMET - INSPIRE themes, version 1.0',
+            'uri' => 'https://eionet.europa.eu/gemet/concept/3638/',
+            'description' => 'Science of the shape and size of the earth.',
+        ];
+
+        $result = OldDatasetKeywordTransformer::transform($old);
+
+        expect($result)->not->toBeNull()
+            ->and($result['scheme'])->toBe('GEMET - GEneral Multilingual Environmental Thesaurus')
+            ->and($result['text'])->toBe('geodesy')
+            ->and($result['id'])->toBe('http://www.eionet.europa.eu/gemet/concept/3638')
+            ->and($result['schemeURI'])->toBe('http://www.eionet.europa.eu/gemet/concept/')
+            ->and($result['uuid'])->toBeNull();
+    });
+
+    it('rejects a non GEMET URI for a legacy GEMET keyword', function () {
+        $old = (object) [
+            'keyword' => 'geodesy',
+            'thesaurus' => 'GEMET - INSPIRE themes, version 1.0',
+            'uri' => 'https://example.org/concept/3638',
+            'description' => null,
+        ];
+
+        expect(OldDatasetKeywordTransformer::transform($old))->toBeNull();
+    });
+
     it('returns null when URI has no valid UUID', function () {
         $old = (object) [
             'keyword' => 'Something',
@@ -146,6 +175,7 @@ describe('mapScheme', function () {
         ['GCMD Platforms', 'Platforms'],
         ['NASA/GCMD Instruments', 'Instruments'],
         ['GCMD Instruments', 'Instruments'],
+        ['GEMET - INSPIRE themes, version 1.0', 'GEMET - GEneral Multilingual Environmental Thesaurus'],
     ]);
 
     it('returns null for unknown thesaurus', function () {
@@ -197,12 +227,13 @@ describe('transformMany', function () {
 // =========================================================================
 
 describe('getSupportedThesauri', function () {
-    it('returns all 6 supported thesaurus names', function () {
+    it('returns all 7 supported thesaurus names', function () {
         $thesauri = OldDatasetKeywordTransformer::getSupportedThesauri();
 
-        expect($thesauri)->toHaveCount(6)
+        expect($thesauri)->toHaveCount(7)
             ->and($thesauri)->toContain('NASA/GCMD Earth Science Keywords')
-            ->and($thesauri)->toContain('GCMD Instruments');
+            ->and($thesauri)->toContain('GCMD Instruments')
+            ->and($thesauri)->toContain('GEMET - INSPIRE themes, version 1.0');
     });
 });
 

--- a/tests/pest/Unit/Services/Xml/OriginalDataCiteSubjectExtractionServiceTest.php
+++ b/tests/pest/Unit/Services/Xml/OriginalDataCiteSubjectExtractionServiceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Xml\OriginalDataCiteSubjectExtractionService;
+use App\Services\Xml\OriginalDataCiteXmlDecoder;
+use Illuminate\Support\Facades\Log;
+
+covers(OriginalDataCiteSubjectExtractionService::class, OriginalDataCiteXmlDecoder::class);
+
+beforeEach(function (): void {
+    $this->service = app(OriginalDataCiteSubjectExtractionService::class);
+});
+
+it('extracts subjects and their DataCite attributes from original XML', function (): void {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <subjects>
+    <subject subjectScheme="GEMET - INSPIRE themes, version 1.0" schemeURI="http://www.eionet.europa.eu/gemet/" valueURI="http://www.eionet.europa.eu/gemet/concept/3638" classificationCode="3638" xml:lang="en"> geodesy </subject>
+    <subject xml:lang="de"> Hydrologie </subject>
+    <subject> </subject>
+  </subjects>
+</resource>
+XML;
+
+    expect($this->service->extract($xml, 'issue-1115'))->toBe([
+        [
+            'subject' => 'geodesy',
+            'subjectScheme' => 'GEMET - INSPIRE themes, version 1.0',
+            'schemeUri' => 'http://www.eionet.europa.eu/gemet/',
+            'valueUri' => 'http://www.eionet.europa.eu/gemet/concept/3638',
+            'classificationCode' => '3638',
+            'lang' => 'en',
+        ],
+        [
+            'subject' => 'Hydrologie',
+            'lang' => 'de',
+        ],
+    ]);
+});
+
+it('prefers base64 encoded original XML subjects over REST subjects', function (): void {
+    $xml = <<<'XML'
+<resource xmlns="http://datacite.org/schema/kernel-4">
+  <subjects>
+    <subject>Biology</subject>
+    <subject subjectScheme="GEMET">geophysics</subject>
+  </subjects>
+</resource>
+XML;
+    $record = [
+        'id' => '10.5880/TRR228DB.398',
+        'attributes' => [
+            'xml' => base64_encode($xml),
+            'subjects' => [
+                ['subject' => 'Biology'],
+                ['subject' => 'FOS: Biological sciences'],
+            ],
+        ],
+    ];
+
+    $result = $this->service->preferOriginalSubjects($record, $record['id']);
+
+    expect($result['attributes']['subjects'])->toBe([
+        ['subject' => 'Biology'],
+        ['subject' => 'geophysics', 'subjectScheme' => 'GEMET'],
+    ]);
+});
+
+it('supports flat records and treats a valid empty subjects section as authoritative', function (): void {
+    $record = [
+        'xml' => '<resource xmlns="http://datacite.org/schema/kernel-4"><subjects /></resource>',
+        'subjects' => [['subject' => 'REST only']],
+    ];
+
+    expect($this->service->preferOriginalSubjects($record)['subjects'])->toBe([]);
+});
+
+it('keeps REST subjects when original XML is absent or malformed', function (): void {
+    Log::spy();
+
+    $record = [
+        'attributes' => [
+            'subjects' => [['subject' => 'REST fallback']],
+        ],
+    ];
+    $malformedRecord = [
+        'attributes' => [
+            'xml' => base64_encode('<resource><subjects><subject>broken'),
+            'subjects' => [['subject' => 'REST fallback']],
+        ],
+    ];
+
+    expect($this->service->preferOriginalSubjects($record))->toBe($record)
+        ->and($this->service->preferOriginalSubjects($malformedRecord, 'broken-doi'))->toBe($malformedRecord);
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Could not read XML subjects.'
+            && $context['context'] === 'broken-doi')
+        ->once();
+});

--- a/tests/pest/Unit/Services/Xml/OriginalDataCiteSubjectExtractionServiceTest.php
+++ b/tests/pest/Unit/Services/Xml/OriginalDataCiteSubjectExtractionServiceTest.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use App\Services\Xml\OriginalDataCiteSubjectExtractionService;
-use App\Services\Xml\OriginalDataCiteXmlDecoder;
+use App\Services\Xml\OriginalDataCiteXmlDecoderService;
 use Illuminate\Support\Facades\Log;
 
-covers(OriginalDataCiteSubjectExtractionService::class, OriginalDataCiteXmlDecoder::class);
+covers(OriginalDataCiteSubjectExtractionService::class, OriginalDataCiteXmlDecoderService::class);
 
 beforeEach(function (): void {
     $this->service = app(OriginalDataCiteSubjectExtractionService::class);


### PR DESCRIPTION
This pull request introduces major improvements to the handling of subject metadata during DataCite imports, with a focus on using original XML subjects when available, enhancing GEMET term handling, and ensuring robust subject scheme mapping. The changes also include new services for XML extraction and decoding, more precise subject merging logic, and updates to both import and export pipelines. Key areas addressed are subject extraction from original XML, improved merging and enrichment of legacy and DataCite subjects, and better normalization and mapping of subject schemes, especially for GEMET.

**Subject extraction and import improvements:**

* Added `OriginalDataCiteSubjectExtractionService` and `OriginalDataCiteXmlDecoderService` to extract and decode original subject metadata directly from embedded DataCite XML, preferring this over REST-derived subjects when available. The import job now uses this service to ensure accurate subject import. [[1]](diffhunk://#diff-b5eabe81abc7c78efb1b684e57c2357ee70614ade790395b9a5f795859aaea56R1-R110) [[2]](diffhunk://#diff-02e1ebf3a53029185508a72d0a46269837c20c5ab4c261d35ef100b3a144b171R1-R28) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R26) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R980-R982)
* Updated the changelog to document that legacy DataCite imports now use embedded original XML subjects, enrich GEMET terms with stable identifiers, and ensure unrelated subject schemes are not altered.

**Subject merging and enrichment enhancements:**

* Refined `DataCiteSubjectMergeService` to enrich existing DataCite subjects with missing metadata from equivalent legacy subjects, appending only genuinely new legacy subjects, and ensuring subject order and uniqueness. [[1]](diffhunk://#diff-e7d4dfb8d7687aafdd888243ce56202b76d689a9557687a6a0798fd4628470f1L14-R15) [[2]](diffhunk://#diff-e7d4dfb8d7687aafdd888243ce56202b76d689a9557687a6a0798fd4628470f1L56-R64) [[3]](diffhunk://#diff-e7d4dfb8d7687aafdd888243ce56202b76d689a9557687a6a0798fd4628470f1L79-R134)

**GEMET and subject scheme normalization:**

* Improved GEMET subject handling by mapping the legacy DataCite scheme title to a canonical scheme name, normalizing GEMET concept URIs, and ensuring correct scheme/URI assignment in both import and transformation logic. [[1]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R46) [[2]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R64-R68) [[3]](diffhunk://#diff-cf026b33160c24859ae3f441e4a7b9bcf27396cdb23fb86ae030e1ea0a239959R1284-R1286) [[4]](diffhunk://#diff-da661d69416750b9215f39802550a055e4bc0664a1c2d3f6b8aa0bf4fb3bbd95R8-R14) [[5]](diffhunk://#diff-da661d69416750b9215f39802550a055e4bc0664a1c2d3f6b8aa0bf4fb3bbd95R26-R27) [[6]](diffhunk://#diff-da661d69416750b9215f39802550a055e4bc0664a1c2d3f6b8aa0bf4fb3bbd95L73-R93) [[7]](diffhunk://#diff-da661d69416750b9215f39802550a055e4bc0664a1c2d3f6b8aa0bf4fb3bbd95R149-R165)

**Testing and validation:**

* Added and updated feature tests to verify that original XML subjects are preferred over REST subjects during import, and that GEMET and other subject schemes are correctly processed. [[1]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR833-R883) [[2]](diffhunk://#diff-6bdfe5479c8d44831c89959a0b78116f6a922a3332aad701067d9ea0eccb580bR6-R12) [[3]](diffhunk://#diff-6bdfe5479c8d44831c89959a0b78116f6a922a3332aad701067d9ea0eccb580bR25)

**Codebase simplification and reliability:**

* Refactored XML decoding logic into a dedicated service, and updated related services to use dependency injection for XML decoding. [[1]](diffhunk://#diff-fa75f3e2b91101ea5c64ffb6636ad4c1535476cc7f04cd634aec6018b0e09436R19-R24) [[2]](diffhunk://#diff-02e1ebf3a53029185508a72d0a46269837c20c5ab4c261d35ef100b3a144b171R1-R28)

These changes improve the reliability and fidelity of DataCite subject imports, especially for legacy and GEMET terms, and ensure that subject metadata is accurately preserved and enriched throughout the import pipeline.