### PR TITLE
Feature: CRC806 rights fallback and improve CC license display

### DIFF
--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Enums\AccessLevel;
 use App\Enums\CitationLabelResolutionMode;
 use App\Models\Datacenter;
 use App\Models\LandingPage;
@@ -1146,7 +1147,10 @@ class ImportFromDataCiteJob implements ShouldQueue
             return $preparedDoiRecord;
         }
 
-        $attributes['rightsList'] = [$rights];
+        $attributes['rightsList'] = [
+            ...$this->coarAccessRightStatements($attributes['rightsList'] ?? null),
+            $rights,
+        ];
 
         if ($hasAttributesWrapper) {
             $preparedDoiRecord['attributes'] = $attributes;
@@ -1172,10 +1176,44 @@ class ImportFromDataCiteJob implements ShouldQueue
                 continue;
             }
 
+            if ($this->isCoarAccessRightStatement($statement)) {
+                continue;
+            }
+
             foreach (['rights', 'rights_text', 'rightsUri', 'rightsURI', 'rights_uri', 'rightsIdentifier', 'rights_identifier'] as $key) {
                 if (is_string($statement[$key] ?? null) && trim($statement[$key]) !== '') {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function coarAccessRightStatements(mixed $rightsList): array
+    {
+        if (! is_array($rightsList)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $rightsList,
+            fn (mixed $statement): bool => is_array($statement)
+                && $this->isCoarAccessRightStatement($statement),
+        ));
+    }
+
+    /** @param array<string, mixed> $statement */
+    private function isCoarAccessRightStatement(array $statement): bool
+    {
+        foreach (['rightsUri', 'rightsURI', 'rights_uri'] as $key) {
+            $uri = $statement[$key] ?? null;
+
+            if (is_string($uri) && AccessLevel::fromCoarUri($uri) !== null) {
+                return true;
             }
         }
 

--- a/app/Jobs/ImportFromDataCiteJob.php
+++ b/app/Jobs/ImportFromDataCiteJob.php
@@ -8,6 +8,7 @@ use App\Enums\CitationLabelResolutionMode;
 use App\Models\Datacenter;
 use App\Models\LandingPage;
 use App\Models\Resource;
+use App\Services\Crc806LegacyRightsService;
 use App\Services\DataCiteImportService;
 use App\Services\DataCiteLandingPageImportService;
 use App\Services\DataCiteSubjectMergeService;
@@ -63,6 +64,8 @@ class ImportFromDataCiteJob implements ShouldQueue
 
     /** @var list<int> */
     private array $resourceIdsForDataCiteSync = [];
+
+    private ?Crc806LegacyRightsService $crc806LegacyRightsService = null;
 
     /**
      * Create a new job instance.
@@ -1005,10 +1008,17 @@ class ImportFromDataCiteJob implements ShouldQueue
                 $legacyMetadata['subjects'],
             );
 
+            $legacyLandingPageUrl = $this->doiRecordLandingPageUrl($doiRecord);
+
             $preparedDoiRecord = $transformer->prepareDoiData(
                 $doiRecord,
                 $legacyMetadata['relatedIdentifiers'],
                 $citationLabelResolutionMode,
+            );
+            $preparedDoiRecord = $this->withCrc806LegacyRightsFallback(
+                $preparedDoiRecord,
+                $doi,
+                $legacyLandingPageUrl,
             );
 
             // Use database transaction to ensure atomicity of the check-then-insert operation.
@@ -1097,6 +1107,79 @@ class ImportFromDataCiteJob implements ShouldQueue
 
             throw $exception;
         }
+    }
+
+    /**
+     * @param  array<string, mixed>  $doiRecord
+     */
+    private function doiRecordLandingPageUrl(array $doiRecord): mixed
+    {
+        $attributes = is_array($doiRecord['attributes'] ?? null)
+            ? $doiRecord['attributes']
+            : $doiRecord;
+
+        return $attributes['url'] ?? null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $preparedDoiRecord
+     * @return array<string, mixed>
+     */
+    private function withCrc806LegacyRightsFallback(
+        array $preparedDoiRecord,
+        string $doi,
+        mixed $landingPageUrl,
+    ): array {
+        $hasAttributesWrapper = is_array($preparedDoiRecord['attributes'] ?? null);
+        $attributes = $hasAttributesWrapper
+            ? $preparedDoiRecord['attributes']
+            : $preparedDoiRecord;
+
+        if ($this->hasUsableRights($attributes['rightsList'] ?? null)) {
+            return $preparedDoiRecord;
+        }
+
+        $rights = ($this->crc806LegacyRightsService ??= app(Crc806LegacyRightsService::class))
+            ->findRights($doi, $landingPageUrl);
+
+        if ($rights === null) {
+            return $preparedDoiRecord;
+        }
+
+        $attributes['rightsList'] = [$rights];
+
+        if ($hasAttributesWrapper) {
+            $preparedDoiRecord['attributes'] = $attributes;
+
+            return $preparedDoiRecord;
+        }
+
+        return $attributes;
+    }
+
+    private function hasUsableRights(mixed $rightsList): bool
+    {
+        if (! is_array($rightsList)) {
+            return false;
+        }
+
+        foreach ($rightsList as $statement) {
+            if (is_string($statement) && trim($statement) !== '') {
+                return true;
+            }
+
+            if (! is_array($statement)) {
+                continue;
+            }
+
+            foreach (['rights', 'rights_text', 'rightsUri', 'rightsURI', 'rights_uri', 'rightsIdentifier', 'rights_identifier'] as $key) {
+                if (is_string($statement[$key] ?? null) && trim($statement[$key]) !== '') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/app/Services/Crc806LegacyRightsService.php
+++ b/app/Services/Crc806LegacyRightsService.php
@@ -94,6 +94,15 @@ final class Crc806LegacyRightsService
             return null;
         }
 
+        if ($response->status() === 429) {
+            $this->providerUnavailable = true;
+            $this->logFailure($normalizedDoi, 'provider-rate-limited', [
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
         if ($response->serverError()) {
             $this->providerUnavailable = true;
             $this->logFailure($normalizedDoi, 'provider-server-error', [
@@ -161,19 +170,25 @@ final class Crc806LegacyRightsService
 
         $identifier = $this->spdxIdentifierFromCreativeCommonsUri($uri);
 
-        if ($identifier === null || ! $this->licenseNameMatchesIdentifier($name, $identifier)) {
+        if ($identifier === null) {
             $this->logFailure($normalizedDoi, 'unsupported-or-conflicting-license');
 
             return null;
         }
 
-        $catalogLicense = ($this->licenseLookup ??= SpdxLicenseLookup::fromRightsCatalog())
-            ->findByIdentifier($identifier);
+        $licenseLookup = $this->licenseLookup ??= SpdxLicenseLookup::fromRightsCatalog();
+        $catalogLicense = $licenseLookup->findByIdentifier($identifier);
 
         if ($catalogLicense === null || $catalogLicense->schemeUri !== SpdxLicenseLookup::SCHEME_URI) {
             $this->logFailure($normalizedDoi, 'license-not-in-active-spdx-catalog', [
                 'rights_identifier' => $identifier,
             ]);
+
+            return null;
+        }
+
+        if (! $this->licenseNameMatchesIdentifier($name, $identifier, $licenseLookup)) {
+            $this->logFailure($normalizedDoi, 'unsupported-or-conflicting-license');
 
             return null;
         }
@@ -443,8 +458,11 @@ final class Crc806LegacyRightsService
         return null;
     }
 
-    private function licenseNameMatchesIdentifier(string $name, string $identifier): bool
-    {
+    private function licenseNameMatchesIdentifier(
+        string $name,
+        string $identifier,
+        SpdxLicenseLookup $licenseLookup,
+    ): bool {
         $normalizedName = strtoupper(trim($name));
         $normalizedName = preg_replace('/^CC-/', 'CC ', $normalizedName) ?? $normalizedName;
         $normalizedName = preg_replace('/\s+/', ' ', $normalizedName) ?? $normalizedName;
@@ -461,8 +479,10 @@ final class Crc806LegacyRightsService
                 && (! isset($match[2]) || $identifier === $identifierFamily.'-'.$match[2]);
         }
 
-        return ! str_starts_with($normalizedName, 'CC ')
-            && ! str_starts_with($normalizedName, 'CC0');
+        $namedLicense = $licenseLookup->findByName($name)
+            ?? $licenseLookup->findByAlias($name);
+
+        return $namedLicense?->identifier === $identifier;
     }
 
     /** @param array<string, int|string> $context */

--- a/app/Services/Crc806LegacyRightsService.php
+++ b/app/Services/Crc806LegacyRightsService.php
@@ -449,17 +449,20 @@ final class Crc806LegacyRightsService
         $normalizedName = preg_replace('/^CC-/', 'CC ', $normalizedName) ?? $normalizedName;
         $normalizedName = preg_replace('/\s+/', ' ', $normalizedName) ?? $normalizedName;
 
-        if (preg_match('/^CC0(?:\s+\d+\.\d+)?$/', $normalizedName) === 1) {
-            return str_starts_with($identifier, 'CC0-');
+        if (preg_match('/^CC0(?:\s+(\d+\.\d+))?$/', $normalizedName, $match) === 1) {
+            return str_starts_with($identifier, 'CC0-')
+                && (! isset($match[1]) || $identifier === 'CC0-'.$match[1]);
         }
 
-        if (preg_match('/^CC\s+(BY(?:-(?:NC|ND|SA))*)(?:\s+\d+\.\d+)?$/', $normalizedName, $match) === 1) {
+        if (preg_match('/^CC\s+(BY(?:-(?:NC|ND|SA))*)(?:\s+(\d+\.\d+))?$/', $normalizedName, $match) === 1) {
             $identifierFamily = preg_replace('/-\d+\.\d+$/', '', $identifier) ?? $identifier;
 
-            return $identifierFamily === 'CC-'.$match[1];
+            return $identifierFamily === 'CC-'.$match[1]
+                && (! isset($match[2]) || $identifier === $identifierFamily.'-'.$match[2]);
         }
 
-        return true;
+        return ! str_starts_with($normalizedName, 'CC ')
+            && ! str_starts_with($normalizedName, 'CC0');
     }
 
     /** @param array<string, int|string> $context */

--- a/app/Services/Crc806LegacyRightsService.php
+++ b/app/Services/Crc806LegacyRightsService.php
@@ -235,8 +235,7 @@ final class Crc806LegacyRightsService
         $contentLength = $response->header('Content-Length');
 
         if (
-            is_string($contentLength)
-            && ctype_digit($contentLength)
+            ctype_digit($contentLength)
             && (int) $contentLength > self::MAX_RESPONSE_BYTES
         ) {
             return null;
@@ -259,7 +258,7 @@ final class Crc806LegacyRightsService
 
             $chunk = $stream->read(min(8192, $remaining));
 
-            if ($chunk === '' && ! $stream->eof()) {
+            if ($chunk === '') {
                 throw new \RuntimeException('CRC806 response stream stopped before EOF.');
             }
 

--- a/app/Services/Crc806LegacyRightsService.php
+++ b/app/Services/Crc806LegacyRightsService.php
@@ -1,0 +1,474 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Services\Spdx\SpdxLicenseLookup;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use JsonException;
+use Throwable;
+
+/**
+ * Loads a missing license from the trusted CRC806 legacy landing page.
+ *
+ * This adapter is deliberately provider-specific. DataCite target URLs are
+ * user-controlled metadata, so broad or redirect-following scraping would
+ * introduce an SSRF risk and make legal metadata dependent on heuristics.
+ */
+final class Crc806LegacyRightsService
+{
+    private const string HOST = 'crc806db.uni-koeln.de';
+
+    private const int MAX_RESPONSE_BYTES = 1_000_000;
+
+    private const int CONNECT_TIMEOUT_SECONDS = 2;
+
+    private const int REQUEST_TIMEOUT_SECONDS = 5;
+
+    private const int REQUEST_ATTEMPTS = 2;
+
+    /** @var list<string> */
+    private const array CC_LICENSE_FAMILIES = [
+        'by',
+        'by-sa',
+        'by-nd',
+        'by-nc',
+        'by-nc-sa',
+        'by-nc-nd',
+    ];
+
+    private bool $providerUnavailable = false;
+
+    private ?SpdxLicenseLookup $licenseLookup = null;
+
+    /**
+     * @return array{
+     *     rights: string,
+     *     rightsUri: string,
+     *     rightsIdentifier: string,
+     *     rightsIdentifierScheme: string,
+     *     schemeUri: string,
+     *     source: string
+     * }|null
+     */
+    public function findRights(string $doi, mixed $landingPageUrl): ?array
+    {
+        if ($this->providerUnavailable || ! is_string($landingPageUrl)) {
+            return null;
+        }
+
+        $requestUrl = $this->canonicalLandingPageUrl($landingPageUrl);
+
+        if ($requestUrl === null) {
+            return null;
+        }
+
+        $normalizedDoi = $this->normalizeDoi($doi);
+
+        try {
+            $response = Http::accept('text/html,application/xhtml+xml')
+                ->withUserAgent('ERNIE CRC806 legacy rights importer')
+                ->connectTimeout(self::CONNECT_TIMEOUT_SECONDS)
+                ->timeout(self::REQUEST_TIMEOUT_SECONDS)
+                ->withoutRedirecting()
+                ->withOptions(['stream' => true])
+                ->retry(
+                    self::REQUEST_ATTEMPTS,
+                    100,
+                    static fn (Throwable $exception): bool => $exception instanceof ConnectionException
+                        || ($exception instanceof RequestException && $exception->response->serverError()),
+                    throw: false,
+                )
+                ->get($requestUrl);
+        } catch (Throwable $exception) {
+            $this->providerUnavailable = true;
+            $this->logFailure($normalizedDoi, 'provider-connection-failure', [
+                'exception' => $exception::class,
+            ]);
+
+            return null;
+        }
+
+        if ($response->serverError()) {
+            $this->providerUnavailable = true;
+            $this->logFailure($normalizedDoi, 'provider-server-error', [
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        if (! $response->successful()) {
+            $this->logFailure($normalizedDoi, 'landing-page-http-error', [
+                'status' => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        try {
+            $html = $this->readLimitedBody($response);
+        } catch (Throwable $exception) {
+            $this->providerUnavailable = true;
+            $this->logFailure($normalizedDoi, 'provider-response-read-failure', [
+                'exception' => $exception::class,
+            ]);
+
+            return null;
+        }
+
+        if ($html === null) {
+            $this->logFailure($normalizedDoi, 'landing-page-response-too-large');
+
+            return null;
+        }
+
+        $routeInfo = $this->extractRouteInfo($html);
+        $dataset = $routeInfo['allProps']['dataset'] ?? null;
+
+        if (! is_array($dataset)) {
+            $this->logFailure($normalizedDoi, 'missing-structured-dataset');
+
+            return null;
+        }
+
+        $embeddedDoi = $this->extractDatasetDoi($dataset['extras'] ?? null);
+
+        if ($embeddedDoi === null || $embeddedDoi !== $normalizedDoi) {
+            $this->logFailure($normalizedDoi, 'embedded-doi-mismatch');
+
+            return null;
+        }
+
+        $license = $dataset['license'] ?? null;
+        $name = is_array($license) && is_string($license['name'] ?? null)
+            ? trim($license['name'])
+            : '';
+        $uri = is_array($license) && is_string($license['url'] ?? null)
+            ? trim($license['url'])
+            : '';
+
+        if ($name === '' || $uri === '' || strlen($name) > 500 || strlen($uri) > 2048) {
+            $this->logFailure($normalizedDoi, 'missing-or-invalid-license');
+
+            return null;
+        }
+
+        $identifier = $this->spdxIdentifierFromCreativeCommonsUri($uri);
+
+        if ($identifier === null || ! $this->licenseNameMatchesIdentifier($name, $identifier)) {
+            $this->logFailure($normalizedDoi, 'unsupported-or-conflicting-license');
+
+            return null;
+        }
+
+        $catalogLicense = ($this->licenseLookup ??= SpdxLicenseLookup::fromRightsCatalog())
+            ->findByIdentifier($identifier);
+
+        if ($catalogLicense === null || $catalogLicense->schemeUri !== SpdxLicenseLookup::SCHEME_URI) {
+            $this->logFailure($normalizedDoi, 'license-not-in-active-spdx-catalog', [
+                'rights_identifier' => $identifier,
+            ]);
+
+            return null;
+        }
+
+        return [
+            'rights' => $name,
+            'rightsUri' => $uri,
+            'rightsIdentifier' => $catalogLicense->identifier,
+            'rightsIdentifierScheme' => SpdxLicenseLookup::RIGHTS_IDENTIFIER_SCHEME,
+            'schemeUri' => SpdxLicenseLookup::SCHEME_URI,
+            'source' => 'legacy-crc806',
+        ];
+    }
+
+    private function canonicalLandingPageUrl(string $url): ?string
+    {
+        $url = trim($url);
+
+        if (
+            $url === ''
+            || strlen($url) > 4096
+            || preg_match('/[\x00-\x20\x7f]/', $url) === 1
+            || filter_var($url, FILTER_VALIDATE_URL) === false
+        ) {
+            return null;
+        }
+
+        $parts = parse_url($url);
+
+        if (! is_array($parts)) {
+            return null;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $port = $parts['port'] ?? null;
+        $usesStandardPort = $port === null
+            || ($scheme === 'http' && $port === 80)
+            || ($scheme === 'https' && $port === 443);
+
+        if (
+            ! in_array($scheme, ['http', 'https'], true)
+            || $host !== self::HOST
+            || isset($parts['user'])
+            || isset($parts['pass'])
+            || ! $usesStandardPort
+        ) {
+            return null;
+        }
+
+        $path = $parts['path'] ?? '/';
+        $query = isset($parts['query']) ? '?'.$parts['query'] : '';
+
+        return 'https://'.self::HOST.($path === '' ? '/' : $path).$query;
+    }
+
+    private function readLimitedBody(Response $response): ?string
+    {
+        $contentLength = $response->header('Content-Length');
+
+        if (
+            is_string($contentLength)
+            && ctype_digit($contentLength)
+            && (int) $contentLength > self::MAX_RESPONSE_BYTES
+        ) {
+            return null;
+        }
+
+        $stream = $response->toPsrResponse()->getBody();
+
+        if ($stream->isSeekable()) {
+            $stream->rewind();
+        }
+
+        $html = '';
+
+        while (! $stream->eof()) {
+            $remaining = self::MAX_RESPONSE_BYTES + 1 - strlen($html);
+
+            if ($remaining <= 0) {
+                return null;
+            }
+
+            $chunk = $stream->read(min(8192, $remaining));
+
+            if ($chunk === '' && ! $stream->eof()) {
+                throw new \RuntimeException('CRC806 response stream stopped before EOF.');
+            }
+
+            $html .= $chunk;
+        }
+
+        return strlen($html) > self::MAX_RESPONSE_BYTES ? null : $html;
+    }
+
+    /** @return array<string, mixed> */
+    private function extractRouteInfo(string $html): array
+    {
+        if (preg_match('/window\s*\.\s*__routeInfo\s*=\s*/', $html, $match, PREG_OFFSET_CAPTURE) !== 1) {
+            return [];
+        }
+
+        $assignmentEnd = $match[0][1] + strlen($match[0][0]);
+        $jsonStart = strpos($html, '{', $assignmentEnd);
+
+        if ($jsonStart === false) {
+            return [];
+        }
+
+        $depth = 0;
+        $inString = false;
+        $escaped = false;
+        $length = strlen($html);
+
+        for ($index = $jsonStart; $index < $length; $index++) {
+            $character = $html[$index];
+
+            if ($inString) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ($character === '\\') {
+                    $escaped = true;
+                } elseif ($character === '"') {
+                    $inString = false;
+                }
+
+                continue;
+            }
+
+            if ($character === '"') {
+                $inString = true;
+
+                continue;
+            }
+
+            if ($character === '{') {
+                $depth++;
+            } elseif ($character === '}') {
+                $depth--;
+
+                if ($depth === 0) {
+                    $json = substr($html, $jsonStart, $index - $jsonStart + 1);
+
+                    try {
+                        $decoded = json_decode($json, true, 64, JSON_THROW_ON_ERROR);
+                    } catch (JsonException) {
+                        return [];
+                    }
+
+                    return is_array($decoded) ? $decoded : [];
+                }
+            }
+        }
+
+        return [];
+    }
+
+    private function extractDatasetDoi(mixed $extras): ?string
+    {
+        if (! is_array($extras)) {
+            return null;
+        }
+
+        $candidates = [];
+        $this->collectDoiCandidates($extras, $candidates);
+        $candidates = array_values(array_unique(array_filter(array_map(
+            fn (string $candidate): string => $this->normalizeDoi($candidate),
+            $candidates,
+        ))));
+
+        return count($candidates) === 1 ? $candidates[0] : null;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $node
+     * @param  list<string>  $candidates
+     */
+    private function collectDoiCandidates(array $node, array &$candidates): void
+    {
+        $entryKey = $node['key'] ?? $node['name'] ?? null;
+
+        if (is_string($entryKey) && $this->isDoiExtraKey($entryKey)) {
+            $this->appendDoiCandidate($node['value'] ?? $node['text'] ?? null, $candidates);
+        }
+
+        foreach ($node as $key => $value) {
+            if (is_string($key) && $this->isDoiExtraKey($key)) {
+                $this->appendDoiCandidate($value, $candidates);
+            }
+
+            if (is_array($value)) {
+                $this->collectDoiCandidates($value, $candidates);
+            }
+        }
+    }
+
+    /** @param list<string> $candidates */
+    private function appendDoiCandidate(mixed $value, array &$candidates): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        $value = trim($value);
+
+        if (preg_match('~10\.\d{4,9}/[^\s"\'<>\]},]+~i', $value, $match) === 1) {
+            $candidates[] = rtrim($match[0], '.,;');
+        }
+    }
+
+    private function isDoiExtraKey(string $key): bool
+    {
+        return in_array(strtolower(trim($key)), ['bibtex:doi', 'doi'], true);
+    }
+
+    private function normalizeDoi(string $doi): string
+    {
+        $doi = preg_replace(
+            '~^(?:doi:\s*|https?://(?:dx\.)?doi\.org/)~i',
+            '',
+            trim($doi),
+        ) ?? trim($doi);
+
+        return strtolower(rtrim(trim($doi), '.,;'));
+    }
+
+    private function spdxIdentifierFromCreativeCommonsUri(string $uri): ?string
+    {
+        if (filter_var($uri, FILTER_VALIDATE_URL) === false) {
+            return null;
+        }
+
+        $parts = parse_url($uri);
+
+        if (! is_array($parts)) {
+            return null;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $path = strtolower((string) ($parts['path'] ?? ''));
+
+        if (
+            ! in_array($scheme, ['http', 'https'], true)
+            || ! in_array($host, ['creativecommons.org', 'www.creativecommons.org'], true)
+            || isset($parts['user'])
+            || isset($parts['pass'])
+            || isset($parts['port'])
+            || isset($parts['query'])
+            || isset($parts['fragment'])
+        ) {
+            return null;
+        }
+
+        $familyPattern = implode('|', array_map(
+            static fn (string $family): string => preg_quote($family, '~'),
+            self::CC_LICENSE_FAMILIES,
+        ));
+
+        if (preg_match('~^/licenses/('.$familyPattern.')/(\d+\.\d+)/?$~', $path, $match) === 1) {
+            return 'CC-'.strtoupper($match[1]).'-'.$match[2];
+        }
+
+        if (preg_match('~^/publicdomain/zero/(\d+\.\d+)/?$~', $path, $match) === 1) {
+            return 'CC0-'.$match[1];
+        }
+
+        return null;
+    }
+
+    private function licenseNameMatchesIdentifier(string $name, string $identifier): bool
+    {
+        $normalizedName = strtoupper(trim($name));
+        $normalizedName = preg_replace('/^CC-/', 'CC ', $normalizedName) ?? $normalizedName;
+        $normalizedName = preg_replace('/\s+/', ' ', $normalizedName) ?? $normalizedName;
+
+        if (preg_match('/^CC0(?:\s+\d+\.\d+)?$/', $normalizedName) === 1) {
+            return str_starts_with($identifier, 'CC0-');
+        }
+
+        if (preg_match('/^CC\s+(BY(?:-(?:NC|ND|SA))*)(?:\s+\d+\.\d+)?$/', $normalizedName, $match) === 1) {
+            $identifierFamily = preg_replace('/-\d+\.\d+$/', '', $identifier) ?? $identifier;
+
+            return $identifierFamily === 'CC-'.$match[1];
+        }
+
+        return true;
+    }
+
+    /** @param array<string, int|string> $context */
+    private function logFailure(string $doi, string $reason, array $context = []): void
+    {
+        Log::warning('CRC806 legacy license fallback was not applied.', array_merge([
+            'doi' => $doi,
+            'reason' => $reason,
+        ], $context));
+    }
+}

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -4,6 +4,10 @@
         "date": "2026-08-20",
         "features": [
             {
+                "title": "Clear Creative Commons License Labels on Landing Pages",
+                "description": "Landing page license badges now show the full license name together with the conventional Creative Commons short notation, for example 'Creative Commons Attribution 4.0 International (CC BY 4.0)'. Existing license links, SPDX tooltips, and Creative Commons symbols remain available."
+            },
+            {
                 "title": "Resources List Datacenter Filter",
                 "description": "The Resources list now includes a Datacenter dropdown for showing resources assigned to one selected datacenter. Its options include only datacenters used by regular resources, while the new \"Without Datacenter\" choice finds resources that still need an assignment. The filter remains active while sorting or loading more results and can be removed from the active filter badges."
             },

--- a/resources/js/pages/LandingPages/components/CreativeCommonsIcon.tsx
+++ b/resources/js/pages/LandingPages/components/CreativeCommonsIcon.tsx
@@ -59,6 +59,26 @@ export function getCreativeCommonsBadgePath(spdxId: string): string | null {
 }
 
 /**
+ * Format supported SPDX identifiers as the familiar Creative Commons short name.
+ */
+export function getCreativeCommonsShortName(spdxId: string): string | null {
+    const upper = spdxId.trim().toUpperCase();
+    const cc0Match = upper.match(/^CC0-(\d+\.\d+)$/);
+
+    if (cc0Match) {
+        return `CC0 ${cc0Match[1]}`;
+    }
+
+    const licenseMatch = upper.match(/^CC-(BY|BY-SA|BY-ND|BY-NC|BY-NC-SA|BY-NC-ND)-(\d+\.\d+)$/);
+
+    if (!licenseMatch) {
+        return null;
+    }
+
+    return `CC ${licenseMatch[1]} ${licenseMatch[2]}`;
+}
+
+/**
  * Creative Commons Badge Component
  *
  * Returns null for non-CC licenses and for CC identifiers without an official
@@ -71,16 +91,7 @@ export function CreativeCommonsIcon({ spdxId, className = 'h-[31px] w-[88px]' }:
         return null;
     }
 
-    return (
-        <img
-            src={badgePath}
-            alt={`Creative Commons ${spdxId}`}
-            width={88}
-            height={31}
-            className={`${className} shrink-0`}
-            loading="lazy"
-        />
-    );
+    return <img src={badgePath} alt={`Creative Commons ${spdxId}`} width={88} height={31} className={`${className} shrink-0`} loading="lazy" />;
 }
 
 /**

--- a/resources/js/pages/LandingPages/components/FilesSection.tsx
+++ b/resources/js/pages/LandingPages/components/FilesSection.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import type { LandingPageContactPerson, LandingPageLicense, LandingPageLink } from '@/types/landing-page';
 
 import { ContactModal } from './ContactModal';
-import { CreativeCommonsIcon } from './CreativeCommonsIcon';
+import { CreativeCommonsIcon, getCreativeCommonsShortName } from './CreativeCommonsIcon';
 import { LandingPageCard } from './LandingPageCard';
 
 interface FilesSectionProps {
@@ -34,9 +34,7 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
     // Build effective list of download URLs: prefer downloadFiles, fall back to single downloadUrl
     const hasDownloadUrl = typeof downloadUrl === 'string' && downloadUrl !== '#' && downloadUrl.trim() !== '';
     const effectiveDownloads =
-        downloadFiles && downloadFiles.length > 0
-            ? downloadFiles.map((file) => file.tracked_url ?? file.url)
-            : hasDownloadUrl ? [downloadUrl!] : [];
+        downloadFiles && downloadFiles.length > 0 ? downloadFiles.map((file) => file.tracked_url ?? file.url) : hasDownloadUrl ? [downloadUrl!] : [];
 
     // Find contact persons for fallback options
     const contactPersonWithEmail = contactPersons.find((p) => p.has_email);
@@ -51,12 +49,12 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
      */
     const displayMode: FallbackMode =
         effectiveDownloads.length > 0
-        ? 'download'
-        : contactPersonWithEmail
-          ? 'contact-form'
-          : contactPersonWithWebsite
-            ? 'website'
-            : 'fallback-message';
+            ? 'download'
+            : contactPersonWithEmail
+              ? 'contact-form'
+              : contactPersonWithWebsite
+                ? 'website'
+                : 'fallback-message';
 
     const handleContactClick = (person: LandingPageContactPerson) => {
         setSelectedPerson(person);
@@ -70,11 +68,10 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
 
     return (
         <>
-            <LandingPageCard
-                aria-labelledby="heading-files"
-                data-testid="files-section"
-            >
-                <h2 id="heading-files" className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">Files</h2>
+            <LandingPageCard aria-labelledby="heading-files" data-testid="files-section">
+                <h2 id="heading-files" className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    Files
+                </h2>
 
                 <div className="space-y-3">
                     {/* Download Link(s) - shown when download URLs are available */}
@@ -164,6 +161,8 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
                             <div className="flex flex-col gap-2">
                                 {licenses.map((license) => {
                                     const title = license.spdx_id ?? license.name;
+                                    const shortName = license.spdx_id ? getCreativeCommonsShortName(license.spdx_id) : null;
+                                    const showShortName = shortName !== null && license.name.trim().toUpperCase() !== shortName.toUpperCase();
                                     const icon = license.spdx_id ? (
                                         <CreativeCommonsIcon spdxId={license.spdx_id} />
                                     ) : license.reference ? (
@@ -172,7 +171,10 @@ export function FilesSection({ downloadUrl, downloadFiles, licenses, contactPers
                                     const badgeContent = (
                                         <>
                                             {icon}
-                                            <span>{license.name}</span>
+                                            <span className="min-w-0 break-words">
+                                                {license.name}
+                                                {showShortName && ` (${shortName})`}
+                                            </span>
                                         </>
                                     );
 

--- a/resources/js/pages/docs.tsx
+++ b/resources/js/pages/docs.tsx
@@ -1695,6 +1695,12 @@ DATACITE_TEST_PASSWORD=your_test_password`}
                             the setup modal, but hides the complete Files section on the preview and public landing page until the option is disabled
                             again.
                         </p>
+                        <h4>License Display</h4>
+                        <p>
+                            In the Files section, Creative Commons licenses show both the full license name and the conventional short notation, for
+                            example <strong>Creative Commons Attribution 4.0 International (CC BY 4.0)</strong>. The badge remains linked to the
+                            license text when a URL is available, and its tooltip shows the SPDX identifier.
+                        </p>
                         <p>
                             From the Data Editor, click <strong>Show LP Preview</strong> in the bottom-right action bar next to{' '}
                             <strong>Save Draft</strong> and <strong>Save &amp; Validate</strong> to save the current metadata as a draft and open the

--- a/tests/pest/Feature/Api/ChangelogApiTest.php
+++ b/tests/pest/Feature/Api/ChangelogApiTest.php
@@ -18,6 +18,9 @@ it('returns changelog data grouped by release', function () {
         ])
         ->assertJsonFragment([
             'title' => 'Assistance: Description Segmentation Suggestions',
+        ])
+        ->assertJsonFragment([
+            'title' => 'Clear Creative Commons License Labels on Landing Pages',
         ]);
 });
 

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -10,6 +10,7 @@ use App\Models\LandingPageDomain;
 use App\Models\LandingPageFile;
 use App\Models\LandingPageLink;
 use App\Models\Resource;
+use App\Models\Right;
 use App\Models\User;
 use App\Services\DataCiteImportService;
 use App\Services\DataCiteSyncService;
@@ -27,6 +28,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -135,6 +137,21 @@ beforeEach(function () {
 afterEach(function () {
     Mockery::close();
 });
+
+function crc806ImportJobPage(string $doi = '10.5880/sfb806.80'): string
+{
+    return '<script>window.__routeInfo = '.json_encode([
+        'allProps' => [
+            'dataset' => [
+                'extras' => ['bibtex:doi' => $doi],
+                'license' => [
+                    'name' => 'CC BY-NC-ND',
+                    'url' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+                ],
+            ],
+        ],
+    ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES).';</script>';
+}
 
 describe('ImportFromDataCiteJob', function () {
     it('updates cache with progress during import', function () {
@@ -386,6 +403,193 @@ describe('ImportFromDataCiteJob', function () {
             ->handle($this->importService, $this->transformer, $this->metaworksService);
 
         expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(1);
+    });
+
+    it('adds CRC806 rights after preparation when DataCite and XML rights are empty', function (): void {
+        Right::query()->create([
+            'identifier' => 'CC-BY-NC-ND-4.0',
+            'name' => 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International',
+            'uri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+            'is_active' => true,
+            'is_elmo_active' => true,
+        ]);
+
+        $doiRecord = [
+            'id' => '10.5880/sfb806.80',
+            'attributes' => [
+                'doi' => '10.5880/sfb806.80',
+                'url' => 'http://crc806db.uni-koeln.de/dataset/show/example/',
+                'titles' => [['title' => 'CRC806 rights import']],
+            ],
+        ];
+        $preparedRecord = $doiRecord;
+        unset($preparedRecord['attributes']['url']);
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(1);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($doiRecord) {
+            yield $doiRecord;
+        })());
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->once()
+            ->with($doiRecord, [], CitationLabelResolutionMode::BEST_EFFORT)
+            ->andReturn($preparedRecord);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->withArgs(function (array $record, int $userId): bool {
+                return $userId === $this->user->id
+                    && ($record['attributes']['rightsList'] ?? null) === [[
+                        'rights' => 'CC BY-NC-ND',
+                        'rightsUri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+                        'rightsIdentifier' => 'CC-BY-NC-ND-4.0',
+                        'rightsIdentifierScheme' => 'SPDX',
+                        'schemeUri' => 'https://spdx.org/licenses/',
+                        'source' => 'legacy-crc806',
+                    ]];
+            })
+            ->andReturn(Resource::factory()->make(['doi' => '10.5880/sfb806.80']));
+
+        Http::fake([
+            'https://crc806db.uni-koeln.de/*' => Http::response(crc806ImportJobPage()),
+        ]);
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(1);
+        Http::assertSentCount(1);
+    });
+
+    it('does not request CRC806 when prepared DataCite or XML rights are present', function (): void {
+        $doiRecord = [
+            'id' => '10.5880/sfb806.existing-rights',
+            'attributes' => [
+                'doi' => '10.5880/sfb806.existing-rights',
+                'url' => 'https://crc806db.uni-koeln.de/dataset/show/example/',
+            ],
+        ];
+        $preparedRecord = [
+            'id' => $doiRecord['id'],
+            'attributes' => [
+                'doi' => $doiRecord['attributes']['doi'],
+                'rightsList' => [[
+                    'rights' => 'Original XML rights',
+                    'rightsUri' => 'https://example.test/original-rights',
+                    'source' => 'datacite-import',
+                ]],
+            ],
+        ];
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(1);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($doiRecord) {
+            yield $doiRecord;
+        })());
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->once()
+            ->andReturn($preparedRecord);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->with($preparedRecord, $this->user->id)
+            ->andReturn(Resource::factory()->make(['doi' => $doiRecord['id']]));
+
+        Http::fake();
+        Http::preventStrayRequests();
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(1);
+        Http::assertNothingSent();
+    });
+
+    it('continues a CRC806 import without rights when the legacy page is malformed', function (): void {
+        $doiRecord = [
+            'id' => '10.5880/sfb806.malformed',
+            'attributes' => [
+                'doi' => '10.5880/sfb806.malformed',
+                'url' => 'https://crc806db.uni-koeln.de/dataset/show/malformed/',
+            ],
+        ];
+        $preparedRecord = $doiRecord;
+        unset($preparedRecord['attributes']['url']);
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(1);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($doiRecord) {
+            yield $doiRecord;
+        })());
+        $this->transformer->shouldReceive('prepareDoiData')->once()->andReturn($preparedRecord);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->with($preparedRecord, $this->user->id)
+            ->andReturn(Resource::factory()->make(['doi' => $doiRecord['id']]));
+
+        Http::fake([
+            'https://crc806db.uni-koeln.de/*' => Http::response('<html>legacy page without route data</html>'),
+        ]);
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        $status = Cache::get("datacite_import:{$importId}");
+        expect($status['imported'])->toBe(1)
+            ->and($status['failed'])->toBe(0);
+    });
+
+    it('shares the CRC806 circuit breaker across records in one bulk job', function (): void {
+        $records = [
+            [
+                'id' => '10.5880/sfb806.unavailable.1',
+                'attributes' => [
+                    'doi' => '10.5880/sfb806.unavailable.1',
+                    'url' => 'https://crc806db.uni-koeln.de/dataset/show/one/',
+                ],
+            ],
+            [
+                'id' => '10.5880/sfb806.unavailable.2',
+                'attributes' => [
+                    'doi' => '10.5880/sfb806.unavailable.2',
+                    'url' => 'https://crc806db.uni-koeln.de/dataset/show/two/',
+                ],
+            ],
+        ];
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(2);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($records) {
+            yield from $records;
+        })());
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->twice()
+            ->andReturnUsing(function (array $record): array {
+                unset($record['attributes']['url']);
+
+                return $record;
+            });
+        $this->transformer
+            ->shouldReceive('transform')
+            ->twice()
+            ->andReturnUsing(fn (array $record): Resource => Resource::factory()->make([
+                'doi' => $record['attributes']['doi'],
+            ]));
+
+        Http::fake([
+            'https://crc806db.uni-koeln.de/*' => Http::response('Unavailable', 503),
+        ]);
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(2);
+        Http::assertSentCount(2);
     });
 
     it('continues without legacy metadata and opens the metaworks circuit breaker after lookup failure', function () {

--- a/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
+++ b/tests/pest/Feature/DataCiteImport/ImportFromDataCiteJobTest.php
@@ -508,6 +508,75 @@ describe('ImportFromDataCiteJob', function () {
         Http::assertNothingSent();
     });
 
+    it('adds CRC806 rights beside a COAR access-right statement', function (): void {
+        Right::query()->create([
+            'identifier' => 'CC-BY-NC-ND-4.0',
+            'name' => 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International',
+            'uri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+            'is_active' => true,
+            'is_elmo_active' => true,
+        ]);
+
+        $doiRecord = [
+            'id' => '10.5880/sfb806.coar-only',
+            'attributes' => [
+                'doi' => '10.5880/sfb806.coar-only',
+                'url' => 'https://crc806db.uni-koeln.de/dataset/show/coar-only/',
+            ],
+        ];
+        $coarRights = [
+            'rights' => 'Open access',
+            'rightsUri' => 'https://purl.org/coar/access_right/c_abf2',
+            'rightsIdentifier' => 'c_abf2',
+            'rightsIdentifierScheme' => 'COAR Access Rights',
+            'schemeUri' => 'http://purl.org/coar/access_right/',
+        ];
+        $preparedRecord = $doiRecord;
+        unset($preparedRecord['attributes']['url']);
+        $preparedRecord['attributes']['rightsList'] = [$coarRights];
+
+        $this->importService->shouldReceive('getTotalDoiCount')->once()->andReturn(1);
+        $this->importService->shouldReceive('fetchAllDois')->once()->andReturn((function () use ($doiRecord) {
+            yield $doiRecord;
+        })());
+        $this->transformer
+            ->shouldReceive('prepareDoiData')
+            ->once()
+            ->andReturn($preparedRecord);
+        $this->transformer
+            ->shouldReceive('transform')
+            ->once()
+            ->withArgs(function (array $record, int $userId) use ($coarRights): bool {
+                return $userId === $this->user->id
+                    && ($record['attributes']['rightsList'] ?? null) === [
+                        $coarRights,
+                        [
+                            'rights' => 'CC BY-NC-ND',
+                            'rightsUri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+                            'rightsIdentifier' => 'CC-BY-NC-ND-4.0',
+                            'rightsIdentifierScheme' => 'SPDX',
+                            'schemeUri' => 'https://spdx.org/licenses/',
+                            'source' => 'legacy-crc806',
+                        ],
+                    ];
+            })
+            ->andReturn(Resource::factory()->make(['doi' => $doiRecord['id']]));
+
+        Http::fake([
+            'https://crc806db.uni-koeln.de/*' => Http::response(crc806ImportJobPage(
+                doi: '10.5880/sfb806.coar-only',
+            )),
+        ]);
+
+        $importId = Str::uuid()->toString();
+        (new ImportFromDataCiteJob($this->user->id, $importId))
+            ->handle($this->importService, $this->transformer, $this->metaworksService);
+
+        expect(Cache::get("datacite_import:{$importId}")['imported'])->toBe(1);
+        Http::assertSentCount(1);
+    });
+
     it('continues a CRC806 import without rights when the legacy page is malformed', function (): void {
         $doiRecord = [
             'id' => '10.5880/sfb806.malformed',

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -41,6 +41,45 @@ beforeEach(function (): void {
 });
 
 describe('DataCiteToResourceTransformer - rights import', function (): void {
+    it('links trusted CRC806 SPDX rights while preserving the legacy statement', function (): void {
+        $right = Right::query()->create([
+            'identifier' => 'CC-BY-NC-ND-4.0',
+            'name' => 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International',
+            'uri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+            'is_active' => true,
+        ]);
+        $user = User::factory()->create();
+
+        $resource = (new DataCiteToResourceTransformer)->transform([
+            'attributes' => [
+                'doi' => '10.5880/sfb806.80',
+                'publicationYear' => 2014,
+                'titles' => [['title' => 'CRC806 rights persistence']],
+                'creators' => [['name' => 'Tester, Ada', 'nameType' => 'Personal']],
+                'rightsList' => [[
+                    'rights' => 'CC BY-NC-ND',
+                    'rightsUri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+                    'rightsIdentifier' => 'CC-BY-NC-ND-4.0',
+                    'rightsIdentifierScheme' => 'SPDX',
+                    'schemeUri' => 'https://spdx.org/licenses/',
+                    'source' => 'legacy-crc806',
+                ]],
+            ],
+        ], $user->id);
+
+        $resourceRight = ResourceRight::where('resource_id', $resource->id)->sole();
+
+        expect($resourceRight->rights_id)->toBe($right->id)
+            ->and($resourceRight->rights_text)->toBe('CC BY-NC-ND')
+            ->and($resourceRight->rights_uri)->toBe('https://creativecommons.org/licenses/by-nc-nd/4.0')
+            ->and($resourceRight->rights_identifier)->toBe('CC-BY-NC-ND-4.0')
+            ->and($resourceRight->rights_identifier_scheme)->toBe('SPDX')
+            ->and($resourceRight->scheme_uri)->toBe('https://spdx.org/licenses/')
+            ->and($resourceRight->source)->toBe('legacy-crc806')
+            ->and($resource->rights()->pluck('rights.identifier')->all())->toBe(['CC-BY-NC-ND-4.0']);
+    });
+
     it('stores raw rights statements without immediately linking alias-only SPDX data', function (): void {
         $user = User::factory()->create();
         $transformer = new DataCiteToResourceTransformer;

--- a/tests/pest/Feature/Services/EditorDataTransformerTest.php
+++ b/tests/pest/Feature/Services/EditorDataTransformerTest.php
@@ -242,6 +242,30 @@ describe('transformTitles', function (): void {
 // =========================================================================
 
 describe('transformLicenses', function (): void {
+    it('returns a linked CRC806 fallback as the selected SPDX license', function (): void {
+        $right = Right::query()->create([
+            'identifier' => 'CC-BY-NC-ND-4.0',
+            'name' => 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International',
+            'uri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+            'is_active' => true,
+        ]);
+        ResourceRight::query()->create([
+            'resource_id' => $this->resource->id,
+            'rights_id' => $right->id,
+            'rights_text' => 'CC BY-NC-ND',
+            'rights_uri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+            'rights_identifier' => 'CC-BY-NC-ND-4.0',
+            'rights_identifier_scheme' => 'SPDX',
+            'scheme_uri' => 'https://spdx.org/licenses/',
+            'source' => 'legacy-crc806',
+        ]);
+        $this->resource->load('rights');
+
+        expect($this->transformer->transformLicenses($this->resource))
+            ->toBe(['CC-BY-NC-ND-4.0']);
+    });
+
     it('returns license identifiers', function (): void {
         $right = Right::factory()->ccBy4()->create();
         $this->resource->rights()->attach($right->id);

--- a/tests/pest/Unit/Services/Crc806LegacyRightsServiceTest.php
+++ b/tests/pest/Unit/Services/Crc806LegacyRightsServiceTest.php
@@ -14,10 +14,11 @@ function createCrc806CatalogRight(
     string $identifier = 'CC-BY-NC-ND-4.0',
     string $uri = 'https://creativecommons.org/licenses/by-nc-nd/4.0',
     bool $active = true,
+    ?string $name = null,
 ): Right {
     return Right::query()->create([
         'identifier' => $identifier,
-        'name' => 'Catalog '.$identifier,
+        'name' => $name ?? 'Catalog '.$identifier,
         'uri' => $uri,
         'scheme_uri' => SpdxLicenseLookup::SCHEME_URI,
         'is_active' => $active,
@@ -110,6 +111,55 @@ it('maps every supported Creative Commons family', function (string $name, strin
     'public domain dedication' => ['CC0', 'https://creativecommons.org/publicdomain/zero/1.0/', 'CC0-1.0'],
 ]);
 
+it('accepts a full Creative Commons name only when it matches the catalog license', function (): void {
+    $name = 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International';
+    createCrc806CatalogRight(name: $name);
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response(crc806LicensePage(name: $name)),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    )['rightsIdentifier'] ?? null)->toBe('CC-BY-NC-ND-4.0');
+});
+
+it('accepts a reviewed full-name alias when it resolves to the URI license', function (): void {
+    createCrc806CatalogRight(
+        identifier: 'CC-BY-4.0',
+        uri: 'https://creativecommons.org/licenses/by/4.0',
+    );
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response(crc806LicensePage(
+            name: 'Creative Commons Attribution 4.0 International',
+            licenseUrl: 'https://creativecommons.org/licenses/by/4.0',
+        )),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    )['rightsIdentifier'] ?? null)->toBe('CC-BY-4.0');
+});
+
+it('rejects a reviewed full-name alias when it resolves to a different active license', function (): void {
+    createCrc806CatalogRight();
+    createCrc806CatalogRight(
+        identifier: 'CC-BY-4.0',
+        uri: 'https://creativecommons.org/licenses/by/4.0',
+    );
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response(crc806LicensePage(
+            name: 'Creative Commons Attribution 4.0 International',
+        )),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    ))->toBeNull();
+});
+
 it('does not request an unsafe landing page URL', function (string $url): void {
     Http::fake();
     Http::preventStrayRequests();
@@ -181,6 +231,7 @@ it('does not guess an unsupported or conflicting license', function (string $nam
     'URI with query' => ['CC BY', 'https://creativecommons.org/licenses/by/4.0/?lang=en'],
     'foreign URI host' => ['CC BY', 'https://creativecommons.org.example/licenses/by/4.0/'],
     'conflicting short name' => ['CC BY 4.0', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
+    'conflicting full name' => ['Creative Commons Attribution 4.0 International', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
     'conflicting version in short name' => ['CC BY-NC-ND 3.0', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
     'unrecognized CC-like short name' => ['CC BY NC ND', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
 ]);
@@ -240,6 +291,22 @@ it('retries server errors and opens the in-memory circuit breaker', function ():
         ->and($service->findRights('10.5880/sfb806.80', $url))->toBeNull();
 
     Http::assertSentCount(2);
+});
+
+it('opens the in-memory circuit breaker when the provider rate limits requests', function (): void {
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::sequence()
+            ->push('Too many requests', 429, ['Retry-After' => '120'])
+            ->push(crc806LicensePage(), 200),
+    ]);
+
+    $service = new Crc806LegacyRightsService;
+    $url = 'https://crc806db.uni-koeln.de/dataset/show/example/';
+
+    expect($service->findRights('10.5880/sfb806.80', $url))->toBeNull()
+        ->and($service->findRights('10.5880/sfb806.80', $url))->toBeNull();
+
+    Http::assertSentCount(1);
 });
 
 it('retries connection failures and opens the in-memory circuit breaker', function (): void {

--- a/tests/pest/Unit/Services/Crc806LegacyRightsServiceTest.php
+++ b/tests/pest/Unit/Services/Crc806LegacyRightsServiceTest.php
@@ -181,6 +181,8 @@ it('does not guess an unsupported or conflicting license', function (string $nam
     'URI with query' => ['CC BY', 'https://creativecommons.org/licenses/by/4.0/?lang=en'],
     'foreign URI host' => ['CC BY', 'https://creativecommons.org.example/licenses/by/4.0/'],
     'conflicting short name' => ['CC BY 4.0', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
+    'conflicting version in short name' => ['CC BY-NC-ND 3.0', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
+    'unrecognized CC-like short name' => ['CC BY NC ND', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
 ]);
 
 it('requires an active matching SPDX catalog right', function (bool $createInactiveRight): void {

--- a/tests/pest/Unit/Services/Crc806LegacyRightsServiceTest.php
+++ b/tests/pest/Unit/Services/Crc806LegacyRightsServiceTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Right;
+use App\Services\Crc806LegacyRightsService;
+use App\Services\Spdx\SpdxLicenseLookup;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+covers(Crc806LegacyRightsService::class);
+
+function createCrc806CatalogRight(
+    string $identifier = 'CC-BY-NC-ND-4.0',
+    string $uri = 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+    bool $active = true,
+): Right {
+    return Right::query()->create([
+        'identifier' => $identifier,
+        'name' => 'Catalog '.$identifier,
+        'uri' => $uri,
+        'scheme_uri' => SpdxLicenseLookup::SCHEME_URI,
+        'is_active' => $active,
+        'is_elmo_active' => true,
+        'usage_count' => 0,
+    ]);
+}
+
+/**
+ * @param  array<int|string, mixed>|null  $extras
+ */
+function crc806LicensePage(
+    string $doi = '10.5880/sfb806.80',
+    string $name = 'CC BY-NC-ND',
+    string $licenseUrl = 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+    ?array $extras = null,
+): string {
+    $routeInfo = [
+        'allProps' => [
+            'dataset' => [
+                'title' => 'Data with a }; marker inside a JSON string',
+                'extras' => $extras ?? ['bibtex:doi' => $doi],
+                'license' => [
+                    'name' => $name,
+                    'url' => $licenseUrl,
+                ],
+            ],
+        ],
+    ];
+
+    return '<!doctype html><script>window.__routeInfo = '
+        .json_encode($routeInfo, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES)
+        .';</script>';
+}
+
+it('imports the structured CRC806 license and canonicalizes the request URL', function (): void {
+    createCrc806CatalogRight();
+    $html = crc806LicensePage(extras: [[
+        'key' => 'bibtex:doi',
+        'value' => '@misc{record, doi = {https://doi.org/10.5880/SFB806.80}}',
+    ]]);
+
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response($html, 200, [
+            'Content-Type' => 'text/html; charset=UTF-8',
+            'Content-Length' => (string) strlen($html),
+        ]),
+    ]);
+    Http::preventStrayRequests();
+
+    $result = (new Crc806LegacyRightsService)->findRights(
+        'https://doi.org/10.5880/sfb806.80',
+        'http://CRC806DB.UNI-KOELN.DE:80/dataset/show/example/?view=full#license',
+    );
+
+    expect($result)->toBe([
+        'rights' => 'CC BY-NC-ND',
+        'rightsUri' => 'https://creativecommons.org/licenses/by-nc-nd/4.0',
+        'rightsIdentifier' => 'CC-BY-NC-ND-4.0',
+        'rightsIdentifierScheme' => 'SPDX',
+        'schemeUri' => SpdxLicenseLookup::SCHEME_URI,
+        'source' => 'legacy-crc806',
+    ]);
+
+    Http::assertSent(fn (Request $request): bool => $request->url()
+        === 'https://crc806db.uni-koeln.de/dataset/show/example/?view=full'
+        && $request->hasHeader('Accept', 'text/html,application/xhtml+xml'));
+});
+
+it('maps every supported Creative Commons family', function (string $name, string $uri, string $identifier): void {
+    createCrc806CatalogRight($identifier, $uri);
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response(crc806LicensePage(name: $name, licenseUrl: $uri)),
+    ]);
+
+    $result = (new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    );
+
+    expect($result['rightsIdentifier'] ?? null)->toBe($identifier)
+        ->and($result['rightsUri'] ?? null)->toBe($uri);
+})->with([
+    'attribution' => ['CC BY', 'https://creativecommons.org/licenses/by/4.0/', 'CC-BY-4.0'],
+    'share alike' => ['CC BY-SA', 'https://creativecommons.org/licenses/by-sa/4.0', 'CC-BY-SA-4.0'],
+    'no derivatives' => ['CC BY-ND', 'https://creativecommons.org/licenses/by-nd/4.0', 'CC-BY-ND-4.0'],
+    'non-commercial' => ['CC BY-NC', 'https://creativecommons.org/licenses/by-nc/4.0', 'CC-BY-NC-4.0'],
+    'non-commercial share alike' => ['CC BY-NC-SA', 'https://creativecommons.org/licenses/by-nc-sa/4.0', 'CC-BY-NC-SA-4.0'],
+    'non-commercial no derivatives' => ['CC BY-NC-ND', 'https://creativecommons.org/licenses/by-nc-nd/4.0', 'CC-BY-NC-ND-4.0'],
+    'public domain dedication' => ['CC0', 'https://creativecommons.org/publicdomain/zero/1.0/', 'CC0-1.0'],
+]);
+
+it('does not request an unsafe landing page URL', function (string $url): void {
+    Http::fake();
+    Http::preventStrayRequests();
+
+    expect((new Crc806LegacyRightsService)->findRights('10.5880/sfb806.80', $url))->toBeNull();
+
+    Http::assertNothingSent();
+})->with([
+    'untrusted host' => ['https://example.org/dataset/show/example/'],
+    'host suffix attack' => ['https://crc806db.uni-koeln.de.example.org/dataset/show/example/'],
+    'host prefix attack' => ['https://crc806db.uni-koeln.de@evil.example/dataset/show/example/'],
+    'userinfo' => ['https://user:secret@crc806db.uni-koeln.de/dataset/show/example/'],
+    'unexpected port' => ['https://crc806db.uni-koeln.de:8443/dataset/show/example/'],
+    'unsupported scheme' => ['ftp://crc806db.uni-koeln.de/dataset/show/example/'],
+    'control characters' => ["https://crc806db.uni-koeln.de/dataset/\nshow/example/"],
+]);
+
+it('does not follow redirects, including redirects to foreign hosts', function (): void {
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response('', 302, [
+            'Location' => 'https://169.254.169.254/latest/meta-data/',
+        ]),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    ))->toBeNull();
+
+    Http::assertSentCount(1);
+});
+
+it('rejects malformed or unverifiable structured data', function (string $html): void {
+    createCrc806CatalogRight();
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response($html),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    ))->toBeNull();
+})->with([
+    'missing assignment' => ['<html><body>No route data</body></html>'],
+    'invalid JSON' => ['<script>window.__routeInfo = {not: "json"};</script>'],
+    'missing dataset' => ['<script>window.__routeInfo = {"allProps":{}};</script>'],
+    'missing DOI extra' => [crc806LicensePage(extras: ['description' => 'No DOI'])],
+    'different DOI' => [crc806LicensePage(doi: '10.5880/sfb806.81')],
+    'ambiguous DOI extras' => [crc806LicensePage(extras: [
+        'bibtex:doi' => '10.5880/sfb806.80',
+        'doi' => '10.5880/sfb806.81',
+    ])],
+]);
+
+it('does not guess an unsupported or conflicting license', function (string $name, string $uri): void {
+    createCrc806CatalogRight();
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response(crc806LicensePage(name: $name, licenseUrl: $uri)),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    ))->toBeNull();
+})->with([
+    'unversioned URI' => ['CC BY-NC-ND', 'https://creativecommons.org/licenses/by-nc-nd/'],
+    'unknown family' => ['CC Sampling Plus', 'https://creativecommons.org/licenses/sampling+/1.0/'],
+    'localized URI' => ['CC BY', 'https://creativecommons.org/licenses/by/3.0/de/'],
+    'URI with query' => ['CC BY', 'https://creativecommons.org/licenses/by/4.0/?lang=en'],
+    'foreign URI host' => ['CC BY', 'https://creativecommons.org.example/licenses/by/4.0/'],
+    'conflicting short name' => ['CC BY 4.0', 'https://creativecommons.org/licenses/by-nc-nd/4.0/'],
+]);
+
+it('requires an active matching SPDX catalog right', function (bool $createInactiveRight): void {
+    if ($createInactiveRight) {
+        createCrc806CatalogRight(active: false);
+    }
+
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::response(crc806LicensePage()),
+    ]);
+
+    expect((new Crc806LegacyRightsService)->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/example/',
+    ))->toBeNull();
+})->with([
+    'missing right' => [false],
+    'inactive right' => [true],
+]);
+
+it('keeps the provider available after a record-specific 404 response', function (): void {
+    createCrc806CatalogRight();
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::sequence()
+            ->push('Not found', 404)
+            ->push(crc806LicensePage(), 200),
+    ]);
+
+    $service = new Crc806LegacyRightsService;
+
+    expect($service->findRights(
+        '10.5880/sfb806.80',
+        'https://crc806db.uni-koeln.de/dataset/show/missing/',
+    ))->toBeNull()
+        ->and($service->findRights(
+            '10.5880/sfb806.80',
+            'https://crc806db.uni-koeln.de/dataset/show/example/',
+        )['rightsIdentifier'] ?? null)->toBe('CC-BY-NC-ND-4.0');
+
+    Http::assertSentCount(2);
+});
+
+it('retries server errors and opens the in-memory circuit breaker', function (): void {
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::sequence()
+            ->push('Unavailable', 503)
+            ->push('Unavailable', 503)
+            ->push(crc806LicensePage(), 200),
+    ]);
+
+    $service = new Crc806LegacyRightsService;
+    $url = 'https://crc806db.uni-koeln.de/dataset/show/example/';
+
+    expect($service->findRights('10.5880/sfb806.80', $url))->toBeNull()
+        ->and($service->findRights('10.5880/sfb806.80', $url))->toBeNull();
+
+    Http::assertSentCount(2);
+});
+
+it('retries connection failures and opens the in-memory circuit breaker', function (): void {
+    Http::fake(fn () => Http::failedConnection());
+
+    $service = new Crc806LegacyRightsService;
+    $url = 'https://crc806db.uni-koeln.de/dataset/show/example/';
+
+    expect($service->findRights('10.5880/sfb806.80', $url))->toBeNull()
+        ->and($service->findRights('10.5880/sfb806.80', $url))->toBeNull();
+
+    Http::assertSentCount(2);
+});
+
+it('rejects responses whose declared or streamed body exceeds the size limit', function (): void {
+    Http::fake([
+        'https://crc806db.uni-koeln.de/*' => Http::sequence()
+            ->push('short', 200, ['Content-Length' => '1000001'])
+            ->push(str_repeat('x', 1_000_001), 200),
+    ]);
+
+    $url = 'https://crc806db.uni-koeln.de/dataset/show/example/';
+
+    expect((new Crc806LegacyRightsService)->findRights('10.5880/sfb806.80', $url))->toBeNull()
+        ->and((new Crc806LegacyRightsService)->findRights('10.5880/sfb806.80', $url))->toBeNull();
+
+    Http::assertSentCount(2);
+});

--- a/tests/vitest/components/landing-pages/__tests__/CreativeCommonsIcon.test.tsx
+++ b/tests/vitest/components/landing-pages/__tests__/CreativeCommonsIcon.test.tsx
@@ -4,7 +4,12 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { CreativeCommonsIcon, getCreativeCommonsBadgePath, isCreativeCommonsLicense } from '@/pages/LandingPages/components/CreativeCommonsIcon';
+import {
+    CreativeCommonsIcon,
+    getCreativeCommonsBadgePath,
+    getCreativeCommonsShortName,
+    isCreativeCommonsLicense,
+} from '@/pages/LandingPages/components/CreativeCommonsIcon';
 
 describe('CreativeCommonsIcon', () => {
     it.each([
@@ -32,10 +37,7 @@ describe('CreativeCommonsIcon', () => {
     it('handles lowercase SPDX identifiers', () => {
         render(<CreativeCommonsIcon spdxId="cc-by-4.0" />);
 
-        expect(screen.getByRole('img', { name: 'Creative Commons cc-by-4.0' })).toHaveAttribute(
-            'src',
-            '/images/creative-commons/88x31/by.svg',
-        );
+        expect(screen.getByRole('img', { name: 'Creative Commons cc-by-4.0' })).toHaveAttribute('src', '/images/creative-commons/88x31/by.svg');
     });
 
     it('applies a custom className to the badge image', () => {
@@ -50,6 +52,28 @@ describe('CreativeCommonsIcon', () => {
 
         expect(container).toBeEmptyDOMElement();
         expect(getCreativeCommonsBadgePath('MIT')).toBeNull();
+    });
+});
+
+describe('getCreativeCommonsShortName', () => {
+    it.each([
+        ['CC-BY-4.0', 'CC BY 4.0'],
+        ['CC-BY-SA-4.0', 'CC BY-SA 4.0'],
+        ['CC-BY-ND-4.0', 'CC BY-ND 4.0'],
+        ['CC-BY-NC-4.0', 'CC BY-NC 4.0'],
+        ['CC-BY-NC-SA-4.0', 'CC BY-NC-SA 4.0'],
+        ['CC-BY-NC-ND-4.0', 'CC BY-NC-ND 4.0'],
+        ['CC0-1.0', 'CC0 1.0'],
+    ])('formats %s as %s', (spdxId, shortName) => {
+        expect(getCreativeCommonsShortName(spdxId)).toBe(shortName);
+    });
+
+    it('handles whitespace and lowercase identifiers', () => {
+        expect(getCreativeCommonsShortName('  cc-by-nc-nd-4.0 ')).toBe('CC BY-NC-ND 4.0');
+    });
+
+    it.each(['MIT', 'CC-PDM-1.0', 'CC-BY-NC-ND', 'CC-BY-NC-ND-latest', ''])('returns null for unsupported identifier %s', (spdxId) => {
+        expect(getCreativeCommonsShortName(spdxId)).toBeNull();
     });
 });
 

--- a/tests/vitest/components/landing-pages/__tests__/FilesSection.test.tsx
+++ b/tests/vitest/components/landing-pages/__tests__/FilesSection.test.tsx
@@ -63,12 +63,7 @@ const mockContactPersonNoContact = {
 describe('FilesSection', () => {
     describe('when downloadUrl is provided', () => {
         it('renders download button with correct URL', () => {
-            render(
-                <FilesSection
-                    downloadUrl="https://datapub.gfz-potsdam.de/download/test.zip"
-                    licenses={[]}
-                />,
-            );
+            render(<FilesSection downloadUrl="https://datapub.gfz-potsdam.de/download/test.zip" licenses={[]} />);
 
             const downloadLink = screen.getByRole('link', { name: /download data and description/i });
             expect(downloadLink).toBeInTheDocument();
@@ -77,26 +72,14 @@ describe('FilesSection', () => {
         });
 
         it('shows download button even when contact person with email exists', () => {
-            render(
-                <FilesSection
-                    downloadUrl="https://example.com/data.zip"
-                    licenses={[]}
-                    contactPersons={[mockContactPersonWithEmail]}
-                />,
-            );
+            render(<FilesSection downloadUrl="https://example.com/data.zip" licenses={[]} contactPersons={[mockContactPersonWithEmail]} />);
 
             expect(screen.getByRole('link', { name: /download data and description/i })).toBeInTheDocument();
             expect(screen.queryByRole('button', { name: /request data via contact form/i })).not.toBeInTheDocument();
         });
 
         it('does not show contact button when download URL is available', () => {
-            render(
-                <FilesSection
-                    downloadUrl="https://example.com/data.zip"
-                    licenses={[]}
-                    contactPersons={[mockContactPersonWithEmail]}
-                />,
-            );
+            render(<FilesSection downloadUrl="https://example.com/data.zip" licenses={[]} contactPersons={[mockContactPersonWithEmail]} />);
 
             expect(screen.queryByRole('button', { name: /request data via contact form/i })).not.toBeInTheDocument();
         });
@@ -136,13 +119,7 @@ describe('FilesSection', () => {
 
     describe('contact form fallback (when no download URL)', () => {
         it('shows contact form button when contact person with email exists', () => {
-            render(
-                <FilesSection
-                    licenses={[]}
-                    contactPersons={[mockContactPersonWithEmail]}
-                    datasetTitle="Test Dataset"
-                />,
-            );
+            render(<FilesSection licenses={[]} contactPersons={[mockContactPersonWithEmail]} datasetTitle="Test Dataset" />);
 
             const contactButton = screen.getByRole('button', { name: /request data via contact form/i });
             expect(contactButton).toBeInTheDocument();
@@ -165,13 +142,7 @@ describe('FilesSection', () => {
 
     describe('website fallback (when no download URL and no email)', () => {
         it('shows website link when contact person has website but no email', () => {
-            render(
-                <FilesSection
-                    licenses={[]}
-                    contactPersons={[mockContactPersonWithWebsite]}
-                    datasetTitle="Test Dataset"
-                />,
-            );
+            render(<FilesSection licenses={[]} contactPersons={[mockContactPersonWithWebsite]} datasetTitle="Test Dataset" />);
 
             const websiteLink = screen.getByRole('link', { name: /visit contact person website/i });
             expect(websiteLink).toBeInTheDocument();
@@ -180,12 +151,7 @@ describe('FilesSection', () => {
         });
 
         it('does not show website link when contact person has no website', () => {
-            render(
-                <FilesSection
-                    licenses={[]}
-                    contactPersons={[mockContactPersonNoContact]}
-                />,
-            );
+            render(<FilesSection licenses={[]} contactPersons={[mockContactPersonNoContact]} />);
 
             expect(screen.queryByRole('link', { name: /visit contact person website/i })).not.toBeInTheDocument();
         });
@@ -206,12 +172,7 @@ describe('FilesSection', () => {
         });
 
         it('shows fallback message when contact persons have neither email nor website', () => {
-            render(
-                <FilesSection
-                    licenses={[]}
-                    contactPersons={[mockContactPersonNoContact]}
-                />,
-            );
+            render(<FilesSection licenses={[]} contactPersons={[mockContactPersonNoContact]} />);
 
             expect(screen.getByText(/download information not available/i)).toBeInTheDocument();
         });
@@ -245,26 +206,72 @@ describe('FilesSection', () => {
             render(<FilesSection licenses={fullNameLicenses} />);
 
             // CC licenses include icon aria-label in accessible name
-            expect(
-                screen.getByRole('link', { name: /Creative Commons Attribution 4\.0 International/ }),
-            ).toBeInTheDocument();
-            expect(
-                screen.getByRole('link', { name: /Creative Commons Attribution Share Alike 4\.0 International/ }),
-            ).toBeInTheDocument();
+            expect(screen.getByRole('link', { name: /Creative Commons Attribution 4\.0 International/ })).toBeInTheDocument();
+            expect(screen.getByRole('link', { name: /Creative Commons Attribution Share Alike 4\.0 International/ })).toBeInTheDocument();
+            expect(screen.getByText(/\(CC BY 4\.0\)/)).toBeInTheDocument();
+            expect(screen.getByText(/\(CC BY-SA 4\.0\)/)).toBeInTheDocument();
+        });
+
+        it('adds the conventional compound CC short name to the full license name', () => {
+            render(
+                <FilesSection
+                    licenses={[
+                        {
+                            id: 7,
+                            name: 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International',
+                            spdx_id: 'CC-BY-NC-ND-4.0',
+                            reference: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+                        },
+                    ]}
+                />,
+            );
+
+            const link = screen.getByRole('link', {
+                name: /Creative Commons Attribution-NonCommercial-NoDerivatives 4\.0 International \(CC BY-NC-ND 4\.0\)/,
+            });
+            expect(link).toHaveAttribute('href', 'https://creativecommons.org/licenses/by-nc-nd/4.0/');
+            expect(link).toHaveAttribute('title', 'CC-BY-NC-ND-4.0');
+        });
+
+        it('adds the CC short name to a non-link badge', () => {
+            render(
+                <FilesSection
+                    licenses={[
+                        {
+                            id: 8,
+                            name: 'Creative Commons Attribution 4.0 International',
+                            spdx_id: 'CC-BY-4.0',
+                            reference: null,
+                        },
+                    ]}
+                />,
+            );
+
+            const badge = screen.getByTestId('license-badge');
+            expect(badge).toHaveTextContent('Creative Commons Attribution 4.0 International (CC BY 4.0)');
+            expect(badge.closest('a')).toBeNull();
+        });
+
+        it('does not duplicate a license name that already is the CC short name', () => {
+            render(<FilesSection licenses={[mockLicenses[0]]} />);
+
+            expect(screen.getByTestId('license-badge')).toHaveTextContent('CC BY 4.0');
+            expect(screen.queryByText(/\(CC BY 4\.0\)/)).not.toBeInTheDocument();
+        });
+
+        it('does not add a generated short name to non-CC licenses', () => {
+            render(<FilesSection licenses={[mockLicenses[1]]} />);
+
+            expect(screen.getByTestId('license-badge')).toHaveTextContent('MIT');
+            expect(screen.getByTestId('license-badge')).not.toHaveTextContent(/\(MIT\)/);
         });
 
         it('license links have correct href', () => {
             render(<FilesSection licenses={mockLicenses} />);
 
             // CC licenses include icon aria-label in accessible name
-            expect(screen.getByRole('link', { name: /CC BY 4\.0/ })).toHaveAttribute(
-                'href',
-                'https://creativecommons.org/licenses/by/4.0/',
-            );
-            expect(screen.getByRole('link', { name: 'MIT' })).toHaveAttribute(
-                'href',
-                'https://opensource.org/licenses/MIT',
-            );
+            expect(screen.getByRole('link', { name: /CC BY 4\.0/ })).toHaveAttribute('href', 'https://creativecommons.org/licenses/by/4.0/');
+            expect(screen.getByRole('link', { name: 'MIT' })).toHaveAttribute('href', 'https://opensource.org/licenses/MIT');
         });
 
         it('renders a license without reference as a non-link badge', () => {
@@ -316,36 +323,21 @@ describe('FilesSection', () => {
 
     describe('GFZ branding', () => {
         it('applies GFZ action button styling to download button', () => {
-            render(
-                <FilesSection
-                    downloadUrl="https://example.com/data.zip"
-                    licenses={[]}
-                />,
-            );
+            render(<FilesSection downloadUrl="https://example.com/data.zip" licenses={[]} />);
 
             const downloadLink = screen.getByRole('link', { name: /download data and description/i });
             expect(downloadLink).toHaveClass('gfz-action-button');
         });
 
         it('applies GFZ action button styling to contact button', () => {
-            render(
-                <FilesSection
-                    licenses={[]}
-                    contactPersons={[mockContactPersonWithEmail]}
-                />,
-            );
+            render(<FilesSection licenses={[]} contactPersons={[mockContactPersonWithEmail]} />);
 
             const contactButton = screen.getByRole('button', { name: /request data via contact form/i });
             expect(contactButton).toHaveClass('gfz-action-button');
         });
 
         it('applies GFZ action button styling to website link', () => {
-            render(
-                <FilesSection
-                    licenses={[]}
-                    contactPersons={[mockContactPersonWithWebsite]}
-                />,
-            );
+            render(<FilesSection licenses={[]} contactPersons={[mockContactPersonWithWebsite]} />);
 
             const websiteLink = screen.getByRole('link', { name: /visit contact person website/i });
             expect(websiteLink).toHaveClass('gfz-action-button');

--- a/tests/vitest/pages/__tests__/docs.test.tsx
+++ b/tests/vitest/pages/__tests__/docs.test.tsx
@@ -492,6 +492,8 @@ describe('Docs page', () => {
         // Beginners can set up landing pages as part of the training workflow
         expect(screen.getByText('Creating Landing Pages')).toBeInTheDocument();
         expect(screen.getByText(/Beginner users can create, edit, preview, and publish landing pages/i)).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'License Display', level: 4 })).toBeInTheDocument();
+        expect(screen.getByText(/Creative Commons Attribution 4\.0 International \(CC BY 4\.0\)/i)).toBeInTheDocument();
     });
 
     it('shows landing pages documentation for curator', async () => {


### PR DESCRIPTION
This pull request introduces a clearer display of Creative Commons license labels on landing pages and implements a fallback mechanism for missing rights information during DataCite imports. The main changes include updating the UI to show both the full license name and the conventional short notation, enhancing the backend to supplement missing rights data, and adding supporting tests and documentation.

**Landing Page License Display Improvements:**

* The Files section on landing pages now displays Creative Commons licenses with both the full name and the short notation (e.g., "Creative Commons Attribution 4.0 International (CC BY 4.0)"). The badge remains linked to the license text, and the tooltip shows the SPDX identifier. [[1]](diffhunk://#diff-7f2333c407955bf082905ff703ed67e52eb1fcd0cda92402d42765d4344958c0R164-R165) [[2]](diffhunk://#diff-7f2333c407955bf082905ff703ed67e52eb1fcd0cda92402d42765d4344958c0L175-R177) [[3]](diffhunk://#diff-3ebf370f09df5a51ca982454c40a36825140c8c31763dba40c5961a0acda638fR61-R80) [[4]](diffhunk://#diff-7f2333c407955bf082905ff703ed67e52eb1fcd0cda92402d42765d4344958c0L8-R8) [[5]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR1698-R1703)

**Backend: DataCite Import Rights Fallback:**

* During DataCite imports, if no usable rights information is found, the system now attempts to supplement it using the `Crc806LegacyRightsService`, improving metadata completeness for legacy datasets. [[1]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R69-R70) [[2]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R1012-R1023) [[3]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R1113-R1222) [[4]](diffhunk://#diff-94cc7ab5aa6cfc5ecaf6ca917468a45663e06f8933c8011916d06a1397eea528R7-R12)

**Documentation and Changelog:**

* The changelog and documentation have been updated to describe the new license label display and its behavior for users. [[1]](diffhunk://#diff-74ce5e5ea976ccf9456e2d08ad96851e65ee0a116a39d35c8fbf385b977ef94fR6-R9) [[2]](diffhunk://#diff-af0cc31f5b077e6faf7e20be0753eda2d81afaa33de9dc2acb59ec3a6f726b7aR1698-R1703)

**Testing Enhancements:**

* Added and updated tests to verify the new license label display and the DataCite import fallback logic, including a utility for generating test landing pages with legacy rights data. [[1]](diffhunk://#diff-82c254f17dbb7fae23b2d2910ff705baa5806ec1089c0f8c1def04df71a1a99fR21-R23) [[2]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR13) [[3]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR31) [[4]](diffhunk://#diff-4e71d08158d90ed993061690c3d44b2cf2d4e42969638e627a1956c3b3c2587dR141-R155)

These changes together ensure users see clearer license information and that imported datasets are more likely to include accurate rights metadata.