### PR TITLE
Fix: Handle staff collectives as institutions

### DIFF
--- a/app/Services/DataCiteToResourceTransformer.php
+++ b/app/Services/DataCiteToResourceTransformer.php
@@ -1072,12 +1072,17 @@ class DataCiteToResourceTransformer
     }
 
     /**
-     * Recognize the narrowly scoped collective phrase in legacy DEKORP party
-     * names without broadening the general organization keyword list.
+     * Recognize narrowly scoped collective phrases in legacy party names
+     * without broadening the general organization keyword list.
      */
     private function looksLikeCollectiveOrganizationName(string $name): bool
     {
-        return preg_match('/\bproject\s+leaders\b/iu', $name) === 1;
+        if (preg_match('/\bproject\s+leaders\b/iu', $name) === 1) {
+            return true;
+        }
+
+        return ! str_contains($name, ',')
+            && preg_match('/\bstaff\b/iu', $name) === 1;
     }
 
     /**

--- a/resources/data/changelog.json
+++ b/resources/data/changelog.json
@@ -412,6 +412,10 @@
         ],
         "fixes": [
             {
+                "title": "Staff Collectives Import as Institutions",
+                "description": "New legacy DataCite imports now recognize unstructured staff collectives such as 'ISG Staff' as institutions instead of splitting them into person-name fields. Their original contributor names, roles, and affiliations remain intact, while explicit or structured person metadata continues to take precedence. Existing imported resources remain unchanged."
+            },
+            {
                 "title": "Reliable Legacy Subject Imports",
                 "description": "New legacy DataCite imports now use the embedded original XML subjects when the REST representation differs and enrich matching GEMET terms with stable identifiers from SUMARIOPMD. REST-only additions are no longer imported, GEMET selections reopen correctly in the Data Editor, and unrelated DataCite subject scheme names remain unchanged during import and re-export. Existing imported resources remain unchanged."
             },

--- a/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
+++ b/tests/pest/Feature/Services/DataCiteToResourceTransformerTest.php
@@ -2055,6 +2055,138 @@ describe('DataCiteToResourceTransformer - nameType inference and null family_nam
         expect($resource->contributors()->sole()->contributorable_type)->toBe(Institution::class);
     });
 
+    it('imports an unstructured staff contributor as an institution for issue 1125', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform([
+            'attributes' => [
+                'doi' => '10.5880/isg.2023.007',
+                'publicationYear' => 2023,
+                'titles' => [['title' => 'The Colombian gravimetric quasi-geoid: QgeoidCOL2023']],
+                'creators' => [
+                    ['familyName' => 'Liu', 'givenName' => 'Qing', 'nameType' => 'Personal'],
+                ],
+                'contributors' => [
+                    [
+                        'name' => 'ISG Staff',
+                        'affiliation' => ['International Service for the Geoid (ISG)'],
+                        'contributorType' => 'ContactPerson',
+                        'nameIdentifiers' => [],
+                    ],
+                ],
+            ],
+        ], $user->id);
+
+        $contributor = $resource->contributors()
+            ->with(['affiliations', 'contributorTypes'])
+            ->sole();
+        $institution = Institution::findOrFail($contributor->contributorable_id);
+
+        expect($contributor->contributorable_type)->toBe(Institution::class)
+            ->and($institution->name)->toBe('ISG Staff')
+            ->and($contributor->contributorTypes->pluck('slug')->all())->toBe(['ContactPerson'])
+            ->and($contributor->affiliations->pluck('name')->all())
+            ->toBe(['International Service for the Geoid (ISG)'])
+            ->and(Person::query()
+                ->where('given_name', 'ISG')
+                ->where('family_name', 'Staff')
+                ->exists())->toBeFalse();
+    });
+
+    it('matches the staff collective word case-insensitively for creators and contributors', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform([
+            'attributes' => [
+                'doi' => '10.5880/staff-collective-case.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Staff Collective Case Test']],
+                'creators' => [
+                    ['name' => 'ISG STAFF'],
+                ],
+                'contributors' => [
+                    [
+                        'name' => 'Project staff',
+                        'contributorType' => 'Other',
+                    ],
+                ],
+            ],
+        ], $user->id);
+
+        expect($resource->creators()->sole()->creatorable_type)->toBe(Institution::class)
+            ->and($resource->contributors()->sole()->contributorable_type)->toBe(Institution::class);
+    });
+
+    it('does not treat staff substrings or comma-formatted names as collectives', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform([
+            'attributes' => [
+                'doi' => '10.5880/staff-collective-boundaries.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Staff Collective Boundary Test']],
+                'creators' => [
+                    ['name' => 'John Stafford'],
+                    ['name' => 'Staff, Jane'],
+                ],
+            ],
+        ], $user->id);
+
+        $creators = $resource->creators()->orderBy('position')->get();
+        $stafford = Person::findOrFail($creators[0]->creatorable_id);
+        $staff = Person::findOrFail($creators[1]->creatorable_id);
+
+        expect($creators)->toHaveCount(2)
+            ->and($creators[0]->creatorable_type)->toBe(Person::class)
+            ->and($stafford->given_name)->toBe('John')
+            ->and($stafford->family_name)->toBe('Stafford')
+            ->and($creators[1]->creatorable_type)->toBe(Person::class)
+            ->and($staff->given_name)->toBe('Jane')
+            ->and($staff->family_name)->toBe('Staff');
+    });
+
+    it('keeps stronger person signals ahead of the staff collective heuristic', function (): void {
+        $user = User::factory()->create();
+        $transformer = new DataCiteToResourceTransformer;
+
+        $resource = $transformer->transform([
+            'attributes' => [
+                'doi' => '10.5880/staff-person-signals.2024.001',
+                'publicationYear' => 2024,
+                'titles' => [['title' => 'Staff Person Signal Test']],
+                'creators' => [
+                    [
+                        'name' => 'Jane Staff',
+                        'nameType' => 'Personal',
+                    ],
+                    [
+                        'name' => 'Structured Staff',
+                        'givenName' => 'Structured',
+                        'familyName' => 'Staff',
+                    ],
+                    [
+                        'name' => 'Research Staff',
+                        'nameIdentifiers' => [
+                            [
+                                'nameIdentifier' => 'https://orcid.org/0000-0002-1825-0097',
+                                'nameIdentifierScheme' => 'ORCID',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $user->id);
+
+        $creators = $resource->creators()->orderBy('position')->get();
+
+        expect($creators)->toHaveCount(3)
+            ->and($creators->pluck('creatorable_type')->all())
+            ->toBe([Person::class, Person::class, Person::class]);
+    });
+
     it('corrects legacy institutional creators that DataCite marks as Personal', function (): void {
         $user = User::factory()->create();
         $transformer = new DataCiteToResourceTransformer;


### PR DESCRIPTION
This pull request improves the way legacy DataCite imports handle unstructured staff collectives, ensuring that names like "ISG Staff" are now recognized as institutions rather than being incorrectly split into person-name fields. The update includes logic enhancements, comprehensive tests, and a changelog entry. Explicit or structured person metadata will still take precedence over the new heuristic.

**Improvements to staff collective handling:**

* Enhanced the `looksLikeCollectiveOrganizationName` method in `DataCiteToResourceTransformer` to recognize unstructured staff collectives (e.g., "ISG Staff" or "Project staff") as institutions, provided the name does not contain a comma and matches "staff" as a whole word, in addition to the previous "project leaders" check. This prevents accidental splitting into person fields.

* Added a changelog entry describing that new legacy DataCite imports will treat unstructured staff collectives as institutions, preserving their original contributor names, roles, and affiliations, while existing imports remain unchanged.

**Test coverage:**

* Added multiple feature tests to verify:
  - Staff collectives are imported as institutions.
  - Case-insensitive matching of "staff" in both creators and contributors.
  - Names with "staff" as a substring or comma-formatted names are not misclassified as collectives.
  - Explicit or structured person metadata takes precedence over the staff collective heuristic.